### PR TITLE
Refactor config options parsing

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -3008,7 +3008,7 @@ def parse_compression(value: str) -> Union[str, bool]:
     return parse_boolean(value)
 
 
-def parse_args() -> CommandLineArguments:
+def parse_args() -> (CommandLineArguments, ArgumentConfigParser):
     parser = ArgumentConfigParser(description='Build Legacy-Free OS Images', add_help=False)
 
     # command-line arguments only
@@ -3148,7 +3148,7 @@ def parse_args() -> CommandLineArguments:
 
     args_find_path(args, 'all_directory', "mkosi.files/")
 
-    return args
+    return args, parser
 
 
 def parse_bytes(bytes: Optional[str]) -> Optional[int]:
@@ -3319,245 +3319,59 @@ def parse_boolean(s: str) -> bool:
 
     raise ValueError(f'Invalid literal for bool(): {s!r}')
 
-
-def process_setting(args: CommandLineArguments, section: str, key: Optional[str], value: Any) -> bool:
-    if section == "Distribution":
-        if key == "Distribution":
-            if args.distribution is None:
-                args.distribution = value
-        elif key == "Release":
-            if args.release is None:
-                args.release = value
-        elif key == "Repositories":
-            list_value = value if type(value) == list else value.split()
-            if args.repositories is None:
-                args.repositories = list_value
-            else:
-                args.repositories.extend(list_value)
-        elif key == "Mirror":
-            if args.mirror is None:
-                args.mirror = value
-        elif key == 'Architecture':
-            if args.architecture is None:
-                args.architecture = value
-        elif key is None:
-            return True
-        else:
-            return False
-    elif section == "Output":
-        if key == "Format":
-            if args.output_format is None:
-                args.output_format = OutputFormat[value]
-        elif key == "Output":
-            if args.output is None:
-                args.output = value
-        elif key == "OutputDirectory":
-            if args.output_dir is None:
-                args.output_dir = value
-        elif key == "Force":
-            if args.force is None:
-                args.force = parse_boolean(value)
-        elif key == "Bootable":
-            if args.bootable is None:
-                args.bootable = parse_boolean(value)
-        elif key == "BootProtocols":
-            if not args.boot_protocols:
-                args.boot_protocols = value if type(value) == list else value.split()
-        elif key == "KernelCommandLine":
-            if args.kernel_command_line is None:
-                args.kernel_command_line = value
-        elif key == "SecureBoot":
-            if args.secure_boot is None:
-                args.secure_boot = parse_boolean(value)
-        elif key == "SecureBootKey":
-            if args.secure_boot_key is None:
-                args.secure_boot_key = value
-        elif key == "SecureBootCertificate":
-            if args.secure_boot_certificate is None:
-                args.secure_boot_certificate = value
-        elif key == "ReadOnly":
-            if args.read_only is None:
-                args.read_only = parse_boolean(value)
-        elif key == "Encrypt":
-            if args.encrypt is None:
-                if value not in ("all", "data"):
-                    raise ValueError("Invalid encryption setting: " + value)
-                args.encrypt = value
-        elif key == "Verity":
-            if args.verity is None:
-                args.verity = parse_boolean(value)
-        elif key == "Compress":
-            if args.compress is None:
-                args.compress = parse_compression(value)
-        elif key == 'Mksquashfs':
-            if args.mksquashfs_tool is None:
-                args.mksquashfs_tool = value.split()
-        elif key == "XZ":
-            if args.xz is None:
-                args.xz = parse_boolean(value)
-        elif key == "QCow2":
-            if args.qcow2 is None:
-                args.qcow2 = parse_boolean(value)
-        elif key == "Hostname":
-            if not args.hostname:
-                args.hostname = value
-        elif key is None:
-            return True
-        else:
-            return False
-    elif section == "Packages":
-        if key == "Packages":
-            list_value = value if type(value) == list else value.split()
-            args.packages.extend(list_value)
-        elif key == "WithDocs":
-            if args.with_docs is None:
-                args.with_docs = parse_boolean(value)
-        elif key == "WithTests":
-            if args.with_tests is None:
-                args.with_tests = parse_boolean(value)
-        elif key == "Cache":
-            if args.cache_path is None:
-                args.cache_path = value
-        elif key == "ExtraTrees":
-            list_value = value if type(value) == list else value.split()
-            args.extra_trees.extend(list_value)
-        elif key == "SkeletonTrees":
-            list_value = value if type(value) == list else value.split()
-            args.skeleton_trees.extend(list_value)
-        elif key == "BuildScript":
-            if args.build_script is None:
-                args.build_script = value
-        elif key == "BuildSources":
-            if args.build_sources is None:
-                args.build_sources = value
-        elif key == "SourceFileTransfer":
-            if args.source_file_transfer is None:
-                try:
-                    args.source_file_transfer = SourceFileTransfer(value)
-                except ValueError:
-                    raise ValueError(f"Invalid source file transfer setting: {value}")
-        elif key == "BuildDirectory":
-            if args.build_dir is None:
-                args.build_dir = value
-        elif key == "BuildPackages":
-            list_value = value if type(value) == list else value.split()
-            args.build_packages.extend(list_value)
-        elif key in {"PostinstallScript", "PostInstallationScript"}:
-            if args.postinst_script is None:
-                args.postinst_script = value
-        elif key == "FinalizeScript":
-            if args.finalize_script is None:
-                args.finalize_script = value
-        elif key == "WithNetwork":
-            if args.with_network is None:
-                args.with_network = parse_boolean(value)
-        elif key == "NSpawnSettings":
-            if args.nspawn_settings is None:
-                args.nspawn_settings = value
-        elif key is None:
-            return True
-        else:
-            return False
-    elif section == "Partitions":
-        if key == "RootSize":
-            if args.root_size is None:
-                args.root_size = value
-        elif key == "ESPSize":
-            if args.esp_size is None:
-                args.esp_size = value
-        elif key == "SwapSize":
-            if args.swap_size is None:
-                args.swap_size = value
-        elif key == "HomeSize":
-            if args.home_size is None:
-                args.home_size = value
-        elif key == "SrvSize":
-            if args.srv_size is None:
-                args.srv_size = value
-        elif key is None:
-            return True
-        else:
-            return False
-    elif section == "Validation":
-        if key == "CheckSum":
-            if args.checksum is None:
-                args.checksum = parse_boolean(value)
-        elif key == "Sign":
-            if args.sign is None:
-                args.sign = parse_boolean(value)
-        elif key == "Key":
-            if args.key is None:
-                args.key = value
-        elif key == "Bmap":
-            if args.bmap is None:
-                args.bmap = parse_boolean(value)
-        elif key == "Password":
-            if args.password is None:
-                args.password = value
-        elif key is None:
-            return True
-        else:
-            return False
-    elif section == "Host":
-        if key == "ExtraSearchPaths":
-            list_value = value if type(value) == list else value.split()
-            for v in list_value:
-                args.extra_search_paths.extend(v.split(":"))
-    else:
-        return False
-
-    return True
-
-
-def load_defaults_file(fname: str, options: Dict[str, Dict[str, Any]]) -> Optional[Dict[str, Dict[str, Any]]]:
+def load_defaults_file(fname: str, argconf: ArgumentConfigParser, options: Dict[str, Dict[str, Any]]) -> Optional[Dict[str, Dict[str, Any]]]:
     try:
         f = open(fname)
     except FileNotFoundError:
         return None
 
