### PR TITLE
set correct defaults for optional args

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -2594,7 +2594,7 @@ def parse_args() -> CommandLineArguments:
 
     group = parser.add_argument_group("Packages")
     group.add_argument('-p', "--package", action=CommaDelimitedListAction, dest='packages', default=[], help='Add an additional package to the OS image', metavar='PACKAGE')
-    group.add_argument("--with-docs", action='store_true', help='Install documentation (only Fedora, CentOS and Mageia)')
+    group.add_argument("--with-docs", action='store_true', help='Install documentation (only Fedora, CentOS and Mageia)', default=None)
     group.add_argument('-T', "--without-tests", action='store_false', dest='with_tests', default=True, help='Do not run tests as part of build script, if supported')
     group.add_argument("--cache", dest='cache_path', help='Package cache path', metavar='PATH')
     group.add_argument("--extra-tree", action='append', dest='extra_trees', default=[], help='Copy an extra tree on top of image', metavar='PATH')
@@ -2609,7 +2609,7 @@ def parse_args() -> CommandLineArguments:
                        help='Ignore any files that git itself ignores (default: guess)')
     group.add_argument('--git-files', choices=('cached', 'others'),
                        help='Whether to include untracked files (default: others)')
-    group.add_argument("--with-network", action='store_true', help='Run build and postinst scripts with network access (instead of private network)')
+    group.add_argument("--with-network", action='store_true', help='Run build and postinst scripts with network access (instead of private network)', default=None)
     group.add_argument("--settings", dest='nspawn_settings', help='Add in .spawn settings file', metavar='PATH')
 
     group = parser.add_argument_group("Partitions")


### PR DESCRIPTION
args.with_network and args.with_docs were always initialized to `False`
thus ignoring any setting in a config file (WithNetwork/WithDocs).

This breaks the config parser (load_defaults) because it checks if the
current value of `key` is None before assigning the value from the
config file.

Signed-off-by: Thore Bödecker <me@foxxx0.de>