### PR TITLE
mkosi: strip man-db from arch-linux package list

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -884,6 +884,8 @@ SigLevel    = Required DatabaseOptional
                  "e2fsprogs",
                  "jfsutils",
                  "lvm2",
+                 "man-db",
+                 "man-pages",
                  "mdadm",
                  "netctl",
                  "pcmciautils",


### PR DESCRIPTION
The man-db hooks might trigger on boot and regenerate the database, taking up to several minutes. There is no need to trigger this in a minimal image, so strip `man-db` from the arch-linux package list. While at it, let's remove the man-pages as well, since there is little need for those either.