### PR TITLE
fix incremental mode when used without build script

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -2655,6 +2655,9 @@ def load_args():
         if args.secure_boot_certificate is None:
             die("UEFI SecureBoot enabled, but couldn't find certificate. (Consider placing it in mkosi.secure-boot.crt?)")
 
+    if args.incremental and args.build_script is None:
+        sys.stderr.write("WARNING: Incremental mode requested (-i), but no build script defined. Incremental mode will have no effect.\n")
+
     return args
 
 def check_output(args):

--- a/mkosi
+++ b/mkosi
@@ -259,6 +259,8 @@ def reuse_cache_image(args, workspace, run_build_script, for_cache):
 
     if not args.incremental:
         return None, False
+    if args.build_script is None:
+        return None, False
     if for_cache:
         return None, False
     if args.output_format not in (OutputFormat.raw_gpt, OutputFormat.raw_btrfs):
@@ -2778,6 +2780,8 @@ def reuse_cache_tree(args, workspace, run_build_script, for_cache, cached):
 
     if not args.incremental:
         return False
+    if args.build_script is None:
+        return False
     if for_cache:
         return False
     if args.output_format in (OutputFormat.raw_gpt, OutputFormat.raw_btrfs):
@@ -2910,6 +2914,13 @@ def run_build_script(args, workspace, raw):
 def need_cache_images(args):
 
     if not args.incremental:
+        return False
+
+    # Caching of images only is useful when we build with a build
+    # script, as only then we want to optimize that we can start
+    # right-away with the build script without preparing the build
+    # image first.
+    if args.build_script is None:
         return False
 
     if args.force_count > 1:


### PR DESCRIPTION
A fix for #143. I don't think -i without build script makes sense, but we should handle it gracefully.