### PR TITLE
openSUSE: don't use https to access mirrors for now

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -2574,7 +2574,7 @@ def load_args():
             if platform.machine() == "aarch64":
                 args.mirror = "http://mirror.archlinuxarm.org"
         elif args.distribution == Distribution.opensuse:
-            args.mirror = "https://download.opensuse.org"
+            args.mirror = "http://download.opensuse.org"
 
     if args.bootable:
         if args.distribution == Distribution.ubuntu:


### PR DESCRIPTION
Some openSUSE mirrors redirect https to http and this seems to make
curl(1) unhappy now.

There's a request to fix that on mirror side:
https://github.com/openSUSE/mirrorbrain/issues/3 but for the time
being switch to http to access all mirrors.

There seems to be no additional values in https:// as the rpms are
signed by gpg keys already, so is the repodata anyways.

Fixes: #137
Fixes: #159