### PR TITLE
Enable community repository for Arch Linux

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -507,6 +507,9 @@ def install_arch(args, workspace, run_build_script):
         f.write("\n")
         f.write("[extra]\n")
         f.write("Server = https://mirrors.kernel.org/archlinux/$repo/os/$arch\n")
+        f.write("\n")
+        f.write("[community]\n")
+        f.write("Server = https://mirrors.kernel.org/archlinux/$repo/os/$arch\n")
 
     subprocess.run(["pacman", "--config", os.path.join(workspace, "pacman.conf"), "-Sy"], check=True)
     c = subprocess.run(["pacman", "--config", os.path.join(workspace, "pacman.conf"), "-Sg", "base"], stdout=subprocess.PIPE, universal_newlines=True, check=True)


### PR DESCRIPTION
Hi,

this PR enables the `community` repository in the package manager configuration (`pacman.conf`) for *Arch Linux*.

Packages in the `community` repository are added from [trusted users](https://wiki.archlinux.org/index.php/Trusted_Users) see [1]. So with this PR more packages are found and can be installed with *Arch Linux*.

[1] https://wiki.archlinux.org/index.php/official_repositories#community