### PR TITLE
mkosi: generate default UTF-8 locale for Arch Linux

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1201,6 +1201,11 @@ SigLevel    = Required DatabaseOptional
     else:
         enable_networkd(workspace)
 
+    with open(os.path.join(workspace, 'root', 'etc/locale.gen'), 'w') as f:
+        f.write('en_US.UTF-8 UTF-8\n')
+
+    run_workspace_command(args, workspace, '/usr/bin/locale-gen')
+
 @complete_step('Installing openSUSE')
 def install_opensuse(args, workspace, run_build_script):
 


### PR DESCRIPTION
Fixes: #186