### PR TITLE
[RFC] Add basic support for ARM64

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -47,8 +47,10 @@ GPT_SRV         = uuid.UUID("3b8f842520e04f3b907f1a25a76f98e8")
 
 if platform.machine() == "x86_64":
     GPT_ROOT_NATIVE = GPT_ROOT_X86_64
+elif platform.machine() == "aarch64":
+    GPT_ROOT_NATIVE = GPT_ROOT_ARM_64
 else:
-    sys.stderr.write("Don't known the native architecture.")
+    sys.stderr.write("Don't known the %s architecture.\n" % platform.machine())
     sys.exit(1)
 
 CLONE_NEWNS = 0x00020000
@@ -524,8 +526,18 @@ def install_arch(args, workspace, run_build_script):
 
     print_step("Installing ArchLinux...")
 
+    keyring = "archlinux"
+
+    if platform.machine() == "aarch64":
+        keyring += "arm"
+
     subprocess.run(["pacman-key", "--nocolor", "--init"], check=True)
-    subprocess.run(["pacman-key", "--nocolor", "--populate", "archlinux"], check=True)
+    subprocess.run(["pacman-key", "--nocolor", "--populate", keyring], check=True)
+
+    server = "Server = %s/$repo/os/$arch\n"
+
+    if platform.machine() == "aarch64":
+        server = "Server = %s/$arch/$repo\n"
 
     with open(os.path.join(workspace, "pacman.conf"), "w") as f:
         f.write("[options]\n")
@@ -536,13 +548,13 @@ def install_arch(args, workspace, run_build_script):
         f.write("SigLevel    = Required DatabaseOptional\n")
         f.write("\n")
         f.write("[core]\n")
-        f.write("Server = %s/$repo/os/$arch\n" % args.mirror)
+        f.write(server % args.mirror)
         f.write("\n")
         f.write("[extra]\n")
-        f.write("Server = %s/$repo/os/$arch\n" % args.mirror)
+        f.write(server % args.mirror)
         f.write("\n")
         f.write("[community]\n")
-        f.write("Server = %s/$repo/os/$arch\n" % args.mirror)
+        f.write(server % args.mirror)
 
     subprocess.run(["pacman", "--color", "never", "--config", os.path.join(workspace, "pacman.conf"), "-Sy"], check=True)
     c = subprocess.run(["pacman", "--color", "never", "--config", os.path.join(workspace, "pacman.conf"), "-Sg", "base"], stdout=subprocess.PIPE, universal_newlines=True, check=True)
@@ -567,7 +579,8 @@ def install_arch(args, workspace, run_build_script):
         elif args.output_format == OutputFormat.raw_btrfs:
             packages.add("btrfs-progs")
     else:
-        packages.remove("linux")
+        if "linux" in packages:
+            packages.remove("linux")
 
     if args.packages is not None:
         packages |= set(args.packages)
@@ -1286,6 +1299,8 @@ def load_args():
             args.mirror = "http://archive.ubuntu.com/ubuntu"
         elif args.distribution == Distribution.arch:
             args.mirror = "https://mirrors.kernel.org/archlinux"
+            if platform.machine() == "aarch64":
+                args.mirror = "http://mirror.archlinuxarm.org"
 
     if args.bootable:
         if args.distribution not in (Distribution.fedora, Distribution.arch, Distribution.debian):


### PR DESCRIPTION
This PR adds basic support for ARM64.

With Arch Linux on an ODROID-C2 I tested the following things.

# Debootstrap

On Arch Linux the `debootstrap` package adds the following [patch](https://archlinuxarm.org/packages/any/debootstrap/files/arch-detect.patch):

```diff
+elif in_path pacman; then
+	CARCH="$(. /etc/makepkg.conf && echo $CARCH)"
+    case "$CARCH" in
+        "i686")   HOST_ARCH="i386" ;;
+        "x86_64") HOST_ARCH="amd64" ;;
+        "armv7h") HOST_ARCH="armhf" ;;
+        *) echo "Unknown architecture: $CARCH" && exit 1
+    esac
```

I tried the current `debootstrap` package with the patch included, but it didn't work for me. But after adding one line for `aarch64`:

```diff
+elif in_path pacman; then
+	CARCH="$(. /etc/makepkg.conf && echo $CARCH)"
+    case "$CARCH" in
+        "i686")   HOST_ARCH="i386" ;;
+        "x86_64") HOST_ARCH="amd64" ;;
+        "armv7h") HOST_ARCH="armhf" ;;
+        "aarch64") HOST_ARCH="arm64" ;;
+        *) echo "Unknown architecture: $CARCH" && exit 1
+    esac
```

then it is possible to build an ARM64 Debian image on Arch Linux (I tested it with `jessie` and `unstable`). I contacted the `debootstrap` maintainer for Arch Linux, so maybe this patch will come into the Arch `debootstrap`. So if you want to build Debian ARM64 images on Arch Linux please apply this patch to your `debootstrap` installation (usually located under `/usr/bin/debootstrap`).

# Arch Linux

To build an Arch Linux ARM64 I had to change two things. The keyring name is `archlinuxarm` and not `archlinux` as on *x86_64*. The mirror format is kind of weird: "Normally" the format for *x86_64* is:

```text
MIRROR/$repo/os/$arch
```

But for the Arch Linux ARM mirror it is:

```text
MIRROR/$arch/$repo
```

I used `http://mirror.archlinuxarm.org` as new default mirror for ARM installations.

**Notice 1**: I only tested the `directory` output format and booting into the created container. The `archlinuxarm-keyring` needs to be installed.

**Notice 2**: To support more platforms like ARMv7 (e.g. Raspberry PI 2) the following extension can be done:

```python
if platform.machine() == "x86_64":
    GPT_ROOT_NATIVE = GPT_ROOT_X86_64
elif platform.machine() == "aarch64":
    GPT_ROOT_NATIVE = GPT_ROOT_ARM_64
elif platform.machine().startswith("arm"):
    GPT_ROOT_NATIVE = GPT_ROOT_ARM
else:
    sys.stderr.write("Don't known the %s architecture.\n" % platform.machine())
    sys.exit(1)
```

But I haven't tested it yet!