### PR TITLE
mkosi: create builddir if configured but missing

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -2910,6 +2910,17 @@ def make_output_dir(args):
     except FileExistsError:
         pass
 
+def make_build_dir(args):
+    """Create the build directory if set and not existing yet"""
+    if args.build_dir is None:
+        return
+
+    try:
+        # Only create the final component, hence no mkdirs()
+        os.mkdir(args.build_dir, 0o755)
+    except FileExistsError:
+        pass
+
 def build_image(args, workspace, run_build_script, for_cache=False):
 
     # If there's no build script set, there's no point in executing
@@ -2918,6 +2929,7 @@ def build_image(args, workspace, run_build_script, for_cache=False):
         return None, None, None
 
     make_output_dir(args)
+    make_build_dir(args)
 
     raw, cached = reuse_cache_image(args, workspace.name, run_build_script, for_cache)
     if not cached:


### PR DESCRIPTION
If a builddir is explicitly configured but missing, automatically create
it.

This follows the logic already implemented for mkosi.output/ and
mkosi.cache/.

This is particularly useful when storing mkosi settings in a git repo,
as git normally doesn't allow us to store empty directories, and hence
we cannot make use of auto-discovery of mkosi.output/ and mkosi.cache/.
By configuring these paths explicitly in mkosi.default however, we can
work around this, as in that case we'll create the directories if
needed.