### PR TITLE
Modify so that `flake8` and `mypy` are happy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.cache-pre-dev
 *.cache-pre-inst
+.mypy_cache/
 /.mkosi-*
 /SHA256SUMS
 /SHA256SUMS.gpg

--- a/mkosi
+++ b/mkosi
@@ -1543,8 +1543,8 @@ def install_debian_or_ubuntu(args: CommandLineArguments,
         cmdline += ["--merged-usr"]
 
     cmdline += [args.release,
-               workspace + "/root",
-               mirror]
+                workspace + "/root",
+                mirror]
 
     if args.bootable and args.output_format == OutputFormat.gpt_btrfs:
         cmdline[4] += ",btrfs-tools"
@@ -2039,9 +2039,9 @@ def install_grub(args, workspace, loopdev, grub):
     ]
 
     run_workspace_command(
-            args, workspace, f"{grub}-install",
-            "--modules=ext2 part_gpt", "--target=i386-pc",
-            loopdev, nspawn_params=nspawn_params)
+        args, workspace, f"{grub}-install",
+        "--modules=ext2 part_gpt", "--target=i386-pc",
+        loopdev, nspawn_params=nspawn_params)
 
     run_workspace_command(
             args, workspace, f"{grub}-mkconfig",
@@ -2073,7 +2073,7 @@ def install_boot_loader_debian(args, workspace):
     kernel_version = next(filter(lambda x: x[0].isdigit(), os.listdir(os.path.join(workspace, "root", "lib/modules"))))
 
     run_workspace_command(args, workspace,
-                    "/usr/bin/kernel-install", "add", kernel_version, "/boot/vmlinuz-" + kernel_version)
+                          "/usr/bin/kernel-install", "add", kernel_version, "/boot/vmlinuz-" + kernel_version)
 
 
 def install_boot_loader_ubuntu(args, workspace):
@@ -2711,7 +2711,7 @@ def _link_output(args: CommandLineArguments, oldpath: str, newpath: str):
     sudo_user = os.getenv("SUDO_USER", default=sudo_uid)
     with complete_step(f"Changing ownership of output file {newpath} to user {sudo_user} (acquired from sudo)",
                        f"Successfully changed ownership of {newpath}"):
-       os.chown(newpath, int(sudo_uid), int(sudo_gid))
+        os.chown(newpath, int(sudo_uid), int(sudo_gid))
 
 
 def link_output(args: CommandLineArguments, workspace: str, artifact: str) -> None:
@@ -4204,8 +4204,8 @@ def run_qemu(args: CommandLineArguments) -> None:
                     ['qemu', '-machine', 'accel=kvm'],
                     ['qemu-kvm']):
 
-           if cmdline[0] and shutil.which(cmdline[0]):
-               break
+        if cmdline[0] and shutil.which(cmdline[0]):
+            break
     else:
         die("Couldn't find QEMU/KVM binary")
 

--- a/mkosi
+++ b/mkosi
@@ -45,12 +45,6 @@ from typing import (
     cast,
 )
 
-try:
-    import argcomplete
-except ImportError:
-    pass
-
-
 __version__ = '4'
 
 if sys.version_info < (3, 6):
@@ -2966,8 +2960,9 @@ def parse_args() -> CommandLineArguments:
                        help='When running with sudo, disable reassignment of ownership of the generated files to the original user')  # NOQA: E501
 
     try:
+        import argcomplete  # type: ignore
         argcomplete.autocomplete(parser)
-    except NameError:
+    except ImportError:
         pass
 
     args = parser.parse_args(namespace=CommandLineArguments())

--- a/mkosi
+++ b/mkosi
@@ -123,7 +123,7 @@ class OutputFormat(enum.Enum):
             return cls[name]
         except KeyError:
             # this let's argparse generate a proper error message
-            return name
+            return name  # type: ignore
 
     def is_disk_rw(self) -> bool:
         "Output format is a disk image with a parition table and a writable filesystem"
@@ -368,7 +368,7 @@ def copy(oldpath: str, newpath: str) -> None:
             symlink_f(target, newentry)
             shutil.copystat(entry.path, newentry, follow_symlinks=False)
         else:
-            st = entry.stat(follow_symlinks=False)
+            st = entry.stat(follow_symlinks=False)  # type: ignore  # mypy 0.641 doesn't know about follow_symlinks
             if stat.S_ISREG(st.st_mode):
                 copy_file(entry.path, newentry)
             else:
@@ -2868,6 +2868,7 @@ def print_output_size(args: CommandLineArguments) -> None:
 
 
 def setup_package_cache(args: CommandLineArguments) -> Optional[tempfile.TemporaryDirectory]:
+    d: Optional[tempfile.TemporaryDirectory] = None
     with complete_step('Setting up package cache',
                        'Setting up package cache {} complete') as output:
         if args.cache_path is None:
