### PR TITLE
Use host resolver with host network for build script

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -3113,7 +3113,10 @@ def run_build_script(args, workspace, raw):
             cmdline.append("--setenv=BUILDDIR=/root/build")
             cmdline.append("--bind=" + args.build_dir + ":/root/build")
 
-        if not args.with_network:
+        if args.with_network:
+            # If we're using the host network namespace, use the same resolver
+            cmdline.append("--bind-ro=/etc/resolv.conf")
+        else:
             cmdline.append("--private-network")
 
         cmdline.append("/root/" + os.path.basename(args.build_script))


### PR DESCRIPTION
This is essentially a copy of f4ee420a00, but for the build script, since @juaningan pointed out in a comment in #188 that we need it there as well.

---

Note: I’m not sure if this is actually necessary – I haven’t been able to build a scenario that fails without this change yet. @NeilW or @juaningan can you look into this perhaps?