### PR TITLE
Add support to skeleton trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ they exist in the local directory:
   additional files to an image, on top of what the
   distribution includes in its packages.
 
+* `mkosi.skeleton/` may be a directory and works in the same way as
+  `mkosi.extra`, but the files are copied before anything else so to
+  have a skeleton tree for the OS. This allows to change the package
+  manager and create files that need to be there before anythin is
+  installed.
+
 * `mkosi.build` may be an executable script. If it exists the image
   will be built twice: the first iteration will be the *development*
   image, the second iteration will be the *final* image. The

--- a/README.md
+++ b/README.md
@@ -153,17 +153,22 @@ they exist in the local directory:
   and the argument gets converted as follows: "--with-network" becomes
   "WithNetwork=yes".
 
-* `mkosi.extra/` may be a directory. If this exists all files
-  contained in it are copied over the directory tree of the
-  image after the *OS* was installed. This may be used to add in
-  additional files to an image, on top of what the
-  distribution includes in its packages.
+* `mkosi.extra/` or `mkosi.extra.tar` may be respectively a directory
+  or archive. If any exist all files contained in it are copied over the
+  directory tree of the image after the *OS* was installed. This may be used to
+  add in additional files to an image, on top of what the distribution includes
+  in its packages. When using a directory file ownership is not preserved:
+  all files copied will be owned by root. To preserve ownership use a tar
+  archive.
 
-* `mkosi.skeleton/` may be a directory and works in the same way as
-  `mkosi.extra`, but the files are copied before anything else so to
-  have a skeleton tree for the OS. This allows to change the package
-  manager and create files that need to be there before anythin is
-  installed.
+* `mkosi.skeleton/` or `mkosi.skeleton.tar` may be respectively a directory
+  or archive, and they work in the same way as
+  `mkosi.extra`/`mkosi.skeleton.tar`. However the files are copied before
+  anything else so to have a skeleton tree for the OS. This allows to change
+  the package manager and create files that need to be there before anything is
+  installed. When using a directory file ownership is not preserved:
+  all files copied will be owned by root. To preserve ownership use a tar
+  archive.
 
 * `mkosi.build` may be an executable script. If it exists the image
   will be built twice: the first iteration will be the *development*

--- a/mkosi
+++ b/mkosi
@@ -2593,11 +2593,11 @@ def find_nspawn_settings(args):
         args.nspawn_settings = "mkosi.nspawn"
 
 def find_extra(args):
-    if os.path.exists("mkosi.extra"):
+    if os.path.isdir("mkosi.extra"):
         args.extra_trees.append("mkosi.extra")
 
 def find_skeleton(args):
-    if os.path.exists("mkosi.skeleton"):
+    if os.path.isdir("mkosi.skeleton"):
         args.skeleton_trees.append("mkosi.skeleton")
 
 def find_cache(args):

--- a/mkosi
+++ b/mkosi
@@ -1574,6 +1574,14 @@ def install_extra_trees(args, workspace, for_cache):
         for d in args.extra_trees:
             copy(d, os.path.join(workspace, "root"))
 
+def install_skeleton_trees(args, workspace, for_cache):
+    if args.skeleton_trees is None:
+        return
+
+    with complete_step('Copying in skeleton file trees'):
+        for d in args.skeleton_trees:
+            copy(d, os.path.join(workspace, "root"))
+
 def copy_git_files(src, dest, *, git_files):
     run(['git', 'clone', '--depth=1', '--recursive', '--shallow-submodules', src, dest],
         check=True)
@@ -2194,6 +2202,7 @@ def parse_args():
     group.add_argument('-T', "--without-tests", action='store_false', dest='with_tests', default=True, help='Do not run tests as part of build script, if supported')
     group.add_argument("--cache", dest='cache_path', help='Package cache path', metavar='PATH')
     group.add_argument("--extra-tree", action='append', dest='extra_trees', help='Copy an extra tree on top of image', metavar='PATH')
+    group.add_argument("--skeleton-tree", action='append', dest='skeleton_trees', help='Use a skeleton tree to bootstrap the image before installing anything', metavar='PATH')
     group.add_argument("--build-script", help='Build script to run inside image', metavar='PATH')
     group.add_argument("--build-sources", help='Path for sources to build', metavar='PATH')
     group.add_argument("--build-dir", help='Path to use as persistent build directory', metavar='PATH')
@@ -2466,6 +2475,12 @@ def process_setting(args, section, key, value):
                 args.extra_trees = list_value
             else:
                 args.extra_trees.extend(list_value)
