### PR TITLE
mkosi: add --no-check-valid-until to debootstrap args to fix #314

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1577,6 +1577,7 @@ def install_debian_or_ubuntu(args: CommandLineArguments,
 
     cmdline = ["debootstrap",
                "--verbose",
+               "--no-check-valid-until",
                "--variant=minbase",
                "--include=systemd-sysv",
                "--exclude=sysv-rc,initscripts,startpar,lsb-base,insserv",

--- a/mkosi
+++ b/mkosi
@@ -1561,9 +1561,8 @@ gpgkey={gpg_key}
     reenable_kernel_install(args, workspace, masked)
 
 
-def debootstrap_knows_merged_usr() -> bool:
-    return bytes("invalid option", "UTF-8") not in run(["debootstrap", "--merged-usr"], stdout=PIPE).stdout
-
+def debootstrap_knows_arg(arg: str) -> bool:
+    return bytes("invalid option", "UTF-8") not in run(["debootstrap", arg], stdout=PIPE).stdout
 
 def install_debian_or_ubuntu(args: CommandLineArguments,
                              workspace: str,
@@ -1583,9 +1582,10 @@ def install_debian_or_ubuntu(args: CommandLineArguments,
                "--exclude=sysv-rc,initscripts,startpar,lsb-base,insserv",
                "--components=" + ','.join(repos)]
 
-    # Let's use --merged-usr only if debootstrap knows it
-    if debootstrap_knows_merged_usr():
-        cmdline += ["--merged-usr"]
+    # Let's use --merged-usr and --no-check-valid-until only if debootstrap knows it
+    for arg in ["--merged-usr", "--no-check-valid-until"]:
+        if debootstrap_knows_arg(arg):
+            cmdline += [arg]
 
     cmdline += [args.release,
                 workspace + "/root",

--- a/mkosi
+++ b/mkosi
@@ -1576,7 +1576,6 @@ def install_debian_or_ubuntu(args: CommandLineArguments,
 
     cmdline = ["debootstrap",
                "--verbose",
-               "--no-check-valid-until",
                "--variant=minbase",
                "--include=systemd-sysv",
                "--exclude=sysv-rc,initscripts,startpar,lsb-base,insserv",


### PR DESCRIPTION
This branch includes a tiny fix to the `cmdline` array for `debootstrap` to resolve #314 with failed builds resulting in the following message:

`E: InRelease file http://archive.ubuntu.com/ubuntu/dists/xenial/InRelease is expired since (Tue, 08 Jan 2019 00:00:00 -0500)`