### PR TITLE
Fix FileNotFound error while running with -i

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1649,7 +1649,7 @@ def calculate_signature(args, checksum):
 
 def save_cache(args, workspace, raw, cache_path):
 
-    if cache_path is None:
+    if cache_path is None or raw is None:
         return
 
     with complete_step('Installing cache copy ',


### PR DESCRIPTION
Hi!

I've tried to run mkosi like this:

`mkosi -d fedora -t directory -o fedora -b false -i`

And I've got a traceback instead.

So this change fixes it.

Signed-off-by: Aleksei Slaikovskii <aslaikov@redhat.com>