### PR TITLE
Fix breakage when generating image without bmap

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1987,6 +1987,9 @@ def calculate_signature(args, checksum):
     return f
 
 def calculate_bmap(args, raw):
+    if not args.bmap:
+        return None
+
     if args.output_format not in (OutputFormat.raw_gpt, OutputFormat.raw_btrfs):
         return None
 


### PR DESCRIPTION
When generating an image without bmap it was failing with:

       ‣ Creating BMAP file...
        Traceback (most recent call last):
          File "/usr/bin/mkosi", line 3304, in <module>
            main()
          File "/usr/bin/mkosi", line 3297, in main
            build_stuff(args)
          File "/usr/bin/mkosi", line 3231, in build_stuff
            bmap = calculate_bmap(args, raw)
          File "/usr/bin/mkosi", line 1995, in calculate_bmap
            dir=os.path.dirname(args.output_bmap))
        AttributeError: 'Namespace' object has no attribute 'output_bmap'

Fix it by doing the same as we do in other functions, checking if
bmap is actually enabled.

Closes #194 