### PR TITLE
mkosi: add support for running postinst scripts and other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,18 @@ they exist in the local directory:
   build script copied in. However, this time the contents of
   `$DESTDIR` is added into the image.
 
+* `mkost.postinst` may be an executable script. If it exists it is
+  invoked as last step of preparing an image, from within the image
+  context. It is once called for the *development* image (if this is
+  enabled, see above) with the "build" command line parameter, right
+  before invoking the build script. It is called a second time for the
+  *final* image with the "final" command line parameter, right before
+  the image is considered complete. This script may be used to alter
+  the images without any restrictions, after all software packages and
+  built sources have been installed. Note that this script is executed
+  directly in the image context with the final root directory in
+  place, without any `$SRCDIR`/`$DESTDIR` setup.
+
 * `mkosi.nspawn` may be an nspawn settings file. If this exists
   it will be copied into the same place as the output image
   file. This is useful since nspawn looks for settings files

--- a/mkosi
+++ b/mkosi
@@ -738,20 +738,28 @@ def install_distribution(args, workspace, run_build_script):
 
     install[args.distribution](args, workspace, run_build_script)
 
-@complete_step('Resetting machine ID')
-def reset_machine_id(args, workspace):
+def reset_machine_id(args, workspace, run_build_script):
     """Make /etc/machine-id an empty file.
 
     This way, on the next boot is either initialized and commited (if /etc is
     writable) or the image runs with a transient machine ID, that changes on
     each boot (if the image is read-only).
     """
-    machine_id = os.path.join(workspace, 'root', 'etc/machine-id')
-    os.unlink(machine_id)
-    open(machine_id, "w+b").close()
 
-def set_root_password(args, workspace):
+    if run_build_script:
+        return
+
+    with complete_step('Resetting machine ID'):
+        machine_id = os.path.join(workspace, 'root', 'etc/machine-id')
+        os.unlink(machine_id)
+        open(machine_id, "w+b").close()
+
+def set_root_password(args, workspace, run_build_script):
     "Set the root account password, or just delete it so it's easy to log in"
