### PR TITLE
Fix package manager cleanup

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1113,7 +1113,23 @@ def clean_rpm_metadata(root):
         print_step('Cleaning rpm metadata...')
         remove_glob(root + '/var/lib/rpm')
 
-def invoke_dnf(args: CommandLineArguments, workspace: str, repositories: List[str], packages: List[str], config_file: str, cleanup: bool=False) -> None:
+def clean_package_manager_metadata(workspace: str):
+    """Clean up package manager metadata
+
+    Try them all regardless of the distro: metadata is only removed if the
+    package manager is present in the image.
+    """
+
+    root = os.path.join(workspace, "root")
+
+    # we try then all: metadata will only be touched if any of them are in the
+    # final image
+    clean_dnf_metadata(root)
+    clean_yum_metadata(root)
+    clean_rpm_metadata(root)
+    # FIXME: implement cleanup for other package managers
+
+def invoke_dnf(args: CommandLineArguments, workspace: str, repositories: List[str], packages: List[str], config_file: str) -> None:
     repos = ["--enablerepo=" + repo for repo in repositories]
 
     packages = make_rpm_list(args, packages)
@@ -1142,13 +1158,8 @@ def invoke_dnf(args: CommandLineArguments, workspace: str, repositories: List[st
     with mount_api_vfs(args, workspace):
         run(cmdline, check=True)
 
-    if cleanup:
-        # Clean up package manager metadata
-        clean_dnf_metadata(root)
-        clean_rpm_metadata(root)
-
 @complete_step('Installing Clear Linux')
-def install_clear(args: CommandLineArguments, workspace: str, run_build_script: bool, cleanup: bool) -> None:
+def install_clear(args: CommandLineArguments, workspace: str, run_build_script: bool) -> None:
     if args.release == "latest":
         release = "clear"
     else:
@@ -1198,10 +1209,8 @@ ensure that you have openssl program in your system.
         if args.password == "":
             args.password = None
 
-    # FIXME: implement cleanup
-
 @complete_step('Installing Fedora')
-def install_fedora(args: CommandLineArguments, workspace: str, run_build_script: bool, cleanup: bool) -> None:
+def install_fedora(args: CommandLineArguments, workspace: str, run_build_script: bool) -> None:
     if args.release == 'rawhide':
         last = sorted(FEDORA_KEYS_MAP)[-1]
         warn(f'Assuming rawhide is version {last} — ' +
@@ -1261,8 +1270,7 @@ gpgkey={gpg_key}
     invoke_dnf(args, workspace,
                args.repositories or ["fedora", "updates"],
                packages,
-               config_file,
-               cleanup=cleanup)
+               config_file)
 
     with open(os.path.join(workspace, 'root', 'etc/locale.conf'), 'w') as f:
         f.write('LANG=C.UTF-8\n')
@@ -1270,7 +1278,7 @@ gpgkey={gpg_key}
     reenable_kernel_install(args, workspace, masked)
 
 @complete_step('Installing Mageia')
-def install_mageia(args, workspace, *, run_build_script, cleanup):
+def install_mageia(args, workspace, *, run_build_script):
     masked = disable_kernel_install(args, workspace)
 
     # Mageia does not (yet) have RPM GPG key on the web
@@ -1312,12 +1320,11 @@ gpgkey={gpg_key}
     invoke_dnf(args, workspace,
                args.repositories if args.repositories else ["mageia", "updates"],
                packages,
-               config_file,
-               cleanup=cleanup)
+               config_file)
 
     reenable_kernel_install(args, workspace, masked)
 
-def invoke_yum(args: CommandLineArguments, workspace: str, repositories: List[str], packages: List[str], config_file: str, cleanup: bool=False) -> None:
+def invoke_yum(args: CommandLineArguments, workspace: str, repositories: List[str], packages: List[str], config_file: str) -> None:
     repos = ["--enablerepo=" + repo for repo in repositories]
 
     packages = make_rpm_list(args, packages)
@@ -1343,11 +1350,6 @@ def invoke_yum(args: CommandLineArguments, workspace: str, repositories: List[st
     with mount_api_vfs(args, workspace):
         run(cmdline, check=True)
 
-    if cleanup:
-        # Clean up package manager metadata
-        clean_yum_metadata(root)
-        clean_rpm_metadata(root)
-
 def invoke_dnf_or_yum(*args, **kwargs) -> None:
     if shutil.which("dnf") is None:
         invoke_yum(*args, **kwargs)
@@ -1355,7 +1357,7 @@ def invoke_dnf_or_yum(*args, **kwargs) -> None:
         invoke_dnf(*args, **kwargs)
 
 @complete_step('Installing CentOS')
-def install_centos(args: CommandLineArguments, workspace: str, *, run_build_script: bool, cleanup: bool) -> None:
+def install_centos(args: CommandLineArguments, workspace: str, *, run_build_script: bool) -> None:
     masked = disable_kernel_install(args, workspace)
 
     gpg_key = f"/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-{args.release}"
@@ -1395,15 +1397,14 @@ gpgkey={gpg_key}
     invoke_dnf_or_yum(args, workspace,
                       args.repositories or ["base", "updates"],
                       packages,
-                      config_file,
-                      cleanup=cleanup)
+                      config_file)
 
     reenable_kernel_install(args, workspace, masked)
 
 def debootstrap_knows_merged_usr():
     return bytes("invalid option", "UTF-8") not in run(("debootstrap", "--merged-usr"), stdout=PIPE).stdout
 
-def install_debian_or_ubuntu(args: CommandLineArguments, workspace: str, *, run_build_script: bool, mirror: str, cleanup: bool) -> None:
+def install_debian_or_ubuntu(args: CommandLineArguments, workspace: str, *, run_build_script: bool, mirror: str) -> None:
     repos = args.repositories if args.repositories else ["main"]
     # Ubuntu needs the 'universe' repo to install 'dracut'
     if args.distribution == Distribution.ubuntu and args.bootable and 'universe' not in repos:
@@ -1496,18 +1497,16 @@ def install_debian_or_ubuntu(args: CommandLineArguments, workspace: str, *, run_
     run_workspace_command(args, workspace, network=True, env={'DEBIAN_FRONTEND': 'noninteractive', 'DEBCONF_NONINTERACTIVE_SEEN': 'true'}, *cmdline)
     os.unlink(policyrcd)
 
-    # FIXME: implement cleanup
-
 @complete_step('Installing Debian')
-def install_debian(args, workspace, *, run_build_script, cleanup):
-    install_debian_or_ubuntu(args, workspace, run_build_script=run_build_script, mirror=args.mirror, cleanup=cleanup)
+def install_debian(args, workspace, *, run_build_script):
+    install_debian_or_ubuntu(args, workspace, run_build_script=run_build_script, mirror=args.mirror)
 
 @complete_step('Installing Ubuntu')
-def install_ubuntu(args, workspace, *, run_build_script, cleanup):
-    install_debian_or_ubuntu(args, workspace, run_build_script=run_build_script, mirror=args.mirror, cleanup=cleanup)
+def install_ubuntu(args, workspace, *, run_build_script):
+    install_debian_or_ubuntu(args, workspace, run_build_script=run_build_script, mirror=args.mirror)
 
 @complete_step('Installing Arch Linux')
-def install_arch(args, workspace, *, run_build_script, cleanup):
+def install_arch(args, workspace, *, run_build_script):
     if args.release is not None:
         sys.stderr.write("Distribution release specification is not supported for Arch Linux, ignoring.\n")
 
@@ -1665,10 +1664,8 @@ SigLevel    = Required DatabaseOptional
     # At this point, no process should be left running, kill then
     run(["fuser", "-c", root, "--kill"])
 
-    # FIXME: implement cleanup
-
 @complete_step('Installing openSUSE')
-def install_opensuse(args, workspace, *, run_build_script, cleanup):
+def install_opensuse(args, workspace, *, run_build_script):
     root = os.path.join(workspace, "root")
     release = args.release.strip('"')
 
@@ -1749,8 +1746,6 @@ def install_opensuse(args, workspace, *, run_build_script, cleanup):
         # dracut from openSUSE is missing upstream commit 016613c774baf.
         with open(os.path.join(root, "etc/kernel/cmdline"), "w") as cmdline:
             cmdline.write(args.kernel_commandline + " root=/dev/gpt-auto-root\n")
-
-    # FIXME: implement cleanup
 
 def install_distribution(args, workspace, *, cached, **kwargs):
     if cached:
@@ -3689,7 +3684,7 @@ def build_image(args: CommandLineArguments, workspace: tempfile.TemporaryDirecto
                     cached = reuse_cache_tree(args, workspace.name, run_build_script, for_cache, cached)
                     install_skeleton_trees(args, workspace.name, for_cache)
                     install_distribution(args, workspace.name,
-                                         run_build_script=run_build_script, cached=cached, cleanup=cleanup)
+                                         run_build_script=run_build_script, cached=cached)
                     install_etc_hostname(args, workspace.name)
                     install_boot_loader(args, workspace.name, loopdev, cached)
                     install_extra_trees(args, workspace.name, for_cache)
@@ -3698,6 +3693,8 @@ def build_image(args: CommandLineArguments, workspace: tempfile.TemporaryDirecto
                     set_root_password(args, workspace.name, run_build_script, for_cache)
                     run_postinst_script(args, workspace.name, run_build_script, for_cache)
 
+                if cleanup:
+                    clean_package_manager_metadata(workspace.name)
                 reset_machine_id(args, workspace.name, run_build_script, for_cache)
                 reset_random_seed(args, workspace.name)
                 make_read_only(args, workspace.name, for_cache)


### PR DESCRIPTION
As the cache is still mounted when we try to cleanup the metadata, it
was removing the downloaded packages from mkosi.cache (or whatever path
the user specified).

Tested Fedora only, with multiple invocations of

    touch mkosi.cache

and multiple invocations of

    sudo mkosi -f --default /dev/null  -d fedora -r 29
    find mkosi.cache -name '*.rpm'