### PR TITLE
mkosi: when a .nspawn file is used, actually use it when running nspawn

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -3920,6 +3920,10 @@ def run_shell(args: CommandLineArguments) -> None:
     if args.read_only:
         cmdline += ('--read-only',)
 
+    # If we copied in a .nspawn file, make sure it's actually honoured
+    if args.nspawn_settings is not None:
+        cmdline += ('--settings=trusted',)
+
     if args.verb == "boot":
         cmdline += ('--boot',)
 


### PR DESCRIPTION
Previously, we'd move it in place, but when invoking nspawn on "mkosi
shell" or "mkosi boot" it would be ignored, since that's what nspawn
does unless the file is in /etc or /run.

Let's change this and mark it trusted, after all it's coming from the
same source that just built the image.

This is very useful for cases where you want to default to
"--private-network" when "mkosi boot" is invoked.