### PR TITLE
Add basic bootable Ubuntu image support

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -781,7 +781,11 @@ def install_debian_or_ubuntu(args, workspace, run_build_script, mirror):
         f.write("hostonly=no")
 
     if args.bootable:
-        extra_packages += ["linux-image-amd64", "dracut"]
+        if args.distribution == Distribution.ubuntu:
+            # Dracut is not supported in Ubuntu
+            extra_packages += ["linux-image-generic", "initramfs-tools"]
+        else:
+            extra_packages += ["linux-image-amd64", "dracut"]
 
     if extra_packages:
         # Debian policy is to start daemons by default.
@@ -2017,8 +2021,8 @@ def load_args():
                 args.mirror = "http://mirror.archlinuxarm.org"
 
     if args.bootable:
-        if args.distribution not in (Distribution.fedora, Distribution.arch, Distribution.debian):
-            die("Bootable images are currently supported only on Debian, Fedora and Arch Linux.")
+        if args.distribution not in (Distribution.fedora, Distribution.arch, Distribution.debian, Distribution.ubuntu):
+            die("Bootable images are currently supported only on Debian, Ubuntu, Fedora and Arch Linux.")
 
         if not args.output_format in (OutputFormat.raw_gpt, OutputFormat.raw_btrfs, OutputFormat.raw_squashfs):
             die("Directory, subvolume and tar images cannot be booted.")


### PR DESCRIPTION
This pull request adds basic support for creating bootable Ubuntu images into mkosi. It uses _initramfs-tools_ instead of _dracut_ because dracut is [not supported](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1660587) by Ubuntu kernel packages.

I did not test any advanced things like crypto, but a basic btrfs image seems to be working correctly when booted using nspawn. There are [some errors](https://gist.github.com/anonymous/401cc790fd4ad633ce2c6ba618715b9e) being shown when trying to boot a squashfs image using nspawn (and the image seems to be booted read-only), but I am not sure if the errors are related to mkosi or are some local issues with my system.