### PR TITLE
Stop patching nsswitch.conf and make resolv.conf points to stub-resolv.conf on Arch Linux

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -844,13 +844,6 @@ def patch_file(filepath, line_rewriter):
     os.remove(filepath)
     shutil.move(temp_new_filepath, filepath)
 
-def fix_hosts_line_in_nsswitch(line):
-    if line.startswith("hosts:"):
-        sources = line.split(" ")
-        if 'resolve' not in sources:
-            return " ".join(["resolve" if w == "dns" else w for w in sources])
-    return line
-
 def enable_networkd(workspace):
     run(["systemctl",
          "--root", os.path.join(workspace, "root"),
@@ -858,9 +851,7 @@ def enable_networkd(workspace):
         check=True)
 
     os.remove(os.path.join(workspace, "root", "etc/resolv.conf"))
-    os.symlink("../usr/lib/systemd/resolv.conf", os.path.join(workspace, "root", "etc/resolv.conf"))
-
-    patch_file(os.path.join(workspace, "root", "etc/nsswitch.conf"), fix_hosts_line_in_nsswitch)
+    os.symlink("../run/systemd/resolve/stub-resolv.conf", os.path.join(workspace, "root", "etc/resolv.conf"))
 
     with open(os.path.join(workspace, "root", "etc/systemd/network/all-ethernet.network"), "w") as f:
         f.write("""\


### PR DESCRIPTION
The `nsswitch.conf` file that comes by default on Arch Linux is now fully systemd-resolved compatible.
Its `hosts:` line is now:
```
hosts: files mymachines resolve [!UNAVAIL=return] dns myhostname
```
So, there is no need to patch this file when enabling systemd-resolved on Arch Linux anymore.

Also make `/etc/resolv.conf` points to the new dynamic `/run/systemd/resolve/stub-resolv.conf` rather than the older static `/usr/lib/systemd/resolv.conf`.
  