+        elif key == "SkeletonTrees":
+            list_value = value if type(value) == list else value.split()
+            if args.skeleton_trees is None:
+                args.skeleton_trees = list_value
+            else:
+                args.skeleton_trees.extend(list_value)
         elif key == "BuildScript":
             if args.build_script is None:
                 args.build_script = value
@@ -2601,6 +2616,13 @@ def find_extra(args):
         else:
             args.extra_trees.append("mkosi.extra")
 
+def find_skeleton(args):
+    if os.path.exists("mkosi.skeleton"):
+        if args.skeleton_trees is None:
+            args.skeleton_trees = ["mkosi.skeleton"]
+        else:
+            args.skeleton_trees.append("mkosi.skeleton")
+
 def find_cache(args):
 
     if args.cache_path is not None:
@@ -2729,6 +2751,7 @@ def load_args():
     load_defaults(args)
     find_nspawn_settings(args)
     find_extra(args)
+    find_skeleton(args)
     find_build_script(args)
     find_build_sources(args)
     find_build_dir(args)
@@ -2889,6 +2912,10 @@ def load_args():
         for i in range(len(args.extra_trees)):
             args.extra_trees[i] = os.path.abspath(args.extra_trees[i])
 
+    if args.skeleton_trees is not None:
+        for i in range(len(args.skeleton_trees)):
+            args.skeleton_trees[i] = os.path.abspath(args.skeleton_trees[i])
+
     args.root_size = parse_bytes(args.root_size)
     args.home_size = parse_bytes(args.home_size)
     args.srv_size = parse_bytes(args.srv_size)
@@ -3025,6 +3052,7 @@ def print_summary(args):
 
     sys.stderr.write("         Package Cache: " + none_to_none(args.cache_path) + "\n")
     sys.stderr.write("           Extra Trees: " + line_join_list(args.extra_trees) + "\n")
+    sys.stderr.write("        Skeleton Trees: " + line_join_list(args.skeleton_trees) + "\n")
     sys.stderr.write("          Build Script: " + none_to_none(args.build_script) + "\n")
 
     if args.build_script:
@@ -3131,6 +3159,7 @@ def build_image(args, workspace, run_build_script, for_cache=False):
 
                 with mount_cache(args, workspace.name):
                     cached = reuse_cache_tree(args, workspace.name, run_build_script, for_cache, cached)
+                    install_skeleton_trees(args, workspace.name, for_cache)
                     install_distribution(args, workspace.name, run_build_script, cached)
                     install_boot_loader(args, workspace.name, cached)
 

--- a/mkosi
+++ b/mkosi
@@ -934,10 +934,9 @@ def invoke_dnf(args, workspace, repositories, base_packages, boot_packages, conf
                *base_packages
                ])
 
-    if args.packages is not None:
-        cmdline.extend(args.packages)
+    cmdline.extend(args.packages)
 
-    if run_build_script and args.build_packages is not None:
+    if run_build_script:
         cmdline.extend(args.build_packages)
 
     if args.bootable:
@@ -1080,10 +1079,9 @@ def invoke_yum(args, workspace, repositories, base_packages, boot_packages, conf
                *base_packages
                ])
 
-    if args.packages is not None:
-        cmdline.extend(args.packages)
+    cmdline.extend(args.packages)
 
-    if run_build_script and args.build_packages is not None:
+    if run_build_script:
         cmdline.extend(args.build_packages)
 
     if args.bootable:
@@ -1180,11 +1178,10 @@ def install_debian_or_ubuntu(args, workspace, run_build_script, mirror):
 
     # Also install extra packages via the secondary APT run, because it is smarter and
     # can deal better with any conflicts
-    if args.packages is not None:
-        extra_packages += args.packages
+    extra_packages.extend(args.packages)
 
-    if run_build_script and args.build_packages is not None:
-        extra_packages += args.build_packages
+    if run_build_script:
+        extra_packages.extend(args.build_packages)
 
     # Work around debian bug #835628
     os.makedirs(os.path.join(workspace, "root/etc/dracut.conf.d"), exist_ok=True)
@@ -1286,7 +1283,7 @@ SigLevel    = Required DatabaseOptional
     ]
 
     kernel_packages = {"linux"}
-    if args.packages is not None:
+    if args.packages:
         kernel_packages = set.intersection(set(args.packages), set(official_kernel_packages))
         # prefer user-specified packages over implicit base kernel
         if kernel_packages and "linux" not in kernel_packages:
@@ -1316,10 +1313,9 @@ SigLevel    = Required DatabaseOptional
     else:
         packages -= kernel_packages
 
-    if args.packages is not None:
-        packages |= set(args.packages)
+    packages |= set(args.packages)
 