-    config = configparser.ConfigParser(delimiters='=')
-    config.optionxform = str  # type: ignore
-    config.read_file(f)
+    file_parser = configparser.ConfigParser(delimiters='=')
+    file_parser.optionxform = str
+    file_parser.read_file(f)
 
-    # this is used only for validation
-    args = parse_args()
-
-    for section in config.sections():
-        if not process_setting(args, section, None, None):
+    for section in file_parser.sections():
+        if not section in argconf.sections():
             sys.stderr.write(f"Unknown section in {fname!r}, ignoring: [{section}]\n")
             continue
         if section not in options:
             options[section] = {}
-        for key in config[section]:
-            if not process_setting(args, section, key, config[section][key]):
-                sys.stderr.write(f'Unknown key in section [{section}] in {fname!r}, ignoring: {key}=\n')
+        for key in file_parser[section]:
+            if not key in argconf.keys(section):
+                sys.stderr.write(f'Unknown key in section [{section}] in {fname!r}, ignoring: {key}\n')
                 continue
-            if section == "Packages" and key in ["Packages", "ExtraTrees", "BuildPackages"]:
-                if key in options[section]:
-                    options[section][key].extend(config[section][key].split())
-                else:
-                    options[section][key] = config[section][key].split()
+            if argconf.flags(section, key) == ArgumentConfigParser.FLAGS.Extend:
+                value = file_parser[section][key].split()
+                options[section].setdefault(key, []).extend(value)
             else:
