### PR TITLE
Support package cache on arch despite have no Release defined

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -2266,7 +2266,8 @@ def find_cache(args):
         return
 
     if os.path.exists("mkosi.cache/"):
-        args.cache_path = "mkosi.cache/" + args.distribution.name + "~" + args.release
+        release = "~" + args.release if args.distribution.name != "arch" else ""
+        args.cache_path = "mkosi.cache/" + args.distribution.name + release
 
 def find_build_script(args):
     if args.build_script is not None:

--- a/mkosi
+++ b/mkosi
@@ -2266,8 +2266,8 @@ def find_cache(args):
         return
 
     if os.path.exists("mkosi.cache/"):
-        release = "~" + args.release if args.distribution.name != "arch" else ""
-        args.cache_path = "mkosi.cache/" + args.distribution.name + release
+        args.cache_path = "mkosi.cache/" + args.distribution.name
+        args.cache_path += "~" + args.release if args.release is not None else ""
 
 def find_build_script(args):
     if args.build_script is not None:


### PR DESCRIPTION
Arch being a rolling distro, it does not have a release, so it will crash when trying to determine the package cache folder name; this commit only appends the "~release" string if present. Fixes #146 