### PR TITLE
set new/current DebianGeoMirror

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -2406,7 +2406,7 @@ def load_args():
         if args.distribution == Distribution.fedora:
             args.mirror = None
         elif args.distribution == Distribution.debian:
-            args.mirror = "http://httpredir.debian.org/debian"
+            args.mirror = "http://deb.debian.org/debian"
         elif args.distribution == Distribution.ubuntu:
             args.mirror = "http://archive.ubuntu.com/ubuntu"
             if platform.machine() == "aarch64":


### PR DESCRIPTION
To avoid problems deb.debian.org should be used.

httpredir.debian.org is discontinued since 2017-02-17; see:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=817155