### PR TITLE
ubuntu: fix docs removal

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1335,7 +1335,7 @@ def install_debian_or_ubuntu(args, workspace, run_build_script, mirror):
     ]
     if not args.with_docs:
         # Remove documentation installed by debootstrap
-        cmdline = ["rm", "-rf"] + doc_paths
+        cmdline = ["/bin/rm", "-rf"] + doc_paths
         run_workspace_command(args, workspace, *cmdline)
         # Create dpkg.cfg to ignore documentation on new packages
         dpkg_conf = os.path.join(workspace, "root/etc/dpkg/dpkg.cfg.d/01_nodoc")


### PR DESCRIPTION
Now `mkosi -d ubuntu` fails for me: :x:

```
$ uname -a
Linux localhost 4.18.12-arch1-1-ARCH #1 SMP PREEMPT Thu Oct 4 01:01:27 UTC 2018 x86_64 GNU/Linux
$ pacman -Qi mkosi-git | grep Version
Version         : 4.r26.gfae2f13-1
$ sudo mkosi -d ubuntu
...
I: Configuring libhogweed4:amd64...
I: Configuring libp11-kit0:amd64...
I: Configuring libgnutls30:amd64...
I: Configuring apt...
I: Configuring libc-bin...
I: Base system installed successfully.
Failed to mount n/a on /var/tmp/mkosi-_jl3y0do/root/usr/share/zoneinfo/UTC (MS_BIND ""): No such file or directory

execv(rm) failed: No such file or directory
‣ Unmounting Package Cache...
‣ Unmounting Package Cache complete.
‣ Unmounting image...
‣ Unmounting image complete.
‣ Detaching image file...
‣ Detaching image file complete.
Traceback (most recent call last):
  File "/usr/bin/mkosi", line 3693, in <module>
    main()
  File "/usr/bin/mkosi", line 3683, in main
    build_stuff(args)
  File "/usr/bin/mkosi", line 3526, in build_stuff
    raw, tar, root_hash = build_image(args, workspace, run_build_script=False, for_cache=True)
  File "/usr/bin/mkosi", line 3391, in build_image
    install_distribution(args, workspace.name, run_build_script, cached)
  File "/usr/bin/mkosi", line 1599, in install_distribution
    install[args.distribution](args, workspace, run_build_script)
  File "/usr/lib/python3.7/contextlib.py", line 74, in inner
    return func(*args, **kwds)
  File "/usr/bin/mkosi", line 1355, in install_ubuntu
    install_debian_or_ubuntu(args, workspace, run_build_script, args.mirror)
  File "/usr/bin/mkosi", line 1339, in install_debian_or_ubuntu
    run_workspace_command(args, workspace, *cmdline)
  File "/usr/bin/mkosi", line 929, in run_workspace_command
    run(cmdline, check=True)
  File "/usr/lib/python3.7/subprocess.py", line 468, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['systemd-nspawn', '--quiet', '--directory=/var/tmp/mkosi-_jl3y0do/root', '--uuid=79b8d7e8794b4717bdad692d9cd921ee', '--machine=mkosi-5fe3f365c4bd4d93ba60f7a9b8f90355', '--as-pid2', '--register=no', '--bind=/var/tmp/mkosi-_jl3y0do/var-tmp:/var/tmp', '--private-network', '--', 'rm', '-rf', '/usr/share/locale', '/usr/share/doc', '/usr/share/man', '/usr/share/groff', '/usr/share/info', '/usr/share/lintian', '/usr/share/linda']' returned non-zero exit status 1.
```

With the changes of this commit, it succeeds: :heavy_check_mark: 

```
$ uname -a
Linux localhost 4.18.12-arch1-1-ARCH #1 SMP PREEMPT Thu Oct 4 01:01:27 UTC 2018 x86_64 GNU/Linux
$ pacman -Qi mkosi-git | grep Version
Version         : 4.r26.gfae2f13-1
$ sudo mkosi -d ubuntu
...
Failed to mount n/a on /var/tmp/mkosi-a8glm5c2/root/usr/share/zoneinfo/UTC (MS_BIND ""): No such file or directory
Reading package lists... Done
Building dependency tree... Done
The following additional packages will be installed:
  libdbus-1-3 libexpat1
Suggested packages:
  default-dbus-session-bus | dbus-session-bus
The following NEW packages will be installed:
  dbus libdbus-1-3 libexpat1 libpam-systemd
0 upgraded, 4 newly installed, 0 to remove and 0 not upgraded.
Need to get 492 kB of archives.
After this operation, 1758 kB of additional disk space will be used.
Get:1 http://no.archive.ubuntu.com/ubuntu artful/main amd64 libdbus-1-3 amd64 1.10.22-1ubuntu1 [165 kB]
Get:2 http://no.archive.ubuntu.com/ubuntu artful/main amd64 libexpat1 amd64 2.2.3-1 [72.3 kB]
Get:3 http://no.archive.ubuntu.com/ubuntu artful/main amd64 dbus amd64 1.10.22-1ubuntu1 [144 kB]
Get:4 http://no.archive.ubuntu.com/ubuntu artful/main amd64 libpam-systemd amd64 234-2ubuntu12 [111 kB]
Fetched 492 kB in 0s (2056 kB/s)
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package libdbus-1-3:amd64.
(Reading database ... 4716 files and directories currently installed.)
Preparing to unpack .../libdbus-1-3_1.10.22-1ubuntu1_amd64.deb ...
Unpacking libdbus-1-3:amd64 (1.10.22-1ubuntu1) ...
Selecting previously unselected package libexpat1:amd64.
Preparing to unpack .../libexpat1_2.2.3-1_amd64.deb ...
Unpacking libexpat1:amd64 (2.2.3-1) ...
Selecting previously unselected package dbus.
Preparing to unpack .../dbus_1.10.22-1ubuntu1_amd64.deb ...
Unpacking dbus (1.10.22-1ubuntu1) ...
Selecting previously unselected package libpam-systemd:amd64.
Preparing to unpack .../libpam-systemd_234-2ubuntu12_amd64.deb ...
Unpacking libpam-systemd:amd64 (234-2ubuntu12) ...
Setting up libexpat1:amd64 (2.2.3-1) ...
Processing triggers for libc-bin (2.26-0ubuntu2) ...
Processing triggers for systemd (234-2ubuntu12) ...
Setting up libdbus-1-3:amd64 (1.10.22-1ubuntu1) ...
Setting up dbus (1.10.22-1ubuntu1) ...
Setting up libpam-systemd:amd64 (234-2ubuntu12) ...
Processing triggers for libc-bin (2.26-0ubuntu2) ...
Processing triggers for systemd (234-2ubuntu12) ...
‣ Installing Ubuntu complete.
‣ Assigning hostname...
‣ Assigning hostname complete.
‣ Unmounting Package Cache...
‣ Unmounting Package Cache complete.
‣ Resetting machine ID...
‣ Resetting machine ID complete.
‣ Unmounting image...
‣ Unmounting image complete.
‣ Mounting image...
‣ Mounting image complete.
‣ Unmounting image...
‣ Unmounting image complete.
‣ Detaching image file...
‣ Detaching image file complete.
‣ Linking image file...
‣ Successfully linked /home/user/image.raw.
‣ Resulting image size is 1.0G, consumes 124.1M.
```
