### PR TITLE
Install dbus and libpam-systemd with debootstrap

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -454,7 +454,7 @@ def install_debian_or_ubuntu(args, workspace, run_build_script, mirror):
     cmdline = ["debootstrap",
                "--verbose",
                "--variant=minbase",
-               "--include=systemd",
+               "--include=systemd,dbus,libpam-systemd",
                "--exclude=sysv-rc,initscripts,startpar,lsb-base,insserv",
                args.release,
                workspace + "/root",


### PR DESCRIPTION
Both packages are recommended by the Debian systemd package, but debootstrap does not install Recommends.

Installing dbus fixes #15; the addition of libpam-systemd was suggested by @stefan-it in that same issue.