### PR TITLE
mkosi: try hard to cleanup the workspace

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -23,6 +23,7 @@ import sys
 import tempfile
 import urllib.request
 import uuid
+import weakref
 
 try:
     import argcomplete
@@ -268,12 +269,26 @@ def init_namespace(args):
 def setup_workspace(args):
     print_step("Setting up temporary workspace.")
     if args.output_format in (OutputFormat.directory, OutputFormat.subvolume):
-        d = tempfile.TemporaryDirectory(dir=os.path.dirname(args.output), prefix='.mkosi-')
+        d = Workspace(dir=os.path.dirname(args.output), prefix='.mkosi-')
     else:
-        d = tempfile.TemporaryDirectory(dir='/var/tmp', prefix='mkosi-')
+        d = Workspace(dir='/var/tmp', prefix='mkosi-')
 
     print_step("Temporary workspace in " + d.name + " is now set up.")
     return d
+
+class Workspace(object):
+    def __init__(self, suffix=None, prefix=None, dir=None):
+        self._tempdir = tempfile.TemporaryDirectory(suffix=suffix, prefix=prefix, dir=dir)
+        weakref.finalize(self, self._cleanup, self._tempdir)
+
+    @property
+    def name(self):
+        return self._tempdir.name
+
+    @staticmethod
+    def _cleanup(tempdir):
+        empty_directory(tempdir.name)
+        tempdir.cleanup()
 
 def btrfs_subvol_create(path, mode=0o755):
     m = os.umask(~mode & 0o7777)


### PR DESCRIPTION
The workspace is a `tempfile.TemporaryDirectory` and its cleanup fails
if it cannot delete a file or directory contained in the workspace.

This is the case when an exception occurs during the build of a BTRFS
subvolume image. `tempfile.TemporaryDirectory` cannot delete the
subvolumes and the workspace remains.

The workspace is now an instance of `Workspace`, a class that wraps a
`tempfile.TemporaryDirectory`. When the workspace instance is deleted,
its contents are first deleted with unlink_try_hard and the temporary
directory can finally be cleaned up.

Fixes #182