### PR TITLE
Optimize size of Debian rootfs

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1312,35 +1312,34 @@ def install_debian_or_ubuntu(args, workspace, run_build_script, mirror):
     if args.bootable:
         extra_packages += ["linux-image-amd64", "dracut"]
 
-    if extra_packages:
-        # Debian policy is to start daemons by default.
-        # The policy-rc.d script can be used choose which ones to start
-        # Let's install one that denies all daemon startups
-        # See https://people.debian.org/~hmh/invokerc.d-policyrc.d-specification.txt
-        # Note: despite writing in /usr/sbin, this file is not shipped by the OS
-        # and instead should be managed by the admin.
-        policyrcd = os.path.join(workspace, "root/usr/sbin/policy-rc.d")
-        with open(policyrcd, "w") as f:
-            f.write("#!/bin/sh\n")
-            f.write("exit 101")
-        os.chmod(policyrcd, 0o755)
-        if not args.with_docs:
-            # Create dpkg.cfg to ingore documentation
-            dpkg_conf = os.path.join(workspace, "root/etc/dpkg/dpkg.cfg.d/01_nodoc")
-            with open(dpkg_conf, "w") as f:
-                f.writelines([
-                    'path-exclude /usr/share/locale/*\n',
-                    'path-exclude /usr/share/doc/*\n',
-                    'path-exclude /usr/share/man/*\n',
-                    'path-exclude /usr/share/groff/*\n',
-                    'path-exclude /usr/share/info/*\n',
-                    'path-exclude /usr/share/lintian/*\n',
-                    'path-exclude /usr/share/linda/*\n',
-                ])
+    # Debian policy is to start daemons by default.
+    # The policy-rc.d script can be used choose which ones to start
+    # Let's install one that denies all daemon startups
+    # See https://people.debian.org/~hmh/invokerc.d-policyrc.d-specification.txt
+    # Note: despite writing in /usr/sbin, this file is not shipped by the OS
+    # and instead should be managed by the admin.
+    policyrcd = os.path.join(workspace, "root/usr/sbin/policy-rc.d")
+    with open(policyrcd, "w") as f:
+        f.write("#!/bin/sh\n")
+        f.write("exit 101")
+    os.chmod(policyrcd, 0o755)
+    if not args.with_docs:
+        # Create dpkg.cfg to ingore documentation
+        dpkg_conf = os.path.join(workspace, "root/etc/dpkg/dpkg.cfg.d/01_nodoc")
+        with open(dpkg_conf, "w") as f:
+            f.writelines([
+                'path-exclude /usr/share/locale/*\n',
+                'path-exclude /usr/share/doc/*\n',
+                'path-exclude /usr/share/man/*\n',
+                'path-exclude /usr/share/groff/*\n',
+                'path-exclude /usr/share/info/*\n',
+                'path-exclude /usr/share/lintian/*\n',
+                'path-exclude /usr/share/linda/*\n',
+            ])
 
-        cmdline = ["/usr/bin/apt-get", "--assume-yes", "--no-install-recommends", "install"] + extra_packages
-        run_workspace_command(args, workspace, network=True, env={'DEBIAN_FRONTEND': 'noninteractive', 'DEBCONF_NONINTERACTIVE_SEEN': 'true'}, *cmdline)
-        os.unlink(policyrcd)
+    cmdline = ["/usr/bin/apt-get", "--assume-yes", "--no-install-recommends", "install"] + extra_packages
+    run_workspace_command(args, workspace, network=True, env={'DEBIAN_FRONTEND': 'noninteractive', 'DEBCONF_NONINTERACTIVE_SEEN': 'true'}, *cmdline)
+    os.unlink(policyrcd)
 
 @complete_step('Installing Debian')
 def install_debian(args, workspace, run_build_script):

--- a/mkosi
+++ b/mkosi
@@ -1323,19 +1323,24 @@ def install_debian_or_ubuntu(args, workspace, run_build_script, mirror):
         f.write("#!/bin/sh\n")
         f.write("exit 101")
     os.chmod(policyrcd, 0o755)
+
+    doc_paths = [
+        '/usr/share/locale',
+        '/usr/share/doc',
+        '/usr/share/man',
+        '/usr/share/groff',
+        '/usr/share/info',
+        '/usr/share/lintian',
+        '/usr/share/linda',
+    ]
     if not args.with_docs:
-        # Create dpkg.cfg to ingore documentation
+        # remove documentation installed by debootstrap
+        cmdline = ["rm", "-rf"] + doc_paths
+        run_workspace_command(args, workspace, *cmdline)
+        # Create dpkg.cfg to ingore documentation on new packages
         dpkg_conf = os.path.join(workspace, "root/etc/dpkg/dpkg.cfg.d/01_nodoc")
         with open(dpkg_conf, "w") as f:
-            f.writelines([
-                'path-exclude /usr/share/locale/*\n',
-                'path-exclude /usr/share/doc/*\n',
-                'path-exclude /usr/share/man/*\n',
-                'path-exclude /usr/share/groff/*\n',
-                'path-exclude /usr/share/info/*\n',
-                'path-exclude /usr/share/lintian/*\n',
-                'path-exclude /usr/share/linda/*\n',
-            ])
+            f.writelines(["path-exclude %s/*\n" % d for d in doc_paths])
 
     cmdline = ["/usr/bin/apt-get", "--assume-yes", "--no-install-recommends", "install"] + extra_packages
     run_workspace_command(args, workspace, network=True, env={'DEBIAN_FRONTEND': 'noninteractive', 'DEBCONF_NONINTERACTIVE_SEEN': 'true'}, *cmdline)


### PR DESCRIPTION
On my tests, removing the documentation installed by debootstrap reduces a
minimal Debian stable rootfs from ~204 MB to ~157 MB