### PR TITLE
Do not install usrmerge on Debian/Ubuntu images

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -454,7 +454,7 @@ def install_debian_or_ubuntu(args, workspace, run_build_script, mirror):
     cmdline = ["debootstrap",
                "--verbose",
                "--variant=minbase",
-               "--include=systemd,usrmerge",
+               "--include=systemd",
                "--exclude=sysv-rc,initscripts,startpar,lsb-base,insserv",
                args.release,
                workspace + "/root",


### PR DESCRIPTION
This reverts commit a7f5575b1a49cee812e3b4f6f105b2d8ce111bee

Turns out debootstrap now has native support for merged /usr, and will likely be default (for the supported targets) in the near future. 

Thus disable explicitly installing usrmerge, unbreaking the generation of debian < stretch and ubuntu images.