### PR TITLE
mkosi: properly copy symlinks again

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1242,7 +1242,7 @@ def copy_git_files(src, dest):
         directory = os.path.dirname(dest_path)
         os.makedirs(directory, exist_ok=True)
 
-        shutil.copy2(src_path, dest_path, follow_symlinks=True)
+        shutil.copy2(src_path, dest_path, follow_symlinks=False)
 
 def install_build_src(args, workspace, run_build_script, for_cache):
     if not run_build_script:


### PR DESCRIPTION
We really shouldn't follow symlinks when we copy stuff. Otherwise we
can't build casync, because it contains a number of dangling symlinks in
its test-files/ directory.