### PR TITLE
use rsync instead of cp in order to support copying into symlink folders

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1420,7 +1420,10 @@ def install_boot_loader(args, workspace, cached):
             install_boot_loader_opensuse(args, workspace)
 
 def enumerate_and_copy(source, dest):
-    subprocess.run(["cp", "--reflink=auto", "--recursive", "--no-dereference", "--preserve=all", "--no-target-directory", source, dest], check=True)
+    # rsync will create the source root folder unless a trailing slash is present
+    if not source.endswith('/'):
+        source += '/'
+    subprocess.run(["rsync", "--recursive", "--keep-dirlinks", "--perms", "--group", "--specials", source, dest], check=True)
 
 def install_extra_trees(args, workspace, for_cache):
     if args.extra_trees is None:


### PR DESCRIPTION
Some distros (e.g. Arch, see #166) have symlinks on / (e.g. /lib > /usr/lib), and cp is unable to copy into symlink folders. This PR replaces cp by rsync, which supports copying into symlink folders.