### PR TITLE
mkosi: make sure when copying files we unlink existing matching files…

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -186,7 +186,7 @@ def copy_file(oldpath, newpath):
         st = os.stat(oldfd)
 
         try:
-            with open_close(newpath, os.O_WRONLY|os.O_CREAT, st.st_mode) as newfd:
+            with open_close(newpath, os.O_WRONLY|os.O_CREAT|os.O_EXCL, st.st_mode) as newfd:
                 _copy_file(oldfd, newfd)
         except FileExistsError:
             os.unlink(newpath)


### PR DESCRIPTION
… first

Previously, if a file already existed before, we'd open it for write and
write the new file into the same file. If the old file was larger than
the new file we'd not truncate it, so that in that case the resulting
file was a combination of the new small file plus the old suffix.

This one confused the hell out of me...