### PR TITLE
Update help for '--with-docs'

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -2694,7 +2694,7 @@ def parse_args() -> CommandLineArguments:
 
     group = parser.add_argument_group("Packages")
     group.add_argument('-p', "--package", action=CommaDelimitedListAction, dest='packages', default=[], help='Add an additional package to the OS image', metavar='PACKAGE')
-    group.add_argument("--with-docs", action='store_true', help='Install documentation (only Fedora, CentOS and Mageia)', default=None)
+    group.add_argument("--with-docs", action='store_true', help='Install documentation', default=None)
     group.add_argument('-T', "--without-tests", action='store_false', dest='with_tests', default=True, help='Do not run tests as part of build script, if supported')
     group.add_argument("--cache", dest='cache_path', help='Package cache path', metavar='PATH')
     group.add_argument("--extra-tree", action='append', dest='extra_trees', default=[], help='Copy an extra tree on top of image', metavar='PATH')


### PR DESCRIPTION
The restriction "only Fedora, CentOS and Mageia"
does not (no longer?) apply, since the option is also handled for
other distributions (Debian, Ubuntu, openSUSE).