### PR TITLE
Do not duplicate btrfs metadata

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -287,7 +287,7 @@ def mkfs_ext4(label, mount, dev):
     subprocess.run(["mkfs.ext4", "-L", label, "-M", mount, dev], check=True)
 
 def mkfs_btrfs(label, dev):
-    subprocess.run(["mkfs.btrfs", "-L", label, dev], check=True)
+    subprocess.run(["mkfs.btrfs", "-L", label, "-d", "single", "-m", "single", dev], check=True)
 
 def luks_format(dev, passphrase):
 


### PR DESCRIPTION
By default `mkfs.btrfs` uses the `dup` profile for metadata of non-SSD
single device btrfs filesystem.
This duplication is not desired for VM drives. So, let’s use the `single`
profile instead.