### PR TITLE
Fix function signature for Clear

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1122,7 +1122,7 @@ def invoke_dnf(args: CommandLineArguments, workspace: str, repositories: List[st
         clean_rpm_metadata(root)
 
 @complete_step('Installing Clear Linux')
-def install_clear(args: CommandLineArguments, *, workspace: str, run_build_script: bool, cleanup: bool):
+def install_clear(args: CommandLineArguments, workspace: str, run_build_script: bool, cleanup: bool) -> None:
     if args.release == "latest":
         release = "clear"
     else:


### PR DESCRIPTION
  File "/usr/lib64/python3.7/contextlib.py", line 74, in inner
    return func(*args, **kwds)
TypeError: install_clear() takes 1 positional argument but 2 positional arguments (and 2 keyword-only arguments) were given