### PR TITLE
Remove `pcmciautils` from the filtered packages for archlinux

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1434,7 +1434,6 @@ SigLevel    = Required DatabaseOptional
         "man-pages",
         "mdadm",
         "netctl",
-        "pcmciautils",
         "reiserfsprogs",
         "xfsprogs",
     }


### PR DESCRIPTION
`pcmciautils` was dropped from the base group and the official repositories for good, there is no need to explicitly remove it from the list