### PR TITLE
mkosi qemu doesn’t need to be run as root

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -3413,7 +3413,7 @@ def run_qemu(args):
 def main():
     args = load_args()
 
-    if args.verb in ("build", "clean", "shell", "boot", "qemu"):
+    if args.verb in ("build", "clean", "shell", "boot"):
         check_root()
         unlink_output(args)
 


### PR DESCRIPTION
On my setup, once I’ve changed the owner of the image generated by `mkosi -b` (launched as root), `mkosi qemu` can successfully be run with a non-privileged user.