### PR TITLE
Make Ubuntu GPT images bootable

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1337,13 +1337,15 @@ def install_debian_or_ubuntu(args, workspace, run_build_script, mirror):
         f.write("#!/bin/sh\n")
         f.write("exit 101")
     os.chmod(policyrcd, 0o755)
-    # Work around "Failed to find module 'crc32c'" dracut issue
-    # See also:
-    # - https://github.com/antonio-petricca/buddy-linux/issues/2#issuecomment-404505527
-    # - https://bugs.launchpad.net/ubuntu/+source/dracut/+bug/1781143
+    dracut_bug_comment = [
+        '# Work around "Failed to find module \'crc32c\'" dracut issue\n',
+        '# See also:\n',
+        '# - https://github.com/antonio-petricca/buddy-linux/issues/2#issuecomment-404505527\n',
+        '# - https://bugs.launchpad.net/ubuntu/+source/dracut/+bug/1781143\n',
+    ]
     dracut_bug_conf = os.path.join(workspace, "root/etc/dpkg/dpkg.cfg.d/01_no_dracut_10-debian")
     with open(dracut_bug_conf, "w") as f:
-        f.writelines(['path-exclude /etc/dracut.conf.d/10-debian.conf\n'])
+        f.writelines(dracut_bug_comment + ['path-exclude /etc/dracut.conf.d/10-debian.conf\n'])
 
     doc_paths = [
         '/usr/share/locale',

--- a/mkosi
+++ b/mkosi
@@ -40,7 +40,6 @@ if sys.version_info < (3, 5):
 
 # TODO
 # - volatile images
-# - make ubuntu images bootable
 # - work on device nodes
 # - allow passing env vars
 

--- a/mkosi
+++ b/mkosi
@@ -1712,6 +1712,12 @@ def install_boot_loader_debian(args, workspace):
     run_workspace_command(args, workspace,
                     "/usr/bin/kernel-install", "add", kernel_version, "/boot/vmlinuz-" + kernel_version)
 
+def install_boot_loader_ubuntu(args, workspace):
+    kernel_version = next(filter(lambda x: x[0].isdigit(), os.listdir(os.path.join(workspace, "root", "lib/modules"))))
+
+    run_workspace_command(args, workspace,
+                    "/usr/bin/kernel-install", "add", kernel_version, "/boot/vmlinuz-" + kernel_version)
+
 def install_boot_loader_opensuse(args, workspace):
     install_boot_loader_debian(args, workspace)
 
@@ -1749,6 +1755,9 @@ def install_boot_loader(args, workspace, loopdev, cached):
 
         if args.distribution == Distribution.debian:
             install_boot_loader_debian(args, workspace)
+
+        if args.distribution == Distribution.ubuntu:
+            install_boot_loader_ubuntu(args, workspace)
 
         if args.distribution == Distribution.opensuse:
             install_boot_loader_opensuse(args, workspace)

--- a/mkosi
+++ b/mkosi
@@ -3054,9 +3054,6 @@ def load_args():
             args.mirror = "http://download.opensuse.org"
 
     if args.bootable:
-        if args.distribution == Distribution.ubuntu:
-            die("Bootable images are currently not supported on Ubuntu.")
-
         if args.output_format in (OutputFormat.directory, OutputFormat.subvolume, OutputFormat.tar):
             die("Directory, subvolume and tar images cannot be booted.")
 

--- a/mkosi
+++ b/mkosi
@@ -1719,10 +1719,7 @@ def install_boot_loader_debian(args, workspace):
                     "/usr/bin/kernel-install", "add", kernel_version, "/boot/vmlinuz-" + kernel_version)
 
 def install_boot_loader_ubuntu(args, workspace):
-    kernel_version = next(filter(lambda x: x[0].isdigit(), os.listdir(os.path.join(workspace, "root", "lib/modules"))))
-
-    run_workspace_command(args, workspace,
-                    "/usr/bin/kernel-install", "add", kernel_version, "/boot/vmlinuz-" + kernel_version)
+    install_boot_loader_debian(args, workspace)
 
 def install_boot_loader_opensuse(args, workspace):
     install_boot_loader_debian(args, workspace)

--- a/mkosi
+++ b/mkosi
@@ -1284,17 +1284,17 @@ gpgkey={gpg_key}
     reenable_kernel_install(args, workspace, masked)
 
 def install_debian_or_ubuntu(args, workspace, run_build_script, mirror):
-    if args.repositories:
-        components = ','.join(args.repositories)
-    else:
-        components = 'main'
+    repos = args.repositories if args.repositories else ["main"]
+    # Ubuntu needs the 'universe' repo to install 'dracut'
+    if args.distribution == Distribution.ubuntu and args.bootable and 'universe' not in repos:
+        repos.append('universe')
     cmdline = ["debootstrap",
                "--verbose",
                "--merged-usr",
                "--variant=minbase",
                "--include=systemd-sysv",
                "--exclude=sysv-rc,initscripts,startpar,lsb-base,insserv",
-               "--components=" + components,
+               "--components=" + ','.join(repos),
                args.release,
                workspace + "/root",
                mirror]

--- a/mkosi
+++ b/mkosi
@@ -1338,6 +1338,13 @@ def install_debian_or_ubuntu(args, workspace, run_build_script, mirror):
         f.write("#!/bin/sh\n")
         f.write("exit 101")
     os.chmod(policyrcd, 0o755)
+    # Work around "Failed to find module 'crc32c'" dracut issue
+    # See also:
+    # - https://github.com/antonio-petricca/buddy-linux/issues/2#issuecomment-404505527
+    # - https://bugs.launchpad.net/ubuntu/+source/dracut/+bug/1781143
+    dracut_bug_conf = os.path.join(workspace, "root/etc/dpkg/dpkg.cfg.d/01_no_dracut_10-debian")
+    with open(dracut_bug_conf, "w") as f:
+        f.writelines(['path-exclude /etc/dracut.conf.d/10-debian.conf\n'])
 
     doc_paths = [
         '/usr/share/locale',

--- a/mkosi
+++ b/mkosi
@@ -1321,7 +1321,11 @@ def install_debian_or_ubuntu(args, workspace, run_build_script, mirror):
         f.write("hostonly=no")
 
     if args.bootable:
-        extra_packages += ["linux-image-amd64", "dracut"]
+        extra_packages += ["dracut"]
+        if args.distribution == Distribution.ubuntu:
+            extra_packages += ["linux-generic"]
+        else:
+            extra_packages += ["linux-image-amd64"]
 
     # Debian policy is to start daemons by default.
     # The policy-rc.d script can be used choose which ones to start


### PR DESCRIPTION
As today the discussion about making Ubuntu GPT images bootable came up on IRC again, I remembered having fixed this problem before but just never pushed it + filed a PR.

So here it is...

This basically overrides #267 which lacks:
- the fix for the dracut/crc32 issue
- `install_boot_loader_ubuntu()`
- the handling of the `universe` repository required for installing `dracut` on Ubuntu