### PR TITLE
Fix btrfs_subvol_delete by deleting recursively

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -150,6 +150,7 @@ def btrfs_subvol_create(path, mode=0o755):
     os.umask(m)
 
 def btrfs_subvol_delete(path):
+    subprocess.run(["find", "-P", path, "-depth", "-mindepth", "1", "-execdir", "rm", "-d", "{}", ";", "-or", "-type", "d", "-execdir", "btrfs", "subvolume", "delete", "{}", ";"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     subprocess.run(["btrfs", "subvol", "delete", path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
 
 def btrfs_subvol_make_ro(path, b=True):


### PR DESCRIPTION
`btrfs subvol delete` errors out when the subvolume still contains
anything so we have to delete the contents first. However the subvolumes
we have to delete usually themselves contain subvolumes so we can't just
use `rm -r`. What we do instead is go through the directory depth first
using `find` and then try to delete each entry with `rm -d` first and if
that fails check if the entry is a directory and if so assume it's a
subvolume and fall back to `btrfs subvol delete`.