### PR TITLE
mkosi: recursively delete btrfs subvolumes

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -152,6 +152,23 @@ def btrfs_subvol_create(path, mode=0o755):
     os.umask(m)
 
 def btrfs_subvol_delete(path):
+    # Extract the path of the subvolume relative to the filesystem
+    c = subprocess.run(["btrfs", "subvol", "show", path], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=True)
+    subvol_path = c.stdout.decode("utf-8").splitlines()[0]
+    # Make the subvolume RW again if it was set RO by btrfs_subvol_delete
+    subprocess.run(["btrfs", "property", "set", path, "ro", "false"], check=True)
+    # Recursively delete the direct children of the subvolume
+    c = subprocess.run(["btrfs", "subvol", "list", "-o", path], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=True)
+    for line in c.stdout.decode("utf-8").splitlines():
+        if not line:
+            continue
+        child_subvol_path = line.split(" ", 8)[-1]
+        child_path = os.path.normpath(os.path.join(
+            path,
+            os.path.relpath(child_subvol_path, subvol_path)
+        ))
+        btrfs_subvol_delete(child_path)
+    # Delete the subvolume now that all its descendants have been deleted
     subprocess.run(["btrfs", "subvol", "delete", path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
 
 def btrfs_subvol_make_ro(path, b=True):


### PR DESCRIPTION
`btrfs subvol delete` can only delete a subvolume if it is not read-only
and if it does not contain another subvolume.

`btrfs subvol list -o` prints the subvolumes below a certain path, but
only gives the paths relative to the filesystem mount point for those
subvolumes. To compute the paths of the children, we need the relative
path of the parent subvolume given by `btrfs subvol show`.

Read-only subvolumes also have to be writeable again before being
deleted. We unconditionally unset the readonly property on a subvolume
before deletion.