### PR TITLE
generate unified kernel+initrd images that include the root hash as last step of the build + other improvements

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1088,7 +1088,7 @@ def read_partition_table(loopdev):
 
         table.append(stripped)
 
-        name, rest = stripped.split(":")
+        name, rest = stripped.split(":", 1)
         fields = rest.split(",")
 
         start = None

--- a/mkosi
+++ b/mkosi
@@ -24,7 +24,6 @@ __version__ = '1'
 
 # TODO
 # - volatile images
-# - set gpt read-only bit
 # - make debian/ubuntu images bootable
 # - work on device nodes
 # - allow passing env vars

--- a/mkosi
+++ b/mkosi
@@ -214,7 +214,7 @@ def create_image(args, workspace):
                 run_sfdisk = True
 
         if args.output_format != OutputFormat.raw_squashfs:
-            table += 'type={}, name="Root Partition", attrs="{}"\n'.format(GPT_ROOT_NATIVE, "GUID:60" if args.read_only and args.output_format == OutputFormat.raw_gpt else "")
+            table += 'type={}, attrs={}, name="Root Partition"\n'.format(GPT_ROOT_NATIVE, "GUID:60" if args.read_only and args.output_format != OutputFormat.raw_btrfs else "")
             run_sfdisk = True
 
         args.root_partno = pn
