### PR TITLE
README: on debian, the ubuntu keyring is named ubuntu-archive-keyring

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,11 +331,11 @@ necessary dependencies. For example, on *Fedora* you need:
 dnf install arch-install-scripts btrfs-progs debootstrap dosfstools edk2-ovmf squashfs-tools gnupg python3 tar veritysetup xz zypper
 ```
 
-On Debian/Ubuntu it might be necessary to install the `ubuntu-keyring`
-and/or `debian-archive-keyring` packages explicitly, in addition to
-`debootstrap`, depending on what kind of distribution images you want
-to build. `debootstrap` on Debian only pulls in the Debian keyring on
-its own, and the version on Ubuntu only the one from Ubuntu.
+On Debian/Ubuntu it might be necessary to install the `ubuntu-keyring`,
+`ubuntu-archive-keyring` and/or `debian-archive-keyring` packages explicitly,
+in addition to `debootstrap`, depending on what kind of distribution images
+you want to build. `debootstrap` on Debian only pulls in the Debian keyring
+on its own, and the version on Ubuntu only the one from Ubuntu.
 
 Note that the minimum required Python version is 3.5.
 


### PR DESCRIPTION
Followup to #163 . Sorry for pressing the green button too fast. Turns out the ubuntu keyring is not named the same in debian and ubuntu.