### PR TITLE
[WIP] allow apt-get to install unauthenticated packages

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -970,7 +970,7 @@ def install_debian_or_ubuntu(args, workspace, run_build_script, mirror):
                     'path-exclude /usr/share/linda/*\n',
                 ])
 
-        cmdline = ["/usr/bin/apt-get", "--assume-yes", "--no-install-recommends", "install"] + extra_packages
+        cmdline = ["/usr/bin/apt-get", "--assume-yes", "--allow-unauthenticated", "--no-install-recommends", "install"] + extra_packages
         run_workspace_command(args, workspace, network=True, env={'DEBIAN_FRONTEND': 'noninteractive', 'DEBCONF_NONINTERACTIVE_SEEN': 'true'}, *cmdline)
         os.unlink(policyrcd)
 


### PR DESCRIPTION
There might be a better solution (see https://github.com/systemd/mkosi/issues/139#issuecomment-324106303)
---
As described in issue #139 Debian fails due to 'apt-get' errors which are caused by unauthenticated packages: libdbus-1-3 libexpat1 dbus libpam-systemd