@@ -1137,7 +1137,7 @@ def insert_partition(args, workspace, raw, loopdev, partno, blob, name, type_uui
     if uuid is not None:
         table += "uuid=" + str(uuid) + ", "
 
-    table += 'size={}, type={}, name="{}", attrs="GUID:60"\n'.format((blob_size + luks_extra) // 512, type_uuid, name)
+    table += 'size={}, type={}, attrs=GUID:60, name="{}"\n'.format((blob_size + luks_extra) // 512, type_uuid, name)
 
     print(table)
 
@@ -1415,7 +1415,7 @@ def parse_args():
     group.add_argument('-f', "--force", action='store_true', help='Remove existing image file before operation')
     group.add_argument('-b', "--bootable", type=parse_boolean, nargs='?', const=True,
                        help='Make image bootable on EFI (only raw_gpt, raw_btrfs, raw_squashfs)')
-    group.add_argument("--read-only", action='store_true', help='Make root volume read-only (only raw_btrfs, subvolume)')
+    group.add_argument("--read-only", action='store_true', help='Make root volume read-only (only raw_gpt, raw_btrfs, subvolume, implied on raw_squashs)')
     group.add_argument("--encrypt", choices=("all", "data"), help='Encrypt everything except: ESP ("all") or ESP and root ("data")')
     group.add_argument("--verity", action='store_true', help='Add integrity partition (implies --read-only)')
     group.add_argument("--compress", action='store_true', help='Enable compression in file system (only raw_btrfs, subvolume)')
@@ -2017,8 +2017,9 @@ def print_summary(args):
     sys.stderr.write("      Output Signature: " + none_to_na(args.output_signature if args.sign else None) + "\n")
     sys.stderr.write("Output nspawn Settings: " + none_to_na(args.output_nspawn_settings if args.nspawn_settings is not None else None) + "\n")
 
-    if args.output_format in (OutputFormat.raw_btrfs, OutputFormat.subvolume):
+    if args.output_format in (OutputFormat.raw_gpt, OutputFormat.raw_btrfs, OutputFormat.raw_squashfs, OutputFormat.subvolume):
         sys.stderr.write("             Read-only: " + yes_no(args.read_only) + "\n")
+    if args.output_format in (OutputFormat.raw_btrfs, OutputFormat.subvolume):
         sys.stderr.write("        FS Compression: " + yes_no(args.compress) + "\n")
 
     if args.output_format in (OutputFormat.raw_gpt, OutputFormat.raw_btrfs, OutputFormat.raw_squashfs, OutputFormat.tar):

--- a/mkosi
+++ b/mkosi
@@ -437,13 +437,16 @@ def prepare_srv(args, dev):
     with complete_step('Formatting server data partition'):
         mkfs_ext4("srv", "/srv", dev)
 
-def mount_loop(args, dev, where):
+def mount_loop(args, dev, where, read_only=False):
     os.makedirs(where, 0o755, True)
 
     options = "-odiscard"
 
     if args.compress and args.output_format == OutputFormat.raw_btrfs:
         options += ",compress"
+
+    if read_only:
+        options += ",ro"
 
     subprocess.run(["mount", "-n", dev, where, options], check=True)
 
@@ -456,7 +459,7 @@ def mount_tmpfs(where):
     subprocess.run(["mount", "tmpfs", "-t", "tmpfs", where], check=True)
 
 @contextlib.contextmanager
-def mount_image(args, workspace, loopdev, root_dev, home_dev, srv_dev):
+def mount_image(args, workspace, loopdev, root_dev, home_dev, srv_dev, root_read_only=False):
     if loopdev is None:
         yield None
         return
@@ -465,7 +468,7 @@ def mount_image(args, workspace, loopdev, root_dev, home_dev, srv_dev):
         root = os.path.join(workspace, "root")
 
         if args.output_format != OutputFormat.raw_squashfs:
-            mount_loop(args, root_dev, root)
+            mount_loop(args, root_dev, root, root_read_only)
 
         if home_dev is not None:
             mount_loop(args, home_dev, os.path.join(root, "home"))
@@ -548,6 +551,7 @@ def prepare_tree(args, workspace, run_build_script):
 
         os.mkdir(os.path.join(workspace, "root", "efi/EFI"), 0o700)
         os.mkdir(os.path.join(workspace, "root", "efi/EFI/BOOT"), 0o700)
+        os.mkdir(os.path.join(workspace, "root", "efi/EFI/Linux"), 0o700)
         os.mkdir(os.path.join(workspace, "root", "efi/EFI/systemd"), 0o700)
         os.mkdir(os.path.join(workspace, "root", "efi/loader"), 0o700)
         os.mkdir(os.path.join(workspace, "root", "efi/loader/entries"), 0o700)
@@ -633,8 +637,31 @@ def check_if_url_exists(url):
     except:
         return False
 
+def disable_kernel_install(args, workspace):
+
+    # Let's disable the automatic kernel installation done by the
+    # kernel RPMs. After all, we want to built our own unified kernels
+    # that include the root hash in the kernel command line and can be
+    # signed as a single EFI executable. Since the root hash is only
+    # known when the root file system is finalized we turn off any
+    # kernel installation beforehand.
+
+    if not args.bootable:
+        return
+
+    for d in ("etc", "etc/kernel", "etc/kernel/install.d"):
+        try:
+            os.mkdir(os.path.join(workspace, "root", d), 0o755)
+        except FileExistsError:
+            pass
+
+    for f in ("50-dracut.install", "51-dracut-rescue.install", "90-loaderentry.install"):
+        os.symlink("/dev/null", os.path.join(workspace, "root", "etc/kernel/install.d", f))
+
 @complete_step('Installing Fedora')
 def install_fedora(args, workspace, run_build_script):
+
+    disable_kernel_install(args, workspace)
 
     gpg_key = "/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-%s-x86_64" % args.release
     if os.path.exists(gpg_key):
@@ -708,7 +735,7 @@ gpgkey={gpg_key}
         cmdline.extend(args.build_packages)
 
     if args.bootable:
-        cmdline.extend(["kernel", "systemd-udev"])
+        cmdline.extend(["kernel", "systemd-udev", "binutils"])
 
         # Temporary hack: dracut only adds crypto support to the initrd, if the cryptsetup binary is installed
         if args.encrypt or args.verity:
@@ -1187,14 +1214,14 @@ def insert_squashfs(args, workspace, raw, loopdev, squashfs):
         args.root_size = insert_partition(args, workspace, raw, loopdev, args.root_partno, squashfs,
                                           "Root Partition", GPT_ROOT_NATIVE)
 
-def make_verity(args, workspace, loopdev, run_build_script):
+def make_verity(args, workspace, dev, run_build_script):
 
     if run_build_script or not args.verity:
         return None, None
 
     with complete_step('Generating verity hashes'):
         f = tempfile.NamedTemporaryFile(dir=os.path.dirname(args.output), prefix=".mkosi-")
-        c = subprocess.run(["veritysetup", "format", partition(loopdev, args.root_partno), f.name],
+        c = subprocess.run(["veritysetup", "format", dev, f.name],
                            stdout=subprocess.PIPE, check=True)
 
         for line in c.stdout.decode("utf-8").split('\n'):
@@ -1227,6 +1254,58 @@ def patch_root_uuid(args, loopdev, root_hash):
     with complete_step('Patching root partition UUID'):
         subprocess.run(["sfdisk", "--part-uuid", loopdev, str(args.root_partno), str(u)],
                        check=True)
+
+def install_unified_kernel(args, workspace, run_build_script, root_hash):
+
+    # Iterates through all kernel versions included in the image and
+    # generates a combined kernel+initrd+cmdline+osrelease EFI file
+    # from it and places it in the /EFI/Linux directory of the
+    # ESP. sd-boot iterates through them and shows them in the
+    # menu. These "unified" single-file images have the benefit that
+    # they can be signed like normal EFI binaries, and can encode
+    # everything necessary to boot a specific root device, including
+    # the root hash.
+
+    if not args.bootable:
+        return
+
+    if args.distribution != Distribution.fedora:
+        return
+
+    with complete_step("Generating combined kernel + initrd boot file"):
+
+        cmdline = args.kernel_commandline
+        if root_hash is not None:
+            cmdline += " roothash=" + root_hash
+
+        for kver in os.scandir(os.path.join(workspace, "root", "usr/lib/modules")):
+            if not kver.is_dir():
+                continue
+
+            boot_binary = "/efi/EFI/Linux/linux-" + kver.name
+            if root_hash is not None:
+                boot_binary += "-" + root_hash
+            boot_binary += ".efi"
+
+            dracut = ["/usr/bin/dracut",
+                      "-v",
+                      "--no-hostonly",
+                      "--uefi",
+                      "--kver", kver.name,
+                      "--kernel-cmdline", cmdline ]
+
+            # Temporary fix until dracut includes these in the image anyway
+            dracut += ("-i",) + ("/usr/lib/systemd/system/systemd-volatile-root.service",)*2 + \
+                      ("-i",) + ("/usr/lib/systemd/systemd-volatile-root",)*2 + \
+                      ("-i",) + ("/usr/lib/systemd/systemd-veritysetup",)*2 + \
+                      ("-i",) + ("/usr/lib/systemd/system-generators/systemd-veritysetup-generator",)*2
+
+            if args.output_format == OutputFormat.raw_squashfs:
+                dracut += [ '--add-drivers', 'squashfs' ]
+
+            dracut += [ boot_binary ]
+
+            run_workspace_command(args, workspace, *dracut);
 
 def xz_output(args, raw):
     if not args.output_format in (OutputFormat.raw_btrfs, OutputFormat.raw_gpt, OutputFormat.raw_squashfs):
@@ -2117,9 +2196,15 @@ def build_image(args, workspace, run_build_script):
             squashfs = make_squashfs(args, workspace.name)
             insert_squashfs(args, workspace.name, raw, loopdev, squashfs)
 
-        verity, root_hash = make_verity(args, workspace.name, loopdev, run_build_script)
-        patch_root_uuid(args, loopdev, root_hash)
-        insert_verity(args, workspace.name, raw, loopdev, verity, root_hash)
+            verity, root_hash = make_verity(args, workspace.name, encrypted_root, run_build_script)
+            patch_root_uuid(args, loopdev, root_hash)
+            insert_verity(args, workspace.name, raw, loopdev, verity, root_hash)
+
+            # This time we mount read-only, as we already generated
+            # the verity data, and hence really shouldn't modify the
+            # image anymore.
+            with mount_image(args, workspace.name, loopdev, encrypted_root, encrypted_home, encrypted_srv, root_read_only=True):
+                install_unified_kernel(args, workspace.name, run_build_script, root_hash)
 
     tar = make_tar(args, workspace.name, run_build_script)
 

--- a/mkosi
+++ b/mkosi
@@ -710,6 +710,16 @@ gpgkey={gpg_key}
     if args.bootable:
         cmdline.extend(["kernel", "systemd-udev"])
 
+        # Temporary hack: dracut only adds crypto support to the initrd, if the cryptsetup binary is installed
+        if args.encrypt or args.verity:
+            cmdline.append("cryptsetup")
+
+        if args.output_format == OutputFormat.raw_gpt:
+            cmdline.append("e2fsprogs")
+
+        if args.output_format == OutputFormat.raw_btrfs:
+            cmdline.append("btrfs-progs")
+
     with mount_api_vfs(args, workspace):
         subprocess.run(cmdline, check=True)
 

--- a/mkosi
+++ b/mkosi
@@ -602,12 +602,20 @@ DHCP=yes
 """)
 
 def run_workspace_command(args, workspace, *cmd, network=False, env={}):
+
+    var_tmp = os.path.join(workspace, "var-tmp")
+    try:
+        os.mkdir(var_tmp)
+    except FileExistsError:
+        pass
+
     cmdline = ["systemd-nspawn",
                '--quiet',
                "--directory=" + os.path.join(workspace, "root"),
                "--uuid=" + args.machine_id,
                "--as-pid2",
-               "--register=no"]
+               "--register=no",
+               "--bind=" + var_tmp + ":/var/tmp" ]
 
     if not network:
         cmdline += ["--private-network"]

--- a/mkosi
+++ b/mkosi
@@ -2125,6 +2125,12 @@ def print_summary(args):
     sys.stderr.write("            Encryption: " + none_to_no(args.encrypt) + "\n")
     sys.stderr.write("                Verity: " + yes_no(args.verity) + "\n")
 
+    if args.output_format in (OutputFormat.raw_gpt, OutputFormat.raw_btrfs, OutputFormat.raw_squashfs):
+        sys.stderr.write("              Bootable: " + yes_no(args.bootable) + "\n")
+
+        if args.bootable:
+            sys.stderr.write("   Kernel Command Line: " + args.kernel_commandline + "\n")
+
     sys.stderr.write("\nPACKAGES:\n")
     sys.stderr.write("              Packages: " + line_join_list(args.packages) + "\n")
 
@@ -2142,7 +2148,6 @@ def print_summary(args):
 
     if args.output_format in (OutputFormat.raw_gpt, OutputFormat.raw_btrfs, OutputFormat.raw_squashfs):
         sys.stderr.write("\nPARTITIONS:\n")
-        sys.stderr.write("              Bootable: " + yes_no(args.bootable) + "\n")
         sys.stderr.write("        Root Partition: " + format_bytes_or_auto(args.root_size) + "\n")
         sys.stderr.write("        Swap Partition: " + format_bytes_or_disabled(args.swap_size) + "\n")
         sys.stderr.write("                   ESP: " + format_bytes_or_disabled(args.esp_size) + "\n")


### PR DESCRIPTION
This adds support for generating combined kernel+initrd image files as last step of the boot that also contain the root hash if verity is enabled. These kernel+initrd images are unified blobs that can be signed as one, in order to implement a complete SecureBoot chain.