### PR TITLE
Use an UTF-8 locale on Arch Linux

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1369,6 +1369,9 @@ SigLevel    = Required DatabaseOptional
 
     run_workspace_command(args, workspace, '/usr/bin/locale-gen')
 
+    with open(os.path.join(workspace, 'root', 'etc/locale.conf'), 'w') as f:
+        f.write('LANG=en_US.UTF-8\n')
+
 @complete_step('Installing openSUSE')
 def install_opensuse(args, workspace, run_build_script):
 


### PR DESCRIPTION
Commit 0dc40f40 introduced the generation of an UTF-8 locale at build time.
This commit makes it used.

For example, before this commit, we still had:
```
[root@archlinux ~]# systemctl status
* archlinux
    State: running
     Jobs: 0 queued
   Failed: 0 units
    Since: Sun 2018-01-07 22:13:47 CET; 32min ago
   CGroup: /
           |-user.slice
           | `-user-0.slice
           |   |-session-c1.scope
           |   | |-125 login -- root
```
whereas with this commit, we now have a prettier printed:
```
[root@archlinux ~]# systemctl status
● archlinux
    State: running
     Jobs: 0 queued
   Failed: 0 units
    Since: Sun 2018-01-07 22:13:47 CET; 33min ago
   CGroup: /
           ├─user.slice
           │ └─user-0.slice
           │   ├─session-c1.scope
           │   │ ├─125 login -- root
```