-                options[section][key] = config[section][key]
+                value = file_parser[section][key]
+                options[section][key] = value
     return options
 
 
-def load_defaults(args: CommandLineArguments) -> None:
+def load_defaults(args: CommandLineArguments, argconf: ArgumentConfigParser) -> None:
     fname = "mkosi.default" if args.default_path is None else args.default_path
 
-    config: Dict[str, Dict[str, str]] = {}
-    load_defaults_file(fname, config)
+    options = {} # type: Dict[str, Dict[str, str]]
+    load_defaults_file(fname, argconf, options)
 
     defaults_dir = fname + '.d'
     if os.path.isdir(defaults_dir):
         for defaults_file in sorted(os.listdir(defaults_dir)):
             defaults_path = os.path.join(defaults_dir, defaults_file)
             if os.path.isfile(defaults_path):
-                load_defaults_file(defaults_path, config)
+                load_defaults_file(defaults_path, argconf, options)
 
-    for section in config.keys():
-        for key in config[section]:
-            process_setting(args, section, key, config[section][key])
+    for section in options.keys():
+        for key in options[section]:
+            value = options[section][key]
+            _, arg, flags = argconf.option(section, key)
+
+            if flags == ArgumentConfigParser.FLAGS.Extend:
+                value.extend(getattr(args, arg.dest))
+            elif not getattr(args, arg.dest) is None:
+                continue
+
+            setattr(args, arg.dest, value)
 
 
 def find_nspawn_settings(args: CommandLineArguments) -> None:
@@ -3697,11 +3511,11 @@ def build_root_hash_file_path(path: str) -> str:
     return strip_suffixes(path) + ".roothash"
 
 
-def load_args(args) -> CommandLineArguments:
+def load_args(args, argconf) -> CommandLineArguments:
     global arg_debug
     arg_debug = args.debug
 
-    load_defaults(args)
+    load_defaults(args, argconf)
 
     args_find_path(args, 'nspawn_settings', "mkosi.nspawn")
     args_find_path(args, 'build_script',    "mkosi.build")
@@ -4498,8 +4312,8 @@ def prepend_to_environ_path(paths: List[str]) -> None:
         os.environ["PATH"] = new_path + ":" + original_path
 
 
-def run_verb(args):
-    load_args(args)
+def run_verb(args, argconf):
+    load_args(args, argconf)
 
     prepend_to_environ_path(args.extra_search_paths)
 
@@ -4530,14 +4344,13 @@ def run_verb(args):
 
 
 def main() -> None:
-    args = parse_args()
+    args, argconf = parse_args()
 
     if args.directory is not None:
         os.chdir(args.directory)
 
     if args.all:
         for f in os.scandir(args.all_directory):
-
             if not f.name.startswith("mkosi."):
                 continue
 
@@ -4545,9 +4358,9 @@ def main() -> None:
             a.default_path = f.path
 
             with complete_step('Processing ' + f.path):
-                run_verb(a)
+                run_verb(a, argconf)
     else:
-        run_verb(args)
+        run_verb(args, argconf)
 
 
 if __name__ == "__main__":

--- a/mkosi
+++ b/mkosi
@@ -3051,8 +3051,9 @@ def parse_args() -> CommandLineArguments:
     group.add_argument("--password", help='Set the root password')
 
     group = parser.add_argument_group("Host configuration")
