### PR TITLE
include args.packages for centos builds

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1363,6 +1363,7 @@ gpgkey={gpg_key}
 """)
 
     packages = ['centos-release']
+    packages += args.packages or []
     if args.bootable:
         packages += ["kernel", "systemd-udev", "binutils"]
     invoke_dnf_or_yum(args, workspace,


### PR DESCRIPTION
There seems to be a regression in `install_centos()`, at no point the user provided `args.packages` are used when installing centos.

Excerpt `install_fedora()`:
```python
    packages = ['fedora-release', 'glibc-minimal-langpack']
    packages += args.packages or []
    if args.bootable:
        packages += ['kernel-core', 'systemd-udev', 'binutils']
    if run_build_script:
        packages += args.build_packages or []
    invoke_dnf(args, workspace,
               args.repositories or ["fedora", "updates"],
               packages,
               config_file,
               cleanup=cleanup)
```

Excerpt `install_centos()`:
```python
    packages = ['centos-release']
    if args.bootable:
        packages += ["kernel", "systemd-udev", "binutils"]
    invoke_dnf_or_yum(args, workspace,
                      args.repositories or ["base", "updates"],
                      packages,
                      config_file,
                      cleanup=cleanup)
```

This PR fixes `install_centos()` by adding `args.packages` to the `packages` variable before handing that over to dnf or yum.