### PR TITLE
Fix installation for Ubuntu

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -453,7 +453,7 @@ def install_debian(args, workspace, run_build_script):
 def install_ubuntu(args, workspace, run_build_script):
     print_step("Installing Ubuntu...")
 
-    install_debian_or_ubuntu(args, workspace, "http://archive.ubuntu.com/ubuntu/")
+    install_debian_or_ubuntu(args, workspace, run_build_script, "http://archive.ubuntu.com/ubuntu/")
 
     print_step("Installing Ubuntu completed.")
 


### PR DESCRIPTION
Hi,

currently the `install_ubuntu()` method does not pass the correct number of arguments to the `install_debian_or_ubuntu()` method (`run_build_script` is missing) so the installation of *Ubuntu* won't work - the following error message appears (tested on *Arch Linux*):

```bash
Traceback (most recent call last):
  File "./mkosi", line 1475, in <module>
    main()
  File "./mkosi", line 1471, in main
    build_stuff(args)
  File "./mkosi", line 1432, in build_stuff
    (raw, tar) = build_image(args, workspace, run_build_script=False)
  File "./mkosi", line 1369, in build_image
    install_distribution(args, workspace.name, run_build_script)
  File "./mkosi", line 535, in install_distribution
    install[args.distribution](args, workspace, run_build_script)
  File "./mkosi", line 456, in install_ubuntu
    install_debian_or_ubuntu(args, workspace, "http://archive.ubuntu.com/ubuntu/")
TypeError: install_debian_or_ubuntu() missing 1 required positional argument: 'mirror'
```

This PR passes the correct arguments to the `install_debian_or_ubuntu()` method.