-    group.add_argument("--extra-search-paths", action=ColonDelimitedListAction, default=[],
+    group.add_argument("--extra-search-path", dest='extra_search_paths', action=ColonDelimitedListAction, default=[],
                        help="List of colon-separated paths to look for programs before looking in PATH")
+    group.add_argument("--extra-search-paths", dest='extra_search_paths', action=ColonDelimitedListAction, help=argparse.SUPPRESS) # Compatibility option
 
     group = parser.add_argument_group("Additional Configuration")
     group.add_argument('-C', "--directory", help='Change to specified directory before doing anything', metavar='PATH')

--- a/mkosi
+++ b/mkosi
@@ -2909,6 +2909,64 @@ def setup_package_cache(args: CommandLineArguments) -> Optional[tempfile.Tempora
     return d
 
 
+class ArgumentConfigParser():
+    options = dict()
+    argparser = None
+    curr_group_title = None
+    curr_group = None
+    FLAGS = enum.Enum('FLAGS', 'Extend')
+
+    def __init__(self, *kargs, **kwargs):
+        self.argparser = argparse.ArgumentParser(*kargs, **kwargs)
+
+    def add_section(self, *kargs, **kwargs):
+        fp_name = kwargs.pop('file_parser_name', None)
+
+        self.curr_group = self.argparser.add_argument_group(*kargs, **kwargs)
+        self.curr_group_title = fp_name or self.curr_group.title
+        self.options[self.curr_group_title] = []
+
+    def add_argument(self, *kargs, **kwargs):
+        # default to add an option to config file that has the same name as the argument option,
+        # except that it is converted to CamelCase as per _arg_to_option().
+        # Setting file_parser_name=None allows to add the option only to the command line
+        fp_name = kwargs.pop('file_parser_name', "")
+        fp_flags = kwargs.pop('file_parser_flags', None)
+
+        arg = self.argparser.add_argument(*kargs, **kwargs)
+        if fp_name is None:
+            return
+
+        if not fp_name:
+            fp_name = self._arg_to_option(arg)
+
+        self.options[self.curr_group_title] += [(fp_name, arg, fp_flags)]
+
+        return arg
+
+    def sections(self):
+        return self.options.keys()
+
+    def keys(self, section):
+        return [t[0] for t in self.options[section]]
+
+    def flags(self, section, key):
+        for t in self.options[section]:
+            if t[0] == key:
+                return t[2]
+        return None
+
+    def option(self, section, key):
+        for t in self.options[section]:
+            if t[0] == key:
+                return t
+        return None
+
+    def _arg_to_option(self, arg):
+        """Convert command line argument into CamelCase to be used as config option"""
+        return "".join(w.capitalize() for w in arg.dest.split("_"))
+
+
 class ListAction(argparse.Action):
     delimiter: str
 
@@ -2951,129 +3009,138 @@ def parse_compression(value: str) -> Union[str, bool]:
 
 
 def parse_args() -> CommandLineArguments:
-    parser = argparse.ArgumentParser(description='Build Legacy-Free OS Images', add_help=False)
+    parser = ArgumentConfigParser(description='Build Legacy-Free OS Images', add_help=False)
 
-    group = parser.add_argument_group("Commands")
+    # command-line arguments only
+    group = parser.argparser.add_argument_group("Commands")
     group.add_argument("verb", choices=("build", "clean", "help", "summary", "shell", "boot", "qemu"), nargs='?',
                        default="build", help='Operation to execute')
     group.add_argument("cmdline", nargs=argparse.REMAINDER, help="The command line to use for 'shell', 'boot', 'qemu'")
     group.add_argument('-h', '--help', action='help', help="Show this help")
     group.add_argument('--version', action='version', version='%(prog)s ' + __version__)
 
-    group = parser.add_argument_group("Distribution")
-    group.add_argument('-d', "--distribution", choices=Distribution.__members__, help='Distribution to install')
-    group.add_argument('-r', "--release", help='Distribution release to install')
-    group.add_argument('-m', "--mirror", help='Distribution mirror to use')
-    group.add_argument("--repositories", action=CommaDelimitedListAction, dest='repositories',
-                       help='Repositories to use', metavar='REPOS')
-    group.add_argument('--architecture', help='Override the architecture of installation')
+    parser.add_section("Distribution")
+    parser.add_argument('-d', "--distribution", choices=Distribution.__members__, help='Distribution to install')
+    parser.add_argument('-r', "--release", help='Distribution release to install')
+    parser.add_argument('-m', "--mirror", help='Distribution mirror to use')
+    parser.add_argument("--repositories", action=CommaDelimitedListAction, dest='repositories',
+                        help='Repositories to use', metavar='REPOS',
+                        file_parser_flags=ArgumentConfigParser.FLAGS.Extend)
+    parser.add_argument('--architecture', help='Override the architecture of installation')
 
-    group = parser.add_argument_group("Output")
-    group.add_argument('-t', "--format", dest='output_format', choices=OutputFormat, type=OutputFormat.from_string,
-                       help='Output Format')
-    group.add_argument('-o', "--output", help='Output image path', metavar='PATH')
-    group.add_argument('-O', "--output-dir", help='Output root directory', metavar='DIR')
-    group.add_argument('-f', "--force", action='count', dest='force_count', default=0,
-                       help='Remove existing image file before operation')
-    group.add_argument('-b', "--bootable", type=parse_boolean, nargs='?', const=True,
-                       help='Make image bootable on EFI (only gpt_ext4, gpt_xfs, gpt_btrfs, gpt_squashfs)')
-    group.add_argument("--boot-protocols", action=CommaDelimitedListAction,
-                       help="Boot protocols to use on a bootable image", metavar="PROTOCOLS", default=[])
-    group.add_argument("--kernel-command-line", help='Set the kernel command line (only bootable images)')
-    group.add_argument("--kernel-commandline", dest='kernel_command_line', help=argparse.SUPPRESS) # Compatibility option
-    group.add_argument("--secure-boot", action='store_true',
-                       help='Sign the resulting kernel/initrd image for UEFI SecureBoot')
-    group.add_argument("--secure-boot-key", help="UEFI SecureBoot private key in PEM format", metavar='PATH')
-    group.add_argument("--secure-boot-certificate", help="UEFI SecureBoot certificate in X509 format", metavar='PATH')
-    group.add_argument("--read-only", action='store_true',
-                       help='Make root volume read-only (only gpt_ext4, gpt_xfs, gpt_btrfs, subvolume, implied with gpt_squashfs and plain_squashfs)')
-    group.add_argument("--encrypt", choices=("all", "data"),
-                       help='Encrypt everything except: ESP ("all") or ESP and root ("data")')
-    group.add_argument("--verity", action='store_true', help='Add integrity partition (implies --read-only)')
-    group.add_argument("--compress", type=parse_compression,
-                       help='Enable compression in file system (only gpt_btrfs, subvolume, gpt_squashfs, plain_squashfs)')
-    group.add_argument('--mksquashfs', dest='mksquashfs_tool', type=str.split,
-                       help='Script to call instead of mksquashfs')
-    group.add_argument("--xz", action='store_true',
-                       help='Compress resulting image with xz (only gpt_ext4, gpt_xfs, gpt_btrfs, gpt_squashfs, implied on tar)')  # NOQA: E501
-    group.add_argument("--qcow2", action='store_true',
-                       help='Convert resulting image to qcow2 (only gpt_ext4, gpt_xfs, gpt_btrfs, gpt_squashfs)')
-    group.add_argument("--hostname", help="Set hostname")
-    group.add_argument('--no-chown', action='store_true',
-                       help='When running with sudo, disable reassignment of ownership of the generated files to the original user')  # NOQA: E501
-    group.add_argument('-i', "--incremental", action='store_true',
-                       help='Make use of and generate intermediary cache images')
+    parser.add_section("Output")
+    parser.add_argument('-t', "--format", dest='output_format', choices=OutputFormat, type=OutputFormat.from_string,
+                        help='Output Format')
+    parser.add_argument('-o', "--output", help='Output image path', metavar='PATH')
+    parser.add_argument('-O', "--output-dir", help='Output root directory', metavar='DIR',
+                        file_parser_name="OutputDirectory")
+    parser.add_argument('-f', "--force", action='count', dest='force_count', default=0,
+                        help='Remove existing image file before operation',
+                        file_parser_name=None)
+    parser.add_argument('-b', "--bootable", type=parse_boolean, nargs='?', const=True,
+                        help='Make image bootable on EFI (only gpt_ext4, gpt_xfs, gpt_btrfs, gpt_squashfs)')
+    parser.add_argument("--boot-protocols", action=CommaDelimitedListAction,
+                        help="Boot protocols to use on a bootable image", metavar="PROTOCOLS", default=[])
+    parser.add_argument("--kernel-command-line", help='Set the kernel command line (only bootable images)')
+    parser.add_argument("--kernel-commandline", dest='kernel_command_line', help=argparse.SUPPRESS,
+                        file_parser_name=None) # Compatibility option
+    parser.add_argument("--secure-boot", action='store_true',
+                        help='Sign the resulting kernel/initrd image for UEFI SecureBoot')
+    parser.add_argument("--secure-boot-key", help="UEFI SecureBoot private key in PEM format", metavar='PATH')
+    parser.add_argument("--secure-boot-certificate", help="UEFI SecureBoot certificate in X509 format", metavar='PATH')
+    parser.add_argument("--read-only", action='store_true',
+                        help='Make root volume read-only (only gpt_ext4, gpt_xfs, gpt_btrfs, subvolume, implied with gpt_squashfs and plain_squashfs)')
+    parser.add_argument("--encrypt", choices=("all", "data"),
+                        help='Encrypt everything except: ESP ("all") or ESP and root ("data")')
+    parser.add_argument("--verity", action='store_true', help='Add integrity partition (implies --read-only)')
+    parser.add_argument("--compress", type=parse_compression,
+                        help='Enable compression in file system (only gpt_btrfs, subvolume, gpt_squashfs, plain_squashfs)')
+    parser.add_argument('--mksquashfs', dest='mksquashfs_tool', type=str.split,
+                        help='Script to call instead of mksquashfs')
+    parser.add_argument("--xz", action='store_true',
+                        help='Compress resulting image with xz (only gpt_ext4, gpt_xfs, gpt_btrfs, gpt_squashfs, implied on tar)')  # NOQA: E501
+    parser.add_argument("--qcow2", action='store_true',
+                        help='Convert resulting image to qcow2 (only gpt_ext4, gpt_xfs, gpt_btrfs, gpt_squashfs)')
+    parser.add_argument("--hostname", help="Set hostname")
+    parser.add_argument('--no-chown', action='store_true',
+                        help='When running with sudo, disable reassignment of ownership of the generated files to the original user',
+                        file_parser_name=None)  # NOQA: E501
+    parser.add_argument('-i', "--incremental", action='store_true',
+                        help='Make use of and generate intermediary cache images')
 
-    group = parser.add_argument_group("Packages")
-    group.add_argument('-p', "--package", action=CommaDelimitedListAction, dest='packages', default=[],
-                       help='Add an additional package to the OS image', metavar='PACKAGE')
-    group.add_argument("--with-docs", action='store_true', default=None,
-                       help='Install documentation')
-    group.add_argument('-T', "--without-tests", action='store_false', dest='with_tests', default=True,
-                       help='Do not run tests as part of build script, if supported')
-    group.add_argument("--cache", dest='cache_path', help='Package cache path', metavar='PATH')
-    group.add_argument("--extra-tree", action='append', dest='extra_trees', default=[],
-                       help='Copy an extra tree on top of image', metavar='PATH')
-    group.add_argument("--skeleton-tree", action='append', dest='skeleton_trees', default=[],
-                       help='Use a skeleton tree to bootstrap the image before installing anything', metavar='PATH')
-    group.add_argument("--build-script", help='Build script to run inside image', metavar='PATH')
-    group.add_argument("--build-sources", help='Path for sources to build', metavar='PATH')
-    group.add_argument("--build-dir", help='Path to use as persistent build directory', metavar='PATH')
-    group.add_argument("--build-package", action=CommaDelimitedListAction, dest='build_packages', default=[],
-                       help='Additional packages needed for build script', metavar='PACKAGE')
-    group.add_argument("--postinst-script", help='Postinstall script to run inside image', metavar='PATH')
-    group.add_argument("--finalize-script", help='Postinstall script to run outside image', metavar='PATH')
-    group.add_argument("--source-file-transfer", type=SourceFileTransfer, choices=list(SourceFileTransfer), default=None,
-                       help="Method used to copy build sources to the build image." +
-                       "; ".join([f"'{k}': {v}" for k, v in SourceFileTransfer.doc().items()]) + " (default: copy-git-cached if in a git repository, otherwise copy-all)")
-    group.add_argument("--with-network", action='store_true', default=None,
-                       help='Run build and postinst scripts with network access (instead of private network)')
-    group.add_argument("--settings", dest='nspawn_settings', help='Add in .spawn settings file', metavar='PATH')
+    parser.add_section("Packages")
+    parser.add_argument('-p', "--package", action=CommaDelimitedListAction, dest='packages', default=[],
+                        help='Add an additional package to the OS image', metavar='PACKAGE')
+    parser.add_argument("--with-docs", action='store_true', default=None,
+                        help='Install documentation')
+    parser.add_argument('-T', "--without-tests", action='store_false', dest='with_tests', default=True,
+                        help='Do not run tests as part of build script, if supported')
+    parser.add_argument("--cache", dest='cache_path', help='Package cache path', metavar='PATH')
+    parser.add_argument("--extra-tree", action='append', dest='extra_trees', default=[],
+                        help='Copy an extra tree on top of image', metavar='PATH',
+                        file_parser_flags=ArgumentConfigParser.FLAGS.Extend)
+    parser.add_argument("--skeleton-tree", action='append', dest='skeleton_trees', default=[],
+                        help='Use a skeleton tree to bootstrap the image before installing anything', metavar='PATH',
+                        file_parser_flags=ArgumentConfigParser.FLAGS.Extend)
+    parser.add_argument("--build-script", help='Build script to run inside image', metavar='PATH')
+    parser.add_argument("--build-sources", help='Path for sources to build', metavar='PATH')
+    parser.add_argument("--build-dir", help='Path to use as persistent build directory', metavar='PATH')
+    parser.add_argument("--build-package", action=CommaDelimitedListAction, dest='build_packages', default=[],
+                        help='Additional packages needed for build script', metavar='PACKAGE',
+                        file_parser_flags=ArgumentConfigParser.FLAGS.Extend)
+    parser.add_argument("--postinst-script", help='Postinstall script to run inside image', metavar='PATH')
+    parser.add_argument("--finalize-script", help='Postinstall script to run outside image', metavar='PATH')
+    parser.add_argument("--source-file-transfer", type=SourceFileTransfer, choices=list(SourceFileTransfer), default=None,
+                        help="Method used to copy build sources to the build image." +
+                        "; ".join([f"'{k}': {v}" for k, v in SourceFileTransfer.doc().items()]) + " (default: copy-git-cached if in a git repository, otherwise copy-all)")
+    parser.add_argument("--with-network", action='store_true', default=None,
+                        help='Run build and postinst scripts with network access (instead of private network)')
+    parser.add_argument("--settings", dest='nspawn_settings', help='Add in .spawn settings file', metavar='PATH')
 
-    group = parser.add_argument_group("Partitions")
-    group.add_argument("--root-size",
-                       help='Set size of root partition (only gpt_ext4, gpt_xfs, gpt_btrfs)', metavar='BYTES')
-    group.add_argument("--esp-size",
-                       help='Set size of EFI system partition (only gpt_ext4, gpt_xfs, gpt_btrfs, gpt_squashfs)', metavar='BYTES')  # NOQA: E501
-    group.add_argument("--swap-size",
-                       help='Set size of swap partition (only gpt_ext4, gpt_xfs, gpt_btrfs, gpt_squashfs)', metavar='BYTES')  # NOQA: E501
-    group.add_argument("--home-size",
-                       help='Set size of /home partition (only gpt_ext4, gpt_xfs, gpt_squashfs)', metavar='BYTES')
-    group.add_argument("--srv-size",
-                       help='Set size of /srv partition (only gpt_ext4, gpt_xfs, gpt_squashfs)', metavar='BYTES')
+    parser.add_section("Partitions")
+    parser.add_argument("--root-size",
+                        help='Set size of root partition (only gpt_ext4, gpt_xfs, gpt_btrfs)', metavar='BYTES')
+    parser.add_argument("--esp-size",
+                        help='Set size of EFI system partition (only gpt_ext4, gpt_xfs, gpt_btrfs, gpt_squashfs)', metavar='BYTES')  # NOQA: E501
+    parser.add_argument("--swap-size",
+                        help='Set size of swap partition (only gpt_ext4, gpt_xfs, gpt_btrfs, gpt_squashfs)', metavar='BYTES')  # NOQA: E501
+    parser.add_argument("--home-size",
+                        help='Set size of /home partition (only gpt_ext4, gpt_xfs, gpt_squashfs)', metavar='BYTES')
+    parser.add_argument("--srv-size",
+                        help='Set size of /srv partition (only gpt_ext4, gpt_xfs, gpt_squashfs)', metavar='BYTES')
 
-    group = parser.add_argument_group("Validation (only gpt_ext4, gpt_xfs, gpt_btrfs, gpt_squashfs, tar)")
-    group.add_argument("--checksum", action='store_true', help='Write SHA256SUMS file')
-    group.add_argument("--sign", action='store_true', help='Write and sign SHA256SUMS file')
-    group.add_argument("--key", help='GPG key to use for signing')
-    group.add_argument("--bmap", action='store_true',
-                       help='Write block map file (.bmap) for bmaptool usage (only gpt_ext4, gpt_btrfs)')
-    group.add_argument("--password", help='Set the root password')
+    parser.add_section("Validation (only gpt_ext4, gpt_xfs, gpt_btrfs, gpt_squashfs, tar)")
+    parser.add_argument("--checksum", action='store_true', help='Write SHA256SUMS file')
+    parser.add_argument("--sign", action='store_true', help='Write and sign SHA256SUMS file')
+    parser.add_argument("--key", help='GPG key to use for signing')
+    parser.add_argument("--bmap", action='store_true',
+                        help='Write block map file (.bmap) for bmaptool usage (only gpt_ext4, gpt_btrfs)')
+    parser.add_argument("--password", help='Set the root password')
 
-    group = parser.add_argument_group("Host configuration")
-    group.add_argument("--extra-search-path", dest='extra_search_paths', action=ColonDelimitedListAction, default=[],
-                       help="List of colon-separated paths to look for programs before looking in PATH")
-    group.add_argument("--extra-search-paths", dest='extra_search_paths', action=ColonDelimitedListAction, help=argparse.SUPPRESS) # Compatibility option
+    parser.add_section("Host configuration", file_parser_name="Host")
+    parser.add_argument("--extra-search-path", dest='extra_search_paths', action=ColonDelimitedListAction, default=[],
+                        help="List of colon-separated paths to look for programs before looking in PATH")
+    parser.add_argument("--extra-search-paths", dest='extra_search_paths', action=ColonDelimitedListAction, help=argparse.SUPPRESS) # Compatibility option
 
-    group = parser.add_argument_group("Additional Configuration")
+    # command-line arguments only
+    group = parser.argparser.add_argument_group("Additional Configuration")
     group.add_argument('-C', "--directory", help='Change to specified directory before doing anything', metavar='PATH')
     group.add_argument("--default", dest='default_path', help='Read configuration data from file', metavar='PATH')
     group.add_argument('-a', "--all", action='store_true', dest='all', default=False, help='Build all settings files in mkosi.files/')
     group.add_argument("--all-directory", dest='all_directory', help='Specify path to directory to read settings files from', metavar='PATH')
-
     group.add_argument('--debug', action=CommaDelimitedListAction, default=[],
                        help='Turn on debugging output', metavar='SELECTOR',
                        choices=('run',))
     try:
         import argcomplete  # type: ignore
-        argcomplete.autocomplete(parser)
+        argcomplete.autocomplete(parser.argparser)
     except ImportError:
         pass
 
-    args = cast(CommandLineArguments, parser.parse_args(namespace=CommandLineArguments()))
+    args = cast(CommandLineArguments, parser.argparser.parse_args(namespace=CommandLineArguments()))
 
     if args.verb == "help":
-        parser.print_help()
+        parser.argparser.print_help()
         sys.exit(0)
 
     if args.all and args.default_path:

--- a/mkosi
+++ b/mkosi
@@ -2980,7 +2980,7 @@ def parse_args() -> CommandLineArguments:
     group.add_argument("--boot-protocols", action=CommaDelimitedListAction,
                        help="Boot protocols to use on a bootable image", metavar="PROTOCOLS", default=[])
     group.add_argument("--kernel-command-line", help='Set the kernel command line (only bootable images)')
-    group.add_argument("--kernel-commandline", help=argparse.SUPPRESS) # Compatibility option
+    group.add_argument("--kernel-commandline", dest='kernel_command_line', help=argparse.SUPPRESS) # Compatibility option
     group.add_argument("--secure-boot", action='store_true',
                        help='Sign the resulting kernel/initrd image for UEFI SecureBoot')
     group.add_argument("--secure-boot-key", help="UEFI SecureBoot private key in PEM format", metavar='PATH')

--- a/mkosi
+++ b/mkosi
@@ -4434,6 +4434,8 @@ def prepend_to_environ_path(paths: List[str]) -> None:
 def run_verb(args):
     load_args(args)
 
+    prepend_to_environ_path(args.extra_search_paths)
+
     if args.verb in ("build", "clean", "shell", "boot", "qemu"):
         check_root()
         unlink_output(args)
@@ -4465,8 +4467,6 @@ def main() -> None:
 
     if args.directory is not None:
         os.chdir(args.directory)
-
-    prepend_to_environ_path(args.extra_search_paths)
 
     if args.all:
         for f in os.scandir(args.all_directory):


### PR DESCRIPTION
This is on top of #292 because I think that one is much closer to be merged. First 3 commits can be ignored.

This reworks the way we add commandline and config options to be more automatic and avoid mistakes we often do while adding an option: wrong section, override vs extend, only override if not set in command line.

In order to simplify, there's a new ConfigParser wrapper to glue together the argparse and configparser. Any argument added to argparse in the form "--this-is-an-option" adds the equivalent CamelCase option to the config parser. There are some exceptions, so we can force the name of the config option, too.

Flags are supported to handle the cases in which we are extending the values from each config file or command line.  Some of our options were not consistent in the way this is handled. All of them are handled the same way now. Example: "Packages", "ExtraTrees", "BuildPackages" were extending the list for multiple files. All the others like "SkeletonTrees" were extending only the command line argument.

There was a lack of consistency in the use of plural with regard to command line and config option. We had `--build-package`, but `BuildPackages`, just to name one. Now they are the same entry, with the only difference being the use of CamelCase for config files.

We are also not parsing the command line arguments multiple times anymore, since validation can be done without it.

There are some intended bugs: `ESPSize` is now `EspSize`, `XZ` is now `Xz`, etc. I think once this is accepted we have to go one by one and decide what to do.