+
+    if run_build_script:
+        return
+
     if args.password == '':
         print_step("Deleting root password...")
         jj = lambda line: (':'.join(['root', ''] + line.split(':')[2:])
@@ -882,7 +890,10 @@ def make_read_only(args, workspace):
     with complete_step('Marking root subvolume read-only'):
         btrfs_subvol_make_ro(os.path.join(workspace, "root"))
 
-def make_tar(args, workspace):
+def make_tar(args, workspace, run_build_script):
+    if run_build_script:
+        return None
+
     if args.output_format != OutputFormat.tar:
         return None
 
@@ -1837,7 +1848,6 @@ def build_image(args, workspace, run_build_script):
     if args.build_script is None and run_build_script:
         return None, None, None
 
-    tar = None
     raw = create_image(args, workspace.name)
 
     with attach_image_loopback(args, raw) as loopdev:
@@ -1851,15 +1861,12 @@ def build_image(args, workspace, run_build_script):
             prepare_tree(args, workspace.name, run_build_script)
             mount_cache(args, workspace.name)
             install_distribution(args, workspace.name, run_build_script)
-            reset_machine_id(args, workspace.name)
+            reset_machine_id(args, workspace.name, run_build_script)
             install_boot_loader(args, workspace.name)
             install_extra_trees(args, workspace.name)
             install_build_src(args, workspace.name, run_build_script)
             install_build_dest(args, workspace.name, run_build_script)
-
-            if not run_build_script:
-                set_root_password(args, workspace.name)
-
+            set_root_password(args, workspace.name, run_build_script)
             make_read_only(args, workspace.name)
 
         squashfs = make_squashfs(args, workspace.name)
@@ -1868,8 +1875,7 @@ def build_image(args, workspace, run_build_script):
         patch_root_uuid(args, loopdev, root_hash)
         insert_verity(args, workspace.name, raw, loopdev, verity, root_hash)
 
-    if not run_build_script:
-        tar = make_tar(args, workspace.name)
+    tar = make_tar(args, workspace.name, run_build_script)
 
     # Remove the root directory again, if this is the build script build
     if run_build_script:

--- a/mkosi
+++ b/mkosi
@@ -668,7 +668,6 @@ def install_arch(args, workspace, run_build_script):
     subprocess.run(["pacman-key", "--nocolor", "--init"], check=True)
     subprocess.run(["pacman-key", "--nocolor", "--populate", keyring], check=True)
 
-
     if platform.machine() == "aarch64":
         server = "Server = {}/$arch/$repo".format(args.mirror)
     else:

--- a/mkosi
+++ b/mkosi
@@ -344,7 +344,7 @@ def mount_image(args, workspace, loopdev):
             mount_loop(args, loopdev, args.srv_partno, os.path.join(root, "srv"))
 
         if args.esp_partno is not None:
-            mount_loop(args, loopdev, args.esp_partno, os.path.join(root, "boot/efi"))
+            mount_loop(args, loopdev, args.esp_partno, os.path.join(root, "efi"))
 
         if args.distribution == Distribution.fedora:
             mount_bind("/proc", os.path.join(root, "proc"))
@@ -361,7 +361,7 @@ def mount_image(args, workspace, loopdev):
         with complete_step('Unmounting image'):
             umount(os.path.join(root, "home"))
             umount(os.path.join(root, "srv"))
-            umount(os.path.join(root, "boot/efi"))
+            umount(os.path.join(root, "efi"))
             umount(os.path.join(root, "proc"))
             umount(os.path.join(root, "sys"))
             umount(os.path.join(root, "dev"))
@@ -412,14 +412,15 @@ def prepare_tree(args, workspace, run_build_script):
         os.mkdir(os.path.join(workspace, "root", "etc"), 0o755)
         open(os.path.join(workspace, "root", "etc/machine-id"), "w").write(args.machine_id + "\n")
 
-        # For now, let's stay compatible with traditional Linux ESP mounts
-        os.mkdir(os.path.join(workspace, "root", "boot/efi/EFI"), 0o700)
-        os.mkdir(os.path.join(workspace, "root", "boot/efi/EFI/BOOT"), 0o700)
-        os.mkdir(os.path.join(workspace, "root", "boot/efi/EFI/systemd"), 0o700)
-        os.mkdir(os.path.join(workspace, "root", "boot/efi/loader"), 0o700)
-        os.mkdir(os.path.join(workspace, "root", "boot/efi/loader/entries"), 0o700)
-        os.mkdir(os.path.join(workspace, "root", "boot/efi", args.machine_id), 0o700)
+        os.mkdir(os.path.join(workspace, "root", "efi/EFI"), 0o700)
+        os.mkdir(os.path.join(workspace, "root", "efi/EFI/BOOT"), 0o700)
+        os.mkdir(os.path.join(workspace, "root", "efi/EFI/systemd"), 0o700)
+        os.mkdir(os.path.join(workspace, "root", "efi/loader"), 0o700)
+        os.mkdir(os.path.join(workspace, "root", "efi/loader/entries"), 0o700)
+        os.mkdir(os.path.join(workspace, "root", "efi", args.machine_id), 0o700)
 
+        os.mkdir(os.path.join(workspace, "root", "boot"), 0o700)
+        os.symlink("../efi", os.path.join(workspace, "root", "boot/efi"))
         os.symlink("efi/loader", os.path.join(workspace, "root", "boot/loader"))
         os.symlink("efi/" + args.machine_id, os.path.join(workspace, "root", "boot", args.machine_id))
 
@@ -565,7 +566,6 @@ gpgkey={gpg_key}
 
     if args.bootable:
         cmdline.extend(["kernel", "systemd-udev"])
-        os.makedirs(os.path.join(root, 'efi'), exist_ok=True)
 
     subprocess.run(cmdline, check=True)
 

--- a/mkosi
+++ b/mkosi
@@ -354,14 +354,11 @@ def mount_image(args, workspace, loopdev):
         yield
     finally:
         with complete_step('Unmounting image'):
-            umount(os.path.join(root, "home"))
-            umount(os.path.join(root, "srv"))
-            umount(os.path.join(root, "efi"))
-            umount(os.path.join(root, "var/cache/dnf"))
-            umount(os.path.join(root, "var/cache/apt/archives"))
-            umount(os.path.join(root, "run"))
-            umount(os.path.join(root, "tmp"))
-            umount(os.path.join(root))
+
+            for d in ("home", "srv", "efi", "var/cache/dnf", "var/cache/apt/archives", "run", "tmp"):
+                umount(os.path.join(root, d))
+
+            umount(root)
 
 @contextlib.contextmanager
 def mount_api_vfs(args, workspace):

--- a/mkosi
+++ b/mkosi
@@ -476,11 +476,12 @@ DHCP=yes
 
 def run_workspace_command(args, workspace, *cmd, network=False, env={}):
     cmdline = ["systemd-nspawn",
-                    '--quiet',
-                    "--directory=" + os.path.join(workspace, "root"),
-                    "--uuid=" + args.machine_id,
-                    "--as-pid2",
-                    "--register=no"]
+               '--quiet',
+               "--directory=" + os.path.join(workspace, "root"),
+               "--uuid=" + args.machine_id,
+               "--as-pid2",
+               "--register=no"]
+
     if not network:
         cmdline += ["--private-network"]
 
