### PR TITLE
Debian fixes

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -528,8 +528,20 @@ def install_debian_or_ubuntu(args, workspace, run_build_script, mirror):
         extra_packages += ["linux-image-amd64", "dracut"]
 
     if extra_packages:
+        # Debian policy is to start daemons by default.
+        # The policy-rc.d script can be used choose which ones to start
+        # Let's install one that denies all daemon startups
+        # See https://people.debian.org/~hmh/invokerc.d-policyrc.d-specification.txt
+        # Note: despite writing in /usr/sbin, this file is not shipped by the OS
+        # and instead should be managed by the admin.
+        policyrcd = os.path.join(workspace, "root/usr/sbin/policy-rc.d")
+        with open(policyrcd, "w") as f:
+            f.write("#!/bin/sh\n")
+            f.write("exit 101")
+        os.chmod(policyrcd, 0o755)
         cmdline = ["/usr/bin/apt-get", "--assume-yes", "--no-install-recommends", "install"] + extra_packages
         run_workspace_command(workspace, *cmdline)
+        os.unlink(policyrcd)
 
 def install_debian(args, workspace, run_build_script):
     print_step("Installing Debian...")

--- a/mkosi
+++ b/mkosi
@@ -406,15 +406,17 @@ Type=ether
 DHCP=yes
 """)
 
-def run_workspace_command(workspace, *cmd):
-    subprocess.run(["systemd-nspawn",
+def run_workspace_command(workspace, *cmd, network=False):
+    cmdline = ["systemd-nspawn",
                     '--quiet',
                     "--directory", os.path.join(workspace, "root"),
                     "--as-pid2",
-                    "--private-network",
-                    "--register=no",
-                    *cmd],
-                   check=True)
+                    "--register=no"]
+    if not network:
+        cmdline += ["--private-network"]
+
+    cmdline += ['--', *cmd]
+    subprocess.run(cmdline, check=True)
 
 def install_fedora(args, workspace, run_build_script):
     print_step("Installing Fedora...")
@@ -540,7 +542,7 @@ def install_debian_or_ubuntu(args, workspace, run_build_script, mirror):
             f.write("exit 101")
         os.chmod(policyrcd, 0o755)
         cmdline = ["/usr/bin/apt-get", "--assume-yes", "--no-install-recommends", "install"] + extra_packages
-        run_workspace_command(workspace, *cmdline)
+        run_workspace_command(workspace, network=True, *cmdline)
         os.unlink(policyrcd)
 
 def install_debian(args, workspace, run_build_script):

--- a/mkosi
+++ b/mkosi
@@ -495,38 +495,41 @@ def install_debian_or_ubuntu(args, workspace, run_build_script, mirror):
     cmdline = ["debootstrap",
                "--verbose",
                "--variant=minbase",
-               "--include=systemd,dbus,libpam-systemd",
+               "--include=systemd-sysv",
                "--exclude=sysv-rc,initscripts,startpar,lsb-base,insserv",
                args.release,
                workspace + "/root",
                mirror]
-
-    if args.packages is not None:
-        cmdline[3] += "," + ",".join(args.packages)
-
-    if run_build_script and args.build_packages is not None:
-        cmdline[3] += "," + ",".join(args.build_packages)
-
     if args.bootable and args.output_format == OutputFormat.raw_btrfs:
         cmdline[3] += ",btrfs-tools"
 
     subprocess.run(cmdline, check=True)
+
+
+    # Debootstrap is not smart enough to deal correctly with alternative dependencies
+    # Installing libpam-systemd via debootstrap results in systemd-shim being installed
+    # Therefore, prefer to install via apt from inside the container
+    extra_packages = [ 'dbus', 'libpam-systemd']
+
+    # Also install extra packages via the secondary APT run, because it is smarter and
+    # can deal better with any conflicts
+    if args.packages is not None:
+        extra_packages += args.packages
+
+    if run_build_script and args.build_packages is not None:
+        extra_packages += args.build_packages
 
     # Work around debian bug #835628
     os.makedirs(os.path.join(workspace, "root/etc/dracut.conf.d"), exist_ok=True)
     with open(os.path.join(workspace, "root/etc/dracut.conf.d/99-generic.conf"), "w") as f:
         f.write("hostonly=no")
 
-    # We cannot install this directly in the debootstrap phase.
-    # linux-image prefers initramfs-tools over dracut, and debootstrap is not smart enough
-    # to realize the solution when installing linux-image-amd64 + dracut is to not install
-    # initramfs-tools...
     if args.bootable:
-        run_workspace_command(workspace,
-                              "/usr/bin/apt-get", "--assume-yes", "--no-install-recommends", "install",
-                              "linux-image-amd64",
-                              "dracut",
-                              "systemd-sysv")
+        extra_packages += ["linux-image-amd64", "dracut"]
+
+    if extra_packages:
+        cmdline = ["/usr/bin/apt-get", "--assume-yes", "--no-install-recommends", "install"] + extra_packages
+        run_workspace_command(workspace, *cmdline)
 
 def install_debian(args, workspace, run_build_script):
     print_step("Installing Debian...")


### PR DESCRIPTION
- Debootstrap does not have a proper resolver so delay installing packages until we have apt.
- Force not starting daemons with policy-rc.d
- Allow running apt with network access

Note that because debootstrap uses the same dir as apt for its cache, the `--cache` is not busted by delaying the installs :)