### PR TITLE
Fix building base Arch image if no additional package was requested

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1196,10 +1196,10 @@ SigLevel    = Required DatabaseOptional
 
     subprocess.run(cmdline, check=True)
 
-    if not "networkmanager" in args.packages:
-        enable_networkd(workspace)
-    else:
+    if args.packages and "networkmanager" in args.packages:
         enable_networkmanager(workspace)
+    else:
+        enable_networkd(workspace)
 
 @complete_step('Installing openSUSE')
 def install_opensuse(args, workspace, run_build_script):


### PR DESCRIPTION
This fixes a regression induced by NetworkManager support (#153), if no packages are defined (at all).
