### PR TITLE
fix release name detection on Debian hosts

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -2313,14 +2313,27 @@ def detect_distribution():
 
     id = None
     version_id = None
+    codename = None
 
     for ln in f:
         if ln.startswith("ID="):
             id = ln[3:].strip()
         if ln.startswith("VERSION_ID="):
             version_id = ln[11:].strip()
+        if ln.startswith("VERSION="):
+            # extract Debain release codename
+            version_str = ln[8:].strip()
+            open_paren_pos = version_str.index("(")
+            close_paren_pos = version_str.index(")")
+
+            if open_paren_pos and close_paren_pos:
+                codename = version_str[(open_paren_pos+1):close_paren_pos]
 
     d = Distribution.__members__.get(id, None)
+
+    if d == Distribution.debian and codename:
+        version_id = codename
+
     return d, version_id
 
 def unlink_try_hard(path):


### PR DESCRIPTION
This fixes release name detection on Debian hosts by extracting the correct codename (jessie, stretch, etc. ) from the VERSION field in the ```/etc/os-release``` file.
If this sounds to brittle, we could replace it by a dictionary lookup with the version numbers and codenames: ``` {"8": "jessie", 9": "stretch"}```.