### PR TITLE
Fix possible None value in prepare_swap

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -522,7 +522,9 @@ def prepare_swap(args: argparse.Namespace, loopdev: Optional[str], cached: bool)
         return
 
     with complete_step('Formatting swap partition'):
-        run(["mkswap", "-Lswap", partition(loopdev, args.swap_partno)], check=True)
+        part = partition(loopdev, args.swap_partno)
+        if part is not None:
+            run(["mkswap", "-Lswap", part], check=True)
 
 def prepare_esp(args: argparse.Namespace, loopdev: Optional[str], cached: bool) -> None:
     if loopdev is None:

--- a/mkosi
+++ b/mkosi
@@ -507,7 +507,7 @@ def attach_image_loopback(args: argparse.Namespace, raw: Optional[IO[str]]):
         with complete_step('Detaching image file'):
             run(["losetup", "--detach", loopdev], check=True)
 
-def partition(loopdev: str, partno: Optional[int]) -> Optional[str]:
+def partition(loopdev: str, partno: int) -> str:
     if partno is None:
         return None
 
@@ -522,9 +522,7 @@ def prepare_swap(args: argparse.Namespace, loopdev: Optional[str], cached: bool)
         return
 
     with complete_step('Formatting swap partition'):
-        part = partition(loopdev, args.swap_partno)
-        if part is not None:
-            run(["mkswap", "-Lswap", part], check=True)
+        run(["mkswap", "-Lswap", partition(loopdev, args.swap_partno)], check=True)
 
 def prepare_esp(args: argparse.Namespace, loopdev: Optional[str], cached: bool) -> None:
     if loopdev is None:


### PR DESCRIPTION
Mypy reports that partition() may return None and break the
requirements of subprocess.run():

    mkosi:525: error: List item 2 has incompatible type "Optional[str]";
    expected "Union[bytes, str, _PathLike[Any]]"

There are plenty of issues like so please treat this patch as an RFC. I
think the best way forward is to reduce the number of optional values to
the point where such checks are not needed. The generic nature of many
helpers (looking at the args and returning None if some condition
doesn't hold) amplifies this problem.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>