### PR TITLE
Ignore chattr failure due to missing file system support

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -129,7 +129,8 @@ def create_image(args, workspace):
     print_step("Creating partition table...")
 
     f = tempfile.NamedTemporaryFile(dir = os.path.dirname(args.output), prefix='.mkosi-')
-    subprocess.run(["chattr", "+C", f.name], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
+    # disable copy-on-write if applicable on filesystem
+    subprocess.run(["chattr", "+C", f.name], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
     f.truncate(image_size(args))
 
     pn = 1


### PR DESCRIPTION
This makes it possible to run mkosi in a tmpfs file system.

---

As I understand it, `chattr +C` (no copy on write) is only an optimization on COW filesystems, so if it can’t be set, that shouldn’t be a problem. With this patch, I was able to build a fully functional image on `/tmp` (tmpfs).