-    if run_build_script and args.build_packages is not None:
+    if run_build_script:
         packages |= set(args.build_packages)
 
     cmdline = ["pacstrap",
@@ -1330,7 +1326,7 @@ SigLevel    = Required DatabaseOptional
 
     run(cmdline, check=True)
 
-    if args.packages and "networkmanager" in args.packages:
+    if "networkmanager" in args.packages:
         enable_networkmanager(workspace)
     else:
         enable_networkd(workspace)
@@ -1395,11 +1391,10 @@ def install_opensuse(args, workspace, run_build_script):
     if args.output_format in (OutputFormat.subvolume, OutputFormat.raw_btrfs):
         extra_packages += ["btrfsprogs"]
 
-    if args.packages:
-        extra_packages += args.packages
+    extra_packages.extend(args.packages)
 
-    if run_build_script and args.build_packages is not None:
-        extra_packages += args.build_packages
+    if run_build_script:
+        extra_packages.extend(args.build_packages)
 
     if extra_packages:
         run(cmdline + extra_packages, check=True)
@@ -1564,7 +1559,7 @@ def install_boot_loader(args, workspace, cached):
             install_boot_loader_opensuse(args, workspace)
 
 def install_extra_trees(args, workspace, for_cache):
-    if args.extra_trees is None:
+    if not args.extra_trees:
         return
 
     if for_cache:
@@ -1575,7 +1570,7 @@ def install_extra_trees(args, workspace, for_cache):
             copy(d, os.path.join(workspace, "root"))
 
 def install_skeleton_trees(args, workspace, for_cache):
-    if args.skeleton_trees is None:
+    if not args.skeleton_trees:
         return
 
     with complete_step('Copying in skeleton file trees'):
@@ -2197,16 +2192,16 @@ def parse_args():
     group.add_argument('-i', "--incremental", action='store_true', help='Make use of and generate intermediary cache images')
 
     group = parser.add_argument_group("Packages")
-    group.add_argument('-p', "--package", action=PackageAction, dest='packages', help='Add an additional package to the OS image', metavar='PACKAGE')
+    group.add_argument('-p', "--package", action=PackageAction, dest='packages', default=[], help='Add an additional package to the OS image', metavar='PACKAGE')
     group.add_argument("--with-docs", action='store_true', help='Install documentation (only Fedora, CentOS and Mageia)')
     group.add_argument('-T', "--without-tests", action='store_false', dest='with_tests', default=True, help='Do not run tests as part of build script, if supported')
     group.add_argument("--cache", dest='cache_path', help='Package cache path', metavar='PATH')
-    group.add_argument("--extra-tree", action='append', dest='extra_trees', help='Copy an extra tree on top of image', metavar='PATH')
-    group.add_argument("--skeleton-tree", action='append', dest='skeleton_trees', help='Use a skeleton tree to bootstrap the image before installing anything', metavar='PATH')
+    group.add_argument("--extra-tree", action='append', dest='extra_trees', default=[], help='Copy an extra tree on top of image', metavar='PATH')
+    group.add_argument("--skeleton-tree", action='append', dest='skeleton_trees', default=[], help='Use a skeleton tree to bootstrap the image before installing anything', metavar='PATH')
     group.add_argument("--build-script", help='Build script to run inside image', metavar='PATH')
     group.add_argument("--build-sources", help='Path for sources to build', metavar='PATH')
     group.add_argument("--build-dir", help='Path to use as persistent build directory', metavar='PATH')
-    group.add_argument("--build-package", action=PackageAction, dest='build_packages', help='Additional packages needed for build script', metavar='PACKAGE')
+    group.add_argument("--build-package", action=PackageAction, dest='build_packages', default=[], help='Additional packages needed for build script', metavar='PACKAGE')
     group.add_argument("--postinst-script", help='Post installation script to run inside image', metavar='PATH')
     group.add_argument('--use-git-files', type=parse_boolean,
                        help='Ignore any files that git itself ignores (default: guess)')
@@ -2456,10 +2451,7 @@ def process_setting(args, section, key, value):
     elif section == "Packages":
         if key == "Packages":
             list_value = value if type(value) == list else value.split()
-            if args.packages is None:
-                args.packages = list_value
-            else:
-                args.packages.extend(list_value)
+            args.packages.extend(list_value)
         elif key == "WithDocs":
             if not args.with_docs:
                 args.with_docs = parse_boolean(value)
@@ -2471,16 +2463,10 @@ def process_setting(args, section, key, value):
                 args.cache_path = value
         elif key == "ExtraTrees":
             list_value = value if type(value) == list else value.split()
-            if args.extra_trees is None:
-                args.extra_trees = list_value
-            else:
-                args.extra_trees.extend(list_value)
+            args.extra_trees.extend(list_value)
         elif key == "SkeletonTrees":
             list_value = value if type(value) == list else value.split()
-            if args.skeleton_trees is None:
-                args.skeleton_trees = list_value
-            else:
-                args.skeleton_trees.extend(list_value)
+            args.skeleton_trees.extend(list_value)
         elif key == "BuildScript":
             if args.build_script is None:
                 args.build_script = value
@@ -2492,10 +2478,7 @@ def process_setting(args, section, key, value):
                 args.build_dir = value
         elif key == "BuildPackages":
             list_value = value if type(value) == list else value.split()
-            if args.build_packages is None:
-                args.build_packages = list_value
-            else:
-                args.build_packages.extend(list_value)
+            args.build_packages.extend(list_value)
         elif key == "PostInstallationScript":
             if args.postinst_script is None:
                 args.postinst_script = value
@@ -2611,17 +2594,11 @@ def find_nspawn_settings(args):
 
 def find_extra(args):
     if os.path.exists("mkosi.extra"):
-        if args.extra_trees is None:
-            args.extra_trees = ["mkosi.extra"]
-        else:
-            args.extra_trees.append("mkosi.extra")
+        args.extra_trees.append("mkosi.extra")
 
 def find_skeleton(args):
     if os.path.exists("mkosi.skeleton"):
-        if args.skeleton_trees is None:
-            args.skeleton_trees = ["mkosi.skeleton"]
-        else:
-            args.skeleton_trees.append("mkosi.skeleton")
+        args.skeleton_trees.append("mkosi.skeleton")
 
 def find_cache(args):
 
@@ -2908,7 +2885,7 @@ def load_args():
     if args.cache_path is not None:
         args.cache_path = os.path.abspath(args.cache_path)
 
-    if args.extra_trees is not None:
+    if args.extra_trees:
         for i in range(len(args.extra_trees)):
             args.extra_trees[i] = os.path.abspath(args.extra_trees[i])
 
@@ -2998,7 +2975,7 @@ def none_to_none(s):
 
 def line_join_list(l):
 
-    if l is None:
+    if not l:
         return "none"
 
     return "\n                        ".join(l)

--- a/mkosi
+++ b/mkosi
@@ -1567,7 +1567,10 @@ def install_extra_trees(args, workspace, for_cache):
 
     with complete_step('Copying in extra file trees'):
         for d in args.extra_trees:
-            copy(d, os.path.join(workspace, "root"))
+            if os.path.isdir(d):
+                copy(d, os.path.join(workspace, "root"))
+            else:
+                shutil.unpack_archive(d, os.path.join(workspace, "root"))
 
 def install_skeleton_trees(args, workspace, for_cache):
     if not args.skeleton_trees:
@@ -1575,7 +1578,10 @@ def install_skeleton_trees(args, workspace, for_cache):
 
     with complete_step('Copying in skeleton file trees'):
         for d in args.skeleton_trees:
-            copy(d, os.path.join(workspace, "root"))
+            if os.path.isdir(d):
+                copy(d, os.path.join(workspace, "root"))
+            else:
+                shutil.unpack_archive(d, os.path.join(workspace, "root"))
 
 def copy_git_files(src, dest, *, git_files):
     run(['git', 'clone', '--depth=1', '--recursive', '--shallow-submodules', src, dest],
@@ -2595,10 +2601,14 @@ def find_nspawn_settings(args):
 def find_extra(args):
     if os.path.isdir("mkosi.extra"):
         args.extra_trees.append("mkosi.extra")
+    if os.path.isfile("mkosi.extra.tar"):
+        args.extra_trees.append("mkosi.extra.tar")
 
 def find_skeleton(args):
     if os.path.isdir("mkosi.skeleton"):
         args.skeleton_trees.append("mkosi.skeleton")
+    if os.path.isfile("mkosi.skeleton.tar"):
+        args.skeleton_trees.append("mkosi.skeleton.tar")
 
 def find_cache(args):
 


### PR DESCRIPTION
It's already possible to pass extra trees to copy over the final tree
after installing all packages. However in some cases it is desirable to
copy the tree before installing packages or running anything in the
image.  One of the cases is if we want to enable additional repositories
for the package manager or want to configure it in a particular way.

Now mkosi can use a mkosi.skeleton directory (or by passing a
--skeleton-tree argument) in the same way it currently supports extra
trees, however copying them before running the "install_distro" phase.

To allow changing the package manager configuration distros may need
more tweaks to point the package manager to the right files. Right now
this has been tested with Fedora 27 by adding
`mkosi.skeleton/etc/yum.repos.d/rpmfusion-free.repo` and installing a
package from that repo.

Closes #106.
May solve #189.