@@ -2875,7 +2876,6 @@ def setup_package_cache(args: CommandLineArguments) -> Optional[tempfile.Tempora
             args.cache_path = d.name
         else:
             os.makedirs(args.cache_path, 0o755, exist_ok=True)
-            d = None
         output.append(args.cache_path)
 
     return d
@@ -3041,7 +3041,7 @@ def parse_args() -> CommandLineArguments:
     except ImportError:
         pass
 
-    args = parser.parse_args(namespace=CommandLineArguments())
+    args = cast(CommandLineArguments, parser.parse_args(namespace=CommandLineArguments()))
 
     if args.verb == "help":
         parser.print_help()
@@ -3407,7 +3407,7 @@ def load_defaults_file(fname: str, options: Dict[str, Dict[str, Any]]) -> Option
         return
 
     config = configparser.ConfigParser(delimiters='=')
-    config.optionxform = str
+    config.optionxform = str  # type: ignore
     config.read_file(f)
 
     # this is used only for validation
@@ -4285,14 +4285,18 @@ def run_shell(args: CommandLineArguments) -> None:
 
 def run_qemu(args: CommandLineArguments) -> None:
     # Look for the right qemu command line to use
+    cmdlines: List[List[str]] = []
     ARCH_BINARIES = {'x86_64': 'qemu-system-x86_64',
                      'i386': 'qemu-system-i386'}
     arch_binary = ARCH_BINARIES.get(platform.machine(), None)
-    for cmdline in ([arch_binary, '-machine', 'accel=kvm'],
-                    ['qemu', '-machine', 'accel=kvm'],
-                    ['qemu-kvm']):
-
-        if cmdline[0] and shutil.which(cmdline[0]):
+    if arch_binary is not None:
+        cmdlines += [[arch_binary, '-machine', 'accel=kvm']]
+    cmdlines += [
+        ['qemu', '-machine', 'accel=kvm'],
+        ['qemu-kvm'],
+    ]
+    for cmdline in cmdlines:
+        if shutil.which(cmdline[0]) is not None:
             break
     else:
         die("Couldn't find QEMU/KVM binary")

--- a/mkosi
+++ b/mkosi
@@ -85,8 +85,8 @@ def warn(message: str, *args: Any, **kwargs: Any) -> None:
 class CommandLineArguments(argparse.Namespace):
     """Type-hinted storage for command line arguments."""
 
-    swap_partno = None  # type: Optional[int]
-    esp_partno = None  # type: Optional[int]
+    swap_partno: Optional[int] = None
+    esp_partno: Optional[int] = None
 
 
 class OutputFormat(enum.Enum):
@@ -376,7 +376,7 @@ def copy(oldpath: str, newpath: str) -> None:
 @contextlib.contextmanager
 def complete_step(text: str, text2: Optional[str] = None) -> Iterator[List[Any]]:
     print_step(text + '...')
-    args = [] # type: List[Any]
+    args: List[Any] = []
     yield args
     if text2 is None:
         text2 = text + ' complete'
@@ -1128,7 +1128,7 @@ def disable_kernel_install(args: CommandLineArguments, workspace: str) -> List[s
     for d in ("etc", "etc/kernel", "etc/kernel/install.d"):
         mkdir_last(os.path.join(workspace, "root", d), 0o755)
 
-    masked = []  # type: List[str]
+    masked: List[str] = []
 
     for f in ("50-dracut.install", "51-dracut-rescue.install", "90-loaderentry.install"):
         path = os.path.join(workspace, "root", "etc/kernel/install.d", f)
@@ -3351,7 +3351,7 @@ def load_defaults_file(fname: str, options: Dict[str, Dict[str, Any]]) -> Option
 def load_defaults(args: CommandLineArguments) -> None:
     fname = "mkosi.default" if args.default_path is None else args.default_path
 
-    config = {}  # type: Dict[str, Dict[str, str]]
+    config: Dict[str, Dict[str, str]] = {}
     load_defaults_file(fname, config)
 
     defaults_dir = fname + '.d'

--- a/mkosi
+++ b/mkosi
@@ -1109,7 +1109,7 @@ def check_if_url_exists(url: str) -> Optional[bool]:
     try:
         if urllib.request.urlopen(req):
             return True
-    except:
+    except:  # NOQA: E722
         return False
 
 
@@ -3039,17 +3039,17 @@ def detect_distribution() -> Tuple[Optional[Distribution], Optional[str]]:
 def unlink_try_hard(path: str) -> None:
     try:
         os.unlink(path)
-    except:
+    except:  # NOQA: E722
         pass
 
     try:
         btrfs_subvol_delete(path)
-    except:
+    except:  # NOQA: E722
         pass
 
     try:
         shutil.rmtree(path)
-    except:
+    except:  # NOQA: E722
         pass
 
 

--- a/mkosi
+++ b/mkosi
@@ -33,7 +33,6 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Generator,
     Iterable,
     Iterator,
     List,

--- a/mkosi
+++ b/mkosi
@@ -130,6 +130,7 @@ class OutputFormat(enum.Enum):
         return self in (OutputFormat.gpt_ext4,
                         OutputFormat.gpt_btrfs,
                         OutputFormat.gpt_xfs)
+
     def is_disk(self):
         "Output format is a disk image with a partition table"
         return self.is_disk_rw() or self == OutputFormat.gpt_squashfs
@@ -2808,6 +2809,7 @@ class ListAction(argparse.Action):
     def __init__(self, *args, choices=None, **kwargs):
         self.list_choices = choices
         super().__init__(*args, **kwargs)
+
     def __call__(self, parser, namespace, values, option_string=None):
         l = getattr(namespace, self.dest)
         if l is None:

--- a/mkosi
+++ b/mkosi
@@ -217,7 +217,10 @@ def gpt_root_native(arch: str) -> GPTRootTypePair:
 
 
 def unshare(flags: int) -> None:
-    libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+    libc_name = ctypes.util.find_library("c")
+    if libc_name is None:
+        die("Could not find libc")
+    libc = ctypes.CDLL(libc_name, use_errno=True)
 
     if libc.unshare(ctypes.c_int(flags)) != 0:
         e = ctypes.get_errno()
@@ -1124,11 +1127,12 @@ def run_workspace_command(args: CommandLineArguments,
     run(cmdline, check=True)
 
 
-def check_if_url_exists(url: str) -> Optional[bool]:
+def check_if_url_exists(url: str) -> bool:
     req = urllib.request.Request(url, method="HEAD")
     try:
         if urllib.request.urlopen(req):
             return True
+        return False
     except:  # NOQA: E722
         return False
 
@@ -1541,7 +1545,7 @@ gpgkey={gpg_key}
 
 
 def debootstrap_knows_merged_usr() -> bool:
-    return bytes("invalid option", "UTF-8") not in run(("debootstrap", "--merged-usr"), stdout=PIPE).stdout
+    return bytes("invalid option", "UTF-8") not in run(["debootstrap", "--merged-usr"], stdout=PIPE).stdout
 
 
 def install_debian_or_ubuntu(args: CommandLineArguments,
@@ -2037,7 +2041,7 @@ def find_kernel_file(workspace_root: str, pattern: str) -> Optional[str]:
         kernel_file = kernel_file[len(workspace_root):]
     else:
         sys.stderr.write(f'Error, kernel file {kernel_file} cannot be used as it is not in the workspace\n')
-        return
+        return None
     if len(kernel_files) > 1:
         warn('More than one kernel file found, will use {}', kernel_file)
     return kernel_file
@@ -2087,11 +2091,9 @@ def install_boot_loader_arch(args: CommandLineArguments, workspace: str, loopdev
         workspace_root = os.path.join(workspace, "root")
         kernel_version = next(filter(lambda x: x[0].isdigit(),
                                      os.listdir(os.path.join(workspace_root, "lib/modules"))))
-        run_workspace_command(args, workspace,
-                              "/usr/bin/kernel-install",
-                              "add",
-                              kernel_version,
-                              find_kernel_file(workspace_root, "/boot/vmlinuz-*"))
+        kernel_file = find_kernel_file(workspace_root, "/boot/vmlinuz-*")
+        if kernel_file is not None:
+            run_workspace_command(args, workspace, "/usr/bin/kernel-install", "add", kernel_version, kernel_file)
 
     if "bios" in args.boot_protocols:
         install_grub(args, workspace, loopdev, "grub")
@@ -2117,16 +2119,17 @@ def install_boot_loader_clear(args: CommandLineArguments, workspace: str, loopde
         # clr-boot-manager uses blkid in the device backing "/" to
         # figure out uuid and related parameters.
         "--bind-ro=/dev",
-        "--property=DeviceAllow=" + loopdev,
 
         # clr-boot-manager compiled in Clear Linux will assume EFI
         # partition is mounted in "/boot".
         "--bind=" + os.path.join(workspace, "root/efi") + ":/boot",
     ]
-    if args.esp_partno is not None:
-        nspawn_params += ["--property=DeviceAllow=" + partition(loopdev, args.esp_partno)]
-    if args.root_partno is not None:
-        nspawn_params += ["--property=DeviceAllow=" + partition(loopdev, args.root_partno)]
+    if loopdev is not None:
+        nspawn_params += ["--property=DeviceAllow=" + loopdev]
+        if args.esp_partno is not None:
+            nspawn_params += ["--property=DeviceAllow=" + partition(loopdev, args.esp_partno)]
+        if args.root_partno is not None:
+            nspawn_params += ["--property=DeviceAllow=" + partition(loopdev, args.root_partno)]
 
     run_workspace_command(args, workspace, "/usr/bin/clr-boot-manager", "update", "-i", nspawn_params=nspawn_params)
 
@@ -3109,7 +3112,9 @@ def detect_distribution() -> Tuple[Optional[Distribution], Optional[str]]:
     if id == "clear-linux-os":
         id = "clear"
 
-    d = Distribution.__members__.get(id, None)
+    d: Optional[Distribution] = None
+    if id is not None:
+        d = Distribution.__members__.get(id, None)
 
     if d == Distribution.debian and (version_codename or extracted_codename):
         # debootstrap needs release codenames, not version numbers
@@ -3404,7 +3409,7 @@ def load_defaults_file(fname: str, options: Dict[str, Dict[str, Any]]) -> Option
     try:
         f = open(fname)
     except FileNotFoundError:
-        return
+        return None
 
     config = configparser.ConfigParser(delimiters='=')
     config.optionxform = str  # type: ignore
@@ -4038,9 +4043,10 @@ def build_image(args: CommandLineArguments,
         prepare_swap(args, loopdev, cached)
         prepare_esp(args, loopdev, cached)
 
-        luks_format_root(args, loopdev, run_build_script, cached)
-        luks_format_home(args, loopdev, run_build_script, cached)
-        luks_format_srv(args, loopdev, run_build_script, cached)
+        if loopdev is not None:
+            luks_format_root(args, loopdev, run_build_script, cached)
+            luks_format_home(args, loopdev, run_build_script, cached)
+            luks_format_srv(args, loopdev, run_build_script, cached)
 
         with luks_setup_all(args, loopdev, run_build_script) as (encrypted_root, encrypted_home, encrypted_srv):
 

--- a/mkosi
+++ b/mkosi
@@ -2517,7 +2517,7 @@ def install_unified_kernel(args, workspace, run_build_script, for_cache, root_ha
 
             dracut += [boot_binary]
 
-            run_workspace_command(args, workspace, *dracut);
+            run_workspace_command(args, workspace, *dracut)
 
 
 def secure_boot_sign(args, workspace, run_build_script, for_cache):
@@ -3507,9 +3507,9 @@ def load_args() -> CommandLineArguments:
     args_find_path(args, 'build_script',    "mkosi.build")
     args_find_path(args, 'build_sources',   ".")
     args_find_path(args, 'build_dir',       "mkosi.builddir/")
-    args_find_path(args, 'postinst_script', "mkosi.postinst");
-    args_find_path(args, 'finalize_script', "mkosi.finalize");
-    args_find_path(args, 'output_dir',      "mkosi.output/");
+    args_find_path(args, 'postinst_script', "mkosi.postinst")
+    args_find_path(args, 'finalize_script', "mkosi.finalize")
+    args_find_path(args, 'output_dir',      "mkosi.output/")
     args_find_path(args, 'mksquashfs_tool', "mkosi.mksquashfs-tool", type=lambda x: [x])
 
     find_extra(args)

--- a/mkosi
+++ b/mkosi
@@ -151,21 +151,21 @@ class Distribution(enum.Enum):
     clear = 8
 
 
-GPT_ROOT_X86           = uuid.UUID("44479540f29741b29af7d131d5f0458a")
-GPT_ROOT_X86_64        = uuid.UUID("4f68bce3e8cd4db196e7fbcaf984b709")
-GPT_ROOT_ARM           = uuid.UUID("69dad7102ce44e3cb16c21a1d49abed3")
-GPT_ROOT_ARM_64        = uuid.UUID("b921b0451df041c3af444c6f280d3fae")
-GPT_ROOT_IA64          = uuid.UUID("993d8d3df80e4225855a9daf8ed7ea97")
-GPT_ESP                = uuid.UUID("c12a7328f81f11d2ba4b00a0c93ec93b")
-GPT_BIOS               = uuid.UUID("2168614864496e6f744e656564454649")
-GPT_SWAP               = uuid.UUID("0657fd6da4ab43c484e50933c84b4f4f")
-GPT_HOME               = uuid.UUID("933ac7e12eb44f13b8440e14e2aef915")
-GPT_SRV                = uuid.UUID("3b8f842520e04f3b907f1a25a76f98e8")
-GPT_ROOT_X86_VERITY    = uuid.UUID("d13c5d3bb5d1422ab29f9454fdc89d76")
-GPT_ROOT_X86_64_VERITY = uuid.UUID("2c7357edebd246d9aec123d437ec2bf5")
-GPT_ROOT_ARM_VERITY    = uuid.UUID("7386cdf2203c47a9a498f2ecce45a2d6")
-GPT_ROOT_ARM_64_VERITY = uuid.UUID("df3300ced69f4c92978c9bfb0f38d820")
-GPT_ROOT_IA64_VERITY   = uuid.UUID("86ed10d5b60745bb8957d350f23d0571")
+GPT_ROOT_X86           = uuid.UUID("44479540f29741b29af7d131d5f0458a")  # NOQA: E221
+GPT_ROOT_X86_64        = uuid.UUID("4f68bce3e8cd4db196e7fbcaf984b709")  # NOQA: E221
+GPT_ROOT_ARM           = uuid.UUID("69dad7102ce44e3cb16c21a1d49abed3")  # NOQA: E221
+GPT_ROOT_ARM_64        = uuid.UUID("b921b0451df041c3af444c6f280d3fae")  # NOQA: E221
+GPT_ROOT_IA64          = uuid.UUID("993d8d3df80e4225855a9daf8ed7ea97")  # NOQA: E221
+GPT_ESP                = uuid.UUID("c12a7328f81f11d2ba4b00a0c93ec93b")  # NOQA: E221
+GPT_BIOS               = uuid.UUID("2168614864496e6f744e656564454649")  # NOQA: E221
+GPT_SWAP               = uuid.UUID("0657fd6da4ab43c484e50933c84b4f4f")  # NOQA: E221
+GPT_HOME               = uuid.UUID("933ac7e12eb44f13b8440e14e2aef915")  # NOQA: E221
+GPT_SRV                = uuid.UUID("3b8f842520e04f3b907f1a25a76f98e8")  # NOQA: E221
+GPT_ROOT_X86_VERITY    = uuid.UUID("d13c5d3bb5d1422ab29f9454fdc89d76")  # NOQA: E221
+GPT_ROOT_X86_64_VERITY = uuid.UUID("2c7357edebd246d9aec123d437ec2bf5")  # NOQA: E221
+GPT_ROOT_ARM_VERITY    = uuid.UUID("7386cdf2203c47a9a498f2ecce45a2d6")  # NOQA: E221
+GPT_ROOT_ARM_64_VERITY = uuid.UUID("df3300ced69f4c92978c9bfb0f38d820")  # NOQA: E221
+GPT_ROOT_IA64_VERITY   = uuid.UUID("86ed10d5b60745bb8957d350f23d0571")  # NOQA: E221
 
 # This is a non-formatted partition used to store the second stage
 # part of the bootloader because it doesn't necessarily fits the MBR
@@ -258,19 +258,19 @@ def mkdir_last(path: str, mode: int = 0o777) -> str:
     return path
 
 
-_IOC_NRBITS   =  8
-_IOC_TYPEBITS =  8
-_IOC_SIZEBITS = 14
-_IOC_DIRBITS  =  2
+_IOC_NRBITS   =  8  # NOQA: E221,E222
+_IOC_TYPEBITS =  8  # NOQA: E221,E222
+_IOC_SIZEBITS = 14  # NOQA: E221,E222
+_IOC_DIRBITS  =  2  # NOQA: E221,E222
 
-_IOC_NRSHIFT   = 0
-_IOC_TYPESHIFT = _IOC_NRSHIFT + _IOC_NRBITS
-_IOC_SIZESHIFT = _IOC_TYPESHIFT + _IOC_TYPEBITS
-_IOC_DIRSHIFT  = _IOC_SIZESHIFT + _IOC_SIZEBITS
+_IOC_NRSHIFT   = 0  # NOQA: E221
+_IOC_TYPESHIFT = _IOC_NRSHIFT + _IOC_NRBITS  # NOQA: E221
+_IOC_SIZESHIFT = _IOC_TYPESHIFT + _IOC_TYPEBITS  # NOQA: E221
+_IOC_DIRSHIFT  = _IOC_SIZESHIFT + _IOC_SIZEBITS  # NOQA: E221
 
-_IOC_NONE  = 0
-_IOC_WRITE = 1
-_IOC_READ  = 2
+_IOC_NONE  = 0  # NOQA: E221
+_IOC_WRITE = 1  # NOQA: E221
+_IOC_READ  = 2  # NOQA: E221
 
 
 def _IOC(dir: int, type: int, nr: int, argtype: str) -> int:
@@ -578,7 +578,7 @@ def reuse_cache_image(args: CommandLineArguments,
             return None, False
 
         with source:
-            f = tempfile.NamedTemporaryFile(dir = os.path.dirname(args.output), prefix='.mkosi-')
+            f = tempfile.NamedTemporaryFile(dir=os.path.dirname(args.output), prefix='.mkosi-')
             output.append(f)
 
             # So on one hand we want CoW off, since this stuff will
@@ -1088,7 +1088,7 @@ def run_workspace_command(args: CommandLineArguments,
                "--as-pid2",
                "--register=no",
                "--bind=" + var_tmp(workspace) + ":/var/tmp",
-               "--setenv=SYSTEMD_OFFLINE=1" ]
+               "--setenv=SYSTEMD_OFFLINE=1"]
 
     if network:
         # If we're using the host network namespace, use the same resolver
@@ -1096,7 +1096,7 @@ def run_workspace_command(args: CommandLineArguments,
     else:
         cmdline += ["--private-network"]
 
-    cmdline += [ f'--setenv={k}={v}' for k, v in env.items() ]
+    cmdline += [f'--setenv={k}={v}' for k, v in env.items()]
 
     if nspawn_params:
         cmdline += nspawn_params
@@ -1888,14 +1888,14 @@ def install_distribution(args, workspace, *, cached, **kwargs):
         return
 
     install = {
-        Distribution.fedora : install_fedora,
-        Distribution.centos : install_centos,
-        Distribution.mageia : install_mageia,
-        Distribution.debian : install_debian,
-        Distribution.ubuntu : install_ubuntu,
-        Distribution.arch : install_arch,
-        Distribution.opensuse : install_opensuse,
-        Distribution.clear : install_clear,
+        Distribution.fedora: install_fedora,
+        Distribution.centos: install_centos,
+        Distribution.mageia: install_mageia,
+        Distribution.debian: install_debian,
+        Distribution.ubuntu: install_ubuntu,
+        Distribution.arch: install_arch,
+        Distribution.opensuse: install_opensuse,
+        Distribution.clear: install_clear,
     }
 
     install[args.distribution](args, workspace, **kwargs)
@@ -2340,7 +2340,7 @@ def read_partition_table(loopdev):
     return table, last_sector * 512
 
 
-def insert_partition(args, workspace, raw, loopdev, partno, blob, name, type_uuid, uuid = None):
+def insert_partition(args, workspace, raw, loopdev, partno, blob, name, type_uuid, uuid=None):
     if args.ran_sfdisk:
         old_table, last_partition_sector = read_partition_table(loopdev)
     else:
@@ -2511,11 +2511,11 @@ def install_unified_kernel(args, workspace, run_build_script, for_cache, root_ha
                       ("-i",) + ("/usr/lib/systemd/system-generators/systemd-veritysetup-generator",)*2
 
             if args.output_format == OutputFormat.gpt_squashfs:
-                dracut += [ '--add-drivers', 'squashfs' ]
+                dracut += ['--add-drivers', 'squashfs']
 
-            dracut += [ '--add', 'qemu' ]
+            dracut += ['--add', 'qemu']
 
-            dracut += [ boot_binary ]
+            dracut += [boot_binary]
 
             run_workspace_command(args, workspace, *dracut);
 
@@ -3427,14 +3427,14 @@ def find_passphrase(args: CommandLineArguments) -> None:
     try:
         require_private_file('mkosi.passphrase', 'passphrase')
 
-        args.passphrase = { 'type': 'file', 'content': 'mkosi.passphrase' }
+        args.passphrase = {'type': 'file', 'content': 'mkosi.passphrase'}
 
     except FileNotFoundError:
         while True:
             passphrase = getpass.getpass("Please enter passphrase: ")
             passphrase_confirmation = getpass.getpass("Passphrase confirmation: ")
             if passphrase == passphrase_confirmation:
-                args.passphrase = { 'type': 'stdin', 'content': passphrase }
+                args.passphrase = {'type': 'stdin', 'content': passphrase}
                 break
 
             sys.stderr.write("Passphrase doesn't match confirmation. Please try again.\n")
@@ -4197,8 +4197,8 @@ def run_shell(args: CommandLineArguments) -> None:
 
 def run_qemu(args: CommandLineArguments) -> None:
     # Look for the right qemu command line to use
-    ARCH_BINARIES = { 'x86_64' : 'qemu-system-x86_64',
-                      'i386'   : 'qemu-system-i386'}
+    ARCH_BINARIES = {'x86_64': 'qemu-system-x86_64',
+                     'i386': 'qemu-system-i386'}
     arch_binary = ARCH_BINARIES.get(platform.machine(), None)
     for cmdline in ([arch_binary, '-machine', 'accel=kvm'],
                     ['qemu', '-machine', 'accel=kvm'],
@@ -4231,11 +4231,11 @@ def run_qemu(args: CommandLineArguments) -> None:
     else:
         die("Couldn't find OVMF UEFI firmware blob.")
 
-    cmdline += [ "-smp", "2",
-                 "-m", "1024",
-                 "-drive", "if=pflash,format=raw,readonly,file=" + firmware,
-                 "-drive", "format=" + ("qcow2" if args.qcow2 else "raw") + ",file=" + args.output,
-                 *args.cmdline ]
+    cmdline += ["-smp", "2",
+                "-m", "1024",
+                "-drive", "if=pflash,format=raw,readonly,file=" + firmware,
+                "-drive", "format=" + ("qcow2" if args.qcow2 else "raw") + ",file=" + args.output,
+                *args.cmdline]
 
     print_running_cmd(cmdline)
 

--- a/mkosi
+++ b/mkosi
@@ -1483,11 +1483,15 @@ def invoke_yum(args: CommandLineArguments,
         run(cmdline, check=True)
 
 
-def invoke_dnf_or_yum(*args, **kwargs) -> None:
+def invoke_dnf_or_yum(args: CommandLineArguments,
+                      workspace: str,
+                      repositories: List[str],
+                      packages: List[str],
+                      config_file: str) -> None:
     if shutil.which("dnf") is None:
-        invoke_yum(*args, **kwargs)
+        invoke_yum(args, workspace, repositories, packages, config_file)
     else:
-        invoke_dnf(*args, **kwargs)
+        invoke_dnf(args, workspace, repositories, packages, config_file)
 
 
 @completestep('Installing CentOS')

--- a/mkosi
+++ b/mkosi
@@ -31,6 +31,7 @@ from subprocess import DEVNULL, PIPE
 from typing import (
     IO,
     Any,
+    BinaryIO,
     Callable,
     Dict,
     Iterable,
@@ -38,8 +39,10 @@ from typing import (
     List,
     NoReturn,
     Optional,
+    TextIO,
     Tuple,
     Union,
+    cast,
 )
 
 try:
@@ -531,7 +534,8 @@ def create_image(args: CommandLineArguments, workspace: str, for_cache: bool) ->
     with complete_step('Creating partition table',
                        'Created partition table as {.name}') as output:
 
-        f = tempfile.NamedTemporaryFile(dir=os.path.dirname(args.output), prefix='.mkosi-', delete=not for_cache)
+        f: BinaryIO = cast(BinaryIO, tempfile.NamedTemporaryFile(prefix='.mkosi-', delete=not for_cache,
+                                                                 dir=os.path.dirname(args.output)))
         output.append(f)
         disable_cow(f.name)
         f.truncate(image_size(args))
@@ -577,7 +581,8 @@ def reuse_cache_image(args: CommandLineArguments,
             return None, False
 
         with source:
-            f = tempfile.NamedTemporaryFile(dir=os.path.dirname(args.output), prefix='.mkosi-')
+            f: BinaryIO = cast(BinaryIO, tempfile.NamedTemporaryFile(prefix='.mkosi-',
+                                                                     dir=os.path.dirname(args.output)))
             output.append(f)
 
             # So on one hand we want CoW off, since this stuff will
@@ -2269,7 +2274,7 @@ def make_tar(args, workspace, run_build_script, for_cache):
         return None
 
     with complete_step('Creating archive'):
-        f = tempfile.NamedTemporaryFile(dir=os.path.dirname(args.output), prefix=".mkosi-")
+        f: BinaryIO = cast(BinaryIO, tempfile.NamedTemporaryFile(dir=os.path.dirname(args.output), prefix=".mkosi-"))
         run(["tar", "-C", os.path.join(workspace, "root"),
              "-c", "-J", "--xattrs", "--xattrs-include=*", "."],
             stdout=f, check=True)
@@ -2292,7 +2297,8 @@ def make_squashfs(args, workspace, for_cache):
         comp_args += ['-comp', args.compress]
 
     with complete_step('Creating squashfs file system'):
-        f = tempfile.NamedTemporaryFile(dir=os.path.dirname(args.output), prefix=".mkosi-squashfs")
+        f: BinaryIO = cast(BinaryIO, tempfile.NamedTemporaryFile(prefix=".mkosi-squashfs",
+                                                                 dir=os.path.dirname(args.output)))
         run([command, os.path.join(workspace, "root"), f.name, *comp_args],
             check=True)
 
@@ -2414,7 +2420,7 @@ def make_verity(args: CommandLineArguments,
         return None, None
 
     with complete_step('Generating verity hashes'):
-        f = tempfile.NamedTemporaryFile(dir=os.path.dirname(args.output), prefix=".mkosi-")
+        f: BinaryIO = cast(BinaryIO, tempfile.NamedTemporaryFile(dir=os.path.dirname(args.output), prefix=".mkosi-"))
         c = run(["veritysetup", "format", dev, f.name], stdout=PIPE, check=True)
 
         for line in c.stdout.decode("utf-8").split('\n'):
@@ -2557,7 +2563,7 @@ def xz_output(args, raw):
     xz_binary = "pxz" if shutil.which("pxz") else "xz"
 
     with complete_step('Compressing image file'):
-        f = tempfile.NamedTemporaryFile(prefix=".mkosi-", dir=os.path.dirname(args.output))
+        f: BinaryIO = cast(BinaryIO, tempfile.NamedTemporaryFile(prefix=".mkosi-", dir=os.path.dirname(args.output)))
         run([xz_binary, "-c", raw.name], stdout=f, check=True)
 
     return f
@@ -2571,7 +2577,7 @@ def qcow2_output(args, raw):
         return raw
 
     with complete_step('Converting image file to qcow2'):
-        f = tempfile.NamedTemporaryFile(prefix=".mkosi-", dir=os.path.dirname(args.output))
+        f: BinaryIO = cast(BinaryIO, tempfile.NamedTemporaryFile(prefix=".mkosi-", dir=os.path.dirname(args.output)))
         run(["qemu-img", "convert", "-fraw", "-Oqcow2", raw.name, f.name], check=True)
 
     return f
@@ -2582,8 +2588,8 @@ def write_root_hash_file(args, root_hash):
         return None
 
     with complete_step('Writing .roothash file'):
-        f = tempfile.NamedTemporaryFile(mode='w+b', prefix='.mkosi',
-                                        dir=os.path.dirname(args.output_root_hash_file))
+        f: BinaryIO = cast(BinaryIO, tempfile.NamedTemporaryFile(mode='w+b', prefix='.mkosi',
+                                                                 dir=os.path.dirname(args.output_root_hash_file)))
         f.write((root_hash + "\n").encode())
 
     return f
@@ -2594,8 +2600,8 @@ def copy_nspawn_settings(args):
         return None
 
     with complete_step('Copying nspawn settings file'):
-        f = tempfile.NamedTemporaryFile(mode="w+b", prefix=".mkosi-",
-                                        dir=os.path.dirname(args.output_nspawn_settings))
+        f: BinaryIO = cast(BinaryIO, tempfile.NamedTemporaryFile(mode="w+b", prefix=".mkosi-",
+                                                                 dir=os.path.dirname(args.output_nspawn_settings)))
 
         with open(args.nspawn_settings, "rb") as c:
             f.write(c.read())
@@ -2628,8 +2634,8 @@ def calculate_sha256sum(args: CommandLineArguments,
         return None
 
     with complete_step('Calculating SHA256SUMS'):
-        f = tempfile.NamedTemporaryFile(mode="w+", prefix=".mkosi-", encoding="utf-8",
-                                        dir=os.path.dirname(args.output_checksum))
+        f: TextIO = cast(TextIO, tempfile.NamedTemporaryFile(mode="w+", prefix=".mkosi-", encoding="utf-8",
+                                                             dir=os.path.dirname(args.output_checksum)))
 
         if raw is not None:
             hash_file(f, raw, os.path.basename(args.output))
@@ -2651,8 +2657,8 @@ def calculate_signature(args: CommandLineArguments, checksum: Optional[IO[Any]])
         return None
 
     with complete_step('Signing SHA256SUMS'):
-        f = tempfile.NamedTemporaryFile(mode="wb", prefix=".mkosi-",
-                                        dir=os.path.dirname(args.output_signature))
+        f: BinaryIO = cast(BinaryIO, tempfile.NamedTemporaryFile(mode="wb", prefix=".mkosi-",
+                                                                 dir=os.path.dirname(args.output_signature)))
 
         cmdline = ["gpg", "--detach-sign"]
 
@@ -2673,8 +2679,8 @@ def calculate_bmap(args: CommandLineArguments, raw: IO[Any]) -> Optional[IO[byte
         return None
 
     with complete_step('Creating BMAP file'):
-        f = tempfile.NamedTemporaryFile(mode="w+", prefix=".mkosi-", encoding="utf-8",
-                                        dir=os.path.dirname(args.output_bmap))
+        f: TextIO = cast(TextIO, tempfile.NamedTemporaryFile(mode="w+", prefix=".mkosi-", encoding="utf-8",
+                                                             dir=os.path.dirname(args.output_bmap)))
 
         cmdline = ["bmaptool", "create", raw.name]
         run(cmdline, stdout=f, check=True)

--- a/mkosi
+++ b/mkosi
@@ -37,6 +37,7 @@ from typing import (
     Generator,
     Iterable,
     List,
+    NamedTuple,
     NoReturn,
     Optional,
     TextIO,
@@ -191,10 +192,13 @@ FEDORA_KEYS_MAP = {
 GPT_HEADER_SIZE = 1024*1024
 GPT_FOOTER_SIZE = 1024*1024
 
-GPTRootTypePair = collections.namedtuple('GPTRootTypePair', 'root verity')
+
+class GPTRootTypePair(NamedTuple):
+    root: uuid.UUID
+    verity: uuid.UUID
 
 
-def gpt_root_native(arch: str) -> Tuple[uuid.UUID, uuid.UUID]:
+def gpt_root_native(arch: str) -> GPTRootTypePair:
     """The tag for the native GPT root partition for the given architecture
 
     Returns a tuple of two tags: for the root partition and for the

--- a/mkosi
+++ b/mkosi
@@ -61,7 +61,7 @@ if sys.version_info < (3, 6):
 arg_debug = ()
 
 
-def run(cmdline: List[str], execvp: bool = False, **kwargs) -> Optional[subprocess.CompletedProcess]:
+def run(cmdline: List[str], execvp: bool = False, **kwargs) -> subprocess.CompletedProcess:
     if 'run' in arg_debug:
         sys.stderr.write('+ ' + ' '.join(shlex.quote(x) for x in cmdline) + '\n')
     if execvp:
@@ -531,7 +531,7 @@ def determine_partition_table(args: CommandLineArguments):
     return table, run_sfdisk
 
 
-def create_image(args: CommandLineArguments, workspace: str, for_cache: bool) -> Optional[IO[str]]:
+def create_image(args: CommandLineArguments, workspace: str, for_cache: bool) -> Optional[BinaryIO]:
     if not args.output_format.is_disk():
         return None
 
@@ -558,7 +558,7 @@ def create_image(args: CommandLineArguments, workspace: str, for_cache: bool) ->
 def reuse_cache_image(args: CommandLineArguments,
                       workspace: str,
                       run_build_script: bool,
-                      for_cache: bool) -> Tuple[Optional[IO[str]], bool]:
+                      for_cache: bool) -> Tuple[Optional[BinaryIO], bool]:
     if not args.incremental:
         return None, False
     if not args.output_format.is_disk_rw():
@@ -607,7 +607,7 @@ def reuse_cache_image(args: CommandLineArguments,
 
 
 @contextlib.contextmanager
-def attach_image_loopback(args: CommandLineArguments, raw: Optional[IO[str]]) -> Generator[Optional[str], None, None]:
+def attach_image_loopback(args: CommandLineArguments, raw: Optional[BinaryIO]) -> Generator[Optional[str], None, None]:
     if raw is None:
         yield None
         return
@@ -821,7 +821,7 @@ def luks_setup_all(args: CommandLineArguments,
         luks_close(root, "Closing LUKS root partition")
 
 
-def prepare_root(args: CommandLineArguments, dev: str, cached: bool) -> None:
+def prepare_root(args: CommandLineArguments, dev: Optional[str], cached: bool) -> None:
     if dev is None:
         return
     if args.output_format == OutputFormat.gpt_squashfs:
@@ -838,7 +838,7 @@ def prepare_root(args: CommandLineArguments, dev: str, cached: bool) -> None:
             mkfs_ext4("root", "/", dev)
 
 
-def prepare_home(args: CommandLineArguments, dev: str, cached: bool) -> None:
+def prepare_home(args: CommandLineArguments, dev: Optional[str], cached: bool) -> None:
     if dev is None:
         return
     if cached:
@@ -848,7 +848,7 @@ def prepare_home(args: CommandLineArguments, dev: str, cached: bool) -> None:
         mkfs_ext4("home", "/home", dev)
 
 
-def prepare_srv(args: CommandLineArguments, dev: str, cached: bool) -> None:
+def prepare_srv(args: CommandLineArguments, dev: Optional[str], cached: bool) -> None:
     if dev is None:
         return
     if cached:
@@ -889,10 +889,10 @@ def mount_tmpfs(where: str) -> None:
 @contextlib.contextmanager
 def mount_image(args: CommandLineArguments,
                 workspace: str,
-                loopdev: str,
+                loopdev: Optional[str],
                 root_dev: str,
-                home_dev: str,
-                srv_dev: str,
+                home_dev: Optional[str],
+                srv_dev: Optional[str],
                 root_read_only: bool = False) -> Generator[None, None, None]:
     if loopdev is None:
         yield None
@@ -2428,7 +2428,7 @@ def make_verity(args: CommandLineArguments,
                 workspace,
                 dev,
                 run_build_script: bool,
-                for_cache: bool) -> Tuple[Optional[IO[str]], Optional[str]]:
+                for_cache: bool) -> Tuple[Optional[BinaryIO], Optional[str]]:
     if run_build_script or not args.verity:
         return None, None
     if for_cache:
@@ -2624,7 +2624,7 @@ def copy_nspawn_settings(args):
     return f
 
 
-def hash_file(of: IO[Any], sf: IO[bytes], fname: str) -> None:
+def hash_file(of: TextIO, sf: BinaryIO, fname: str) -> None:
     bs = 16*1024**2
     h = hashlib.sha256()
 
@@ -2638,10 +2638,10 @@ def hash_file(of: IO[Any], sf: IO[bytes], fname: str) -> None:
 
 
 def calculate_sha256sum(args: CommandLineArguments,
-                        raw: Optional[IO[str]],
-                        tar: Optional[IO[str]],
-                        root_hash_file: str,
-                        nspawn_settings: str) -> Optional[IO[bytes]]:
+                        raw: Optional[BinaryIO],
+                        tar: Optional[BinaryIO],
+                        root_hash_file: Optional[BinaryIO],
+                        nspawn_settings: Optional[BinaryIO]) -> Optional[TextIO]:
     if args.output_format in (OutputFormat.directory, OutputFormat.subvolume):
         return None
 
@@ -2664,7 +2664,7 @@ def calculate_sha256sum(args: CommandLineArguments,
     return f
 
 
-def calculate_signature(args: CommandLineArguments, checksum: Optional[IO[Any]]) -> Optional[IO[bytes]]:
+def calculate_signature(args: CommandLineArguments, checksum: Optional[IO[Any]]) -> Optional[BinaryIO]:
     if not args.sign:
         return None
 
@@ -2686,7 +2686,7 @@ def calculate_signature(args: CommandLineArguments, checksum: Optional[IO[Any]])
     return f
 
 
-def calculate_bmap(args: CommandLineArguments, raw: IO[Any]) -> Optional[IO[bytes]]:
+def calculate_bmap(args: CommandLineArguments, raw: BinaryIO) -> Optional[TextIO]:
     if not args.bmap:
         return None
 
@@ -2703,7 +2703,7 @@ def calculate_bmap(args: CommandLineArguments, raw: IO[Any]) -> Optional[IO[byte
     return f
 
 
-def save_cache(args: CommandLineArguments, workspace: str, raw: str, cache_path: str) -> None:
+def save_cache(args: CommandLineArguments, workspace: str, raw: Optional[str], cache_path: Optional[str]) -> None:
     if cache_path is None or raw is None:
         return
 
@@ -2743,7 +2743,7 @@ def link_output(args: CommandLineArguments, workspace: str, artifact: str) -> No
             _link_output(args, artifact.name, args.output)
 
 
-def link_output_nspawn_settings(args: CommandLineArguments, path: str) -> None:
+def link_output_nspawn_settings(args: CommandLineArguments, path: Optional[str]) -> None:
     if path is None:
         return
 
@@ -2752,7 +2752,7 @@ def link_output_nspawn_settings(args: CommandLineArguments, path: str) -> None:
         _link_output(args, path, args.output_nspawn_settings)
 
 
-def link_output_checksum(args: CommandLineArguments, checksum: str) -> None:
+def link_output_checksum(args: CommandLineArguments, checksum: Optional[str]) -> None:
     if checksum is None:
         return
 
@@ -2761,7 +2761,7 @@ def link_output_checksum(args: CommandLineArguments, checksum: str) -> None:
         _link_output(args, checksum, args.output_checksum)
 
 
-def link_output_root_hash_file(args: CommandLineArguments, root_hash_file: str) -> None:
+def link_output_root_hash_file(args: CommandLineArguments, root_hash_file: Optional[str]) -> None:
     if root_hash_file is None:
         return
 
@@ -2770,7 +2770,7 @@ def link_output_root_hash_file(args: CommandLineArguments, root_hash_file: str) 
         _link_output(args, root_hash_file, args.output_root_hash_file)
 
 
-def link_output_signature(args: CommandLineArguments, signature: str) -> None:
+def link_output_signature(args: CommandLineArguments, signature: Optional[str]) -> None:
     if signature is None:
         return
 
@@ -2779,7 +2779,7 @@ def link_output_signature(args: CommandLineArguments, signature: str) -> None:
         _link_output(args, signature, args.output_signature)
 
 
-def link_output_bmap(args: CommandLineArguments, bmap: str) -> None:
+def link_output_bmap(args: CommandLineArguments, bmap: Optional[str]) -> None:
     if bmap is None:
         return
 
@@ -3075,7 +3075,7 @@ def unlink_try_hard(path: str) -> None:
         pass
 
 
-def remove_glob(*patterns: List[str]) -> None:
+def remove_glob(*patterns: str) -> None:
     pathgen = (glob.glob(pattern) for pattern in patterns)
     paths = set(sum(pathgen, []))  # uniquify
     for path in paths:
@@ -3154,7 +3154,7 @@ def parse_boolean(s: str) -> bool:
     raise ValueError(f'Invalid literal for bool(): {s!r}')
 
 
-def process_setting(args: CommandLineArguments, section: str, key: str, value: Any) -> bool:
+def process_setting(args: CommandLineArguments, section: str, key: Optional[str], value: Any) -> bool:
     if section == "Distribution":
         if key == "Distribution":
             if args.distribution is None:
@@ -3950,7 +3950,7 @@ def build_image(args: CommandLineArguments,
                 *,
                 run_build_script: bool,
                 for_cache: bool = False,
-                cleanup: bool = False) -> Tuple[Optional[IO[str]], Optional[IO[str]], Optional[str]]:
+                cleanup: bool = False) -> Tuple[Optional[BinaryIO], Optional[BinaryIO], Optional[str]]:
     # If there's no build script set, there's no point in executing
     # the build script iteration. Let's quit early.
     if args.build_script is None and run_build_script:
@@ -4027,7 +4027,7 @@ def var_tmp(workspace: str) -> str:
     return mkdir_last(os.path.join(workspace, "var-tmp"))
 
 
-def run_build_script(args: CommandLineArguments, workspace: str, raw: IO[str]) -> None:
+def run_build_script(args: CommandLineArguments, workspace: str, raw: Optional[BinaryIO]) -> None:
     if args.build_script is None:
         return
 
@@ -4085,8 +4085,8 @@ def need_cache_images(args: CommandLineArguments) -> bool:
 
 def remove_artifacts(args: CommandLineArguments,
                      workspace: str,
-                     raw: Optional[IO[str]],
-                     tar: Optional[IO[str]],
+                     raw: Optional[BinaryIO],
+                     tar: Optional[BinaryIO],
                      run_build_script: bool,
                      for_cache: bool = False) -> None:
     if for_cache:

--- a/mkosi
+++ b/mkosi
@@ -671,8 +671,8 @@ def mkfs_xfs(label: str, dev: str) -> None:
 
 def luks_format(dev: str, passphrase: Dict[str, str]) -> None:
     if passphrase['type'] == 'stdin':
-        passphrase = (passphrase['content'] + "\n").encode("utf-8")
-        run(["cryptsetup", "luksFormat", "--batch-mode", dev], input=passphrase, check=True)
+        passphrase_content = (passphrase['content'] + "\n").encode("utf-8")
+        run(["cryptsetup", "luksFormat", "--batch-mode", dev], input=passphrase_content, check=True)
     else:
         assert passphrase['type'] == 'file'
         run(["cryptsetup", "luksFormat", "--batch-mode", dev, passphrase['content']], check=True)
@@ -682,8 +682,8 @@ def luks_open(dev: str, passphrase: Dict[str, str]) -> str:
     name = str(uuid.uuid4())
 
     if passphrase['type'] == 'stdin':
-        passphrase = (passphrase['content'] + "\n").encode("utf-8")
-        run(["cryptsetup", "open", "--type", "luks", dev, name], input=passphrase, check=True)
+        passphrase_content = (passphrase['content'] + "\n").encode("utf-8")
+        run(["cryptsetup", "open", "--type", "luks", dev, name], input=passphrase_content, check=True)
     else:
         assert passphrase['type'] == 'file'
         run(["cryptsetup", "--key-file", passphrase['content'], "open", "--type", "luks", dev, name], check=True)
@@ -1890,8 +1890,8 @@ def install_opensuse(args, workspace, *, run_build_script):
             f.write("hostonly=no\n")
 
         # dracut from openSUSE is missing upstream commit 016613c774baf.
-        with open(os.path.join(root, "etc/kernel/cmdline"), "w") as cmdline:
-            cmdline.write(args.kernel_commandline + " root=/dev/gpt-auto-root\n")
+        with open(os.path.join(root, "etc/kernel/cmdline"), "w") as cmdlinefile:
+            cmdlinefile.write(args.kernel_commandline + " root=/dev/gpt-auto-root\n")
 
 
 def install_distribution(args, workspace, *, cached, **kwargs):

--- a/mkosi
+++ b/mkosi
@@ -62,6 +62,7 @@ if sys.version_info < (3, 6):
 # This global should be initialized after parsing arguments
 arg_debug = ()
 
+
 def run(cmdline: List[str], execvp: bool=False, **kwargs) -> Optional[subprocess.CompletedProcess]:
     if 'run' in arg_debug:
         sys.stderr.write('+ ' + ' '.join(shlex.quote(x) for x in cmdline) + '\n')
@@ -71,10 +72,12 @@ def run(cmdline: List[str], execvp: bool=False, **kwargs) -> Optional[subprocess
     else:
         return subprocess.run(cmdline, **kwargs)
 
+
 def die(message: str, status: int=1) -> NoReturn:
     assert status >= 1 and status < 128
     sys.stderr.write(message + "\n")
     sys.exit(status)
+
 
 def warn(message: str, *args: Any, **kwargs: Any) -> None:
     sys.stderr.write('WARNING: ' + message.format(*args, **kwargs) + '\n')
@@ -135,6 +138,7 @@ class OutputFormat(enum.Enum):
         "The output format contains a squashfs partition"
         return self in {OutputFormat.gpt_squashfs, OutputFormat.plain_squashfs}
 
+
 class Distribution(enum.Enum):
     fedora = 1
     debian = 2
@@ -144,6 +148,7 @@ class Distribution(enum.Enum):
     mageia = 6
     centos = 7
     clear = 8
+
 
 GPT_ROOT_X86           = uuid.UUID("44479540f29741b29af7d131d5f0458a")
 GPT_ROOT_X86_64        = uuid.UUID("4f68bce3e8cd4db196e7fbcaf984b709")
@@ -190,6 +195,7 @@ GPT_FOOTER_SIZE = 1024*1024
 
 GPTRootTypePair = collections.namedtuple('GPTRootTypePair', 'root verity')
 
+
 def gpt_root_native(arch: str) -> Tuple[uuid.UUID, uuid.UUID]:
     """The tag for the native GPT root partition for the given architecture
 
@@ -205,12 +211,14 @@ def gpt_root_native(arch: str) -> Tuple[uuid.UUID, uuid.UUID]:
     else:
         die(f'Unknown architecture {arch}.')
 
+
 def unshare(flags: int) -> None:
     libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
 
     if libc.unshare(ctypes.c_int(flags)) != 0:
         e = ctypes.get_errno()
         raise OSError(e, os.strerror(e))
+
 
 def format_bytes(bytes: int) -> str:
     if bytes >= 1024*1024*1024:
@@ -222,15 +230,19 @@ def format_bytes(bytes: int) -> str:
 
     return f'{bytes}B'
 
+
 def roundup512(x: int) -> int:
     return (x + 511) & ~511
+
 
 def print_step(text: str) -> None:
     sys.stderr.write("‣ \033[0;1;39m" + text + "\033[0m\n")
 
+
 def print_running_cmd(cmdline: Iterable[str]) -> None:
     sys.stderr.write("‣ \033[0;1;39mRunning command:\033[0m\n")
     sys.stderr.write(" ".join(shlex.quote(x) for x in cmdline) + "\n")
+
 
 def mkdir_last(path: str, mode: int=0o777) -> str:
     """Create directory path
@@ -243,6 +255,7 @@ def mkdir_last(path: str, mode: int=0o777) -> str:
         if not os.path.isdir(path):
             raise
     return path
+
 
 _IOC_NRBITS   =  8
 _IOC_TYPEBITS =  8
@@ -258,6 +271,7 @@ _IOC_NONE  = 0
 _IOC_WRITE = 1
 _IOC_READ  = 2
 
+
 def _IOC(dir: int, type: int, nr: int, argtype: str) -> int:
     size = {'int':4, 'size_t':8}[argtype]
     return dir<<_IOC_DIRSHIFT | type<<_IOC_TYPESHIFT | nr<<_IOC_NRSHIFT | size<<_IOC_SIZESHIFT
@@ -266,7 +280,9 @@ def _IOC(dir: int, type: int, nr: int, argtype: str) -> int:
 def _IOW(type: int, nr: int, size: str) -> int:
     return _IOC(_IOC_WRITE, type, nr, size)
 
+
 FICLONE = _IOW(0x94, 9, 'int')
+
 
 @contextlib.contextmanager
 def open_close(path: str, flags: int, mode: int=0o664) -> Iterator[int]:
@@ -276,8 +292,10 @@ def open_close(path: str, flags: int, mode: int=0o664) -> Iterator[int]:
     finally:
         os.close(fd)
 
+
 def _reflink(oldfd: int, newfd: int) -> None:
     fcntl.ioctl(newfd, FICLONE, oldfd)
+
 
 def copy_fd(oldfd: int, newfd: int) -> None:
     try:
@@ -288,6 +306,7 @@ def copy_fd(oldfd: int, newfd: int) -> None:
         shutil.copyfileobj(open(oldfd, 'rb', closefd=False),
                            open(newfd, 'wb', closefd=False))
 
+
 def copy_file_object(oldobject, newobject):
     try:
         _reflink(oldobject.fileno(), newobject.fileno())
@@ -296,9 +315,11 @@ def copy_file_object(oldobject, newobject):
             raise
         shutil.copyfileobj(oldobject, newobject)
 
+
 def copy_symlink(oldpath: str, newpath: str) -> None:
     src = os.readlink(oldpath)
     os.symlink(src, newpath)
+
 
 def copy_file(oldpath: str, newpath: str) -> None:
     if os.path.islink(oldpath):
@@ -317,12 +338,14 @@ def copy_file(oldpath: str, newpath: str) -> None:
                 copy_fd(oldfd, newfd)
     shutil.copystat(oldpath, newpath, follow_symlinks=False)
 
+
 def symlink_f(target: str, path: str) -> None:
     try:
         os.symlink(target, path)
     except FileExistsError:
         os.unlink(path)
         os.symlink(target, path)
+
 
 def copy(oldpath: str, newpath: str) -> None:
     try:
@@ -349,6 +372,7 @@ def copy(oldpath: str, newpath: str) -> None:
                 continue
     shutil.copystat(oldpath, newpath, follow_symlinks=True)
 
+
 @contextlib.contextmanager
 def complete_step(text: str, text2: Optional[str]=None) -> Iterator[List[Any]]:
     print_step(text + '...')
@@ -358,11 +382,13 @@ def complete_step(text: str, text2: Optional[str]=None) -> Iterator[List[Any]]:
         text2 = text + ' complete'
     print_step(text2.format(*args) + '.')
 
+
 @complete_step('Detaching namespace')
 def init_namespace(args):
     args.original_umask = os.umask(0o000)
     unshare(CLONE_NEWNS)
     run(["mount", "--make-rslave", "/"], check=True)
+
 
 def setup_workspace(args: CommandLineArguments) -> tempfile.TemporaryDirectory:
     print_step("Setting up temporary workspace.")
@@ -374,10 +400,12 @@ def setup_workspace(args: CommandLineArguments) -> tempfile.TemporaryDirectory:
     print_step("Temporary workspace in " + d.name + " is now set up.")
     return d
 
+
 def btrfs_subvol_create(path: str, mode: int=0o755) -> None:
     m = os.umask(~mode & 0o7777)
     run(["btrfs", "subvol", "create", path], check=True)
     os.umask(m)
+
 
 def btrfs_subvol_delete(path: str) -> None:
     # Extract the path of the subvolume relative to the filesystem
@@ -401,8 +429,10 @@ def btrfs_subvol_delete(path: str) -> None:
     # Delete the subvolume now that all its descendants have been deleted
     run(["btrfs", "subvol", "delete", path], stdout=DEVNULL, stderr=DEVNULL, check=True)
 
+
 def btrfs_subvol_make_ro(path: str, b:bool=True) -> None:
     run(["btrfs", "property", "set", path, "ro", "true" if b else "false"], check=True)
+
 
 def image_size(args: CommandLineArguments) -> int:
     size = GPT_HEADER_SIZE + GPT_FOOTER_SIZE
@@ -425,10 +455,12 @@ def image_size(args: CommandLineArguments) -> int:
 
     return size
 
+
 def disable_cow(path: str) -> None:
     """Disable copy-on-write if applicable on filesystem"""
 
     run(["chattr", "+C", path], stdout=DEVNULL, stderr=DEVNULL, check=False)
+
 
 def determine_partition_table(args: CommandLineArguments):
     pn = 1
@@ -514,6 +546,7 @@ def create_image(args: CommandLineArguments, workspace: str, for_cache: bool) ->
 
     return f
 
+
 def reuse_cache_image(args: CommandLineArguments,
                       workspace: str,
                       run_build_script: bool,
@@ -563,6 +596,7 @@ def reuse_cache_image(args: CommandLineArguments,
 
     return f, True
 
+
 @contextlib.contextmanager
 def attach_image_loopback(args: CommandLineArguments, raw: Optional[IO[str]]):
     if raw is None:
@@ -582,11 +616,13 @@ def attach_image_loopback(args: CommandLineArguments, raw: Optional[IO[str]]):
         with complete_step('Detaching image file'):
             run(["losetup", "--detach", loopdev], check=True)
 
+
 def partition(loopdev: str, partno: Optional[int]) -> str:
     if partno is None:
         return None
 
     return loopdev + "p" + str(partno)
+
 
 def prepare_swap(args: CommandLineArguments, loopdev: Optional[str], cached: bool) -> None:
     if loopdev is None:
@@ -599,6 +635,7 @@ def prepare_swap(args: CommandLineArguments, loopdev: Optional[str], cached: boo
     with complete_step('Formatting swap partition'):
         run(["mkswap", "-Lswap", partition(loopdev, args.swap_partno)], check=True)
 
+
 def prepare_esp(args: CommandLineArguments, loopdev: Optional[str], cached: bool) -> None:
     if loopdev is None:
         return
@@ -610,14 +647,18 @@ def prepare_esp(args: CommandLineArguments, loopdev: Optional[str], cached: bool
     with complete_step('Formatting ESP partition'):
         run(["mkfs.fat", "-nEFI", "-F32", partition(loopdev, args.esp_partno)], check=True)
 
+
 def mkfs_ext4(label: str, mount: str, dev: str) -> None:
     run(["mkfs.ext4", "-L", label, "-M", mount, dev], check=True)
+
 
 def mkfs_btrfs(label: str, dev: str) -> None:
     run(["mkfs.btrfs", "-L", label, "-d", "single", "-m", "single", dev], check=True)
 
+
 def mkfs_xfs(label: str, dev: str) -> None:
     run(["mkfs.xfs", "-n", "ftype=1", "-L", label, dev], check=True)
+
 
 def luks_format(dev: str, passphrase: Dict[str, str]) -> None:
     if passphrase['type'] == 'stdin':
@@ -626,6 +667,7 @@ def luks_format(dev: str, passphrase: Dict[str, str]) -> None:
     else:
         assert passphrase['type'] == 'file'
         run(["cryptsetup", "luksFormat", "--batch-mode", dev, passphrase['content']], check=True)
+
 
 def luks_open(dev: str, passphrase: Dict[str, str]) -> str:
     name = str(uuid.uuid4())
@@ -639,12 +681,14 @@ def luks_open(dev: str, passphrase: Dict[str, str]) -> str:
 
     return os.path.join("/dev/mapper", name)
 
+
 def luks_close(dev: Optional[str], text: str) -> None:
     if dev is None:
         return
 
     with complete_step(text):
         run(["cryptsetup", "close", dev], check=True)
+
 
 def luks_format_root(args: CommandLineArguments,
                      loopdev: str,
@@ -665,6 +709,7 @@ def luks_format_root(args: CommandLineArguments,
     with complete_step("LUKS formatting root partition"):
         luks_format(partition(loopdev, args.root_partno), args.passphrase)
 
+
 def luks_format_home(args: CommandLineArguments, loopdev: str, run_build_script: bool, cached: bool) -> None:
     if args.encrypt is None:
         return
@@ -678,6 +723,7 @@ def luks_format_home(args: CommandLineArguments, loopdev: str, run_build_script:
     with complete_step("LUKS formatting home partition"):
         luks_format(partition(loopdev, args.home_partno), args.passphrase)
 
+
 def luks_format_srv(args: CommandLineArguments, loopdev: str, run_build_script: bool, cached: bool) -> None:
     if args.encrypt is None:
         return
@@ -690,6 +736,7 @@ def luks_format_srv(args: CommandLineArguments, loopdev: str, run_build_script: 
 
     with complete_step("LUKS formatting server data partition"):
         luks_format(partition(loopdev, args.srv_partno), args.passphrase)
+
 
 def luks_setup_root(args: CommandLineArguments,
                     loopdev: str,
@@ -707,6 +754,7 @@ def luks_setup_root(args: CommandLineArguments,
     with complete_step("Opening LUKS root partition"):
         return luks_open(partition(loopdev, args.root_partno), args.passphrase)
 
+
 def luks_setup_home(args: CommandLineArguments, loopdev: str, run_build_script: bool) -> Optional[str]:
     if args.encrypt is None:
         return None
@@ -718,6 +766,7 @@ def luks_setup_home(args: CommandLineArguments, loopdev: str, run_build_script: 
     with complete_step("Opening LUKS home partition"):
         return luks_open(partition(loopdev, args.home_partno), args.passphrase)
 
+
 def luks_setup_srv(args: CommandLineArguments, loopdev: str, run_build_script: bool) -> Optional[str]:
     if args.encrypt is None:
         return None
@@ -728,6 +777,7 @@ def luks_setup_srv(args: CommandLineArguments, loopdev: str, run_build_script: b
 
     with complete_step("Opening LUKS server data partition"):
         return luks_open(partition(loopdev, args.srv_partno), args.passphrase)
+
 
 @contextlib.contextmanager
 def luks_setup_all(args: CommandLineArguments,
@@ -754,6 +804,7 @@ def luks_setup_all(args: CommandLineArguments,
     finally:
         luks_close(root, "Closing LUKS root partition")
 
+
 def prepare_root(args: CommandLineArguments, dev: str, cached: bool) -> None:
     if dev is None:
         return
@@ -770,6 +821,7 @@ def prepare_root(args: CommandLineArguments, dev: str, cached: bool) -> None:
         else:
             mkfs_ext4("root", "/", dev)
 
+
 def prepare_home(args: CommandLineArguments, dev: str, cached: bool) -> None:
     if dev is None:
         return
@@ -779,6 +831,7 @@ def prepare_home(args: CommandLineArguments, dev: str, cached: bool) -> None:
     with complete_step('Formatting home partition'):
         mkfs_ext4("home", "/home", dev)
 
+
 def prepare_srv(args: CommandLineArguments, dev: str, cached: bool) -> None:
     if dev is None:
         return
@@ -787,6 +840,7 @@ def prepare_srv(args: CommandLineArguments, dev: str, cached: bool) -> None:
 
     with complete_step('Formatting server data partition'):
         mkfs_ext4("srv", "/srv", dev)
+
 
 def mount_loop(args: CommandLineArguments, dev: str, where: str, read_only:bool=False) -> None:
     os.makedirs(where, 0o755, True)
@@ -804,14 +858,17 @@ def mount_loop(args: CommandLineArguments, dev: str, where: str, read_only:bool=
 
     run(["mount", "-n", dev, where, options], check=True)
 
+
 def mount_bind(what: str, where: str) -> None:
     os.makedirs(what, 0o755, True)
     os.makedirs(where, 0o755, True)
     run(["mount", "--bind", what, where], check=True)
 
+
 def mount_tmpfs(where: str) -> None:
     os.makedirs(where, 0o755, True)
     run(["mount", "tmpfs", "-t", "tmpfs", where], check=True)
+
 
 @contextlib.contextmanager
 def mount_image(args: CommandLineArguments,
@@ -850,6 +907,7 @@ def mount_image(args: CommandLineArguments,
         with complete_step('Unmounting image'):
             umount(root)
 
+
 @complete_step("Assigning hostname")
 def install_etc_hostname(args: CommandLineArguments, workspace: str) -> None:
     etc_hostname = os.path.join(workspace, "root", "etc/hostname")
@@ -866,6 +924,7 @@ def install_etc_hostname(args: CommandLineArguments, workspace: str) -> None:
     if args.hostname:
         open(etc_hostname, "w").write(args.hostname + "\n")
 
+
 @contextlib.contextmanager
 def mount_api_vfs(args: CommandLineArguments, workspace: str) -> Iterator[None]:
     paths = ('/proc', '/dev', '/sys')
@@ -880,6 +939,7 @@ def mount_api_vfs(args: CommandLineArguments, workspace: str) -> Iterator[None]:
         with complete_step('Unmounting API VFS'):
             for d in paths:
                 umount(root + d)
+
 
 @contextlib.contextmanager
 def mount_cache(args: CommandLineArguments, workspace: str) -> Iterator[None]:
@@ -910,9 +970,11 @@ def mount_cache(args: CommandLineArguments, workspace: str) -> Iterator[None]:
             for d in ("var/cache/dnf", "var/cache/yum", "var/cache/apt/archives", "var/cache/pacman/pkg", "var/cache/zypp/packages"):  # NOQA: E501
                 umount(os.path.join(workspace, "root", d))
 
+
 def umount(where: str) -> None:
     # Ignore failures and error messages
     run(["umount", "--recursive", "-n", where], stdout=DEVNULL, stderr=DEVNULL)
+
 
 @complete_step('Setting up basic OS tree')
 def prepare_tree(args: CommandLineArguments, workspace: str, run_build_script: bool, cached: bool):
@@ -971,6 +1033,7 @@ def prepare_tree(args: CommandLineArguments, workspace: str, run_build_script: b
         if args.build_dir is not None:
             os.mkdir(os.path.join(workspace, "root", "root/build"), 0o755)
 
+
 def patch_file(filepath: str, line_rewriter: Callable[[str], str]) -> None:
     temp_new_filepath = filepath + ".tmp.new"
 
@@ -982,6 +1045,7 @@ def patch_file(filepath: str, line_rewriter: Callable[[str], str]) -> None:
     shutil.copystat(filepath, temp_new_filepath)
     os.remove(filepath)
     shutil.move(temp_new_filepath, filepath)
+
 
 def enable_networkd(workspace: str) -> None:
     run(["systemctl",
@@ -1001,11 +1065,13 @@ Type=ether
 DHCP=yes
 """)
 
+
 def enable_networkmanager(workspace: str) -> None:
     run(["systemctl",
          "--root", os.path.join(workspace, "root"),
          "enable", "NetworkManager"],
         check=True)
+
 
 def run_workspace_command(args: CommandLineArguments,
                           workspace: str,
@@ -1037,6 +1103,7 @@ def run_workspace_command(args: CommandLineArguments,
     cmdline += ['--', *cmd]
     run(cmdline, check=True)
 
+
 def check_if_url_exists(url: str) -> Optional[bool]:
     req = urllib.request.Request(url, method="HEAD")
     try:
@@ -1044,6 +1111,7 @@ def check_if_url_exists(url: str) -> Optional[bool]:
             return True
     except:
         return False
+
 
 def disable_kernel_install(args: CommandLineArguments, workspace: str) -> List[str]:
     # Let's disable the automatic kernel installation done by the
@@ -1069,6 +1137,7 @@ def disable_kernel_install(args: CommandLineArguments, workspace: str) -> List[s
 
     return masked
 
+
 def reenable_kernel_install(args: CommandLineArguments, workspace: str, masked: List[str]) -> None:
     # Undo disable_kernel_install() so the final image can be used
     # with scripts installing a kernel following the Bootloader Spec
@@ -1078,6 +1147,7 @@ def reenable_kernel_install(args: CommandLineArguments, workspace: str, masked: 
 
     for f in masked:
         os.unlink(f)
+
 
 def make_rpm_list(args: argparse.Namespace, packages: List[str]) -> List[str]:
     packages = list(packages) # make a copy
@@ -1101,6 +1171,7 @@ def make_rpm_list(args: argparse.Namespace, packages: List[str]) -> List[str]:
 
     return packages
 
+
 def clean_dnf_metadata(root):
     """Removes dnf metadata iff /bin/dnf is not present in the image
 
@@ -1118,6 +1189,7 @@ def clean_dnf_metadata(root):
                     root + '/var/log/hawkey.*',
                     root + '/var/cache/dnf')
 
+
 def clean_yum_metadata(root):
     """Removes yum metadata iff /bin/yum is not present in the image"""
     yum_path = root + '/bin/yum'
@@ -1129,6 +1201,7 @@ def clean_yum_metadata(root):
                     root + '/var/log/yum.*',
                     root + '/var/cache/yum')
 
+
 def clean_rpm_metadata(root):
     """Removes rpm metadata iff /bin/rpm is not present in the image"""
     rpm_path = root + '/bin/rpm'
@@ -1137,6 +1210,7 @@ def clean_rpm_metadata(root):
     if not keep_rpm_data:
         print_step('Cleaning rpm metadata...')
         remove_glob(root + '/var/lib/rpm')
+
 
 def clean_package_manager_metadata(workspace: str):
     """Clean up package manager metadata
@@ -1153,6 +1227,7 @@ def clean_package_manager_metadata(workspace: str):
     clean_yum_metadata(root)
     clean_rpm_metadata(root)
     # FIXME: implement cleanup for other package managers
+
 
 def invoke_dnf(args: CommandLineArguments,
                workspace: str,
@@ -1186,6 +1261,7 @@ def invoke_dnf(args: CommandLineArguments,
 
     with mount_api_vfs(args, workspace):
         run(cmdline, check=True)
+
 
 @complete_step('Installing Clear Linux')
 def install_clear(args: CommandLineArguments, workspace: str, run_build_script: bool) -> None:
@@ -1237,6 +1313,7 @@ ensure that you have openssl program in your system.
         # Password is already empty for root, so no need to reset it later.
         if args.password == "":
             args.password = None
+
 
 @complete_step('Installing Fedora')
 def install_fedora(args: CommandLineArguments, workspace: str, run_build_script: bool) -> None:
@@ -1306,6 +1383,7 @@ gpgkey={gpg_key}
 
     reenable_kernel_install(args, workspace, masked)
 
+
 @complete_step('Installing Mageia')
 def install_mageia(args, workspace, *, run_build_script):
     masked = disable_kernel_install(args, workspace)
@@ -1353,6 +1431,7 @@ gpgkey={gpg_key}
 
     reenable_kernel_install(args, workspace, masked)
 
+
 def invoke_yum(args: CommandLineArguments,
                workspace: str,
                repositories: List[str],
@@ -1383,11 +1462,13 @@ def invoke_yum(args: CommandLineArguments,
     with mount_api_vfs(args, workspace):
         run(cmdline, check=True)
 
+
 def invoke_dnf_or_yum(*args, **kwargs) -> None:
     if shutil.which("dnf") is None:
         invoke_yum(*args, **kwargs)
     else:
         invoke_dnf(*args, **kwargs)
+
 
 @complete_step('Installing CentOS')
 def install_centos(args: CommandLineArguments, workspace: str, *, run_build_script: bool) -> None:
@@ -1434,8 +1515,10 @@ gpgkey={gpg_key}
 
     reenable_kernel_install(args, workspace, masked)
 
+
 def debootstrap_knows_merged_usr():
     return bytes("invalid option", "UTF-8") not in run(("debootstrap", "--merged-usr"), stdout=PIPE).stdout
+
 
 def install_debian_or_ubuntu(args: CommandLineArguments,
                              workspace: str,
@@ -1538,13 +1621,16 @@ def install_debian_or_ubuntu(args: CommandLineArguments,
     run_workspace_command(args, workspace, network=True, env=env, *cmdline)
     os.unlink(policyrcd)
 
+
 @complete_step('Installing Debian')
 def install_debian(args, workspace, *, run_build_script):
     install_debian_or_ubuntu(args, workspace, run_build_script=run_build_script, mirror=args.mirror)
 
+
 @complete_step('Installing Ubuntu')
 def install_ubuntu(args, workspace, *, run_build_script):
     install_debian_or_ubuntu(args, workspace, run_build_script=run_build_script, mirror=args.mirror)
+
 
 @complete_step('Installing Arch Linux')
 def install_arch(args, workspace, *, run_build_script):
@@ -1711,6 +1797,7 @@ SigLevel    = Required DatabaseOptional
     # At this point, no process should be left running, kill then
     run(["fuser", "-c", root, "--kill"])
 
+
 @complete_step('Installing openSUSE')
 def install_opensuse(args, workspace, *, run_build_script):
     root = os.path.join(workspace, "root")
@@ -1794,6 +1881,7 @@ def install_opensuse(args, workspace, *, run_build_script):
         with open(os.path.join(root, "etc/kernel/cmdline"), "w") as cmdline:
             cmdline.write(args.kernel_commandline + " root=/dev/gpt-auto-root\n")
 
+
 def install_distribution(args, workspace, *, cached, **kwargs):
     if cached:
         return
@@ -1810,6 +1898,7 @@ def install_distribution(args, workspace, *, cached, **kwargs):
     }
 
     install[args.distribution](args, workspace, **kwargs)
+
 
 def reset_machine_id(args, workspace, run_build_script, for_cache):
     """Make /etc/machine-id an empty file.
@@ -1839,6 +1928,7 @@ def reset_machine_id(args, workspace, run_build_script, for_cache):
         else:
             os.symlink('../../../etc/machine-id', dbus_machine_id)
 
+
 def reset_random_seed(args, workspace):
     """Remove random seed file, so that it is initialized on first boot"""
 
@@ -1848,6 +1938,7 @@ def reset_random_seed(args, workspace):
             os.unlink(random_seed)
         except FileNotFoundError:
             pass
+
 
 def set_root_password(args, workspace, run_build_script, for_cache):
     "Set the root account password, or just delete it so it's easy to log in"
@@ -1874,6 +1965,7 @@ def set_root_password(args, workspace, run_build_script, for_cache):
                 return line
             patch_file(os.path.join(workspace, 'root', 'etc/shadow'), jj)
 
+
 def run_postinst_script(args, workspace, run_build_script, for_cache):
     if args.postinst_script is None:
         return
@@ -1895,6 +1987,7 @@ def run_postinst_script(args, workspace, run_build_script, for_cache):
         run_workspace_command(args, workspace, "/root/postinst", verb, network=args.with_network)
         os.unlink(os.path.join(workspace, "root", "root/postinst"))
 
+
 def run_finalize_script(args: CommandLineArguments, workspace: str, *, verb: str):
     if args.finalize_script is None:
         return
@@ -1903,6 +1996,7 @@ def run_finalize_script(args: CommandLineArguments, workspace: str, *, verb: str
         buildroot = workspace + '/root'
         env = collections.ChainMap({'BUILDROOT':buildroot}, os.environ)
         run([args.finalize_script, verb], env=env, check=True)
+
 
 def find_kernel_file(workspace_root, pattern):
     # Look for the vmlinuz file in the workspace
@@ -1919,6 +2013,7 @@ def find_kernel_file(workspace_root, pattern):
     if len(kernel_files) > 1:
         warn('More than one kernel file found, will use {}', kernel_file)
     return kernel_file
+
 
 def install_grub(args, workspace, loopdev, grub):
     if args.bios_partno is None:
@@ -1952,8 +2047,10 @@ def install_grub(args, workspace, loopdev, grub):
             f"--output=/boot/{grub}/grub.cfg",
             nspawn_params=nspawn_params)
 
+
 def install_boot_loader_fedora(args, workspace, loopdev):
     install_grub(args, workspace, loopdev, "grub2")
+
 
 def install_boot_loader_arch(args, workspace, loopdev):
     if "uefi" in args.boot_protocols:
@@ -1970,17 +2067,21 @@ def install_boot_loader_arch(args, workspace, loopdev):
     if "bios" in args.boot_protocols:
         install_grub(args, workspace, loopdev, "grub")
 
+
 def install_boot_loader_debian(args, workspace):
     kernel_version = next(filter(lambda x: x[0].isdigit(), os.listdir(os.path.join(workspace, "root", "lib/modules"))))
 
     run_workspace_command(args, workspace,
                     "/usr/bin/kernel-install", "add", kernel_version, "/boot/vmlinuz-" + kernel_version)
 
+
 def install_boot_loader_ubuntu(args, workspace):
     install_boot_loader_debian(args, workspace)
 
+
 def install_boot_loader_opensuse(args, workspace):
     install_boot_loader_debian(args, workspace)
+
 
 def install_boot_loader_clear(args, workspace, loopdev):
     nspawn_params = [
@@ -1996,6 +2097,7 @@ def install_boot_loader_clear(args, workspace, loopdev):
         "--bind=" + os.path.join(workspace, "root/efi") + ":/boot",
     ]
     run_workspace_command(args, workspace, "/usr/bin/clr-boot-manager", "update", "-i", nspawn_params=nspawn_params)
+
 
 def install_boot_loader(args, workspace, loopdev, cached):
     if not args.bootable:
@@ -2030,6 +2132,7 @@ def install_boot_loader(args, workspace, loopdev, cached):
         if args.distribution == Distribution.clear:
             install_boot_loader_clear(args, workspace, loopdev)
 
+
 def install_extra_trees(args, workspace, for_cache):
     if not args.extra_trees:
         return
@@ -2044,6 +2147,7 @@ def install_extra_trees(args, workspace, for_cache):
             else:
                 shutil.unpack_archive(d, os.path.join(workspace, "root"))
 
+
 def install_skeleton_trees(args, workspace, for_cache):
     if not args.skeleton_trees:
         return
@@ -2054,6 +2158,7 @@ def install_skeleton_trees(args, workspace, for_cache):
                 copy(d, os.path.join(workspace, "root"))
             else:
                 shutil.unpack_archive(d, os.path.join(workspace, "root"))
+
 
 def copy_git_files(src, dest, *, git_files):
     what_files = ['--exclude-standard', '--cached']
@@ -2096,6 +2201,7 @@ def copy_git_files(src, dest, *, git_files):
 
         copy_file(src_path, dest_path)
 
+
 def install_build_src(args, workspace, run_build_script, for_cache):
     if not run_build_script:
         return
@@ -2127,6 +2233,7 @@ def install_build_src(args, workspace, run_build_script, for_cache):
                                                 os.path.basename(args.build_dir)+"/" if args.build_dir else "mkosi.builddir/")  # NOQA: E501
                 shutil.copytree(args.build_sources, target, symlinks=True, ignore=ignore)
 
+
 def install_build_dest(args, workspace, run_build_script, for_cache):
     if run_build_script:
         return
@@ -2139,6 +2246,7 @@ def install_build_dest(args, workspace, run_build_script, for_cache):
     with complete_step('Copying in build tree'):
         copy(os.path.join(workspace, "dest"), os.path.join(workspace, "root"))
 
+
 def make_read_only(args, workspace, for_cache):
     if not args.read_only:
         return
@@ -2150,6 +2258,7 @@ def make_read_only(args, workspace, for_cache):
 
     with complete_step('Marking root subvolume read-only'):
         btrfs_subvol_make_ro(os.path.join(workspace, "root"))
+
 
 def make_tar(args, workspace, run_build_script, for_cache):
     if run_build_script:
@@ -2166,6 +2275,7 @@ def make_tar(args, workspace, run_build_script, for_cache):
             stdout=f, check=True)
 
     return f
+
 
 def make_squashfs(args, workspace, for_cache):
     if not args.output_format.is_squashfs():
@@ -2187,6 +2297,7 @@ def make_squashfs(args, workspace, for_cache):
             check=True)
 
     return f
+
 
 def read_partition_table(loopdev):
     table = []
@@ -2226,6 +2337,7 @@ def read_partition_table(loopdev):
                 last_sector = end
 
     return table, last_sector * 512
+
 
 def insert_partition(args, workspace, raw, loopdev, partno, blob, name, type_uuid, uuid = None):
     if args.ran_sfdisk:
@@ -2279,6 +2391,7 @@ def insert_partition(args, workspace, raw, loopdev, partno, blob, name, type_uui
 
     return blob_size
 
+
 def insert_squashfs(args, workspace, raw, loopdev, squashfs, for_cache):
     if args.output_format != OutputFormat.gpt_squashfs:
         return
@@ -2288,6 +2401,7 @@ def insert_squashfs(args, workspace, raw, loopdev, squashfs, for_cache):
     with complete_step('Inserting squashfs root partition'):
         args.root_size = insert_partition(args, workspace, raw, loopdev, args.root_partno, squashfs,
                                           "Root Partition", gpt_root_native(args.architecture).root)
+
 
 def make_verity(args: CommandLineArguments,
                 workspace,
@@ -2310,6 +2424,7 @@ def make_verity(args: CommandLineArguments,
 
         raise ValueError('Root hash not found')
 
+
 def insert_verity(args, workspace, raw, loopdev, verity, root_hash, for_cache):
     if verity is None:
         return
@@ -2323,6 +2438,7 @@ def insert_verity(args, workspace, raw, loopdev, verity, root_hash, for_cache):
         insert_partition(args, workspace, raw, loopdev, args.verity_partno, verity,
                          "Verity Partition", gpt_root_native(args.architecture).verity, u)
 
+
 def patch_root_uuid(args, loopdev, root_hash, for_cache):
     if root_hash is None:
         return
@@ -2335,6 +2451,7 @@ def patch_root_uuid(args, loopdev, root_hash, for_cache):
     with complete_step('Patching root partition UUID'):
         run(["sfdisk", "--part-uuid", loopdev, str(args.root_partno), str(u)],
             check=True)
+
 
 def install_unified_kernel(args, workspace, run_build_script, for_cache, root_hash):
     # Iterates through all kernel versions included in the image and
@@ -2401,6 +2518,7 @@ def install_unified_kernel(args, workspace, run_build_script, for_cache, root_ha
 
             run_workspace_command(args, workspace, *dracut);
 
+
 def secure_boot_sign(args, workspace, run_build_script, for_cache):
     if run_build_script:
         return
@@ -2428,6 +2546,7 @@ def secure_boot_sign(args, workspace, run_build_script, for_cache):
 
                 os.rename(p + ".signed", p)
 
+
 def xz_output(args, raw):
     if not args.output_format.is_disk():
         return raw
@@ -2443,6 +2562,7 @@ def xz_output(args, raw):
 
     return f
 
+
 def qcow2_output(args, raw):
     if not args.output_format.is_disk():
         return raw
@@ -2456,6 +2576,7 @@ def qcow2_output(args, raw):
 
     return f
 
+
 def write_root_hash_file(args, root_hash):
     if root_hash is None:
         return None
@@ -2466,6 +2587,7 @@ def write_root_hash_file(args, root_hash):
         f.write((root_hash + "\n").encode())
 
     return f
+
 
 def copy_nspawn_settings(args):
     if args.nspawn_settings is None:
@@ -2480,6 +2602,7 @@ def copy_nspawn_settings(args):
 
     return f
 
+
 def hash_file(of: IO[Any], sf: IO[bytes], fname: str) -> None:
     bs = 16*1024**2
     h = hashlib.sha256()
@@ -2491,6 +2614,7 @@ def hash_file(of: IO[Any], sf: IO[bytes], fname: str) -> None:
         buf = sf.read(bs)
 
     of.write(h.hexdigest() + " *" + fname + "\n")
+
 
 def calculate_sha256sum(args: CommandLineArguments,
                         raw: Optional[IO[str]],
@@ -2518,6 +2642,7 @@ def calculate_sha256sum(args: CommandLineArguments,
 
     return f
 
+
 def calculate_signature(args: CommandLineArguments, checksum: Optional[IO[Any]]) -> Optional[IO[bytes]]:
     if not args.sign:
         return None
@@ -2539,6 +2664,7 @@ def calculate_signature(args: CommandLineArguments, checksum: Optional[IO[Any]])
 
     return f
 
+
 def calculate_bmap(args: CommandLineArguments, raw: IO[Any]) -> Optional[IO[bytes]]:
     if not args.bmap:
         return None
@@ -2555,6 +2681,7 @@ def calculate_bmap(args: CommandLineArguments, raw: IO[Any]) -> Optional[IO[byte
 
     return f
 
+
 def save_cache(args: CommandLineArguments, workspace: str, raw: str, cache_path: str) -> None:
     if cache_path is None or raw is None:
         return
@@ -2567,6 +2694,7 @@ def save_cache(args: CommandLineArguments, workspace: str, raw: str, cache_path:
             shutil.move(raw, cache_path)
         else:
             shutil.move(os.path.join(workspace, "root"), cache_path)
+
 
 def _link_output(args: CommandLineArguments, oldpath: str, newpath: str):
     os.chmod(oldpath, 0o666 & ~args.original_umask)
@@ -2584,6 +2712,7 @@ def _link_output(args: CommandLineArguments, oldpath: str, newpath: str):
                        f"Successfully changed ownership of {newpath}"):
        os.chown(newpath, int(sudo_uid), int(sudo_gid))
 
+
 def link_output(args: CommandLineArguments, workspace: str, artifact: str) -> None:
     with complete_step('Linking image file',
                        'Successfully linked ' + args.output):
@@ -2591,6 +2720,7 @@ def link_output(args: CommandLineArguments, workspace: str, artifact: str) -> No
             os.rename(os.path.join(workspace, "root"), args.output)
         elif args.output_format.is_disk() or args.output_format == OutputFormat.plain_squashfs:
             _link_output(args, artifact.name, args.output)
+
 
 def link_output_nspawn_settings(args: CommandLineArguments, path: str) -> None:
     if path is None:
@@ -2600,6 +2730,7 @@ def link_output_nspawn_settings(args: CommandLineArguments, path: str) -> None:
                        'Successfully linked ' + args.output_nspawn_settings):
         _link_output(args, path, args.output_nspawn_settings)
 
+
 def link_output_checksum(args: CommandLineArguments, checksum: str) -> None:
     if checksum is None:
         return
@@ -2607,6 +2738,7 @@ def link_output_checksum(args: CommandLineArguments, checksum: str) -> None:
     with complete_step('Linking SHA256SUMS file',
                        'Successfully linked ' + args.output_checksum):
         _link_output(args, checksum, args.output_checksum)
+
 
 def link_output_root_hash_file(args: CommandLineArguments, root_hash_file: str) -> None:
     if root_hash_file is None:
@@ -2616,6 +2748,7 @@ def link_output_root_hash_file(args: CommandLineArguments, root_hash_file: str) 
                        'Successfully linked ' + args.output_root_hash_file):
         _link_output(args, root_hash_file, args.output_root_hash_file)
 
+
 def link_output_signature(args: CommandLineArguments, signature: str) -> None:
     if signature is None:
         return
@@ -2624,6 +2757,7 @@ def link_output_signature(args: CommandLineArguments, signature: str) -> None:
                        'Successfully linked ' + args.output_signature):
         _link_output(args, signature, args.output_signature)
 
+
 def link_output_bmap(args: CommandLineArguments, bmap: str) -> None:
     if bmap is None:
         return
@@ -2631,6 +2765,7 @@ def link_output_bmap(args: CommandLineArguments, bmap: str) -> None:
     with complete_step('Linking .bmap file',
                        'Successfully linked ' + args.output_bmap):
         _link_output(args, bmap, args.output_bmap)
+
 
 def dir_size(path: str) -> int:
     sum = 0
@@ -2646,12 +2781,14 @@ def dir_size(path: str) -> int:
             sum += dir_size(entry.path)
     return sum
 
+
 def print_output_size(args: CommandLineArguments) -> None:
     if args.output_format in (OutputFormat.directory, OutputFormat.subvolume):
         print_step("Resulting image size is " + format_bytes(dir_size(args.output)) + ".")
     else:
         st = os.stat(args.output)
         print_step("Resulting image size is " + format_bytes(st.st_size) + ", consumes " + format_bytes(st.st_blocks * 512) + ".")  # NOQA: E501
+
 
 def setup_package_cache(args: CommandLineArguments) -> Optional[tempfile.TemporaryDirectory]:
     with complete_step('Setting up package cache',
@@ -2665,6 +2802,7 @@ def setup_package_cache(args: CommandLineArguments) -> Optional[tempfile.Tempora
         output.append(args.cache_path)
 
     return d
+
 
 class ListAction(argparse.Action):
     def __init__(self, *args, choices=None, **kwargs):
@@ -2681,18 +2819,23 @@ class ListAction(argparse.Action):
             l.append(x)
         setattr(namespace, self.dest, l)
 
+
 class CommaDelimitedListAction(ListAction):
     delimiter = ","
+
 
 class ColonDelimitedListAction(ListAction):
     delimiter = ":"
 
+
 COMPRESSION_ALGORITHMS = 'zlib', 'lzo', 'zstd', 'lz4', 'xz'
+
 
 def parse_compression(value: str) -> Union[str, bool]:
     if value in COMPRESSION_ALGORITHMS:
         return value
     return parse_boolean(value)
+
 
 def parse_args() -> CommandLineArguments:
     parser = argparse.ArgumentParser(description='Build Legacy-Free OS Images', add_help=False)
@@ -2820,6 +2963,7 @@ def parse_args() -> CommandLineArguments:
 
     return args
 
+
 def parse_bytes(bytes: Optional[str]) -> Optional[int]:
     if bytes is None:
         return bytes
@@ -2844,6 +2988,7 @@ def parse_bytes(bytes: Optional[str]) -> Optional[int]:
         raise ValueError("Size not a multiple of 512")
 
     return result
+
 
 def detect_distribution() -> Tuple[Optional[Distribution], Optional[str]]:
     try:
@@ -2889,6 +3034,7 @@ def detect_distribution() -> Tuple[Optional[Distribution], Optional[str]]:
 
     return d, version_id
 
+
 def unlink_try_hard(path: str) -> None:
     try:
         os.unlink(path)
@@ -2905,11 +3051,13 @@ def unlink_try_hard(path: str) -> None:
     except:
         pass
 
+
 def remove_glob(*patterns: List[str]) -> None:
     pathgen = (glob.glob(pattern) for pattern in patterns)
     paths = set(sum(pathgen, [])) # uniquify
     for path in paths:
         unlink_try_hard(path)
+
 
 def empty_directory(path: str) -> None:
     try:
@@ -2917,6 +3065,7 @@ def empty_directory(path: str) -> None:
             unlink_try_hard(os.path.join(path, f))
     except FileNotFoundError:
         pass
+
 
 def unlink_output(args: CommandLineArguments) -> None:
     if not args.force and args.verb != "clean":
@@ -2970,6 +3119,7 @@ def unlink_output(args: CommandLineArguments) -> None:
             with complete_step('Clearing out package cache'):
                 empty_directory(args.cache_path)
 
+
 def parse_boolean(s: str) -> bool:
     "Parse 1/true/yes as true and 0/false/no as false"
     if s in {"1", "true", "yes"}:
@@ -2979,6 +3129,7 @@ def parse_boolean(s: str) -> bool:
         return False
 
     raise ValueError(f'Invalid literal for bool(): {s!r}')
+
 
 def process_setting(args: CommandLineArguments, section: str, key: str, value: Any) -> bool:
     if section == "Distribution":
@@ -3162,6 +3313,7 @@ def process_setting(args: CommandLineArguments, section: str, key: str, value: A
 
     return True
 
+
 def load_defaults_file(fname: str, options: Dict[str, Dict[str, Any]]) -> Optional[Dict[str, Dict[str, Any]]]:
     try:
         f = open(fname)
@@ -3194,6 +3346,7 @@ def load_defaults_file(fname: str, options: Dict[str, Dict[str, Any]]) -> Option
                 options[section][key] = config[section][key]
     return options
 
+
 def load_defaults(args: CommandLineArguments) -> None:
     fname = "mkosi.default" if args.default_path is None else args.default_path
 
@@ -3211,6 +3364,7 @@ def load_defaults(args: CommandLineArguments) -> None:
         for key in config[section]:
             process_setting(args, section, key, config[section][key])
 
+
 def find_nspawn_settings(args: CommandLineArguments) -> None:
     if args.nspawn_settings is not None:
         return
@@ -3218,17 +3372,20 @@ def find_nspawn_settings(args: CommandLineArguments) -> None:
     if os.path.exists("mkosi.nspawn"):
         args.nspawn_settings = "mkosi.nspawn"
 
+
 def find_extra(args: CommandLineArguments) -> None:
     if os.path.isdir("mkosi.extra"):
         args.extra_trees.append("mkosi.extra")
     if os.path.isfile("mkosi.extra.tar"):
         args.extra_trees.append("mkosi.extra.tar")
 
+
 def find_skeleton(args: CommandLineArguments) -> None:
     if os.path.isdir("mkosi.skeleton"):
         args.skeleton_trees.append("mkosi.skeleton")
     if os.path.isfile("mkosi.skeleton.tar"):
         args.skeleton_trees.append("mkosi.skeleton.tar")
+
 
 def args_find_path(args: CommandLineArguments, name: str, path: str, *, type=lambda x:x) -> None:
     if getattr(args, name) is not None:
@@ -3237,6 +3394,7 @@ def args_find_path(args: CommandLineArguments, name: str, path: str, *, type=lam
         path = os.path.abspath(path)
         path = type(path)
         setattr(args, name, path)
+
 
 def find_cache(args: CommandLineArguments) -> None:
     if args.cache_path is not None:
@@ -3250,12 +3408,14 @@ def find_cache(args: CommandLineArguments) -> None:
         if args.distribution != Distribution.clear and args.release is not None:
             args.cache_path += "~" + args.release
 
+
 def require_private_file(name, description):
     mode = os.stat(name).st_mode & 0o777
     if mode & 0o007:
         warn("Permissions of '{}' of '{}' are too open.\n" +
              "When creating {} files use an access mode that restricts access to the owner only.",
              name, oct(mode), description)
+
 
 def find_passphrase(args: CommandLineArguments) -> None:
     if args.encrypt is None:
@@ -3277,6 +3437,7 @@ def find_passphrase(args: CommandLineArguments) -> None:
 
             sys.stderr.write("Passphrase doesn't match confirmation. Please try again.\n")
 
+
 def find_password(args: CommandLineArguments) -> None:
     if args.password is not None:
         return
@@ -3290,6 +3451,7 @@ def find_password(args: CommandLineArguments) -> None:
     except FileNotFoundError:
         pass
 
+
 def find_secure_boot(args: CommandLineArguments) -> None:
     if not args.secure_boot:
         return
@@ -3301,6 +3463,7 @@ def find_secure_boot(args: CommandLineArguments) -> None:
     if args.secure_boot_certificate is None:
         if os.path.exists("mkosi.secure-boot.crt"):
             args.secure_boot_certificate = "mkosi.secure-boot.crt"
+
 
 def strip_suffixes(path: str) -> str:
     t = path
@@ -3318,11 +3481,14 @@ def strip_suffixes(path: str) -> str:
 
     return t
 
+
 def build_nspawn_settings_path(path: str) -> str:
     return strip_suffixes(path) + ".nspawn"
 
+
 def build_root_hash_file_path(path: str) -> str:
     return strip_suffixes(path) + ".roothash"
+
 
 def load_args() -> CommandLineArguments:
     args = parse_args()
@@ -3563,6 +3729,7 @@ def load_args() -> CommandLineArguments:
 
     return args
 
+
 def check_output(args: CommandLineArguments) -> None:
     for f in (args.output,
               args.output_checksum if args.checksum else None,
@@ -3577,8 +3744,10 @@ def check_output(args: CommandLineArguments) -> None:
         if os.path.exists(f):
             die("Output file " + f + " exists already. (Consider invocation with --force.)")
 
+
 def yes_no(b: bool) -> str:
     return "yes" if b else "no"
+
 
 def format_bytes_or_disabled(sz: Optional[int]) -> str:
     if sz is None:
@@ -3586,20 +3755,25 @@ def format_bytes_or_disabled(sz: Optional[int]) -> str:
 
     return format_bytes(sz)
 
+
 def format_bytes_or_auto(sz: Optional[int])-> str:
     if sz is None:
         return "(automatic)"
 
     return format_bytes(sz)
 
+
 def none_to_na(s: Optional[str]) -> str:
     return "n/a" if s is None else s
+
 
 def none_to_no(s: Optional[str]) -> str:
     return "no" if s is None else s
 
+
 def none_to_none(s: Optional[str]) -> str:
     return "none" if s is None else s
+
 
 def line_join_list(l: List[str]) -> str:
 
@@ -3607,6 +3781,7 @@ def line_join_list(l: List[str]) -> str:
         return "none"
 
     return "\n                        ".join(l)
+
 
 def print_summary(args: CommandLineArguments) -> None:
     sys.stderr.write("DISTRIBUTION:\n")
@@ -3698,6 +3873,7 @@ def print_summary(args: CommandLineArguments) -> None:
     sys.stderr.write("\nHOST CONFIGURATION:\n")
     sys.stderr.write("    Extra search paths: " + line_join_list(args.extra_search_paths) + "\n")
 
+
 def reuse_cache_tree(args: CommandLineArguments,
                      workspace: str,
                      run_build_script: bool,
@@ -3729,6 +3905,7 @@ def reuse_cache_tree(args: CommandLineArguments,
 
     return True
 
+
 def make_output_dir(args: CommandLineArguments) -> None:
     """Create the output directory if set and not existing yet"""
     if args.output_dir is None:
@@ -3736,12 +3913,14 @@ def make_output_dir(args: CommandLineArguments) -> None:
 
     mkdir_last(args.output_dir, 0o755)
 
+
 def make_build_dir(args: CommandLineArguments) -> None:
     """Create the build directory if set and not existing yet"""
     if args.build_dir is None:
         return
 
     mkdir_last(args.build_dir, 0o755)
+
 
 def build_image(args: CommandLineArguments,
                 workspace: tempfile.TemporaryDirectory,
@@ -3820,8 +3999,10 @@ def build_image(args: CommandLineArguments,
 
     return raw or squashfs, tar, root_hash
 
+
 def var_tmp(workspace: str) -> str:
     return mkdir_last(os.path.join(workspace, "var-tmp"))
+
 
 def run_build_script(args: CommandLineArguments, workspace: str, raw: IO[str]) -> None:
     if args.build_script is None:
@@ -3868,6 +4049,7 @@ def run_build_script(args: CommandLineArguments, workspace: str, raw: IO[str]) -
         cmdline.append("/root/" + os.path.basename(args.build_script))
         run(cmdline, check=True)
 
+
 def need_cache_images(args: CommandLineArguments) -> bool:
     if not args.incremental:
         return False
@@ -3876,6 +4058,7 @@ def need_cache_images(args: CommandLineArguments) -> bool:
         return True
 
     return not os.path.exists(args.cache_pre_dev) or not os.path.exists(args.cache_pre_inst)
+
 
 def remove_artifacts(args: CommandLineArguments,
                      workspace: str,
@@ -3901,6 +4084,7 @@ def remove_artifacts(args: CommandLineArguments,
     with complete_step("Removing artifacts from " + what):
         unlink_try_hard(os.path.join(workspace, "root"))
         unlink_try_hard(os.path.join(workspace, "var-tmp"))
+
 
 def build_stuff(args: CommandLineArguments) -> None:
     # Let's define a fixed machine ID for all our build-time
@@ -3977,13 +4161,16 @@ def build_stuff(args: CommandLineArguments) -> None:
     if root_hash is not None:
         print_step(f'Root hash is {root_hash}.')
 
+
 def check_root():
     if os.getuid() != 0:
         die("Must be invoked as root.")
 
+
 def check_native(args: CommandLineArguments) -> None:
     if args.architecture is not None and args.architecture != platform.machine() and args.build_script:
         die('Cannot (currently) override the architecture and run build commands')
+
 
 def run_shell(args: CommandLineArguments) -> None:
     if args.output_format in (OutputFormat.directory, OutputFormat.subvolume):
@@ -4004,6 +4191,7 @@ def run_shell(args: CommandLineArguments) -> None:
         cmdline += ('--', *args.cmdline)
 
     run(cmdline, execvp=True)
+
 
 def run_qemu(args: CommandLineArguments) -> None:
     # Look for the right qemu command line to use
@@ -4051,6 +4239,7 @@ def run_qemu(args: CommandLineArguments) -> None:
 
     run(cmdline, execvp=True)
 
+
 def expand_paths(paths: List[str]) -> List[str]:
     if not paths:
         return []
@@ -4073,6 +4262,7 @@ def expand_paths(paths: List[str]) -> List[str]:
             pass
     return expanded
 
+
 def prepend_to_environ_path(paths: List[str]) -> None:
     if not paths:
         return
@@ -4084,6 +4274,7 @@ def prepend_to_environ_path(paths: List[str]) -> None:
         os.environ["PATH"] = new_path
     else:
         os.environ["PATH"] = new_path + ":" + original_path
+
 
 def main() -> None:
     args = load_args()
@@ -4114,6 +4305,7 @@ def main() -> None:
 
     if args.verb == "qemu":
         run_qemu(args)
+
 
 if __name__ == "__main__":
     main()

--- a/mkosi
+++ b/mkosi
@@ -622,10 +622,14 @@ def attach_image_loopback(args: CommandLineArguments, raw: Optional[IO[str]]):
             run(["losetup", "--detach", loopdev], check=True)
 
 
-def partition(loopdev: str, partno: Optional[int]) -> str:
+def optional_partition(loopdev: str, partno: Optional[int]) -> Optional[str]:
     if partno is None:
         return None
 
+    return partition(loopdev, partno)
+
+
+def partition(loopdev: str, partno: int) -> str:
     return loopdev + "p" + str(partno)
 
 
@@ -799,9 +803,9 @@ def luks_setup_all(args: CommandLineArguments,
             try:
                 srv = luks_setup_srv(args, loopdev, run_build_script)
 
-                yield (partition(loopdev, args.root_partno) if root is None else root,
-                       partition(loopdev, args.home_partno) if home is None else home,
-                       partition(loopdev, args.srv_partno) if srv is None else srv)
+                yield (optional_partition(loopdev, args.root_partno) if root is None else root,
+                       optional_partition(loopdev, args.home_partno) if home is None else home,
+                       optional_partition(loopdev, args.srv_partno) if srv is None else srv)
             finally:
                 luks_close(srv, "Closing LUKS server data partition")
         finally:
@@ -2039,8 +2043,9 @@ def install_grub(args, workspace, loopdev, grub):
     nspawn_params = [
         "--bind-ro=/dev",
         "--property=DeviceAllow=" + loopdev,
-        "--property=DeviceAllow=" + partition(loopdev, args.root_partno),
     ]
+    if args.root_partno is not None:
+        nspawn_params += ["--property=DeviceAllow=" + partition(loopdev, args.root_partno)]
 
     run_workspace_command(
         args, workspace, f"{grub}-install",
@@ -2094,13 +2099,16 @@ def install_boot_loader_clear(args, workspace, loopdev):
         # figure out uuid and related parameters.
         "--bind-ro=/dev",
         "--property=DeviceAllow=" + loopdev,
-        "--property=DeviceAllow=" + partition(loopdev, args.esp_partno),
-        "--property=DeviceAllow=" + partition(loopdev, args.root_partno),
 
         # clr-boot-manager compiled in Clear Linux will assume EFI
         # partition is mounted in "/boot".
         "--bind=" + os.path.join(workspace, "root/efi") + ":/boot",
     ]
+    if args.esp_partno is not None:
+        nspawn_params += ["--property=DeviceAllow=" + partition(loopdev, args.esp_partno)]
+    if args.root_partno is not None:
+        nspawn_params += ["--property=DeviceAllow=" + partition(loopdev, args.root_partno)]
+
     run_workspace_command(args, workspace, "/usr/bin/clr-boot-manager", "update", "-i", nspawn_params=nspawn_params)
 
 

--- a/mkosi
+++ b/mkosi
@@ -34,13 +34,14 @@ from typing import (
     BinaryIO,
     Callable,
     Dict,
+    Generator,
     Iterable,
-    Iterator,
     List,
     NoReturn,
     Optional,
     TextIO,
     Tuple,
+    TypeVar,
     Union,
     cast,
 )
@@ -282,7 +283,7 @@ FICLONE = _IOW(0x94, 9, 'int')
 
 
 @contextlib.contextmanager
-def open_close(path: str, flags: int, mode: int = 0o664) -> Iterator[int]:
+def open_close(path: str, flags: int, mode: int = 0o664) -> Generator[int, None, None]:
     fd = os.open(path, flags | os.O_CLOEXEC, mode)
     try:
         yield fd
@@ -371,7 +372,7 @@ def copy(oldpath: str, newpath: str) -> None:
 
 
 @contextlib.contextmanager
-def complete_step(text: str, text2: Optional[str] = None) -> Iterator[List[Any]]:
+def complete_step(text: str, text2: Optional[str] = None) -> Generator[List[Any], None, None]:
     print_step(text + '...')
     args: List[Any] = []
     yield args
@@ -380,7 +381,12 @@ def complete_step(text: str, text2: Optional[str] = None) -> Iterator[List[Any]]
     print_step(text2.format(*args) + '.')
 
 
-@complete_step('Detaching namespace')
+# https://github.com/python/mypy/issues/1317
+C = TypeVar('C', bound=Callable)
+completestep = cast(Callable[[str], Callable[[C], C]], complete_step)
+
+
+@completestep('Detaching namespace')
 def init_namespace(args):
     args.original_umask = os.umask(0o000)
     unshare(CLONE_NEWNS)
@@ -597,7 +603,7 @@ def reuse_cache_image(args: CommandLineArguments,
 
 
 @contextlib.contextmanager
-def attach_image_loopback(args: CommandLineArguments, raw: Optional[IO[str]]):
+def attach_image_loopback(args: CommandLineArguments, raw: Optional[IO[str]]) -> Generator[Optional[str], None, None]:
     if raw is None:
         yield None
         return
@@ -785,7 +791,10 @@ def luks_setup_srv(args: CommandLineArguments, loopdev: str, run_build_script: b
 @contextlib.contextmanager
 def luks_setup_all(args: CommandLineArguments,
                    loopdev: str,
-                   run_build_script: bool) -> Iterator[Tuple[Optional[str], Optional[str], Optional[str]]]:
+                   run_build_script: bool) -> Generator[Tuple[Optional[str],
+                                                              Optional[str],
+                                                              Optional[str]],
+                                                        None, None]:
     if not args.output_format.is_disk():
         yield (None, None, None)
         return
@@ -880,7 +889,7 @@ def mount_image(args: CommandLineArguments,
                 root_dev: str,
                 home_dev: str,
                 srv_dev: str,
-                root_read_only: bool = False) -> Iterator[None]:
+                root_read_only: bool = False) -> Generator[None, None, None]:
     if loopdev is None:
         yield None
         return
@@ -911,7 +920,7 @@ def mount_image(args: CommandLineArguments,
             umount(root)
 
 
-@complete_step("Assigning hostname")
+@completestep("Assigning hostname")
 def install_etc_hostname(args: CommandLineArguments, workspace: str) -> None:
     etc_hostname = os.path.join(workspace, "root", "etc/hostname")
 
@@ -929,7 +938,7 @@ def install_etc_hostname(args: CommandLineArguments, workspace: str) -> None:
 
 
 @contextlib.contextmanager
-def mount_api_vfs(args: CommandLineArguments, workspace: str) -> Iterator[None]:
+def mount_api_vfs(args: CommandLineArguments, workspace: str) -> Generator[None, None, None]:
     paths = ('/proc', '/dev', '/sys')
     root = os.path.join(workspace, "root")
 
@@ -945,7 +954,7 @@ def mount_api_vfs(args: CommandLineArguments, workspace: str) -> Iterator[None]:
 
 
 @contextlib.contextmanager
-def mount_cache(args: CommandLineArguments, workspace: str) -> Iterator[None]:
+def mount_cache(args: CommandLineArguments, workspace: str) -> Generator[None, None, None]:
     if args.cache_path is None:
         yield
         return
@@ -979,7 +988,7 @@ def umount(where: str) -> None:
     run(["umount", "--recursive", "-n", where], stdout=DEVNULL, stderr=DEVNULL)
 
 
-@complete_step('Setting up basic OS tree')
+@completestep('Setting up basic OS tree')
 def prepare_tree(args: CommandLineArguments, workspace: str, run_build_script: bool, cached: bool):
     if args.output_format == OutputFormat.subvolume:
         btrfs_subvol_create(os.path.join(workspace, "root"))
@@ -1266,7 +1275,7 @@ def invoke_dnf(args: CommandLineArguments,
         run(cmdline, check=True)
 
 
-@complete_step('Installing Clear Linux')
+@completestep('Installing Clear Linux')
 def install_clear(args: CommandLineArguments, workspace: str, run_build_script: bool) -> None:
     if args.release == "latest":
         release = "clear"
@@ -1318,7 +1327,7 @@ ensure that you have openssl program in your system.
             args.password = None
 
 
-@complete_step('Installing Fedora')
+@completestep('Installing Fedora')
 def install_fedora(args: CommandLineArguments, workspace: str, run_build_script: bool) -> None:
     if args.release == 'rawhide':
         last = sorted(FEDORA_KEYS_MAP)[-1]
@@ -1387,7 +1396,7 @@ gpgkey={gpg_key}
     reenable_kernel_install(args, workspace, masked)
 
 
-@complete_step('Installing Mageia')
+@completestep('Installing Mageia')
 def install_mageia(args, workspace, *, run_build_script):
     masked = disable_kernel_install(args, workspace)
 
@@ -1473,7 +1482,7 @@ def invoke_dnf_or_yum(*args, **kwargs) -> None:
         invoke_dnf(*args, **kwargs)
 
 
-@complete_step('Installing CentOS')
+@completestep('Installing CentOS')
 def install_centos(args: CommandLineArguments, workspace: str, *, run_build_script: bool) -> None:
     masked = disable_kernel_install(args, workspace)
 
@@ -1625,17 +1634,17 @@ def install_debian_or_ubuntu(args: CommandLineArguments,
     os.unlink(policyrcd)
 
 
-@complete_step('Installing Debian')
+@completestep('Installing Debian')
 def install_debian(args, workspace, *, run_build_script):
     install_debian_or_ubuntu(args, workspace, run_build_script=run_build_script, mirror=args.mirror)
 
 
-@complete_step('Installing Ubuntu')
+@completestep('Installing Ubuntu')
 def install_ubuntu(args, workspace, *, run_build_script):
     install_debian_or_ubuntu(args, workspace, run_build_script=run_build_script, mirror=args.mirror)
 
 
-@complete_step('Installing Arch Linux')
+@completestep('Installing Arch Linux')
 def install_arch(args, workspace, *, run_build_script):
     if args.release is not None:
         sys.stderr.write("Distribution release specification is not supported for Arch Linux, ignoring.\n")
@@ -1801,7 +1810,7 @@ SigLevel    = Required DatabaseOptional
     run(["fuser", "-c", root, "--kill"])
 
 
-@complete_step('Installing openSUSE')
+@completestep('Installing openSUSE')
 def install_opensuse(args, workspace, *, run_build_script):
     root = os.path.join(workspace, "root")
     release = args.release.strip('"')

--- a/mkosi
+++ b/mkosi
@@ -63,7 +63,7 @@ if sys.version_info < (3, 6):
 arg_debug = ()
 
 
-def run(cmdline: List[str], execvp: bool=False, **kwargs) -> Optional[subprocess.CompletedProcess]:
+def run(cmdline: List[str], execvp: bool = False, **kwargs) -> Optional[subprocess.CompletedProcess]:
     if 'run' in arg_debug:
         sys.stderr.write('+ ' + ' '.join(shlex.quote(x) for x in cmdline) + '\n')
     if execvp:
@@ -73,7 +73,7 @@ def run(cmdline: List[str], execvp: bool=False, **kwargs) -> Optional[subprocess
         return subprocess.run(cmdline, **kwargs)
 
 
-def die(message: str, status: int=1) -> NoReturn:
+def die(message: str, status: int = 1) -> NoReturn:
     assert status >= 1 and status < 128
     sys.stderr.write(message + "\n")
     sys.exit(status)
@@ -245,7 +245,7 @@ def print_running_cmd(cmdline: Iterable[str]) -> None:
     sys.stderr.write(" ".join(shlex.quote(x) for x in cmdline) + "\n")
 
 
-def mkdir_last(path: str, mode: int=0o777) -> str:
+def mkdir_last(path: str, mode: int = 0o777) -> str:
     """Create directory path
 
     Only the final component will be created, so this is different than mkdirs().
@@ -274,8 +274,8 @@ _IOC_READ  = 2
 
 
 def _IOC(dir: int, type: int, nr: int, argtype: str) -> int:
-    size = {'int':4, 'size_t':8}[argtype]
-    return dir<<_IOC_DIRSHIFT | type<<_IOC_TYPESHIFT | nr<<_IOC_NRSHIFT | size<<_IOC_SIZESHIFT
+    size = {'int': 4, 'size_t': 8}[argtype]
+    return dir << _IOC_DIRSHIFT | type << _IOC_TYPESHIFT | nr << _IOC_NRSHIFT | size << _IOC_SIZESHIFT
 
 
 def _IOW(type: int, nr: int, size: str) -> int:
@@ -286,7 +286,7 @@ FICLONE = _IOW(0x94, 9, 'int')
 
 
 @contextlib.contextmanager
-def open_close(path: str, flags: int, mode: int=0o664) -> Iterator[int]:
+def open_close(path: str, flags: int, mode: int = 0o664) -> Iterator[int]:
     fd = os.open(path, flags | os.O_CLOEXEC, mode)
     try:
         yield fd
@@ -331,11 +331,11 @@ def copy_file(oldpath: str, newpath: str) -> None:
         st = os.stat(oldfd)
 
         try:
-            with open_close(newpath, os.O_WRONLY|os.O_CREAT|os.O_EXCL, st.st_mode) as newfd:
+            with open_close(newpath, os.O_WRONLY | os.O_CREAT | os.O_EXCL, st.st_mode) as newfd:
                 copy_fd(oldfd, newfd)
         except FileExistsError:
             os.unlink(newpath)
-            with open_close(newpath, os.O_WRONLY|os.O_CREAT, st.st_mode) as newfd:
+            with open_close(newpath, os.O_WRONLY | os.O_CREAT, st.st_mode) as newfd:
                 copy_fd(oldfd, newfd)
     shutil.copystat(oldpath, newpath, follow_symlinks=False)
 
@@ -375,7 +375,7 @@ def copy(oldpath: str, newpath: str) -> None:
 
 
 @contextlib.contextmanager
-def complete_step(text: str, text2: Optional[str]=None) -> Iterator[List[Any]]:
+def complete_step(text: str, text2: Optional[str] = None) -> Iterator[List[Any]]:
     print_step(text + '...')
     args = [] # type: List[Any]
     yield args
@@ -402,7 +402,7 @@ def setup_workspace(args: CommandLineArguments) -> tempfile.TemporaryDirectory:
     return d
 
 
-def btrfs_subvol_create(path: str, mode: int=0o755) -> None:
+def btrfs_subvol_create(path: str, mode: int = 0o755) -> None:
     m = os.umask(~mode & 0o7777)
     run(["btrfs", "subvol", "create", path], check=True)
     os.umask(m)
@@ -431,7 +431,7 @@ def btrfs_subvol_delete(path: str) -> None:
     run(["btrfs", "subvol", "delete", path], stdout=DEVNULL, stderr=DEVNULL, check=True)
 
 
-def btrfs_subvol_make_ro(path: str, b:bool=True) -> None:
+def btrfs_subvol_make_ro(path: str, b: bool = True) -> None:
     run(["btrfs", "property", "set", path, "ro", "true" if b else "false"], check=True)
 
 
@@ -695,7 +695,7 @@ def luks_format_root(args: CommandLineArguments,
                      loopdev: str,
                      run_build_script: bool,
                      cached: bool,
-                     inserting_squashfs: bool=False) -> None:
+                     inserting_squashfs: bool = False) -> None:
     if args.encrypt != "all":
         return
     if args.root_partno is None:
@@ -742,7 +742,7 @@ def luks_format_srv(args: CommandLineArguments, loopdev: str, run_build_script: 
 def luks_setup_root(args: CommandLineArguments,
                     loopdev: str,
                     run_build_script: bool,
-                    inserting_squashfs:bool=False) -> Optional[str]:
+                    inserting_squashfs: bool = False) -> Optional[str]:
     if args.encrypt != "all":
         return None
     if args.root_partno is None:
@@ -843,7 +843,7 @@ def prepare_srv(args: CommandLineArguments, dev: str, cached: bool) -> None:
         mkfs_ext4("srv", "/srv", dev)
 
 
-def mount_loop(args: CommandLineArguments, dev: str, where: str, read_only:bool=False) -> None:
+def mount_loop(args: CommandLineArguments, dev: str, where: str, read_only: bool = False) -> None:
     os.makedirs(where, 0o755, True)
 
     options = "-odiscard"
@@ -878,7 +878,7 @@ def mount_image(args: CommandLineArguments,
                 root_dev: str,
                 home_dev: str,
                 srv_dev: str,
-                root_read_only: bool=False) -> Iterator[None]:
+                root_read_only: bool = False) -> Iterator[None]:
     if loopdev is None:
         yield None
         return
@@ -1077,9 +1077,9 @@ def enable_networkmanager(workspace: str) -> None:
 def run_workspace_command(args: CommandLineArguments,
                           workspace: str,
                           *cmd: str,
-                          network: bool=False,
-                          env: Dict[str, str]={},
-                          nspawn_params: List[str]=[]) -> None:
+                          network: bool = False,
+                          env: Dict[str, str] = {},
+                          nspawn_params: List[str] = []) -> None:
     cmdline = ["systemd-nspawn",
                '--quiet',
                "--directory=" + os.path.join(workspace, "root"),
@@ -1096,7 +1096,7 @@ def run_workspace_command(args: CommandLineArguments,
     else:
         cmdline += ["--private-network"]
 
-    cmdline += [ f'--setenv={k}={v}' for k,v in env.items() ]
+    cmdline += [ f'--setenv={k}={v}' for k, v in env.items() ]
 
     if nspawn_params:
         cmdline += nspawn_params
@@ -1151,7 +1151,7 @@ def reenable_kernel_install(args: CommandLineArguments, workspace: str, masked: 
 
 
 def make_rpm_list(args: argparse.Namespace, packages: List[str]) -> List[str]:
-    packages = list(packages) # make a copy
+    packages = list(packages)  # make a copy
 
     if args.bootable:
         # Temporary hack: dracut only adds crypto support to the initrd, if the cryptsetup binary is installed
@@ -1995,7 +1995,7 @@ def run_finalize_script(args: CommandLineArguments, workspace: str, *, verb: str
 
     with complete_step('Running finalize script'):
         buildroot = workspace + '/root'
-        env = collections.ChainMap({'BUILDROOT':buildroot}, os.environ)
+        env = collections.ChainMap({'BUILDROOT': buildroot}, os.environ)
         run([args.finalize_script, verb], env=env, check=True)
 
 
@@ -2310,7 +2310,7 @@ def read_partition_table(loopdev):
     for line in c.stdout.decode("utf-8").split('\n'):
         stripped = line.strip()
 
-        if stripped == "": # empty line is where the body begins
+        if stripped == "":  # empty line is where the body begins
             in_body = True
             continue
         if not in_body:
@@ -3056,7 +3056,7 @@ def unlink_try_hard(path: str) -> None:
 
 def remove_glob(*patterns: List[str]) -> None:
     pathgen = (glob.glob(pattern) for pattern in patterns)
-    paths = set(sum(pathgen, [])) # uniquify
+    paths = set(sum(pathgen, []))  # uniquify
     for path in paths:
         unlink_try_hard(path)
 
@@ -3194,7 +3194,7 @@ def process_setting(args: CommandLineArguments, section: str, key: str, value: A
         elif key == "Encrypt":
             if args.encrypt is None:
                 if value not in ("all", "data"):
-                    raise ValueError("Invalid encryption setting: "+ value)
+                    raise ValueError("Invalid encryption setting: " + value)
                 args.encrypt = value
         elif key == "Verity":
             if args.verity is None:
@@ -3389,7 +3389,7 @@ def find_skeleton(args: CommandLineArguments) -> None:
         args.skeleton_trees.append("mkosi.skeleton.tar")
 
 
-def args_find_path(args: CommandLineArguments, name: str, path: str, *, type=lambda x:x) -> None:
+def args_find_path(args: CommandLineArguments, name: str, path: str, *, type=lambda x: x) -> None:
     if getattr(args, name) is not None:
         return
     if os.path.exists(path):
@@ -3585,7 +3585,7 @@ def load_args() -> CommandLineArguments:
             args.boot_protocols = ["uefi"]
         if not {"uefi", "bios"}.issuperset(args.boot_protocols):
             die("Not a valid boot protocol")
-        if "bios" in args.boot_protocols and args.distribution not in (Distribution.fedora,Distribution.arch):
+        if "bios" in args.boot_protocols and args.distribution not in (Distribution.fedora, Distribution.arch):
             die(f"bios boot not implemented yet for {args.distribution}")
 
     if args.encrypt is not None:
@@ -3928,8 +3928,8 @@ def build_image(args: CommandLineArguments,
                 workspace: tempfile.TemporaryDirectory,
                 *,
                 run_build_script: bool,
-                for_cache: bool=False,
-                cleanup: bool=False) -> Tuple[Optional[IO[str]], Optional[IO[str]], Optional[str]]:
+                for_cache: bool = False,
+                cleanup: bool = False) -> Tuple[Optional[IO[str]], Optional[IO[str]], Optional[str]]:
     # If there's no build script set, there's no point in executing
     # the build script iteration. Let's quit early.
     if args.build_script is None and run_build_script:
@@ -4067,7 +4067,7 @@ def remove_artifacts(args: CommandLineArguments,
                      raw: Optional[IO[str]],
                      tar: Optional[IO[str]],
                      run_build_script: bool,
-                     for_cache:bool=False) -> None:
+                     for_cache: bool = False) -> None:
     if for_cache:
         what = "cache build"
     elif run_build_script:

--- a/mkosi
+++ b/mkosi
@@ -1626,12 +1626,17 @@ SigLevel    = Required DatabaseOptional
     run_pacstrap(packages)
 
     if args.bootable:
-        # Patch mkinitcpio configuration so: 1) we remove autodetect and
+        # Patch mkinitcpio configuration so:
+        # 1) we remove autodetect and
         # 2) we add the modules needed for encrypt.
-        patch_file(os.path.join(workspace, "root", "etc/mkinitcpio.conf"),
-                   lambda line: "HOOKS=\"systemd modconf block sd-encrypt filesystems keyboard fsck\"\n" if line.startswith("HOOKS=") and args.encrypt == "all" else
-                                "HOOKS=\"systemd modconf block filesystems fsck\"\n"                     if line.startswith("HOOKS=") else
-                                line)
+        def jj(line: str) -> str:
+            if line.startswith("HOOKS="):
+                if args.encrypt == "all":
+                    return "HOOKS=\"systemd modconf block sd-encrypt filesystems keyboard fsck\"\n"
+                else:
+                    return "HOOKS=\"systemd modconf block filesystems fsck\"\n"
+            return line
+        patch_file(os.path.join(workspace, "root", "etc/mkinitcpio.conf"), jj)
 
     # Install the user-specified packages and kernel
     packages = set(args.packages)
@@ -1813,14 +1818,19 @@ def set_root_password(args, workspace, run_build_script, for_cache):
 
     if args.password == '':
         with complete_step("Deleting root password"):
-            jj = lambda line: (':'.join(['root', ''] + line.split(':')[2:])
-                               if line.startswith('root:') else line)
+            def jj(line: str) -> str:
+                if line.startswith('root:'):
+                    return ':'.join(['root', ''] + line.split(':')[2:])
+                return line
             patch_file(os.path.join(workspace, 'root', 'etc/passwd'), jj)
     elif args.password:
         with complete_step("Setting root password"):
             password = crypt.crypt(args.password, crypt.mksalt(crypt.METHOD_SHA512))
-            jj = lambda line: (':'.join(['root', password] + line.split(':')[2:])
-                               if line.startswith('root:') else line)
+
+            def jj(line: str) -> str:
+                if line.startswith('root:'):
+                    return ':'.join(['root', password] + line.split(':')[2:])
+                return line
             patch_file(os.path.join(workspace, 'root', 'etc/shadow'), jj)
 
 def run_postinst_script(args, workspace, run_build_script, for_cache):
@@ -1878,9 +1888,11 @@ def install_grub(args, workspace, loopdev, grub):
         with open(os.path.join(workspace, "root", "etc/default/grub"), "w+") as f:
             f.write(grub_cmdline)
     else:
-        patch_file(os.path.join(workspace, "root", "etc/default/grub"),
-               lambda line: grub_cmdline if line.startswith("GRUB_CMDLINE_LINUX=") else
-               line)
+        def jj(line: str) -> str:
+            if line.startswith("GRUB_CMDLINE_LINUX="):
+                return grub_cmdline
+            return line
+        patch_file(os.path.join(workspace, "root", "etc/default/grub"), jj)
 
     nspawn_params = [
         "--bind-ro=/dev",

--- a/mkosi
+++ b/mkosi
@@ -796,7 +796,7 @@ def luks_setup_srv(args: CommandLineArguments, loopdev: str, run_build_script: b
 
 @contextlib.contextmanager
 def luks_setup_all(args: CommandLineArguments,
-                   loopdev: str,
+                   loopdev: Optional[str],
                    run_build_script: bool) -> Generator[Tuple[Optional[str],
                                                               Optional[str],
                                                               Optional[str]],
@@ -804,6 +804,7 @@ def luks_setup_all(args: CommandLineArguments,
     if not args.output_format.is_disk():
         yield (None, None, None)
         return
+    assert loopdev is not None
 
     try:
         root = luks_setup_root(args, loopdev, run_build_script)
@@ -892,13 +893,14 @@ def mount_tmpfs(where: str) -> None:
 def mount_image(args: CommandLineArguments,
                 workspace: str,
                 loopdev: Optional[str],
-                root_dev: str,
+                root_dev: Optional[str],
                 home_dev: Optional[str],
                 srv_dev: Optional[str],
                 root_read_only: bool = False) -> Generator[None, None, None]:
     if loopdev is None:
         yield None
         return
+    assert root_dev is not None
 
     with complete_step('Mounting image'):
         root = os.path.join(workspace, "root")
@@ -2125,9 +2127,10 @@ def install_boot_loader_clear(args: CommandLineArguments, workspace: str, loopde
     run_workspace_command(args, workspace, "/usr/bin/clr-boot-manager", "update", "-i", nspawn_params=nspawn_params)
 
 
-def install_boot_loader(args: CommandLineArguments, workspace: str, loopdev: str, cached: bool) -> None:
+def install_boot_loader(args: CommandLineArguments, workspace: str, loopdev: Optional[str], cached: bool) -> None:
     if not args.bootable:
         return
+    assert loopdev is not None
 
     if cached:
         return
@@ -2432,14 +2435,17 @@ def insert_partition(args: CommandLineArguments,
 
 def insert_squashfs(args: CommandLineArguments,
                     workspace: str,
-                    raw: BinaryIO,
-                    loopdev: str,
-                    squashfs: BinaryIO,
+                    raw: Optional[BinaryIO],
+                    loopdev: Optional[str],
+                    squashfs: Optional[BinaryIO],
                     for_cache: bool) -> None:
     if args.output_format != OutputFormat.gpt_squashfs:
         return
     if for_cache:
         return
+    assert raw is not None
+    assert loopdev is not None
+    assert squashfs is not None
 
     with complete_step('Inserting squashfs root partition'):
         args.root_size = insert_partition(args, workspace, raw, loopdev, args.root_partno, squashfs,
@@ -2448,13 +2454,14 @@ def insert_squashfs(args: CommandLineArguments,
 
 def make_verity(args: CommandLineArguments,
                 workspace: str,
-                dev: str,
+                dev: Optional[str],
                 run_build_script: bool,
                 for_cache: bool) -> Tuple[Optional[BinaryIO], Optional[str]]:
     if run_build_script or not args.verity:
         return None, None
     if for_cache:
         return None, None
+    assert dev is not None
 
     with complete_step('Generating verity hashes'):
         f: BinaryIO = cast(BinaryIO, tempfile.NamedTemporaryFile(dir=os.path.dirname(args.output), prefix=".mkosi-"))
@@ -2470,15 +2477,18 @@ def make_verity(args: CommandLineArguments,
 
 def insert_verity(args: CommandLineArguments,
                   workspace: str,
-                  raw: BinaryIO,
-                  loopdev: str,
-                  verity: BinaryIO,
-                  root_hash: str,
+                  raw: Optional[BinaryIO],
+                  loopdev: Optional[str],
+                  verity: Optional[BinaryIO],
+                  root_hash: Optional[str],
                   for_cache: bool) -> None:
     if verity is None:
         return
     if for_cache:
         return
+    assert loopdev is not None
+    assert raw is not None
+    assert root_hash is not None
 
     # Use the final 128 bit of the root hash as partition UUID of the verity partition
     u = uuid.UUID(root_hash[-32:])
@@ -2488,9 +2498,14 @@ def insert_verity(args: CommandLineArguments,
                          "Verity Partition", gpt_root_native(args.architecture).verity, u)
 
 
-def patch_root_uuid(args: CommandLineArguments, loopdev: str, root_hash: Optional[str], for_cache: bool) -> None:
+def patch_root_uuid(args: CommandLineArguments,
+                    loopdev: Optional[str],
+                    root_hash: Optional[str],
+                    for_cache: bool) -> None:
     if root_hash is None:
         return
+    assert loopdev is not None
+
     if for_cache:
         return
 
@@ -2600,9 +2615,10 @@ def secure_boot_sign(args: CommandLineArguments, workspace: str, run_build_scrip
                 os.rename(p + ".signed", p)
 
 
-def xz_output(args: CommandLineArguments, raw: BinaryIO) -> BinaryIO:
+def xz_output(args: CommandLineArguments, raw: Optional[BinaryIO]) -> Optional[BinaryIO]:
     if not args.output_format.is_disk():
         return raw
+    assert raw is not None
 
     if not args.xz:
         return raw
@@ -2616,9 +2632,10 @@ def xz_output(args: CommandLineArguments, raw: BinaryIO) -> BinaryIO:
     return f
 
 
-def qcow2_output(args: CommandLineArguments, raw: BinaryIO) -> BinaryIO:
+def qcow2_output(args: CommandLineArguments, raw: Optional[BinaryIO]) -> Optional[BinaryIO]:
     if not args.output_format.is_disk():
         return raw
+    assert raw is not None
 
     if not args.qcow2:
         return raw
@@ -2718,12 +2735,13 @@ def calculate_signature(args: CommandLineArguments, checksum: Optional[IO[Any]])
     return f
 
 
-def calculate_bmap(args: CommandLineArguments, raw: BinaryIO) -> Optional[TextIO]:
+def calculate_bmap(args: CommandLineArguments, raw: Optional[BinaryIO]) -> Optional[TextIO]:
     if not args.bmap:
         return None
 
     if not args.output_format.is_disk_rw():
         return None
+    assert raw is not None
 
     with complete_step('Creating BMAP file'):
         f: TextIO = cast(TextIO, tempfile.NamedTemporaryFile(mode="w+", prefix=".mkosi-", encoding="utf-8",
@@ -2766,12 +2784,14 @@ def _link_output(args: CommandLineArguments, oldpath: str, newpath: str) -> None
         os.chown(newpath, int(sudo_uid), int(sudo_gid))
 
 
-def link_output(args: CommandLineArguments, workspace: str, artifact: str) -> None:
+def link_output(args: CommandLineArguments, workspace: str, artifact: Optional[BinaryIO]) -> None:
     with complete_step('Linking image file',
                        'Successfully linked ' + args.output):
         if args.output_format in (OutputFormat.directory, OutputFormat.subvolume):
+            assert artifact is None
             os.rename(os.path.join(workspace, "root"), args.output)
         elif args.output_format.is_disk() or args.output_format == OutputFormat.plain_squashfs:
+            assert artifact is not None
             _link_output(args, artifact.name, args.output)
 
 

--- a/mkosi
+++ b/mkosi
@@ -3,11 +3,13 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 import argparse
+import collections
 import configparser
 import contextlib
-import collections
 import crypt
-import ctypes, ctypes.util
+import ctypes
+import ctypes.util
+import enum
 import errno
 import fcntl
 import getpass
@@ -20,17 +22,18 @@ import shlex
 import shutil
 import stat
 import string
+import subprocess
 import sys
 import tempfile
 import urllib.request
 import uuid
-
+from subprocess import DEVNULL, PIPE
 from typing import (
-    Any,
-    Dict,
-    Callable,
-    Generator,
     IO,
+    Any,
+    Callable,
+    Dict,
+    Generator,
     Iterable,
     Iterator,
     List,
@@ -45,9 +48,6 @@ try:
 except ImportError:
     pass
 
-import enum
-import subprocess
-from subprocess import DEVNULL, PIPE
 
 __version__ = '4'
 

--- a/mkosi
+++ b/mkosi
@@ -2810,15 +2810,15 @@ class ListAction(argparse.Action):
         super().__init__(*args, **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
-        l = getattr(namespace, self.dest)
-        if l is None:
-            l = []
+        ary = getattr(namespace, self.dest)
+        if ary is None:
+            ary = []
         new = values.split(self.delimiter)
         for x in new:
             if self.list_choices is not None and x not in self.list_choices:
                 raise ValueError(f'Unknown value {x!r}')
-            l.append(x)
-        setattr(namespace, self.dest, l)
+            ary.append(x)
+        setattr(namespace, self.dest, ary)
 
 
 class CommaDelimitedListAction(ListAction):
@@ -3776,12 +3776,12 @@ def none_to_none(s: Optional[str]) -> str:
     return "none" if s is None else s
 
 
-def line_join_list(l: List[str]) -> str:
+def line_join_list(ary: List[str]) -> str:
 
-    if not l:
+    if not ary:
         return "none"
 
-    return "\n                        ".join(l)
+    return "\n                        ".join(ary)
 
 
 def print_summary(args: CommandLineArguments) -> None:

--- a/mkosi
+++ b/mkosi
@@ -40,6 +40,8 @@ from typing import (
     NamedTuple,
     NoReturn,
     Optional,
+    Sequence,
+    Set,
     TextIO,
     Tuple,
     TypeVar,
@@ -61,7 +63,7 @@ if sys.version_info < (3, 6):
 arg_debug = ()
 
 
-def run(cmdline: List[str], execvp: bool = False, **kwargs) -> subprocess.CompletedProcess:
+def run(cmdline: List[str], execvp: bool = False, **kwargs: Any) -> subprocess.CompletedProcess:
     if 'run' in arg_debug:
         sys.stderr.write('+ ' + ' '.join(shlex.quote(x) for x in cmdline) + '\n')
     if execvp:
@@ -106,16 +108,16 @@ class OutputFormat(enum.Enum):
     raw_squashfs = gpt_squashfs
     raw_xfs = gpt_xfs
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return the member name without the class name"""
         return self.name
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return the member name without the class name"""
         return self.name
 
     @classmethod
-    def from_string(cls, name):
+    def from_string(cls, name: str) -> 'OutputFormat':
         """A convenience method to be used with argparse"""
         try:
             return cls[name]
@@ -123,17 +125,17 @@ class OutputFormat(enum.Enum):
             # this let's argparse generate a proper error message
             return name
 
-    def is_disk_rw(self):
+    def is_disk_rw(self) -> bool:
         "Output format is a disk image with a parition table and a writable filesystem"
         return self in (OutputFormat.gpt_ext4,
                         OutputFormat.gpt_btrfs,
                         OutputFormat.gpt_xfs)
 
-    def is_disk(self):
+    def is_disk(self) -> bool:
         "Output format is a disk image with a partition table"
         return self.is_disk_rw() or self == OutputFormat.gpt_squashfs
 
-    def is_squashfs(self):
+    def is_squashfs(self) -> bool:
         "The output format contains a squashfs partition"
         return self in {OutputFormat.gpt_squashfs, OutputFormat.plain_squashfs}
 
@@ -309,7 +311,7 @@ def copy_fd(oldfd: int, newfd: int) -> None:
                            open(newfd, 'wb', closefd=False))
 
 
-def copy_file_object(oldobject, newobject):
+def copy_file_object(oldobject: BinaryIO, newobject: BinaryIO) -> None:
     try:
         _reflink(oldobject.fileno(), newobject.fileno())
     except OSError as e:
@@ -391,7 +393,7 @@ completestep = cast(Callable[[str], Callable[[C], C]], complete_step)
 
 
 @completestep('Detaching namespace')
-def init_namespace(args):
+def init_namespace(args: CommandLineArguments) -> None:
     args.original_umask = os.umask(0o000)
     unshare(CLONE_NEWNS)
     run(["mount", "--make-rslave", "/"], check=True)
@@ -469,7 +471,7 @@ def disable_cow(path: str) -> None:
     run(["chattr", "+C", path], stdout=DEVNULL, stderr=DEVNULL, check=False)
 
 
-def determine_partition_table(args: CommandLineArguments):
+def determine_partition_table(args: CommandLineArguments) -> Tuple[str, bool]:
     pn = 1
     table = "label: gpt\n"
     run_sfdisk = False
@@ -993,7 +995,7 @@ def umount(where: str) -> None:
 
 
 @completestep('Setting up basic OS tree')
-def prepare_tree(args: CommandLineArguments, workspace: str, run_build_script: bool, cached: bool):
+def prepare_tree(args: CommandLineArguments, workspace: str, run_build_script: bool, cached: bool) -> None:
     if args.output_format == OutputFormat.subvolume:
         btrfs_subvol_create(os.path.join(workspace, "root"))
     else:
@@ -1188,7 +1190,7 @@ def make_rpm_list(args: argparse.Namespace, packages: List[str]) -> List[str]:
     return packages
 
 
-def clean_dnf_metadata(root):
+def clean_dnf_metadata(root: str) -> None:
     """Removes dnf metadata iff /bin/dnf is not present in the image
 
     If dnf is not installed, there doesn't seem to be much use in
@@ -1206,7 +1208,7 @@ def clean_dnf_metadata(root):
                     root + '/var/cache/dnf')
 
 
-def clean_yum_metadata(root):
+def clean_yum_metadata(root: str) -> None:
     """Removes yum metadata iff /bin/yum is not present in the image"""
     yum_path = root + '/bin/yum'
     keep_yum_data = os.access(yum_path, os.F_OK, follow_symlinks=False)
@@ -1218,7 +1220,7 @@ def clean_yum_metadata(root):
                     root + '/var/cache/yum')
 
 
-def clean_rpm_metadata(root):
+def clean_rpm_metadata(root: str) -> None:
     """Removes rpm metadata iff /bin/rpm is not present in the image"""
     rpm_path = root + '/bin/rpm'
     keep_rpm_data = os.access(rpm_path, os.F_OK, follow_symlinks=False)
@@ -1228,7 +1230,7 @@ def clean_rpm_metadata(root):
         remove_glob(root + '/var/lib/rpm')
 
 
-def clean_package_manager_metadata(workspace: str):
+def clean_package_manager_metadata(workspace: str) -> None:
     """Clean up package manager metadata
 
     Try them all regardless of the distro: metadata is only removed if the
@@ -1401,7 +1403,7 @@ gpgkey={gpg_key}
 
 
 @completestep('Installing Mageia')
-def install_mageia(args, workspace, *, run_build_script):
+def install_mageia(args: CommandLineArguments, workspace: str, *, run_build_script: bool) -> None:
     masked = disable_kernel_install(args, workspace)
 
     # Mageia does not (yet) have RPM GPG key on the web
@@ -1532,7 +1534,7 @@ gpgkey={gpg_key}
     reenable_kernel_install(args, workspace, masked)
 
 
-def debootstrap_knows_merged_usr():
+def debootstrap_knows_merged_usr() -> bool:
     return bytes("invalid option", "UTF-8") not in run(("debootstrap", "--merged-usr"), stdout=PIPE).stdout
 
 
@@ -1639,17 +1641,17 @@ def install_debian_or_ubuntu(args: CommandLineArguments,
 
 
 @completestep('Installing Debian')
-def install_debian(args, workspace, *, run_build_script):
+def install_debian(args: CommandLineArguments, workspace: str, *, run_build_script: bool) -> None:
     install_debian_or_ubuntu(args, workspace, run_build_script=run_build_script, mirror=args.mirror)
 
 
 @completestep('Installing Ubuntu')
-def install_ubuntu(args, workspace, *, run_build_script):
+def install_ubuntu(args: CommandLineArguments, workspace: str, *, run_build_script: bool) -> None:
     install_debian_or_ubuntu(args, workspace, run_build_script=run_build_script, mirror=args.mirror)
 
 
 @completestep('Installing Arch Linux')
-def install_arch(args, workspace, *, run_build_script):
+def install_arch(args: CommandLineArguments, workspace: str, *, run_build_script: bool) -> None:
     if args.release is not None:
         sys.stderr.write("Distribution release specification is not supported for Arch Linux, ignoring.\n")
 
@@ -1689,7 +1691,7 @@ SigLevel    = Required DatabaseOptional
 {server}
 """)
 
-    def run_pacman(args, **kwargs):
+    def run_pacman(args: List[str], **kwargs: Any) -> subprocess.CompletedProcess:
         cmdline = [
             "pacman",
             "--noconfirm",
@@ -1698,7 +1700,7 @@ SigLevel    = Required DatabaseOptional
         ]
         return run(cmdline + args, **kwargs, check=True)
 
-    def run_pacman_key(args):
+    def run_pacman_key(args: List[str]) -> subprocess.CompletedProcess:
         cmdline = [
             "pacman-key",
             "--nocolor",
@@ -1706,7 +1708,7 @@ SigLevel    = Required DatabaseOptional
         ]
         return run(cmdline + args, check=True)
 
-    def run_pacstrap(packages):
+    def run_pacstrap(packages: Set[str]) -> None:
         cmdline = ["pacstrap", "-C", pacman_conf, "-dGM", root]
         run(cmdline + list(packages), check=True)
 
@@ -1815,7 +1817,7 @@ SigLevel    = Required DatabaseOptional
 
 
 @completestep('Installing openSUSE')
-def install_opensuse(args, workspace, *, run_build_script):
+def install_opensuse(args: CommandLineArguments, workspace: str, *, run_build_script: bool) -> None:
     root = os.path.join(workspace, "root")
     release = args.release.strip('"')
 
@@ -1857,7 +1859,7 @@ def install_opensuse(args, workspace, *, run_build_script):
     #
     # Now install the additional packages if necessary.
     #
-    extra_packages = []
+    extra_packages: List[str] = []
 
     if args.bootable:
         extra_packages += ["kernel-default"]
@@ -1898,7 +1900,11 @@ def install_opensuse(args, workspace, *, run_build_script):
             cmdlinefile.write(args.kernel_commandline + " root=/dev/gpt-auto-root\n")
 
 
-def install_distribution(args, workspace, *, cached, **kwargs):
+def install_distribution(args: CommandLineArguments,
+                         workspace: str,
+                         *,
+                         cached: bool,
+                         **kwargs: Any) -> None:
     if cached:
         return
 
@@ -1916,7 +1922,7 @@ def install_distribution(args, workspace, *, cached, **kwargs):
     install[args.distribution](args, workspace, **kwargs)
 
 
-def reset_machine_id(args, workspace, run_build_script, for_cache):
+def reset_machine_id(args: CommandLineArguments, workspace: str, run_build_script: bool, for_cache: bool) -> None:
     """Make /etc/machine-id an empty file.
 
     This way, on the next boot is either initialized and committed (if /etc is
@@ -1945,7 +1951,7 @@ def reset_machine_id(args, workspace, run_build_script, for_cache):
             os.symlink('../../../etc/machine-id', dbus_machine_id)
 
 
-def reset_random_seed(args, workspace):
+def reset_random_seed(args: CommandLineArguments, workspace: str) -> None:
     """Remove random seed file, so that it is initialized on first boot"""
 
     with complete_step('Removing random seed'):
@@ -1956,7 +1962,7 @@ def reset_random_seed(args, workspace):
             pass
 
 
-def set_root_password(args, workspace, run_build_script, for_cache):
+def set_root_password(args: CommandLineArguments, workspace: str, run_build_script: bool, for_cache: bool) -> None:
     "Set the root account password, or just delete it so it's easy to log in"
 
     if run_build_script:
@@ -1982,7 +1988,7 @@ def set_root_password(args, workspace, run_build_script, for_cache):
             patch_file(os.path.join(workspace, 'root', 'etc/shadow'), jj)
 
 
-def run_postinst_script(args, workspace, run_build_script, for_cache):
+def run_postinst_script(args: CommandLineArguments, workspace: str, run_build_script: bool, for_cache: bool) -> None:
     if args.postinst_script is None:
         return
     if for_cache:
@@ -2004,7 +2010,7 @@ def run_postinst_script(args, workspace, run_build_script, for_cache):
         os.unlink(os.path.join(workspace, "root", "root/postinst"))
 
 
-def run_finalize_script(args: CommandLineArguments, workspace: str, *, verb: str):
+def run_finalize_script(args: CommandLineArguments, workspace: str, *, verb: str) -> None:
     if args.finalize_script is None:
         return
 
@@ -2014,7 +2020,7 @@ def run_finalize_script(args: CommandLineArguments, workspace: str, *, verb: str
         run([args.finalize_script, verb], env=env, check=True)
 
 
-def find_kernel_file(workspace_root, pattern):
+def find_kernel_file(workspace_root: str, pattern: str) -> Optional[str]:
     # Look for the vmlinuz file in the workspace
     workspace_pattern = os.path.join(workspace_root, pattern.lstrip('/'))
     kernel_files = sorted(glob.glob(workspace_pattern))
@@ -2031,7 +2037,7 @@ def find_kernel_file(workspace_root, pattern):
     return kernel_file
 
 
-def install_grub(args, workspace, loopdev, grub):
+def install_grub(args: CommandLineArguments, workspace: str, loopdev: str, grub: str) -> None:
     if args.bios_partno is None:
         return
 
@@ -2065,11 +2071,11 @@ def install_grub(args, workspace, loopdev, grub):
             nspawn_params=nspawn_params)
 
 
-def install_boot_loader_fedora(args, workspace, loopdev):
+def install_boot_loader_fedora(args: CommandLineArguments, workspace: str, loopdev: str) -> None:
     install_grub(args, workspace, loopdev, "grub2")
 
 
-def install_boot_loader_arch(args, workspace, loopdev):
+def install_boot_loader_arch(args: CommandLineArguments, workspace: str, loopdev: str) -> None:
     if "uefi" in args.boot_protocols:
         # add loader entries and copy kernel/initrd under that entry
         workspace_root = os.path.join(workspace, "root")
@@ -2085,22 +2091,22 @@ def install_boot_loader_arch(args, workspace, loopdev):
         install_grub(args, workspace, loopdev, "grub")
 
 
-def install_boot_loader_debian(args, workspace):
+def install_boot_loader_debian(args: CommandLineArguments, workspace: str) -> None:
     kernel_version = next(filter(lambda x: x[0].isdigit(), os.listdir(os.path.join(workspace, "root", "lib/modules"))))
 
     run_workspace_command(args, workspace,
                           "/usr/bin/kernel-install", "add", kernel_version, "/boot/vmlinuz-" + kernel_version)
 
 
-def install_boot_loader_ubuntu(args, workspace):
+def install_boot_loader_ubuntu(args: CommandLineArguments, workspace: str) -> None:
     install_boot_loader_debian(args, workspace)
 
 
-def install_boot_loader_opensuse(args, workspace):
+def install_boot_loader_opensuse(args: CommandLineArguments, workspace: str) -> None:
     install_boot_loader_debian(args, workspace)
 
 
-def install_boot_loader_clear(args, workspace, loopdev):
+def install_boot_loader_clear(args: CommandLineArguments, workspace: str, loopdev: str) -> None:
     nspawn_params = [
         # clr-boot-manager uses blkid in the device backing "/" to
         # figure out uuid and related parameters.
@@ -2119,7 +2125,7 @@ def install_boot_loader_clear(args, workspace, loopdev):
     run_workspace_command(args, workspace, "/usr/bin/clr-boot-manager", "update", "-i", nspawn_params=nspawn_params)
 
 
-def install_boot_loader(args, workspace, loopdev, cached):
+def install_boot_loader(args: CommandLineArguments, workspace: str, loopdev: str, cached: bool) -> None:
     if not args.bootable:
         return
 
@@ -2153,7 +2159,7 @@ def install_boot_loader(args, workspace, loopdev, cached):
             install_boot_loader_clear(args, workspace, loopdev)
 
 
-def install_extra_trees(args, workspace, for_cache):
+def install_extra_trees(args: CommandLineArguments, workspace: str, for_cache: bool) -> None:
     if not args.extra_trees:
         return
 
@@ -2168,7 +2174,7 @@ def install_extra_trees(args, workspace, for_cache):
                 shutil.unpack_archive(d, os.path.join(workspace, "root"))
 
 
-def install_skeleton_trees(args, workspace, for_cache):
+def install_skeleton_trees(args: CommandLineArguments, workspace: str, for_cache: bool) -> None:
     if not args.skeleton_trees:
         return
 
@@ -2180,7 +2186,7 @@ def install_skeleton_trees(args, workspace, for_cache):
                 shutil.unpack_archive(d, os.path.join(workspace, "root"))
 
 
-def copy_git_files(src, dest, *, git_files):
+def copy_git_files(src: str, dest: str, *, git_files: str) -> None:
     what_files = ['--exclude-standard', '--cached']
     if git_files == 'others':
         what_files += ['--others', '--exclude=.mkosi-*']
@@ -2222,7 +2228,7 @@ def copy_git_files(src, dest, *, git_files):
         copy_file(src_path, dest_path)
 
 
-def install_build_src(args, workspace, run_build_script, for_cache):
+def install_build_src(args: CommandLineArguments, workspace: str, run_build_script: bool, for_cache: bool) -> None:
     if not run_build_script:
         return
     if for_cache:
@@ -2254,7 +2260,7 @@ def install_build_src(args, workspace, run_build_script, for_cache):
                 shutil.copytree(args.build_sources, target, symlinks=True, ignore=ignore)
 
 
-def install_build_dest(args, workspace, run_build_script, for_cache):
+def install_build_dest(args: CommandLineArguments, workspace: str, run_build_script: bool, for_cache: bool) -> None:
     if run_build_script:
         return
     if for_cache:
@@ -2267,7 +2273,7 @@ def install_build_dest(args, workspace, run_build_script, for_cache):
         copy(os.path.join(workspace, "dest"), os.path.join(workspace, "root"))
 
 
-def make_read_only(args, workspace, for_cache):
+def make_read_only(args: CommandLineArguments, workspace: str, for_cache: bool) -> None:
     if not args.read_only:
         return
     if for_cache:
@@ -2280,7 +2286,10 @@ def make_read_only(args, workspace, for_cache):
         btrfs_subvol_make_ro(os.path.join(workspace, "root"))
 
 
-def make_tar(args, workspace, run_build_script, for_cache):
+def make_tar(args: CommandLineArguments,
+             workspace: str,
+             run_build_script: bool,
+             for_cache: bool) -> Optional[BinaryIO]:
     if run_build_script:
         return None
     if args.output_format != OutputFormat.tar:
@@ -2297,7 +2306,7 @@ def make_tar(args, workspace, run_build_script, for_cache):
     return f
 
 
-def make_squashfs(args, workspace, for_cache):
+def make_squashfs(args: CommandLineArguments, workspace: str, for_cache: bool) -> Optional[BinaryIO]:
     if not args.output_format.is_squashfs():
         return None
     if for_cache:
@@ -2320,7 +2329,7 @@ def make_squashfs(args, workspace, for_cache):
     return f
 
 
-def read_partition_table(loopdev):
+def read_partition_table(loopdev: str) -> Tuple[List[str], int]:
     table = []
     last_sector = 0
 
@@ -2360,7 +2369,15 @@ def read_partition_table(loopdev):
     return table, last_sector * 512
 
 
-def insert_partition(args, workspace, raw, loopdev, partno, blob, name, type_uuid, uuid=None):
+def insert_partition(args: CommandLineArguments,
+                     workspace: str,
+                     raw: BinaryIO,
+                     loopdev: str,
+                     partno: int,
+                     blob: BinaryIO,
+                     name: str,
+                     type_uuid: uuid.UUID,
+                     uuid: Optional[uuid.UUID] = None) -> int:
     if args.ran_sfdisk:
         old_table, last_partition_sector = read_partition_table(loopdev)
     else:
@@ -2413,7 +2430,12 @@ def insert_partition(args, workspace, raw, loopdev, partno, blob, name, type_uui
     return blob_size
 
 
-def insert_squashfs(args, workspace, raw, loopdev, squashfs, for_cache):
+def insert_squashfs(args: CommandLineArguments,
+                    workspace: str,
+                    raw: BinaryIO,
+                    loopdev: str,
+                    squashfs: BinaryIO,
+                    for_cache: bool) -> None:
     if args.output_format != OutputFormat.gpt_squashfs:
         return
     if for_cache:
@@ -2425,8 +2447,8 @@ def insert_squashfs(args, workspace, raw, loopdev, squashfs, for_cache):
 
 
 def make_verity(args: CommandLineArguments,
-                workspace,
-                dev,
+                workspace: str,
+                dev: str,
                 run_build_script: bool,
                 for_cache: bool) -> Tuple[Optional[BinaryIO], Optional[str]]:
     if run_build_script or not args.verity:
@@ -2446,7 +2468,13 @@ def make_verity(args: CommandLineArguments,
         raise ValueError('Root hash not found')
 
 
-def insert_verity(args, workspace, raw, loopdev, verity, root_hash, for_cache):
+def insert_verity(args: CommandLineArguments,
+                  workspace: str,
+                  raw: BinaryIO,
+                  loopdev: str,
+                  verity: BinaryIO,
+                  root_hash: str,
+                  for_cache: bool) -> None:
     if verity is None:
         return
     if for_cache:
@@ -2460,7 +2488,7 @@ def insert_verity(args, workspace, raw, loopdev, verity, root_hash, for_cache):
                          "Verity Partition", gpt_root_native(args.architecture).verity, u)
 
 
-def patch_root_uuid(args, loopdev, root_hash, for_cache):
+def patch_root_uuid(args: CommandLineArguments, loopdev: str, root_hash: Optional[str], for_cache: bool) -> None:
     if root_hash is None:
         return
     if for_cache:
@@ -2474,7 +2502,11 @@ def patch_root_uuid(args, loopdev, root_hash, for_cache):
             check=True)
 
 
-def install_unified_kernel(args, workspace, run_build_script, for_cache, root_hash):
+def install_unified_kernel(args: CommandLineArguments,
+                           workspace: str,
+                           run_build_script: bool,
+                           for_cache: bool,
+                           root_hash: Optional[str]) -> None:
     # Iterates through all kernel versions included in the image and
     # generates a combined kernel+initrd+cmdline+osrelease EFI file
     # from it and places it in the /EFI/Linux directory of the
@@ -2540,7 +2572,7 @@ def install_unified_kernel(args, workspace, run_build_script, for_cache, root_ha
             run_workspace_command(args, workspace, *dracut)
 
 
-def secure_boot_sign(args, workspace, run_build_script, for_cache):
+def secure_boot_sign(args: CommandLineArguments, workspace: str, run_build_script: bool, for_cache: bool) -> None:
     if run_build_script:
         return
     if not args.bootable:
@@ -2568,7 +2600,7 @@ def secure_boot_sign(args, workspace, run_build_script, for_cache):
                 os.rename(p + ".signed", p)
 
 
-def xz_output(args, raw):
+def xz_output(args: CommandLineArguments, raw: BinaryIO) -> BinaryIO:
     if not args.output_format.is_disk():
         return raw
 
@@ -2584,7 +2616,7 @@ def xz_output(args, raw):
     return f
 
 
-def qcow2_output(args, raw):
+def qcow2_output(args: CommandLineArguments, raw: BinaryIO) -> BinaryIO:
     if not args.output_format.is_disk():
         return raw
 
@@ -2598,7 +2630,7 @@ def qcow2_output(args, raw):
     return f
 
 
-def write_root_hash_file(args, root_hash):
+def write_root_hash_file(args: CommandLineArguments, root_hash: Optional[str]) -> Optional[BinaryIO]:
     if root_hash is None:
         return None
 
@@ -2610,7 +2642,7 @@ def write_root_hash_file(args, root_hash):
     return f
 
 
-def copy_nspawn_settings(args):
+def copy_nspawn_settings(args: CommandLineArguments) -> Optional[BinaryIO]:
     if args.nspawn_settings is None:
         return None
 
@@ -2717,7 +2749,7 @@ def save_cache(args: CommandLineArguments, workspace: str, raw: Optional[str], c
             shutil.move(os.path.join(workspace, "root"), cache_path)
 
 
-def _link_output(args: CommandLineArguments, oldpath: str, newpath: str):
+def _link_output(args: CommandLineArguments, oldpath: str, newpath: str) -> None:
     os.chmod(oldpath, 0o666 & ~args.original_umask)
     os.link(oldpath, newpath)
     if args.no_chown:
@@ -2826,11 +2858,17 @@ def setup_package_cache(args: CommandLineArguments) -> Optional[tempfile.Tempora
 
 
 class ListAction(argparse.Action):
-    def __init__(self, *args, choices=None, **kwargs):
+    delimiter: str
+
+    def __init__(self, *args: Any, choices: Optional[Iterable[Any]] = None, **kwargs: Any):
         self.list_choices = choices
         super().__init__(*args, **kwargs)
 
-    def __call__(self, parser, namespace, values, option_string=None):
+    def __call__(self,  # These type-hints are copied from argparse.pyi
+                 parser: argparse.ArgumentParser,
+                 namespace: argparse.Namespace,
+                 values: Union[str, Sequence[Any], None],
+                 option_string: Optional[str] = None) -> None:
         ary = getattr(namespace, self.dest)
         if ary is None:
             ary = []
@@ -3077,7 +3115,7 @@ def unlink_try_hard(path: str) -> None:
 
 def remove_glob(*patterns: str) -> None:
     pathgen = (glob.glob(pattern) for pattern in patterns)
-    paths = set(sum(pathgen, []))  # uniquify
+    paths: Set[str] = set(sum(pathgen, []))  # uniquify
     for path in paths:
         unlink_try_hard(path)
 
@@ -3410,7 +3448,11 @@ def find_skeleton(args: CommandLineArguments) -> None:
         args.skeleton_trees.append("mkosi.skeleton.tar")
 
 
-def args_find_path(args: CommandLineArguments, name: str, path: str, *, type=lambda x: x) -> None:
+def args_find_path(args: CommandLineArguments,
+                   name: str,
+                   path: str,
+                   *,
+                   type: Callable[[str], Any] = lambda x: x) -> None:
     if getattr(args, name) is not None:
         return
     if os.path.exists(path):
@@ -3432,7 +3474,7 @@ def find_cache(args: CommandLineArguments) -> None:
             args.cache_path += "~" + args.release
 
 
-def require_private_file(name, description):
+def require_private_file(name: str, description: str) -> None:
     mode = os.stat(name).st_mode & 0o777
     if mode & 0o007:
         warn("Permissions of '{}' of '{}' are too open.\n" +
@@ -4185,7 +4227,7 @@ def build_stuff(args: CommandLineArguments) -> None:
         print_step(f'Root hash is {root_hash}.')
 
 
-def check_root():
+def check_root() -> None:
     if os.getuid() != 0:
         die("Must be invoked as root.")
 

--- a/mkosi
+++ b/mkosi
@@ -1405,7 +1405,7 @@ gpgkey={gpg_key}
 
 
 @completestep('Installing Mageia')
-def install_mageia(args: CommandLineArguments, workspace: str, *, run_build_script: bool) -> None:
+def install_mageia(args: CommandLineArguments, workspace: str, run_build_script: bool) -> None:
     masked = disable_kernel_install(args, workspace)
 
     # Mageia does not (yet) have RPM GPG key on the web
@@ -1495,7 +1495,7 @@ def invoke_dnf_or_yum(args: CommandLineArguments,
 
 
 @completestep('Installing CentOS')
-def install_centos(args: CommandLineArguments, workspace: str, *, run_build_script: bool) -> None:
+def install_centos(args: CommandLineArguments, workspace: str, run_build_script: bool) -> None:
     masked = disable_kernel_install(args, workspace)
 
     gpg_key = f"/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-{args.release}"
@@ -1647,17 +1647,17 @@ def install_debian_or_ubuntu(args: CommandLineArguments,
 
 
 @completestep('Installing Debian')
-def install_debian(args: CommandLineArguments, workspace: str, *, run_build_script: bool) -> None:
+def install_debian(args: CommandLineArguments, workspace: str, run_build_script: bool) -> None:
     install_debian_or_ubuntu(args, workspace, run_build_script=run_build_script, mirror=args.mirror)
 
 
 @completestep('Installing Ubuntu')
-def install_ubuntu(args: CommandLineArguments, workspace: str, *, run_build_script: bool) -> None:
+def install_ubuntu(args: CommandLineArguments, workspace: str, run_build_script: bool) -> None:
     install_debian_or_ubuntu(args, workspace, run_build_script=run_build_script, mirror=args.mirror)
 
 
 @completestep('Installing Arch Linux')
-def install_arch(args: CommandLineArguments, workspace: str, *, run_build_script: bool) -> None:
+def install_arch(args: CommandLineArguments, workspace: str, run_build_script: bool) -> None:
     if args.release is not None:
         sys.stderr.write("Distribution release specification is not supported for Arch Linux, ignoring.\n")
 
@@ -1823,7 +1823,7 @@ SigLevel    = Required DatabaseOptional
 
 
 @completestep('Installing openSUSE')
-def install_opensuse(args: CommandLineArguments, workspace: str, *, run_build_script: bool) -> None:
+def install_opensuse(args: CommandLineArguments, workspace: str, run_build_script: bool) -> None:
     root = os.path.join(workspace, "root")
     release = args.release.strip('"')
 
@@ -1909,12 +1909,12 @@ def install_opensuse(args: CommandLineArguments, workspace: str, *, run_build_sc
 def install_distribution(args: CommandLineArguments,
                          workspace: str,
                          *,
-                         cached: bool,
-                         **kwargs: Any) -> None:
+                         run_build_script: bool,
+                         cached: bool) -> None:
     if cached:
         return
 
-    install = {
+    install: Dict[Distribution, Callable[[CommandLineArguments, str, bool], None]] = {
         Distribution.fedora: install_fedora,
         Distribution.centos: install_centos,
         Distribution.mageia: install_mageia,
@@ -1925,7 +1925,7 @@ def install_distribution(args: CommandLineArguments,
         Distribution.clear: install_clear,
     }
 
-    install[args.distribution](args, workspace, **kwargs)
+    install[args.distribution](args, workspace, run_build_script)
 
 
 def reset_machine_id(args: CommandLineArguments, workspace: str, run_build_script: bool, for_cache: bool) -> None:

--- a/mkosi
+++ b/mkosi
@@ -514,7 +514,10 @@ def create_image(args: CommandLineArguments, workspace: str, for_cache: bool) ->
 
     return f
 
-def reuse_cache_image(args: CommandLineArguments, workspace: str, run_build_script: bool, for_cache: bool) -> Tuple[Optional[IO[str]], bool]:
+def reuse_cache_image(args: CommandLineArguments,
+                      workspace: str,
+                      run_build_script: bool,
+                      for_cache: bool) -> Tuple[Optional[IO[str]], bool]:
     if not args.incremental:
         return None, False
     if not args.output_format.is_disk_rw():
@@ -643,7 +646,11 @@ def luks_close(dev: Optional[str], text: str) -> None:
     with complete_step(text):
         run(["cryptsetup", "close", dev], check=True)
 
-def luks_format_root(args: CommandLineArguments, loopdev: str, run_build_script: bool, cached: bool, inserting_squashfs: bool=False) -> None:
+def luks_format_root(args: CommandLineArguments,
+                     loopdev: str,
+                     run_build_script: bool,
+                     cached: bool,
+                     inserting_squashfs: bool=False) -> None:
     if args.encrypt != "all":
         return
     if args.root_partno is None:
@@ -684,7 +691,10 @@ def luks_format_srv(args: CommandLineArguments, loopdev: str, run_build_script: 
     with complete_step("LUKS formatting server data partition"):
         luks_format(partition(loopdev, args.srv_partno), args.passphrase)
 
-def luks_setup_root(args: CommandLineArguments, loopdev: str, run_build_script: bool, inserting_squashfs:bool=False) -> Optional[str]:
+def luks_setup_root(args: CommandLineArguments,
+                    loopdev: str,
+                    run_build_script: bool,
+                    inserting_squashfs:bool=False) -> Optional[str]:
     if args.encrypt != "all":
         return None
     if args.root_partno is None:
@@ -720,7 +730,9 @@ def luks_setup_srv(args: CommandLineArguments, loopdev: str, run_build_script: b
         return luks_open(partition(loopdev, args.srv_partno), args.passphrase)
 
 @contextlib.contextmanager
-def luks_setup_all(args: CommandLineArguments, loopdev: str, run_build_script: bool) -> Iterator[Tuple[Optional[str], Optional[str], Optional[str]]]:
+def luks_setup_all(args: CommandLineArguments,
+                   loopdev: str,
+                   run_build_script: bool) -> Iterator[Tuple[Optional[str], Optional[str], Optional[str]]]:
     if not args.output_format.is_disk():
         yield (None, None, None)
         return
@@ -802,7 +814,13 @@ def mount_tmpfs(where: str) -> None:
     run(["mount", "tmpfs", "-t", "tmpfs", where], check=True)
 
 @contextlib.contextmanager
-def mount_image(args: CommandLineArguments, workspace: str, loopdev: str, root_dev: str, home_dev: str, srv_dev: str, root_read_only: bool=False) -> Iterator[None]:
+def mount_image(args: CommandLineArguments,
+                workspace: str,
+                loopdev: str,
+                root_dev: str,
+                home_dev: str,
+                srv_dev: str,
+                root_read_only: bool=False) -> Iterator[None]:
     if loopdev is None:
         yield None
         return
@@ -874,7 +892,9 @@ def mount_cache(args: CommandLineArguments, workspace: str) -> Iterator[None]:
         if args.distribution in (Distribution.fedora, Distribution.mageia):
             mount_bind(args.cache_path, os.path.join(workspace, "root", "var/cache/dnf"))
         elif args.distribution == Distribution.centos:
-            # We mount both the YUM and the DNF cache in this case, as YUM might just be redirected to DNF even if we invoke the former
+            # We mount both the YUM and the DNF cache in this case, as
+            # YUM might just be redirected to DNF even if we invoke
+            # the former
             mount_bind(os.path.join(args.cache_path, "yum"), os.path.join(workspace, "root", "var/cache/yum"))
             mount_bind(os.path.join(args.cache_path, "dnf"), os.path.join(workspace, "root", "var/cache/dnf"))
         elif args.distribution in (Distribution.debian, Distribution.ubuntu):
@@ -887,7 +907,7 @@ def mount_cache(args: CommandLineArguments, workspace: str) -> Iterator[None]:
         yield
     finally:
         with complete_step('Unmounting Package Cache'):
-            for d in ("var/cache/dnf", "var/cache/yum", "var/cache/apt/archives", "var/cache/pacman/pkg", "var/cache/zypp/packages"):
+            for d in ("var/cache/dnf", "var/cache/yum", "var/cache/apt/archives", "var/cache/pacman/pkg", "var/cache/zypp/packages"):  # NOQA: E501
                 umount(os.path.join(workspace, "root", d))
 
 def umount(where: str) -> None:
@@ -987,7 +1007,12 @@ def enable_networkmanager(workspace: str) -> None:
          "enable", "NetworkManager"],
         check=True)
 
-def run_workspace_command(args: CommandLineArguments, workspace: str, *cmd: str, network: bool=False, env: Dict[str, str]={}, nspawn_params: List[str]=[]) -> None:
+def run_workspace_command(args: CommandLineArguments,
+                          workspace: str,
+                          *cmd: str,
+                          network: bool=False,
+                          env: Dict[str, str]={},
+                          nspawn_params: List[str]=[]) -> None:
     cmdline = ["systemd-nspawn",
                '--quiet',
                "--directory=" + os.path.join(workspace, "root"),
@@ -1129,7 +1154,11 @@ def clean_package_manager_metadata(workspace: str):
     clean_rpm_metadata(root)
     # FIXME: implement cleanup for other package managers
 
-def invoke_dnf(args: CommandLineArguments, workspace: str, repositories: List[str], packages: List[str], config_file: str) -> None:
+def invoke_dnf(args: CommandLineArguments,
+               workspace: str,
+               repositories: List[str],
+               packages: List[str],
+               config_file: str) -> None:
     repos = ["--enablerepo=" + repo for repo in repositories]
 
     packages = make_rpm_list(args, packages)
@@ -1324,7 +1353,11 @@ gpgkey={gpg_key}
 
     reenable_kernel_install(args, workspace, masked)
 
-def invoke_yum(args: CommandLineArguments, workspace: str, repositories: List[str], packages: List[str], config_file: str) -> None:
+def invoke_yum(args: CommandLineArguments,
+               workspace: str,
+               repositories: List[str],
+               packages: List[str],
+               config_file: str) -> None:
     repos = ["--enablerepo=" + repo for repo in repositories]
 
     packages = make_rpm_list(args, packages)
@@ -1404,7 +1437,11 @@ gpgkey={gpg_key}
 def debootstrap_knows_merged_usr():
     return bytes("invalid option", "UTF-8") not in run(("debootstrap", "--merged-usr"), stdout=PIPE).stdout
 
-def install_debian_or_ubuntu(args: CommandLineArguments, workspace: str, *, run_build_script: bool, mirror: str) -> None:
+def install_debian_or_ubuntu(args: CommandLineArguments,
+                             workspace: str,
+                             *,
+                             run_build_script: bool,
+                             mirror: str) -> None:
     repos = args.repositories if args.repositories else ["main"]
     # Ubuntu needs the 'universe' repo to install 'dracut'
     if args.distribution == Distribution.ubuntu and args.bootable and 'universe' not in repos:
@@ -1494,7 +1531,11 @@ def install_debian_or_ubuntu(args: CommandLineArguments, workspace: str, *, run_
             f.writelines(f'path-exclude {d}/*\n' for d in doc_paths)
 
     cmdline = ["/usr/bin/apt-get", "--assume-yes", "--no-install-recommends", "install"] + extra_packages
-    run_workspace_command(args, workspace, network=True, env={'DEBIAN_FRONTEND': 'noninteractive', 'DEBCONF_NONINTERACTIVE_SEEN': 'true'}, *cmdline)
+    env = {
+        'DEBIAN_FRONTEND': 'noninteractive',
+        'DEBCONF_NONINTERACTIVE_SEEN': 'true',
+    }
+    run_workspace_command(args, workspace, network=True, env=env, *cmdline)
     os.unlink(policyrcd)
 
 @complete_step('Installing Debian')
@@ -1868,7 +1909,8 @@ def find_kernel_file(workspace_root, pattern):
     workspace_pattern = os.path.join(workspace_root, pattern.lstrip('/'))
     kernel_files = sorted(glob.glob(workspace_pattern))
     kernel_file = kernel_files[0]
-    # The path the kernel-install script expects is within the workspace reference as it is run from within the container
+    # The path the kernel-install script expects is within the
+    # workspace reference as it is run from within the container
     if kernel_file.startswith(workspace_root):
         kernel_file = kernel_file[len(workspace_root):]
     else:
@@ -1917,8 +1959,13 @@ def install_boot_loader_arch(args, workspace, loopdev):
     if "uefi" in args.boot_protocols:
         # add loader entries and copy kernel/initrd under that entry
         workspace_root = os.path.join(workspace, "root")
-        kernel_version = next(filter(lambda x: x[0].isdigit(), os.listdir(os.path.join(workspace_root, "lib/modules"))))
-        run_workspace_command(args, workspace, "/usr/bin/kernel-install", "add", kernel_version, find_kernel_file(workspace_root, "/boot/vmlinuz-*"))
+        kernel_version = next(filter(lambda x: x[0].isdigit(),
+                                     os.listdir(os.path.join(workspace_root, "lib/modules"))))
+        run_workspace_command(args, workspace,
+                              "/usr/bin/kernel-install",
+                              "add",
+                              kernel_version,
+                              find_kernel_file(workspace_root, "/boot/vmlinuz-*"))
 
     if "bios" in args.boot_protocols:
         install_grub(args, workspace, loopdev, "grub")
@@ -2075,9 +2122,9 @@ def install_build_src(args, workspace, run_build_script, for_cache):
                                                 '.mkosi-*',
                                                 '*.cache-pre-dev',
                                                 '*.cache-pre-inst',
-                                                os.path.basename(args.output_dir)+"/" if args.output_dir else "mkosi.output/",
-                                                os.path.basename(args.cache_path)+"/" if args.cache_path else "mkosi.cache/",
-                                                os.path.basename(args.build_dir)+"/" if args.build_dir else "mkosi.builddir/")
+                                                os.path.basename(args.output_dir)+"/" if args.output_dir else "mkosi.output/",  # NOQA: E501
+                                                os.path.basename(args.cache_path)+"/" if args.cache_path else "mkosi.cache/",  # NOQA: E501
+                                                os.path.basename(args.build_dir)+"/" if args.build_dir else "mkosi.builddir/")  # NOQA: E501
                 shutil.copytree(args.build_sources, target, symlinks=True, ignore=ignore)
 
 def install_build_dest(args, workspace, run_build_script, for_cache):
@@ -2242,7 +2289,11 @@ def insert_squashfs(args, workspace, raw, loopdev, squashfs, for_cache):
         args.root_size = insert_partition(args, workspace, raw, loopdev, args.root_partno, squashfs,
                                           "Root Partition", gpt_root_native(args.architecture).root)
 
-def make_verity(args: CommandLineArguments, workspace, dev, run_build_script: bool, for_cache: bool) -> Tuple[Optional[IO[str]], Optional[str]]:
+def make_verity(args: CommandLineArguments,
+                workspace,
+                dev,
+                run_build_script: bool,
+                for_cache: bool) -> Tuple[Optional[IO[str]], Optional[str]]:
     if run_build_script or not args.verity:
         return None, None
     if for_cache:
@@ -2441,7 +2492,11 @@ def hash_file(of: IO[Any], sf: IO[bytes], fname: str) -> None:
 
     of.write(h.hexdigest() + " *" + fname + "\n")
 
-def calculate_sha256sum(args: CommandLineArguments, raw: Optional[IO[str]], tar: Optional[IO[str]], root_hash_file: str, nspawn_settings: str) -> Optional[IO[bytes]]:
+def calculate_sha256sum(args: CommandLineArguments,
+                        raw: Optional[IO[str]],
+                        tar: Optional[IO[str]],
+                        root_hash_file: str,
+                        nspawn_settings: str) -> Optional[IO[bytes]]:
     if args.output_format in (OutputFormat.directory, OutputFormat.subvolume):
         return None
 
@@ -2596,7 +2651,7 @@ def print_output_size(args: CommandLineArguments) -> None:
         print_step("Resulting image size is " + format_bytes(dir_size(args.output)) + ".")
     else:
         st = os.stat(args.output)
-        print_step("Resulting image size is " + format_bytes(st.st_size) + ", consumes " + format_bytes(st.st_blocks * 512) + ".")
+        print_step("Resulting image size is " + format_bytes(st.st_size) + ", consumes " + format_bytes(st.st_blocks * 512) + ".")  # NOQA: E501
 
 def setup_package_cache(args: CommandLineArguments) -> Optional[tempfile.TemporaryDirectory]:
     with complete_step('Setting up package cache',
@@ -2643,7 +2698,8 @@ def parse_args() -> CommandLineArguments:
     parser = argparse.ArgumentParser(description='Build Legacy-Free OS Images', add_help=False)
 
     group = parser.add_argument_group("Commands")
-    group.add_argument("verb", choices=("build", "clean", "help", "summary", "shell", "boot", "qemu"), nargs='?', default="build", help='Operation to execute')
+    group.add_argument("verb", choices=("build", "clean", "help", "summary", "shell", "boot", "qemu"), nargs='?',
+                       default="build", help='Operation to execute')
     group.add_argument("cmdline", nargs=argparse.REMAINDER, help="The command line to use for 'shell', 'boot', 'qemu'")
     group.add_argument('-h', '--help', action='help', help="Show this help")
     group.add_argument('--version', action='version', version='%(prog)s ' + __version__)
@@ -2652,7 +2708,8 @@ def parse_args() -> CommandLineArguments:
     group.add_argument('-d', "--distribution", choices=Distribution.__members__, help='Distribution to install')
     group.add_argument('-r', "--release", help='Distribution release to install')
     group.add_argument('-m', "--mirror", help='Distribution mirror to use')
-    group.add_argument("--repositories", action=CommaDelimitedListAction, dest='repositories', help='Repositories to use', metavar='REPOS')
+    group.add_argument("--repositories", action=CommaDelimitedListAction, dest='repositories',
+                       help='Repositories to use', metavar='REPOS')
     group.add_argument('--architecture', help='Override the architecture of installation')
 
     group = parser.add_argument_group("Output")
@@ -2660,61 +2717,83 @@ def parse_args() -> CommandLineArguments:
                        help='Output Format')
     group.add_argument('-o', "--output", help='Output image path', metavar='PATH')
     group.add_argument('-O', "--output-dir", help='Output root directory', metavar='DIR')
-    group.add_argument('-f', "--force", action='count', dest='force_count', default=0, help='Remove existing image file before operation')
+    group.add_argument('-f', "--force", action='count', dest='force_count', default=0,
+                       help='Remove existing image file before operation')
     group.add_argument('-b', "--bootable", type=parse_boolean, nargs='?', const=True,
                        help='Make image bootable on EFI (only gpt_ext4, gpt_btrfs, gpt_squashfs, gpt_xfs)')
     group.add_argument("--boot-protocols", action=CommaDelimitedListAction,
                        help="Boot protocols to use on a bootable image", metavar="PROTOCOLS", default=[])
-    group.add_argument("--secure-boot", action='store_true', help='Sign the resulting kernel/initrd image for UEFI SecureBoot')
+    group.add_argument("--secure-boot", action='store_true',
+                       help='Sign the resulting kernel/initrd image for UEFI SecureBoot')
     group.add_argument("--secure-boot-key", help="UEFI SecureBoot private key in PEM format", metavar='PATH')
     group.add_argument("--secure-boot-certificate", help="UEFI SecureBoot certificate in X509 format", metavar='PATH')
-    group.add_argument("--read-only", action='store_true', help='Make root volume read-only (only gpt_ext4, gpt_btrfs, subvolume, implied with squashfs)')
-    group.add_argument("--encrypt", choices=("all", "data"), help='Encrypt everything except: ESP ("all") or ESP and root ("data")')
+    group.add_argument("--read-only", action='store_true',
+                       help='Make root volume read-only (only gpt_ext4, gpt_btrfs, subvolume, implied with squashfs)')
+    group.add_argument("--encrypt", choices=("all", "data"),
+                       help='Encrypt everything except: ESP ("all") or ESP and root ("data")')
     group.add_argument("--verity", action='store_true', help='Add integrity partition (implies --read-only)')
     group.add_argument("--compress", type=parse_compression,
                        help='Enable compression in file system (only gpt_btrfs, subvolume, gpt_squashfs, squashfs)')
-    group.add_argument('--mksquashfs', dest='mksquashfs_tool', type=str.split, help='Script to call instead of mksquashfs')
+    group.add_argument('--mksquashfs', dest='mksquashfs_tool', type=str.split,
+                       help='Script to call instead of mksquashfs')
 
-    group.add_argument("--xz", action='store_true', help='Compress resulting image with xz (only gpt_ext4, gpt_btrfs, gpt_squashfs, gpt_xfs, implied on tar)')
-    group.add_argument("--qcow2", action='store_true', help='Convert resulting image to qcow2 (only gpt_ext4, gpt_btrfs, gpt_squashfs, gpt_xfs)')
-    group.add_argument('-i', "--incremental", action='store_true', help='Make use of and generate intermediary cache images')
+    group.add_argument("--xz", action='store_true',
+                       help='Compress resulting image with xz (only gpt_ext4, gpt_btrfs, gpt_squashfs, gpt_xfs, implied on tar)')  # NOQA: E501
+    group.add_argument("--qcow2", action='store_true',
+                       help='Convert resulting image to qcow2 (only gpt_ext4, gpt_btrfs, gpt_squashfs, gpt_xfs)')
+    group.add_argument('-i', "--incremental", action='store_true',
+                       help='Make use of and generate intermediary cache images')
 
     group = parser.add_argument_group("Packages")
-    group.add_argument('-p', "--package", action=CommaDelimitedListAction, dest='packages', default=[], help='Add an additional package to the OS image', metavar='PACKAGE')
-    group.add_argument("--with-docs", action='store_true', help='Install documentation (only Fedora, CentOS and Mageia)', default=None)
-    group.add_argument('-T', "--without-tests", action='store_false', dest='with_tests', default=True, help='Do not run tests as part of build script, if supported')
+    group.add_argument('-p', "--package", action=CommaDelimitedListAction, dest='packages', default=[],
+                       help='Add an additional package to the OS image', metavar='PACKAGE')
+    group.add_argument("--with-docs", action='store_true', default=None,
+                       help='Install documentation (only Fedora, CentOS and Mageia)')
+    group.add_argument('-T', "--without-tests", action='store_false', dest='with_tests', default=True,
+                       help='Do not run tests as part of build script, if supported')
     group.add_argument("--cache", dest='cache_path', help='Package cache path', metavar='PATH')
-    group.add_argument("--extra-tree", action='append', dest='extra_trees', default=[], help='Copy an extra tree on top of image', metavar='PATH')
-    group.add_argument("--skeleton-tree", action='append', dest='skeleton_trees', default=[], help='Use a skeleton tree to bootstrap the image before installing anything', metavar='PATH')
+    group.add_argument("--extra-tree", action='append', dest='extra_trees', default=[],
+                       help='Copy an extra tree on top of image', metavar='PATH')
+    group.add_argument("--skeleton-tree", action='append', dest='skeleton_trees', default=[],
+                       help='Use a skeleton tree to bootstrap the image before installing anything', metavar='PATH')
     group.add_argument("--build-script", help='Build script to run inside image', metavar='PATH')
     group.add_argument("--build-sources", help='Path for sources to build', metavar='PATH')
     group.add_argument("--build-dir", help='Path to use as persistent build directory', metavar='PATH')
-    group.add_argument("--build-package", action=CommaDelimitedListAction, dest='build_packages', default=[], help='Additional packages needed for build script', metavar='PACKAGE')
+    group.add_argument("--build-package", action=CommaDelimitedListAction, dest='build_packages', default=[],
+                       help='Additional packages needed for build script', metavar='PACKAGE')
     group.add_argument("--postinst-script", help='Postinstall script to run inside image', metavar='PATH')
     group.add_argument("--finalize-script", help='Postinstall script to run outside image', metavar='PATH')
     group.add_argument('--use-git-files', type=parse_boolean,
                        help='Ignore any files that git itself ignores (default: guess)')
     group.add_argument('--git-files', choices=('cached', 'others'),
                        help='Whether to include untracked files (default: others)')
-    group.add_argument("--with-network", action='store_true', help='Run build and postinst scripts with network access (instead of private network)', default=None)
+    group.add_argument("--with-network", action='store_true', default=None,
+                       help='Run build and postinst scripts with network access (instead of private network)')
     group.add_argument("--settings", dest='nspawn_settings', help='Add in .spawn settings file', metavar='PATH')
 
     group = parser.add_argument_group("Partitions")
-    group.add_argument("--root-size", help='Set size of root partition (only gpt_ext4, gpt_btrfs, gpt_xfs)', metavar='BYTES')
-    group.add_argument("--esp-size", help='Set size of EFI system partition (only gpt_ext4, gpt_btrfs, gpt_squashfs, gpt_xfs)', metavar='BYTES')
-    group.add_argument("--swap-size", help='Set size of swap partition (only gpt_ext4, gpt_btrfs, gpt_squashfs, gpt_xfs)', metavar='BYTES')
-    group.add_argument("--home-size", help='Set size of /home partition (only gpt_ext4, gpt_squashfs, gpt_xfs)', metavar='BYTES')
-    group.add_argument("--srv-size", help='Set size of /srv partition (only gpt_ext4, gpt_squashfs, gpt_xfs)', metavar='BYTES')
+    group.add_argument("--root-size",
+                       help='Set size of root partition (only gpt_ext4, gpt_btrfs, gpt_xfs)', metavar='BYTES')
+    group.add_argument("--esp-size",
+                       help='Set size of EFI system partition (only gpt_ext4, gpt_btrfs, gpt_squashfs, gpt_xfs)', metavar='BYTES')  # NOQA: E501
+    group.add_argument("--swap-size",
+                       help='Set size of swap partition (only gpt_ext4, gpt_btrfs, gpt_squashfs, gpt_xfs)', metavar='BYTES')  # NOQA: E501
+    group.add_argument("--home-size",
+                       help='Set size of /home partition (only gpt_ext4, gpt_squashfs, gpt_xfs)', metavar='BYTES')
+    group.add_argument("--srv-size",
+                       help='Set size of /srv partition (only gpt_ext4, gpt_squashfs, gpt_xfs)', metavar='BYTES')
 
     group = parser.add_argument_group("Validation (only gpt_ext4, gpt_btrfs, gpt_squashfs, gpt_xfs, tar)")
     group.add_argument("--checksum", action='store_true', help='Write SHA256SUMS file')
     group.add_argument("--sign", action='store_true', help='Write and sign SHA256SUMS file')
     group.add_argument("--key", help='GPG key to use for signing')
-    group.add_argument("--bmap", action='store_true', help='Write block map file (.bmap) for bmaptool usage (only gpt_ext4, gpt_btrfs)')
+    group.add_argument("--bmap", action='store_true',
+                       help='Write block map file (.bmap) for bmaptool usage (only gpt_ext4, gpt_btrfs)')
     group.add_argument("--password", help='Set the root password')
 
     group = parser.add_argument_group("Host configuration")
-    group.add_argument("--extra-search-paths", action=ColonDelimitedListAction, default=[], help="List of colon-separated paths to look for programs before looking in PATH")
+    group.add_argument("--extra-search-paths", action=ColonDelimitedListAction, default=[],
+                       help="List of colon-separated paths to look for programs before looking in PATH")
 
     group = parser.add_argument_group("Additional Configuration")
     group.add_argument('-C', "--directory", help='Change to specified directory before doing anything', metavar='PATH')
@@ -2725,7 +2804,8 @@ def parse_args() -> CommandLineArguments:
     group.add_argument('--debug', action=CommaDelimitedListAction, default=[],
                        help='Turn on debugging output', metavar='SELECTOR',
                        choices=('run',))
-    group.add_argument('--no-chown', action='store_true', help='When running with sudo, disable reassignment of ownership of the generated files to the original user')
+    group.add_argument('--no-chown', action='store_true',
+                       help='When running with sudo, disable reassignment of ownership of the generated files to the original user')  # NOQA: E501
 
     try:
         argcomplete.autocomplete(parser)
@@ -3462,10 +3542,10 @@ def load_args() -> CommandLineArguments:
 
     if args.secure_boot:
         if args.secure_boot_key is None:
-            die("UEFI SecureBoot enabled, but couldn't find private key. (Consider placing it in mkosi.secure-boot.key?)")
+            die("UEFI SecureBoot enabled, but couldn't find private key. (Consider placing it in mkosi.secure-boot.key?)")  # NOQA: E501
 
         if args.secure_boot_certificate is None:
-            die("UEFI SecureBoot enabled, but couldn't find certificate. (Consider placing it in mkosi.secure-boot.crt?)")
+            die("UEFI SecureBoot enabled, but couldn't find certificate. (Consider placing it in mkosi.secure-boot.crt?)")  # NOQA: E501
 
     if args.verb in ("shell", "boot", "qemu"):
         if args.output_format == OutputFormat.tar:
@@ -3546,7 +3626,7 @@ def print_summary(args: CommandLineArguments) -> None:
     sys.stderr.write("       Output Checksum: " + none_to_na(args.output_checksum if args.checksum else None) + "\n")
     sys.stderr.write("      Output Signature: " + none_to_na(args.output_signature if args.sign else None) + "\n")
     sys.stderr.write("           Output Bmap: " + none_to_na(args.output_bmap if args.bmap else None) + "\n")
-    sys.stderr.write("Output nspawn Settings: " + none_to_na(args.output_nspawn_settings if args.nspawn_settings is not None else None) + "\n")
+    sys.stderr.write("Output nspawn Settings: " + none_to_na(args.output_nspawn_settings if args.nspawn_settings is not None else None) + "\n")  # NOQA: E501
     sys.stderr.write("           Incremental: " + yes_no(args.incremental) + "\n")
 
     sys.stderr.write("             Read-only: " + yes_no(args.read_only) + "\n")
@@ -3618,7 +3698,11 @@ def print_summary(args: CommandLineArguments) -> None:
     sys.stderr.write("\nHOST CONFIGURATION:\n")
     sys.stderr.write("    Extra search paths: " + line_join_list(args.extra_search_paths) + "\n")
 
-def reuse_cache_tree(args: CommandLineArguments, workspace: str, run_build_script: bool, for_cache: bool, cached: bool) -> bool:
+def reuse_cache_tree(args: CommandLineArguments,
+                     workspace: str,
+                     run_build_script: bool,
+                     for_cache: bool,
+                     cached: bool) -> bool:
     """If there's a cached version of this tree around, use it and
     initialize our new root directly from it. Returns a boolean indicating
     whether we are now operating on a cached version or not."""
@@ -3659,7 +3743,12 @@ def make_build_dir(args: CommandLineArguments) -> None:
 
     mkdir_last(args.build_dir, 0o755)
 
-def build_image(args: CommandLineArguments, workspace: tempfile.TemporaryDirectory, *, run_build_script: bool, for_cache: bool=False, cleanup: bool=False) -> Tuple[Optional[IO[str]], Optional[IO[str]], Optional[str]]:
+def build_image(args: CommandLineArguments,
+                workspace: tempfile.TemporaryDirectory,
+                *,
+                run_build_script: bool,
+                for_cache: bool=False,
+                cleanup: bool=False) -> Tuple[Optional[IO[str]], Optional[IO[str]], Optional[str]]:
     # If there's no build script set, there's no point in executing
     # the build script iteration. Let's quit early.
     if args.build_script is None and run_build_script:
@@ -3722,7 +3811,8 @@ def build_image(args: CommandLineArguments, workspace: tempfile.TemporaryDirecto
             # This time we mount read-only, as we already generated
             # the verity data, and hence really shouldn't modify the
             # image anymore.
-            with mount_image(args, workspace.name, loopdev, encrypted_root, encrypted_home, encrypted_srv, root_read_only=True):
+            with mount_image(args, workspace.name, loopdev,
+                             encrypted_root, encrypted_home, encrypted_srv, root_read_only=True):
                 install_unified_kernel(args, workspace.name, run_build_script, for_cache, root_hash)
                 secure_boot_sign(args, workspace.name, run_build_script, for_cache)
 
@@ -3787,7 +3877,12 @@ def need_cache_images(args: CommandLineArguments) -> bool:
 
     return not os.path.exists(args.cache_pre_dev) or not os.path.exists(args.cache_pre_inst)
 
-def remove_artifacts(args: CommandLineArguments, workspace: str, raw: Optional[IO[str]], tar: Optional[IO[str]], run_build_script: bool, for_cache:bool=False) -> None:
+def remove_artifacts(args: CommandLineArguments,
+                     workspace: str,
+                     raw: Optional[IO[str]],
+                     tar: Optional[IO[str]],
+                     run_build_script: bool,
+                     for_cache:bool=False) -> None:
     if for_cache:
         what = "cache build"
     elif run_build_script:
@@ -3891,7 +3986,10 @@ def check_native(args: CommandLineArguments) -> None:
         die('Cannot (currently) override the architecture and run build commands')
 
 def run_shell(args: CommandLineArguments) -> None:
-    target = "--directory=" + args.output if args.output_format in (OutputFormat.directory, OutputFormat.subvolume) else "--image=" + args.output
+    if args.output_format in (OutputFormat.directory, OutputFormat.subvolume):
+        target = "--directory=" + args.output
+    else:
+        target = "--image=" + args.output
 
     cmdline = ["systemd-nspawn",
                target]

--- a/mkosi
+++ b/mkosi
@@ -2889,6 +2889,7 @@ class ListAction(argparse.Action):
                  namespace: argparse.Namespace,
                  values: Union[str, Sequence[Any], None],
                  option_string: Optional[str] = None) -> None:
+        assert isinstance(values, str)
         ary = getattr(namespace, self.dest)
         if ary is None:
             ary = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[isort]
+multi_line_output = 3
+include_trailing_comma = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
+[flake8]
+max-line-length = 119
 [isort]
 multi_line_output = 3
 include_trailing_comma = True

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,11 @@
 
 import sys
 
+from setuptools import setup
+
 if sys.version_info < (3, 6):
     sys.exit("Sorry, we need at least Python 3.6.")
 
-from setuptools import setup
 
 setup(
     name="mkosi",


### PR DESCRIPTION
This is all small changes (naturally), but since there are so many of them it can be hard to review them all at once, so this is a whole bunch of small commits, for easy reviewing.

Come back with no complaints from the following (sometimes using `# NOQA` or `# type: ignore`):

 - `flake8` 3.6.0 with `flake8-isort` 2.5: This turns out to be entirely stylistic changes
 - `mypy --strict` 0.641: Mostly mucking with and adding type hints, but the last 6 commits do make actual changes.

The individual commit messages should be sufficiently detailed.