### PR TITLE
Ensure machine name is unique

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -706,6 +706,7 @@ def run_workspace_command(args, workspace, *cmd, network=False, env={}):
                '--quiet',
                "--directory=" + os.path.join(workspace, "root"),
                "--uuid=" + args.machine_id,
+               "--machine=mkosi-" + uuid.uuid4().hex,
                "--as-pid2",
                "--register=no",
                "--bind=" + var_tmp(workspace) + ":/var/tmp" ]
@@ -2728,6 +2729,7 @@ def run_build_script(args, workspace, raw):
                    '--quiet',
                    target,
                    "--uuid=" + args.machine_id,
+                   "--machine=mkosi-" + uuid.uuid4().hex,
                    "--as-pid2",
                    "--register=no",
                    "--bind", dest + ":/root/dest",


### PR DESCRIPTION
Even though we don't register the machine, systemd-nspawn creates a
scope based on the name. Therefore, make sure the name is unique to
prevent collisions.

See https://github.com/systemd/systemd/issues/6347