### PR TITLE
Sync after creating partition table

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -143,6 +143,8 @@ def create_image(args, workspace):
 
     subprocess.run(["sfdisk", "--color=never", f.name], input=table.encode("utf-8"), check=True)
 
+    subprocess.run(["sync"])
+
     print_step("Created partition table as " + f.name + ".")
 
     return f


### PR DESCRIPTION
Otherwise mkfs.* might be invoked before the kernel realizes there are partitions in the loop device.

I used the sync external process instead of `os.sync` because that requires python 3.3, which was not documented as a required version