### PR TITLE
Fix Arch Linux boot when the root FS is encrypted

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1324,8 +1324,7 @@ SigLevel    = Required DatabaseOptional
         if len(kernel_packages) > 1:
             warn('More than one kernel will be installed: {}', ' '.join(kernel_packages))
 
-    packages -= {"cryptsetup",
-                 "device-mapper",
+    packages -= {"device-mapper",
                  "dhcpcd",
                  "e2fsprogs",
                  "jfsutils",
@@ -1556,7 +1555,9 @@ def find_kernel_file(workspace_root, pattern):
 
 def install_boot_loader_arch(args, workspace):
     patch_file(os.path.join(workspace, "root", "etc/mkinitcpio.conf"),
-               lambda line: "HOOKS=\"systemd modconf block filesystems fsck\"\n" if line.startswith("HOOKS=") else line)
+               lambda line: "HOOKS=\"systemd modconf block sd-encrypt filesystems keyboard fsck\"\n" if line.startswith("HOOKS=") and args.encrypt == "all" else
+                            "HOOKS=\"systemd modconf block filesystems fsck\"\n"                     if line.startswith("HOOKS=") else
+                            line)
 
     workspace_root = os.path.join(workspace, "root")
     kernel_version = next(filter(lambda x: x[0].isdigit(), os.listdir(os.path.join(workspace_root, "lib/modules"))))


### PR DESCRIPTION
When the root FS is encrypted, mkinitcpio needs to be instructed to put in
the initrd what is needed to open the LUKS volume.

https://wiki.archlinux.org/index.php/mkinitcpio#Common_hooks