@@ -778,6 +779,24 @@ def set_root_password(args, workspace, run_build_script):
         jj = lambda line: (':'.join(['root', password] + line.split(':')[2:])
                            if line.startswith('root:') else line)
         patch_file(os.path.join(workspace, 'root', 'etc/shadow'), jj)
+
+def run_postinst_script(args, workspace, run_build_script):
+
+    if args.postinst_script is None:
+        return
+
+    with complete_step('Running post installation script'):
+
+        # We copy the postinst script into the build tree. We'd prefer
+        # mounting it into the tree, but for that we'd need a good
+        # place to mount it to. But if we create that we might as well
+        # just copy the file anyway.
+
+        shutil.copy2(args.postinst_script,
+                     os.path.join(workspace, "root", "root/postinst"))
+
+        run_workspace_command(args, workspace, "/root/postinst", "build" if run_build_script else "final")
+        os.unlink(os.path.join(workspace, "root", "root/postinst"))
 
 def install_boot_loader_arch(args, workspace):
     patch_file(os.path.join(workspace, "root", "etc/mkinitcpio.conf"),
@@ -1272,6 +1291,7 @@ def parse_args():
     group.add_argument("--build-script", help='Build script to run inside image', metavar='PATH')
     group.add_argument("--build-sources", help='Path for sources to build', metavar='PATH')
     group.add_argument("--build-package", action=PackageAction, dest='build_packages', help='Additional packages needed for build script', metavar='PACKAGE')
+    group.add_argument("--postinst-script", help='Post installation script to run inside image', metavar='PATH')
     group.add_argument('--use-git-files', type=parse_boolean,
                        help='Ignore any files that git itself ignores (default: guess)')
     group.add_argument("--settings", dest='nspawn_settings', help='Add in .spawn settings file', metavar='PATH')
@@ -1602,6 +1622,13 @@ def find_build_sources(args):
 
     args.build_sources = os.getcwd()
 
+def find_postinst_script(args):
+    if args.postinst_script is not None:
+        return
+
+    if os.path.exists("mkosi.postinst"):
+        args.postinst_script = "mkosi.postinst"
+
 def strip_suffixes(path):
     t = path
     while True:
@@ -1633,6 +1660,7 @@ def load_args():
     find_extra(args)
     find_build_script(args)
     find_build_sources(args)
+    find_postinst_script(args)
 
     if args.output_format is None:
         args.output_format = OutputFormat.raw_gpt
@@ -1731,6 +1759,9 @@ def load_args():
 
     if args.build_sources is not None:
         args.build_sources = os.path.abspath(args.build_sources)
+
+    if args.postinst_script is not None:
+        args.postinst_script = os.path.abspath(args.postinst_script)
 
     if args.extra_trees is not None:
         for i in range(len(args.extra_trees)):
@@ -1831,6 +1862,7 @@ def print_summary(args):
     sys.stderr.write("          Build Script: " + none_to_none(args.build_script) + "\n")
     sys.stderr.write("         Build Sources: " + none_to_none(args.build_sources) + "\n")
     sys.stderr.write("        Build Packages: " + line_join_list(args.build_packages) + "\n")
+    sys.stderr.write("     Post Inst. Script: " + none_to_none(args.postinst_script) + "\n")
     sys.stderr.write("       nspawn Settings: " + none_to_none(args.nspawn_settings) + "\n")
 
     if args.output_format in (OutputFormat.raw_gpt, OutputFormat.raw_btrfs, OutputFormat.raw_squashfs):
@@ -1874,6 +1906,7 @@ def build_image(args, workspace, run_build_script):
             install_build_src(args, workspace.name, run_build_script)
             install_build_dest(args, workspace.name, run_build_script)
             set_root_password(args, workspace.name, run_build_script)
+            run_postinst_script(args, workspace.name, run_build_script)
             make_read_only(args, workspace.name)
 
         squashfs = make_squashfs(args, workspace.name)

--- a/mkosi
+++ b/mkosi
@@ -1891,10 +1891,11 @@ def run_build_script(args, workspace, raw):
         dest = os.path.join(workspace, "dest")
         os.mkdir(dest, 0o755)
 
-        directory = os.path.join(workspace, "root") if raw is None else "--image=" + raw.name
+        target = "--directory=" + os.path.join(workspace, "root") if raw is None else "--image=" + raw.name
+
         cmdline = ["systemd-nspawn",
                    '--quiet',
-                   "--directory", directory,
+                   target,
                    "--as-pid2",
                    "--private-network",
                    "--register=no",

--- a/mkosi
+++ b/mkosi
@@ -346,11 +346,6 @@ def mount_image(args, workspace, loopdev):
         if args.esp_partno is not None:
             mount_loop(args, loopdev, args.esp_partno, os.path.join(root, "efi"))
 
-        if args.distribution == Distribution.fedora:
-            mount_bind("/proc", os.path.join(root, "proc"))
-            mount_bind("/dev", os.path.join(root, "dev"))
-            mount_bind("/sys", os.path.join(root, "sys"))
-
         # Make sure /tmp and /run are not part of the image
         mount_tmpfs(os.path.join(root, "run"))
         mount_tmpfs(os.path.join(root, "tmp"))
@@ -362,14 +357,26 @@ def mount_image(args, workspace, loopdev):
             umount(os.path.join(root, "home"))
             umount(os.path.join(root, "srv"))
             umount(os.path.join(root, "efi"))
-            umount(os.path.join(root, "proc"))
-            umount(os.path.join(root, "sys"))
-            umount(os.path.join(root, "dev"))
             umount(os.path.join(root, "var/cache/dnf"))
             umount(os.path.join(root, "var/cache/apt/archives"))
             umount(os.path.join(root, "run"))
             umount(os.path.join(root, "tmp"))
             umount(os.path.join(root))
+
+@contextlib.contextmanager
+def mount_api_vfs(args, workspace):
+    paths = ('/proc', '/dev', '/sys')
+    root = os.path.join(workspace, "root")
+
+    with complete_step('Mounting API VFS'):
+        for d in paths:
+            mount_bind(d, root + d)
+    try:
+        yield
+    finally:
+        with complete_step('Unmounting API VFS'):
+            for d in paths:
+                umount(root + d)
 
 def mount_cache(args, workspace):
     if not args.distribution in (Distribution.fedora, Distribution.debian, Distribution.ubuntu):
@@ -567,7 +574,8 @@ gpgkey={gpg_key}
     if args.bootable:
         cmdline.extend(["kernel", "systemd-udev"])
 
-    subprocess.run(cmdline, check=True)
+    with mount_api_vfs(args, workspace):
+        subprocess.run(cmdline, check=True)
 
 def install_debian_or_ubuntu(args, workspace, run_build_script, mirror):
     if args.repositories:

--- a/mkosi
+++ b/mkosi
@@ -409,9 +409,8 @@ def prepare_tree(args, workspace, run_build_script):
 
     if args.bootable:
         # We need an initialized machine ID for the boot logic to work
-        mid = uuid.uuid4().hex
         os.mkdir(os.path.join(workspace, "root", "etc"), 0o755)
-        open(os.path.join(workspace, "root", "etc/machine-id"), "w").write(mid + "\n")
+        open(os.path.join(workspace, "root", "etc/machine-id"), "w").write(args.machine_id + "\n")
 
         # For now, let's stay compatible with traditional Linux ESP mounts
         os.mkdir(os.path.join(workspace, "root", "boot/efi/EFI"), 0o700)
@@ -419,10 +418,10 @@ def prepare_tree(args, workspace, run_build_script):
         os.mkdir(os.path.join(workspace, "root", "boot/efi/EFI/systemd"), 0o700)
         os.mkdir(os.path.join(workspace, "root", "boot/efi/loader"), 0o700)
         os.mkdir(os.path.join(workspace, "root", "boot/efi/loader/entries"), 0o700)
-        os.mkdir(os.path.join(workspace, "root", "boot/efi", mid), 0o700)
+        os.mkdir(os.path.join(workspace, "root", "boot/efi", args.machine_id), 0o700)
 
         os.symlink("efi/loader", os.path.join(workspace, "root", "boot/loader"))
-        os.symlink("efi/" + mid, os.path.join(workspace, "root", "boot", mid))
+        os.symlink("efi/" + args.machine_id, os.path.join(workspace, "root", "boot", args.machine_id))
 
         os.mkdir(os.path.join(workspace, "root", "etc/kernel"), 0o755)
 
@@ -467,10 +466,11 @@ Type=ether
 DHCP=yes
 """)
 
-def run_workspace_command(workspace, *cmd, network=False, env={}):
+def run_workspace_command(args, workspace, *cmd, network=False, env={}):
     cmdline = ["systemd-nspawn",
                     '--quiet',
-                    "--directory", os.path.join(workspace, "root"),
+                    "--directory=" + os.path.join(workspace, "root"),
+                    "--uuid=" + args.machine_id,
                     "--as-pid2",
                     "--register=no"]
     if not network:
@@ -636,7 +636,7 @@ def install_debian_or_ubuntu(args, workspace, run_build_script, mirror):
                 ])
 
         cmdline = ["/usr/bin/apt-get", "--assume-yes", "--no-install-recommends", "install"] + extra_packages
-        run_workspace_command(workspace, network=True, env={'DEBIAN_FRONTEND': 'noninteractive', 'DEBCONF_NONINTERACTIVE_SEEN': 'true'}, *cmdline)
+        run_workspace_command(args, workspace, network=True, env={'DEBIAN_FRONTEND': 'noninteractive', 'DEBCONF_NONINTERACTIVE_SEEN': 'true'}, *cmdline)
         os.unlink(policyrcd)
 
 @complete_step('Installing Debian')
@@ -778,13 +778,13 @@ def install_boot_loader_arch(args, workspace):
 
     kernel_version = next(filter(lambda x: x[0].isdigit(), os.listdir(os.path.join(workspace, "root", "lib/modules"))))
 
-    run_workspace_command(workspace,
+    run_workspace_command(args, workspace,
                       "/usr/bin/kernel-install", "add", kernel_version, "/boot/vmlinuz-linux")
 
 def install_boot_loader_debian(args, workspace):
     kernel_version = next(filter(lambda x: x[0].isdigit(), os.listdir(os.path.join(workspace, "root", "lib/modules"))))
 
-    run_workspace_command(workspace,
+    run_workspace_command(args, workspace,
                     "/usr/bin/kernel-install", "add", kernel_version, "/boot/vmlinuz-" + kernel_version)
 
 def install_boot_loader(args, workspace):
@@ -1896,6 +1896,7 @@ def run_build_script(args, workspace, raw):
         cmdline = ["systemd-nspawn",
                    '--quiet',
                    target,
+                   "--uuid=" + args.machine_id,
                    "--as-pid2",
                    "--private-network",
                    "--register=no",
@@ -1913,10 +1914,16 @@ def run_build_script(args, workspace, raw):
             cmdline.append("--chdir=/root")
 
         cmdline.append("/root/" + os.path.basename(args.build_script))
-
         subprocess.run(cmdline, check=True)
 
 def build_stuff(args):
+
+    # Let's define a fixed machine ID for all our build-time
+    # runs. We'll strip it off the final image, but some build-time
+    # tools (dracut...) want a fixed one, hence provide one, and
+    # always the same
+    args.machine_id = uuid.uuid4().hex
+
     cache = setup_cache(args)
     workspace = setup_workspace(args)
 


### PR DESCRIPTION
This allows running a script "mkosi.postinst" as last step before considering the image built final, inside the environment. This is useful to do arbitrary final adjustments. In particular, when working on systemd it's useful to regenerate the initrd after dropping in the systemd built artifacts, so that they also are updated in the initrd.