### PR TITLE
Ignore temporary directories while copying

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1274,7 +1274,7 @@ def install_build_src(args, workspace, run_build_script, for_cache):
             if use_git:
                 copy_git_files(args.build_sources, target, git_files=args.git_files)
             else:
-                ignore = shutil.ignore_patterns('.git')
+                ignore = shutil.ignore_patterns('.git', '.mkosi-*')
                 shutil.copytree(args.build_sources, target, symlinks=True, ignore=ignore)
 
 def install_build_dest(args, workspace, run_build_script, for_cache):


### PR DESCRIPTION
If we call mkosi passing --build-sources with a directory that contains
the temporary .mkosi-* directories, it will fall in a inifinite
recursion.

This is the case in which we are have the mkosi.* files in a
subdirectory of the git repository and pass the git root dir as argument
to --build-sources.