### PR TITLE
Create hardlink at specified output path for tar-format builds

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -2822,7 +2822,7 @@ def link_output(args: CommandLineArguments, workspace: str, artifact: Optional[B
         if args.output_format in (OutputFormat.directory, OutputFormat.subvolume):
             assert artifact is None
             os.rename(os.path.join(workspace, "root"), args.output)
-        elif args.output_format.is_disk() or args.output_format == OutputFormat.plain_squashfs:
+        elif args.output_format.is_disk() or args.output_format in (OutputFormat.plain_squashfs, OutputFormat.tar):
             assert artifact is not None
             _link_output(args, artifact.name, args.output)
 


### PR DESCRIPTION
I've opened a PR rather than filed an issue as I've got a solution that works for me, but there's a pretty good chance this is a PEBKAC situation, so... anyway: it appears that `--format tar` has been broken since #275 / 947873ca, which [removed the catchall `else` from `link_output`](https://github.com/systemd/mkosi/pull/275/commits/947873cad9bb1c75cf6fe051b474755d157ce022#diff-6980c629516e4165bfaf96be8e5003cfL2375).  This causes tar-based builds to fail:

```
$ uname -a
Linux myhost 4.20.3-arch1-1-ARCH #1 SMP PREEMPT Wed Jan 16 22:38:58 UTC 2019 x86_64 GNU/Linux
$ python --version
Python 3.7.2
$ git rev-parse HEAD
2ecf72d136929105692aaf454216d7d1ddf126d4
$ sudo ./mkosi --default ./mkosi.files/mkosi.ubuntu --format tar --output ubuntu.tar.xz
# <snip>
‣ Successfully linked /home/matt/git/mkosi/ubuntu.tar.xz.                                   
Traceback (most recent call last):                                                          
  File "./mkosi", line 4487, in <module>                                                    
    main()                                                                                  
  File "./mkosi", line 4483, in main                                                        
    run_verb(args)                                                                          
  File "./mkosi", line 4456, in run_verb                                                    
    print_output_size(args)                                                                 
  File "./mkosi", line 2894, in print_output_size                                           
    st = os.stat(args.output)                                                               
FileNotFoundError: [Errno 2] No such file or directory: '/home/matt/git/mkosi/ubuntu.tar.xz'
```

Also -- I'd like to add tests for ensuring that `mkosi` properly generates a file at the expected output path for tar format builds, but haven't been able to determine whether there is a "blessed" testing approach for this project.  Perhaps I could add a `mkosi` invocation with `--format tar`, plus another `-test f ...`, to [`ci/semaphore.sh`](ci/semaphore.sh)?