### PR TITLE
Do not setup systemd-networkd on Arch if networkmanager is used

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -714,6 +714,12 @@ Type=ether
 DHCP=yes
 """)
 
+def enable_networkmanager(workspace):
+    subprocess.run(["systemctl",
+                    "--root", os.path.join(workspace, "root"),
+                    "enable", "NetworkManager"],
+                   check=True)
+
 def run_workspace_command(args, workspace, *cmd, network=False, env={}):
 
     cmdline = ["systemd-nspawn",
@@ -1064,7 +1070,10 @@ SigLevel    = Required DatabaseOptional
 
     subprocess.run(cmdline, check=True)
 
-    enable_networkd(workspace)
+    if not "networkmanager" in args.packages:
+        enable_networkd(workspace)
+    else:
+        enable_networkmanager(workspace)
 
 @complete_step('Installing openSUSE')
 def install_opensuse(args, workspace, run_build_script):


### PR DESCRIPTION
networkd is currently unconditionally used and setup; fixes #153