### PR TITLE
Add more OVMF firmware locations

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -3602,15 +3602,22 @@ def run_qemu(args):
     else:
         die("Couldn't find QEMU/KVM binary")
 
-    # Look for UEFI firmware blob
-    FIRMWARE_LOCATIONS = [
-        '/usr/share/edk2/ovmf/OVMF_CODE.fd',
-        '/usr/share/qemu/OVMF_CODE.fd',
-    ]
+    # UEFI firmware blobs are found in a variety of locations,
+    # depending on distribution and package.
+    FIRMWARE_LOCATIONS = []
+    # First, we look in paths that contain the architecture –
+    # if they exist, they’re almost certainly correct.
     if platform.machine() == 'x86_64':
         FIRMWARE_LOCATIONS.append('/usr/share/ovmf/ovmf_code_x64.bin')
+        # FIRMWARE_LOCATIONS.append('/usr/share/ovmf/x64/OVMF_CODE.fd') # Arch `ovmf` package, but apparently broken
     elif platform.machine() == 'i386':
         FIRMWARE_LOCATIONS.append('/usr/share/ovmf/ovmf_code_ia32.bin')
+        FIRMWARE_LOCATIONS.append('/usr/share/edk2/ovmf-ia32/OVMF_CODE.fd')
+    # After that, we try some generic paths and hope that if they exist,
+    # they’ll correspond to the current architecture, thanks to the package manager.
+    FIRMWARE_LOCATIONS.append('/usr/share/edk2/ovmf/OVMF_CODE.fd')
+    FIRMWARE_LOCATIONS.append('/usr/share/qemu/OVMF_CODE.fd')
+
     for firmware in FIRMWARE_LOCATIONS:
         if os.path.exists(firmware):
             break


### PR DESCRIPTION
/usr/share/ovmf/x64/OVMF_CODE.fd is found in the `ovmf` package in the Arch Linux “extra” repository; /usr/share/edk2/ovmf-ia32/OVMF_CODE.fd is found in the `edk2-ovmf` package in the Arch User Repository.

---

I have to admit, I’m just very confused by this firmware stuff at this point, and I hope someone else can make more sense of it than me…

Here are the file listings of both packages:
```
ovmf /usr/
ovmf /usr/share/
ovmf /usr/share/licenses/
ovmf /usr/share/licenses/ovmf/
ovmf /usr/share/licenses/ovmf/License.txt
ovmf /usr/share/ovmf/
ovmf /usr/share/ovmf/x64/
ovmf /usr/share/ovmf/x64/OVMF_CODE.fd
ovmf /usr/share/ovmf/x64/OVMF_VARS.fd
edk2-ovmf /usr/
edk2-ovmf /usr/share/
edk2-ovmf /usr/share/doc/
edk2-ovmf /usr/share/doc/edk2-ovmf-ia32/
edk2-ovmf /usr/share/doc/edk2-ovmf-ia32/README
edk2-ovmf /usr/share/doc/edk2-ovmf/
edk2-ovmf /usr/share/doc/edk2-ovmf/README
edk2-ovmf /usr/share/edk2/
edk2-ovmf /usr/share/edk2/ovmf-ia32/
edk2-ovmf /usr/share/edk2/ovmf-ia32/EnrollDefaultKeys.efi
edk2-ovmf /usr/share/edk2/ovmf-ia32/OVMF_CODE.fd
edk2-ovmf /usr/share/edk2/ovmf-ia32/OVMF_CODE.secboot.fd
edk2-ovmf /usr/share/edk2/ovmf-ia32/Shell.efi
edk2-ovmf /usr/share/edk2/ovmf-ia32/UefiShell.iso
edk2-ovmf /usr/share/edk2/ovmf/
edk2-ovmf /usr/share/edk2/ovmf/EnrollDefaultKeys.efi
edk2-ovmf /usr/share/edk2/ovmf/OVMF_CODE.fd
edk2-ovmf /usr/share/edk2/ovmf/OVMF_CODE.secboot.fd
edk2-ovmf /usr/share/edk2/ovmf/OVMF_VARS.fd
edk2-ovmf /usr/share/edk2/ovmf/Shell.efi
edk2-ovmf /usr/share/edk2/ovmf/UefiShell.iso
edk2-ovmf /usr/share/licenses/
edk2-ovmf /usr/share/licenses/edk2-ovmf-ia32/
edk2-ovmf /usr/share/licenses/edk2-ovmf-ia32/LICENSE.openssl
edk2-ovmf /usr/share/licenses/edk2-ovmf-ia32/License.txt
edk2-ovmf /usr/share/licenses/edk2-ovmf/
edk2-ovmf /usr/share/licenses/edk2-ovmf/LICENSE.openssl
edk2-ovmf /usr/share/licenses/edk2-ovmf/License.txt
```
As you can see, the `edk2-ovmf` package contains not only `/usr/share/edk2/ovmf-ia32/OVMF_CODE.fd` (which this commit appends to `FIRMWARE_LOCATIONS` on 32-bit systems), but also `/usr/share/edk2/ovmf/OVMF_CODE.fd`, which was already unconditionally at the very beginning of `/usr/share/edk2/ovmf/OVMF_CODE.fd`. Unless I’m mistaken, that means that this file will actually be used on both platforms. Is that bad? I don’t know, sorry.