### PR TITLE
Bump required Python version everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ in addition to `debootstrap`, depending on what kind of distribution images
 you want to build. `debootstrap` on Debian only pulls in the Debian keyring
 on its own, and the version on Ubuntu only the one from Ubuntu.
 
-Note that the minimum required Python version is 3.5.
+Note that the minimum required Python version is 3.6.
 
 If SecureBoot signing is to be used, then the "sbsign" tool needs to
 be installed as well, which is currently not available on Fedora, but

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@
 
 import sys
 
-if sys.version_info < (3, 5):
-    sys.exit("Sorry, we need at least Python 3.5.")
+if sys.version_info < (3, 6):
+    sys.exit("Sorry, we need at least Python 3.6.")
 
 from setuptools import setup
 


### PR DESCRIPTION
The required Python version was bumped to 3.6 in e965e58a3f (because we now use f-strings), but `README.md` and `setup.py` weren’t updated.