### PR TITLE
Fix ubuntu builds

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -741,7 +741,10 @@ def run_workspace_command(args, workspace, *cmd, network=False, env={}):
                "--register=no",
                "--bind=" + var_tmp(workspace) + ":/var/tmp" ]
 
-    if not network:
+    if network:
+        # If we're using the host network namespace, use the same resolver
+        cmdline += ["--bind-ro=/etc/resolv.conf"]
+    else:
         cmdline += ["--private-network"]
 
     cmdline += [ "--setenv={}={}".format(k,v) for k,v in env.items() ]

--- a/mkosi
+++ b/mkosi
@@ -2605,7 +2605,7 @@ def load_args():
         elif args.distribution == Distribution.debian:
             args.release = "unstable"
         elif args.distribution == Distribution.ubuntu:
-            args.release = "yakkety"
+            args.release = "artful"
         elif args.distribution == Distribution.opensuse:
             args.release = "tumbleweed"
 


### PR DESCRIPTION
Fix ubuntu builds by binding in the host resolver when using the host network namespace

Update the default distribution to a supported version. 