### PR TITLE
mkosi: unbreak the squashfs mode, when used together with build trees

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -681,6 +681,9 @@ def prepare_tree(args, workspace, run_build_script, cached):
         os.mkdir(os.path.join(workspace, "root", "root"), 0o750)
         os.mkdir(os.path.join(workspace, "root", "root/dest"), 0o755)
 
+        if args.build_dir is not None:
+            os.mkdir(os.path.join(workspace, "root", "root/build"), 0o755)
+
 def patch_file(filepath, line_rewriter):
     temp_new_filepath = filepath + ".tmp.new"
 


### PR DESCRIPTION
We need to create the mount point for the build tree early on, so that
it is included in the read-only squashfs image, and we can mount the
host's builddir into it.

Without this patch squashfs builds with builddir usage fail.