### PR TITLE
mkosi: btrfs_subvol_delete with mounted subvolumes

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -317,24 +317,19 @@ def btrfs_subvol_create(path: str, mode: int=0o755) -> None:
     os.umask(m)
 
 def btrfs_subvol_delete(path: str) -> None:
-    # Extract the path of the subvolume relative to the filesystem
-    c = run(["btrfs", "subvol", "show", path],
-            stdout=PIPE, stderr=DEVNULL, universal_newlines=True, check=True)
-    subvol_path = c.stdout.splitlines()[0]
-    # Make the subvolume RW again if it was set RO by btrfs_subvol_delete
-    run(["btrfs", "property", "set", path, "ro", "false"], check=True)
+    # Make the subvolume RW again if it was set RO by btrfs_subvol_make_ro
+    run(["btrfs", "property", "set", path, "ro", "false"], stderr=DEVNULL, check=True)
     # Recursively delete the direct children of the subvolume
     c = run(["btrfs", "subvol", "list", "-o", path],
             stdout=PIPE, stderr=DEVNULL, universal_newlines=True, check=True)
     for line in c.stdout.splitlines():
         if not line:
             continue
-        child_subvol_path = line.split(" ", 8)[-1]
-        child_path = os.path.normpath(os.path.join(
-            path,
-            os.path.relpath(child_subvol_path, subvol_path)
-        ))
-        btrfs_subvol_delete(child_path)
+        child_subvol_id = line.split(" ", 2)[1]
+        c = run(["btrfs", "subvol", "show", "-r", child_subvol_id, path],
+                stdout=PIPE, stderr=DEVNULL, universal_newlines=True, check=True)
+        child_subvol_path = c.stdout.splitlines()[0]
+        btrfs_subvol_delete(os.path.join(path, child_subvol_path))
     # Delete the subvolume now that all its descendants have been deleted
     run(["btrfs", "subvol", "delete", path], stdout=DEVNULL, stderr=DEVNULL, check=True)
 


### PR DESCRIPTION
Recursively deleting a subvolume does not work if an ancestor subvolume
is explicitly mounted (e.g. with `mount -o subvolid=<ID>`).

In such a case, the paths returned by `btrfs subvol list -o` are
specific to the BTRFS filesystem and have no relation with the mount
point.  An incorrect path is then constructed for the children and their
deletion will fail.

Instead, we retrieve the ID of the subvolumes below the current one and
query their path relative to the current subvolume with `btrfs subvol
show -r`.