### PR TITLE
Improve args parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,13 @@
 *.cache-pre-dev
 *.cache-pre-inst
+.cache
 .mypy_cache/
+.project
+.pydevproject
+.pytest_cache/
 /.mkosi-*
 /SHA256SUMS
 /SHA256SUMS.gpg
-/__pycache__
 /build
 /dist
 /image
@@ -18,4 +21,4 @@
 /mkosi.extra
 /mkosi.nspawn
 /mkosi.rootpw
-.mypy_cache/
+__pycache__

--- a/ci/semaphore.sh
+++ b/ci/semaphore.sh
@@ -2,9 +2,10 @@
 
 set -ex
 
+# Build an image
 sudo add-apt-repository --yes ppa:jonathonf/python-3.6
 sudo apt --yes update
-sudo apt --yes install python3.6 debootstrap systemd-container squashfs-tools
+sudo apt --yes install python3.6 python3-pip debootstrap systemd-container squashfs-tools
 
 testimg()
 {
@@ -20,3 +21,7 @@ do
 	imgname="$(basename "$i" | cut -d. -f 2-)"
 	testimg "$imgname"
 done
+
+# Run unit tests
+python3.6 -m pip install -U pytest
+python3.6 -m pytest

--- a/mkosi
+++ b/mkosi
@@ -3054,7 +3054,7 @@ def create_parser() -> argparse.ArgumentParser:
     group.add_argument('-d', "--distribution", choices=Distribution.__members__, help='Distribution to install')
     group.add_argument('-r', "--release", help='Distribution release to install')
     group.add_argument('-m', "--mirror", help='Distribution mirror to use')
-    group.add_argument("--repositories", action=CommaDelimitedListAction, dest='repositories',
+    group.add_argument("--repositories", action=CommaDelimitedListAction, dest='repositories', default=[],
                        help='Repositories to use', metavar='REPOS')
     group.add_argument('--architecture', help='Override the architecture of installation')
 
@@ -3101,6 +3101,7 @@ def create_parser() -> argparse.ArgumentParser:
                        help='Install documentation')
     group.add_argument('-T', "--without-tests", action=BooleanAction, dest='with_tests', default=True,
                        help='Do not run tests as part of build script, if supported')
+    group.add_argument("--with-tests", action=BooleanAction, default=True, help=argparse.SUPPRESS)  # Compatibility option
     group.add_argument("--cache", dest='cache_path', help='Package cache path', metavar='PATH')
     group.add_argument("--extra-tree", action='append', dest='extra_trees', default=[],
                        help='Copy an extra tree on top of image', metavar='PATH')
@@ -3108,7 +3109,8 @@ def create_parser() -> argparse.ArgumentParser:
                        help='Use a skeleton tree to bootstrap the image before installing anything', metavar='PATH')
     group.add_argument("--build-script", help='Build script to run inside image', metavar='PATH')
     group.add_argument("--build-sources", help='Path for sources to build', metavar='PATH')
-    group.add_argument("--build-dir", help='Path to use as persistent build directory', metavar='PATH')
+    group.add_argument("--build-dir", help=argparse.SUPPRESS, metavar='PATH')  # Compatibility option
+    group.add_argument("--build-directory", dest='build_dir', help='Path to use as persistent build directory', metavar='PATH')
     group.add_argument("--build-package", action=CommaDelimitedListAction, dest='build_packages', default=[],
                        help='Additional packages needed for build script', metavar='PACKAGE')
     group.add_argument("--postinst-script", help='Postinstall script to run inside image', metavar='PATH')

--- a/mkosi
+++ b/mkosi
@@ -55,6 +55,13 @@ __version__ = '4'
 if sys.version_info < (3, 6):
     sys.exit("Sorry, we need at least Python 3.6.")
 
+
+MKOSI_COMMANDS_CMDLINE = ("shell", "boot", "qemu")
+MKOSI_COMMANDS_NEED_BUILD = MKOSI_COMMANDS_CMDLINE
+MKOSI_COMMANDS_SUDO = ("build", "clean") + MKOSI_COMMANDS_CMDLINE
+MKOSI_COMMANDS = ("build", "clean", "help", "summary") + MKOSI_COMMANDS_CMDLINE
+
+
 # This global should be initialized after parsing arguments
 arg_debug = ()
 
@@ -3005,9 +3012,8 @@ def create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description='Build Legacy-Free OS Images', add_help=False)
 
     group = parser.add_argument_group("Commands")
-    group.add_argument("verb", choices=("build", "clean", "help", "summary", "shell", "boot", "qemu"), nargs='?',
-                       default="build", help='Operation to execute')
-    group.add_argument("cmdline", nargs=argparse.REMAINDER, help="The command line to use for 'shell', 'boot', 'qemu'")
+    group.add_argument("verb", choices=MKOSI_COMMANDS, nargs='?', default="build", help='Operation to execute')
+    group.add_argument("cmdline", nargs=argparse.REMAINDER, help="The command line to use for " + str(MKOSI_COMMANDS_CMDLINE)[1:-1])
     group.add_argument('-h', '--help', action='help', help="Show this help")
     group.add_argument('--version', action='version', version='%(prog)s ' + __version__)
 
@@ -3714,8 +3720,8 @@ def load_args(args) -> CommandLineArguments:
 
     args.extra_search_paths = expand_paths(args.extra_search_paths)
 
-    if args.cmdline and args.verb not in ('shell', 'boot', 'qemu'):
-        die("Additional parameters only accepted for 'shell', 'boot', 'qemu' invocations.")
+    if args.cmdline and args.verb not in MKOSI_COMMANDS_CMDLINE:
+        die("Additional parameters only accepted for " + str(MKOSI_COMMANDS_CMDLINE)[1:-1] + " invocations.")
 
     args.force = args.force_count > 0
 
@@ -3913,7 +3919,7 @@ def load_args(args) -> CommandLineArguments:
         if args.secure_boot_certificate is None:
             die("UEFI SecureBoot enabled, but couldn't find certificate. (Consider placing it in mkosi.secure-boot.crt?)")  # NOQA: E501
 
-    if args.verb in ("shell", "boot", "qemu"):
+    if args.verb in MKOSI_COMMANDS_CMDLINE:
         if args.output_format == OutputFormat.tar:
             die("Sorry, can't acquire shell in or boot a tar archive.")
         if args.xz:
@@ -4512,14 +4518,14 @@ def run_verb(args):
 
     prepend_to_environ_path(args.extra_search_paths)
 
-    if args.verb in ("build", "clean", "shell", "boot", "qemu"):
+    if args.verb in MKOSI_COMMANDS_SUDO:
         check_root()
         unlink_output(args)
 
     if args.verb == "build":
         check_output(args)
 
-    needs_build = args.verb == "build" or (not os.path.exists(args.output) and args.verb in ("shell", "boot", "qemu"))
+    needs_build = args.verb == "build" or (not os.path.exists(args.output) and args.verb in MKOSI_COMMANDS_NEED_BUILD)
 
     if args.verb == "summary" or needs_build:
         print_summary(args)

--- a/mkosi
+++ b/mkosi
@@ -2999,6 +2999,39 @@ class ColonDelimitedListAction(ListAction):
     delimiter = ":"
 
 
+class BooleanAction(argparse.Action):
+    """Parse boolean command line arguments
+
+    The argument may be added more than once. The argument may be set explicitly (--foo yes)
+    or implicitly --foo. If the parameter name starts with "not-" or "without-" the value gets
+    inverted.
+    """
+    def __init__(self, option_strings, dest, nargs=None, const=True, default=False, **kwargs):
+        if nargs is not None:
+            raise ValueError("nargs not allowed")
+        super(BooleanAction, self).__init__(option_strings, dest, nargs='?', const=const, default=default, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        new_value = self.default
+        if isinstance(values, str):
+            try:
+                new_value = parse_boolean(values)
+            except ValueError as exp:
+                raise argparse.ArgumentError(self, str(exp))
+        elif isinstance(values, bool):  # Assign const
+            new_value = values
+        else:
+            raise argparse.ArgumentError(self, 'Invalid argument for %s %s' % (str(option_string), str(values)))
+
+        # invert the value if the argument name starts with "not" or "without"
+        for option in self.option_strings:
+            if option[2:].startswith('not-') or option[2:].startswith('without-'):
+                new_value = not new_value
+                break
+
+        setattr(namespace, self.dest, new_value)
+
+
 COMPRESSION_ALGORITHMS = 'zlib', 'lzo', 'zstd', 'lz4', 'xz'
 
 
@@ -3032,41 +3065,41 @@ def create_parser() -> argparse.ArgumentParser:
     group.add_argument('-O', "--output-dir", help='Output root directory', metavar='DIR')
     group.add_argument('-f', "--force", action='count', dest='force_count', default=0,
                        help='Remove existing image file before operation')
-    group.add_argument('-b', "--bootable", type=parse_boolean, nargs='?', const=True,
+    group.add_argument('-b', "--bootable", action=BooleanAction,
                        help='Make image bootable on EFI (only gpt_ext4, gpt_xfs, gpt_btrfs, gpt_squashfs)')
     group.add_argument("--boot-protocols", action=CommaDelimitedListAction,
                        help="Boot protocols to use on a bootable image", metavar="PROTOCOLS", default=[])
     group.add_argument("--kernel-command-line", help='Set the kernel command line (only bootable images)')
     group.add_argument("--kernel-commandline", dest='kernel_command_line', help=argparse.SUPPRESS) # Compatibility option
-    group.add_argument("--secure-boot", action='store_true',
+    group.add_argument("--secure-boot", action=BooleanAction,
                        help='Sign the resulting kernel/initrd image for UEFI SecureBoot')
     group.add_argument("--secure-boot-key", help="UEFI SecureBoot private key in PEM format", metavar='PATH')
     group.add_argument("--secure-boot-certificate", help="UEFI SecureBoot certificate in X509 format", metavar='PATH')
-    group.add_argument("--read-only", action='store_true',
+    group.add_argument("--read-only", action=BooleanAction,
                        help='Make root volume read-only (only gpt_ext4, gpt_xfs, gpt_btrfs, subvolume, implied with gpt_squashfs and plain_squashfs)')
     group.add_argument("--encrypt", choices=("all", "data"),
                        help='Encrypt everything except: ESP ("all") or ESP and root ("data")')
-    group.add_argument("--verity", action='store_true', help='Add integrity partition (implies --read-only)')
+    group.add_argument("--verity", action=BooleanAction, help='Add integrity partition (implies --read-only)')
     group.add_argument("--compress", type=parse_compression,
                        help='Enable compression in file system (only gpt_btrfs, subvolume, gpt_squashfs, plain_squashfs)')
     group.add_argument('--mksquashfs', dest='mksquashfs_tool', type=str.split,
                        help='Script to call instead of mksquashfs')
-    group.add_argument("--xz", action='store_true',
+    group.add_argument("--xz", action=BooleanAction,
                        help='Compress resulting image with xz (only gpt_ext4, gpt_xfs, gpt_btrfs, gpt_squashfs, implied on tar)')  # NOQA: E501
-    group.add_argument("--qcow2", action='store_true',
+    group.add_argument("--qcow2", action=BooleanAction,
                        help='Convert resulting image to qcow2 (only gpt_ext4, gpt_xfs, gpt_btrfs, gpt_squashfs)')
     group.add_argument("--hostname", help="Set hostname")
-    group.add_argument('--no-chown', action='store_true',
+    group.add_argument('--no-chown', action=BooleanAction,
                        help='When running with sudo, disable reassignment of ownership of the generated files to the original user')  # NOQA: E501
-    group.add_argument('-i', "--incremental", action='store_true',
+    group.add_argument('-i', "--incremental", action=BooleanAction,
                        help='Make use of and generate intermediary cache images')
 
     group = parser.add_argument_group("Packages")
     group.add_argument('-p', "--package", action=CommaDelimitedListAction, dest='packages', default=[],
                        help='Add an additional package to the OS image', metavar='PACKAGE')
-    group.add_argument("--with-docs", action='store_true', default=None,
+    group.add_argument("--with-docs", action=BooleanAction,
                        help='Install documentation')
-    group.add_argument('-T', "--without-tests", action='store_false', dest='with_tests', default=True,
+    group.add_argument('-T', "--without-tests", action=BooleanAction, dest='with_tests', default=True,
                        help='Do not run tests as part of build script, if supported')
     group.add_argument("--cache", dest='cache_path', help='Package cache path', metavar='PATH')
     group.add_argument("--extra-tree", action='append', dest='extra_trees', default=[],
@@ -3083,7 +3116,7 @@ def create_parser() -> argparse.ArgumentParser:
     group.add_argument("--source-file-transfer", type=SourceFileTransfer, choices=list(SourceFileTransfer), default=None,
                        help="Method used to copy build sources to the build image." +
                        "; ".join([f"'{k}': {v}" for k, v in SourceFileTransfer.doc().items()]) + " (default: copy-git-cached if in a git repository, otherwise copy-all)")
-    group.add_argument("--with-network", action='store_true', default=None,
+    group.add_argument("--with-network", action=BooleanAction,
                        help='Run build and postinst scripts with network access (instead of private network)')
     group.add_argument("--settings", dest='nspawn_settings', help='Add in .nspawn settings file', metavar='PATH')
 
@@ -3102,10 +3135,10 @@ def create_parser() -> argparse.ArgumentParser:
                        help='Set size of /srv partition (only gpt_ext4, gpt_xfs, gpt_squashfs)', metavar='BYTES')
 
     group = parser.add_argument_group("Validation (only gpt_ext4, gpt_xfs, gpt_btrfs, gpt_squashfs, tar)")
-    group.add_argument("--checksum", action='store_true', help='Write SHA256SUMS file')
-    group.add_argument("--sign", action='store_true', help='Write and sign SHA256SUMS file')
+    group.add_argument("--checksum", action=BooleanAction, help='Write SHA256SUMS file')
+    group.add_argument("--sign", action=BooleanAction, help='Write and sign SHA256SUMS file')
     group.add_argument("--key", help='GPG key to use for signing')
-    group.add_argument("--bmap", action='store_true',
+    group.add_argument("--bmap", action=BooleanAction,
                        help='Write block map file (.bmap) for bmaptool usage (only gpt_ext4, gpt_btrfs)')
     group.add_argument("--password", help='Set the root password')
 
@@ -3133,8 +3166,23 @@ def create_parser() -> argparse.ArgumentParser:
 
 
 def parse_args() -> CommandLineArguments:
+    # always work on a copy, argv will be altered which might has some side effects e.g. in unit tests. 
+    argv = copy.deepcopy(sys.argv[1:])
+
+    # Insert a -- before the positional verb argument otherwise it might be considered as an argument of
+    # a parameter with nargs='?'. For example mkosi -i summary would be treated as -i=summary.
+    for verb in MKOSI_COMMANDS:
+        try:
+            v_i = argv.index(verb)
+            if v_i > 0:
+                if argv[v_i-1] != '--':
+                    argv.insert(v_i, '--')
+            break
+        except ValueError:
+            pass
+
     parser = create_parser()
-    args = cast(CommandLineArguments, parser.parse_args(namespace=CommandLineArguments()))
+    args = cast(CommandLineArguments, parser.parse_args(argv, CommandLineArguments()))
 
     if args.verb == "help":
         parser.print_help()
@@ -3308,10 +3356,11 @@ def unlink_output(args: CommandLineArguments) -> None:
 
 def parse_boolean(s: str) -> bool:
     "Parse 1/true/yes as true and 0/false/no as false"
-    if s in {"1", "true", "yes"}:
+    s_l = s.lower()
+    if s_l in {"1", "true", "yes"}:
         return True
 
-    if s in {"0", "false", "no"}:
+    if s_l in {"0", "false", "no"}:
         return False
 
     raise ValueError(f'Invalid literal for bool(): {s!r}')

--- a/mkosi
+++ b/mkosi
@@ -3045,7 +3045,7 @@ def create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description='Build Legacy-Free OS Images', add_help=False)
 
     group = parser.add_argument_group("Commands")
-    group.add_argument("verb", choices=MKOSI_COMMANDS, nargs='?', default="build", help='Operation to execute')
+    group.add_argument("verb", choices=MKOSI_COMMANDS, default="build", help='Operation to execute')
     group.add_argument("cmdline", nargs=argparse.REMAINDER, help="The command line to use for " + str(MKOSI_COMMANDS_CMDLINE)[1:-1])
     group.add_argument('-h', '--help', action='help', help="Show this help")
     group.add_argument('--version', action='version', version='%(prog)s ' + __version__)

--- a/mkosi
+++ b/mkosi
@@ -1107,7 +1107,7 @@ def prepare_tree(args: CommandLineArguments, workspace: str, do_run_build_script
         os.mkdir(os.path.join(workspace, "root", "etc/kernel"), 0o755)
 
         with open(os.path.join(workspace, "root", "etc/kernel/cmdline"), "w") as cmdline:
-            cmdline.write(args.kernel_command_line)
+            cmdline.write(' '.join(args.kernel_command_line))
             cmdline.write("\n")
 
     if do_run_build_script:
@@ -1969,7 +1969,7 @@ def install_opensuse(args: CommandLineArguments, workspace: str, do_run_build_sc
 
         # dracut from openSUSE is missing upstream commit 016613c774baf.
         with open(os.path.join(root, "etc/kernel/cmdline"), "w") as cmdlinefile:
-            cmdlinefile.write(args.kernel_command_line + " root=/dev/gpt-auto-root\n")
+            cmdlinefile.write(' '.join(args.kernel_command_line) + " root=/dev/gpt-auto-root\n")
 
 
 def install_distribution(args: CommandLineArguments,
@@ -2113,7 +2113,8 @@ def install_grub(args: CommandLineArguments, workspace: str, loopdev: str, grub:
     if args.bios_partno is None:
         return
 
-    grub_cmdline = f'GRUB_CMDLINE_LINUX="{args.kernel_command_line}"\n'
+    kernel_cmd_line = ' '.join(args.kernel_command_line)
+    grub_cmdline = f'GRUB_CMDLINE_LINUX="{kernel_cmd_line}"\n'
     os.makedirs(os.path.join(workspace, "root", "etc/default"), exist_ok=True, mode=0o755)
     if not os.path.exists(os.path.join(workspace, "root", "etc/default/grub")):
         with open(os.path.join(workspace, "root", "etc/default/grub"), "w+") as f:
@@ -2625,7 +2626,7 @@ def install_unified_kernel(args: CommandLineArguments,
 
     with complete_step("Generating combined kernel + initrd boot file"):
 
-        cmdline = args.kernel_command_line
+        cmdline = ' '.join(args.kernel_command_line)
         if root_hash is not None:
             cmdline += " roothash=" + root_hash
 
@@ -3003,6 +3004,10 @@ class ColonDelimitedListAction(ListAction):
     delimiter = ":"
 
 
+class SpaceDelimitedListAction(ListAction):
+    delimiter = " "
+
+
 class BooleanAction(argparse.Action):
     """Parse boolean command line arguments
 
@@ -3167,8 +3172,9 @@ def create_parser() -> ArgumentParserMkosi:
                        help='Make image bootable on EFI (only gpt_ext4, gpt_xfs, gpt_btrfs, gpt_squashfs)')
     group.add_argument("--boot-protocols", action=CommaDelimitedListAction,
                        help="Boot protocols to use on a bootable image", metavar="PROTOCOLS", default=[])
-    group.add_argument("--kernel-command-line", help='Set the kernel command line (only bootable images)')
-    group.add_argument("--kernel-commandline", dest='kernel_command_line', help=argparse.SUPPRESS) # Compatibility option
+    group.add_argument("--kernel-command-line", action=SpaceDelimitedListAction, default=['rhgb', 'quiet', 'selinux=0', 'audit=0', 'rw'],
+                       help='Set the kernel command line (only bootable images)')
+    group.add_argument("--kernel-commandline", action=SpaceDelimitedListAction, dest='kernel_command_line', help=argparse.SUPPRESS) # Compatibility option
     group.add_argument("--secure-boot", action=BooleanAction,
                        help='Sign the resulting kernel/initrd image for UEFI SecureBoot')
     group.add_argument("--secure-boot-key", help="UEFI SecureBoot private key in PEM format", metavar='PATH')
@@ -3900,9 +3906,6 @@ def load_args(args: CommandLineArguments) -> CommandLineArguments:
 
     args.verity_size = None
 
-    if args.bootable and args.kernel_command_line is None:
-        args.kernel_command_line = "rhgb quiet selinux=0 audit=0 rw"
-
     if args.secure_boot_key is not None:
         args.secure_boot_key = os.path.abspath(args.secure_boot_key)
 
@@ -4031,7 +4034,7 @@ def print_summary(args: CommandLineArguments) -> None:
         sys.stderr.write("              Bootable: " + yes_no(args.bootable) + "\n")
 
         if args.bootable:
-            sys.stderr.write("   Kernel Command Line: " + args.kernel_command_line + "\n")
+            sys.stderr.write("   Kernel Command Line: " + ' '.join(args.kernel_command_line) + "\n")
             sys.stderr.write("       UEFI SecureBoot: " + yes_no(args.secure_boot) + "\n")
 
             if args.secure_boot:

--- a/mkosi
+++ b/mkosi
@@ -3001,7 +3001,7 @@ def parse_compression(value: str) -> Union[str, bool]:
     return parse_boolean(value)
 
 
-def parse_args() -> CommandLineArguments:
+def create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description='Build Legacy-Free OS Images', add_help=False)
 
     group = parser.add_argument_group("Commands")
@@ -3123,6 +3123,11 @@ def parse_args() -> CommandLineArguments:
     except ImportError:
         pass
 
+    return parser
+
+
+def parse_args() -> CommandLineArguments:
+    parser = create_parser()
     args = cast(CommandLineArguments, parser.parse_args(namespace=CommandLineArguments()))
 
     if args.verb == "help":

--- a/mkosi
+++ b/mkosi
@@ -3032,6 +3032,100 @@ class BooleanAction(argparse.Action):
         setattr(namespace, self.dest, new_value)
 
 
+class ArgumentParserMkosi(argparse.ArgumentParser):
+    """ArgumentParser with support for mkosi.defaults file(s)
+
+    This derived class adds a simple ini file parser to python's ArgumentParser features.
+    Each line of the ini file is converted to a command line argument. Example:
+    "FooBar=Hello_World"  in the ini file appends "--foo-bar Hello_World" to sys.argv.
+
+    Command line arguments starting with - or --are considered as regular arguments. Arguments
+    starting with @ are considered as files which are fed to the ini file parser implemented
+    in this class.
+    """
+
+    # Mapping of parameters supported in config files but not as command line arguments.
+    SPECIAL_MKOSI_DEFAULT_PARAMS = {
+        'QCow2': '--qcow2',
+        'OutputDirectory': '--output-dir',
+        'XZ': '--xz',
+        'NSpawnSettings': '--settings',
+        'ESPSize': '--esp-size',
+        'CheckSum': '--checksum',
+        'BMap': '--bmap',
+        'Packages': '--package',
+        'ExtraTrees': '--extra-tree',
+        'SkeletonTrees': '--skeleton-tree',
+        'BuildPackages': '--build-package',
+        'PostInstallationScript': '--postinst-script',
+    }
+
+    fromfile_prefix_chars = '@'
+
+    def __init__(self, *kargs, **kwargs):
+        self._ini_file_section = ""
+        self._ini_file_key = ""  # multi line list processing
+        self._ini_file_list_mode = False
+
+        # Add config files to be parsed
+        kwargs['fromfile_prefix_chars'] = __class__.fromfile_prefix_chars
+        super().__init__(*kargs, **kwargs)
+
+    def _read_args_from_files(self, arg_strings):
+        """Convert @ prefixed command line arguments with corresponding file content
+
+        Regular arguments are just returned. Arguments prefixed with @ are considered as
+        configuration file paths. The settings of each file are parsed and returned as
+        command line arguments.
+        Example:
+          The following mkosi.default is loaded.
+          [Distribution]
+          Distribution=fedora
+
+          mkosi is called like: mkosi -p httpd
+
+          arg_strings: ['@mkosi.default', '-p', 'httpd']
+          return value: ['--distribution', 'fedora', '-p', 'httpd']
+        """
+        def camel_to_arg(camel):
+            s1 = re.sub('(.)([A-Z][a-z]+)', r'\1-\2', camel)
+            return re.sub('([a-z0-9])([A-Z])', r'\1-\2', s1).lower()
+
+        def ini_key_to_cli_arg(key):
+            try:
+                return __class__.SPECIAL_MKOSI_DEFAULT_PARAMS[key]
+            except KeyError:
+                return '--' + camel_to_arg(key)
+
+        # expand arguments referencing files
+        new_arg_strings = []
+        for arg_string in arg_strings:
+            # for regular arguments, just add them back into the list
+            if not arg_string or arg_string[0] not in self.fromfile_prefix_chars:
+                new_arg_strings.append(arg_string)
+                continue
+            # replace arguments referencing files with the file content
+            try:
+                config = configparser.ConfigParser(delimiters='=')
+                config.optionxform = str  # type: ignore
+                with open(arg_string[1:]) as args_file:
+                    config.read_file(args_file)
+                for section in config.sections():
+                    for key, value in config.items(section):
+                        cli_arg = ini_key_to_cli_arg(key)
+
+                        # \n in value strings is forwarded. Depending on the action type, \n is considered as a delimiter or needs to be replaced by a ' '
+                        for action in self._actions:
+                            if cli_arg in action.option_strings:
+                                if isinstance(action, ListAction):
+                                    value = value.replace(os.linesep, action.delimiter)
+                        new_arg_strings.extend([cli_arg, value])
+            except OSError as e:
+                self.error(str(e))
+        # return the modified argument list
+        return new_arg_strings
+
+
 COMPRESSION_ALGORITHMS = 'zlib', 'lzo', 'zstd', 'lz4', 'xz'
 
 
@@ -3041,8 +3135,8 @@ def parse_compression(value: str) -> Union[str, bool]:
     return parse_boolean(value)
 
 
-def create_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description='Build Legacy-Free OS Images', add_help=False)
+def create_parser() -> ArgumentParserMkosi:
+    parser = ArgumentParserMkosi(description='Build Legacy-Free OS Images', add_help=False)
 
     group = parser.add_argument_group("Commands")
     group.add_argument("verb", choices=MKOSI_COMMANDS, default="build", help='Operation to execute')
@@ -3167,34 +3261,127 @@ def create_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def parse_args() -> CommandLineArguments:
-    # always work on a copy, argv will be altered which might has some side effects e.g. in unit tests. 
-    argv = copy.deepcopy(sys.argv[1:])
+class MkosiParseException(Exception):
+    """Leads to sys.exit"""
 
+
+def parse_args(argv=None) -> Dict[str, CommandLineArguments]:
+    """Load default values from files and parse command line arguments
+
+    Do all about default files and command line arguments parsing. If --all argument is passed
+    more than one job needs to be processed. The returned tuple contains CommandLineArguments
+    valid for all jobs as well as a dict containing the arguments per job.
+    """
+    parser = create_parser()
+
+    # always work on a copy, argv will be altered which might has some side effects e.g. in unit tests. 
+    if argv is None:
+        argv = copy.deepcopy(sys.argv[1:])
+    else:
+        argv = copy.deepcopy(argv)
+
+    # If ArgumentParserMkosi loads settings from mkosi.default files, the settings from files
+    # are converted to command line arguments. This breaks ArgumentParser's support for default
+    # values of positional arguments. Make sure the verb command gets explicitly passed.
     # Insert a -- before the positional verb argument otherwise it might be considered as an argument of
     # a parameter with nargs='?'. For example mkosi -i summary would be treated as -i=summary.
+    found_verb = False
     for verb in MKOSI_COMMANDS:
         try:
             v_i = argv.index(verb)
             if v_i > 0:
                 if argv[v_i-1] != '--':
                     argv.insert(v_i, '--')
+            found_verb = True
             break
         except ValueError:
             pass
+    if found_verb is False:
+        argv.extend(['--', 'build'])
 
-    parser = create_parser()
-    args = cast(CommandLineArguments, parser.parse_args(argv, CommandLineArguments()))
+    # First run of command line arguments parsing to get the directory of mkosi.default file and the verb argument.
+    args_pre_parsed, _ = parser.parse_known_args(copy.deepcopy(argv))
 
-    if args.verb == "help":
+    if args_pre_parsed.verb == "help":
         parser.print_help()
         sys.exit(0)
 
-    if args.all and args.default_path:
-        die("--all and --default= may not be combined.")
+    # Make sure all paths are absolute and valid.
+    # Relative paths are not valid yet since we are not in the final working directory yet.
+    if not args_pre_parsed.directory is None:
+        args_pre_parsed.directory = os.path.abspath(args_pre_parsed.directory)
+        directory = args_pre_parsed.directory
+    else:
+        directory = os.path.abspath('.')
 
-    args_find_path(args, 'all_directory', "mkosi.files/")
+    if args_pre_parsed.all_directory:
+        if os.path.isabs(args_pre_parsed.all_directory):
+            all_directory = args_pre_parsed.all_directory
+        else:
+            all_directory = os.path.join(directory, args_pre_parsed.all_directory)
+    else:
+        all_directory = os.path.join(directory, "mkosi.files/")
 
+    if args_pre_parsed.default_path:
+        if os.path.isabs(args_pre_parsed.default_path):
+            default_path = args_pre_parsed.default_path
+        else:
+            default_path = os.path.join(directory, args_pre_parsed.default_path)
+    else:
+        default_path = os.path.join(directory, "mkosi.default")
+
+    if args_pre_parsed.all and args_pre_parsed.default_path:
+        raise MkosiParseException("--all and --default= may not be combined.")
+
+    # Parse everything in --all mode
+    args_all = {}
+    if args_pre_parsed.all:
+        if not os.path.isdir(all_directory):
+            raise MkosiParseException("all-directory %s does not exist." % all_directory)
+        for f in os.scandir(all_directory):
+            if not f.name.startswith("mkosi."):
+                continue
+            args = parse_args_file(copy.deepcopy(argv), f.path)
+            args_all[f.name] = args
+    # Parse everything in normal mode
+    else:
+        args = parse_args_file_group(argv, default_path)
+        args_all['default'] = args
+
+    return args_all
+
+
+def parse_args_file(argv_post_parsed: List[str], default_path: str) -> CommandLineArguments:
+    """Parse just one mkosi.* file (--all mode)
+    """
+    argv_post_parsed.insert(1, ArgumentParserMkosi.fromfile_prefix_chars+default_path)
+    parser = create_parser()
+    # parse all parameters handled by mkosi. Parameters forwarded to subprocesses such as nspawn or qemu end up in cmdline_argv.
+    parsed_args = parser.parse_args(argv_post_parsed, CommandLineArguments())
+    args = cast(CommandLineArguments, parsed_args)
+    return args
+
+
+def parse_args_file_group(argv_post_parsed, default_path) -> CommandLineArguments:
+    """Parse a set of mkosi.default and mkosi.default.d/* files.
+    """
+    # Add the @ prefixed filenames to current argument list in inverse priority order.
+    all_defaults_files = []
+    defaults_dir = default_path + ".d"
+    if os.path.isdir(defaults_dir):
+        for defaults_file in sorted(os.listdir(defaults_dir)):
+            defaults_path = os.path.join(defaults_dir, defaults_file)
+            if os.path.isfile(defaults_path):
+                all_defaults_files.append(ArgumentParserMkosi.fromfile_prefix_chars+defaults_path)
+    if os.path.isfile(default_path):
+        all_defaults_files.insert(0, ArgumentParserMkosi.fromfile_prefix_chars+default_path)
+    argv_post_parsed[0:0] = all_defaults_files
+
+    parser = create_parser()
+
+    # parse all parameters handled by mkosi. Parameters forwarded to subprocesses such as nspawn or qemu end up in cmdline_argv.
+    parsed_args = parser.parse_args(argv_post_parsed, CommandLineArguments())
+    args = cast(CommandLineArguments, parsed_args)
     return args
 
 
@@ -3368,249 +3555,6 @@ def parse_boolean(s: str) -> bool:
     raise ValueError(f'Invalid literal for bool(): {s!r}')
 
 
-def process_setting(args: CommandLineArguments, section: str, key: Optional[str], value: Any) -> bool:
-    if section == "Distribution":
-        if key == "Distribution":
-            if args.distribution is None:
-                args.distribution = value
-        elif key == "Release":
-            if args.release is None:
-                args.release = value
-        elif key == "Repositories":
-            list_value = value if type(value) == list else value.split()
-            if args.repositories is None:
-                args.repositories = list_value
-            else:
-                args.repositories.extend(list_value)
-        elif key == "Mirror":
-            if args.mirror is None:
-                args.mirror = value
-        elif key == 'Architecture':
-            if args.architecture is None:
-                args.architecture = value
-        elif key is None:
-            return True
-        else:
-            return False
-    elif section == "Output":
-        if key == "Format":
-            if args.output_format is None:
-                args.output_format = OutputFormat[value]
-        elif key == "Output":
-            if args.output is None:
-                args.output = value
-        elif key == "OutputDirectory":
-            if args.output_dir is None:
-                args.output_dir = value
-        elif key == "Force":
-            if args.force is None:
-                args.force = parse_boolean(value)
-        elif key == "Bootable":
-            if args.bootable is None:
-                args.bootable = parse_boolean(value)
-        elif key == "BootProtocols":
-            if not args.boot_protocols:
-                args.boot_protocols = value if type(value) == list else value.split()
-        elif key == "KernelCommandLine":
-            if args.kernel_command_line is None:
-                args.kernel_command_line = value
-        elif key == "SecureBoot":
-            if args.secure_boot is None:
-                args.secure_boot = parse_boolean(value)
-        elif key == "SecureBootKey":
-            if args.secure_boot_key is None:
-                args.secure_boot_key = value
-        elif key == "SecureBootCertificate":
-            if args.secure_boot_certificate is None:
-                args.secure_boot_certificate = value
-        elif key == "ReadOnly":
-            if args.read_only is None:
-                args.read_only = parse_boolean(value)
-        elif key == "Encrypt":
-            if args.encrypt is None:
-                if value not in ("all", "data"):
-                    raise ValueError("Invalid encryption setting: " + value)
-                args.encrypt = value
-        elif key == "Verity":
-            if args.verity is None:
-                args.verity = parse_boolean(value)
-        elif key == "Compress":
-            if args.compress is None:
-                args.compress = parse_compression(value)
-        elif key == 'Mksquashfs':
-            if args.mksquashfs_tool is None:
-                args.mksquashfs_tool = value.split()
-        elif key == "XZ":
-            if args.xz is None:
-                args.xz = parse_boolean(value)
-        elif key == "QCow2":
-            if args.qcow2 is None:
-                args.qcow2 = parse_boolean(value)
-        elif key == "Hostname":
-            if not args.hostname:
-                args.hostname = value
-        elif key is None:
-            return True
-        else:
-            return False
-    elif section == "Packages":
-        if key == "Packages":
-            list_value = value if type(value) == list else value.split()
-            args.packages.extend(list_value)
-        elif key == "WithDocs":
-            if args.with_docs is None:
-                args.with_docs = parse_boolean(value)
-        elif key == "WithTests":
-            if args.with_tests is None:
-                args.with_tests = parse_boolean(value)
-        elif key == "Cache":
-            if args.cache_path is None:
-                args.cache_path = value
-        elif key == "ExtraTrees":
-            list_value = value if type(value) == list else value.split()
-            args.extra_trees.extend(list_value)
-        elif key == "SkeletonTrees":
-            list_value = value if type(value) == list else value.split()
-            args.skeleton_trees.extend(list_value)
-        elif key == "BuildScript":
-            if args.build_script is None:
-                args.build_script = value
-        elif key == "BuildSources":
-            if args.build_sources is None:
-                args.build_sources = value
-        elif key == "SourceFileTransfer":
-            if args.source_file_transfer is None:
-                try:
-                    args.source_file_transfer = SourceFileTransfer(value)
-                except ValueError:
-                    raise ValueError(f"Invalid source file transfer setting: {value}")
-        elif key == "BuildDirectory":
-            if args.build_dir is None:
-                args.build_dir = value
-        elif key == "BuildPackages":
-            list_value = value if type(value) == list else value.split()
-            args.build_packages.extend(list_value)
-        elif key in {"PostinstallScript", "PostInstallationScript"}:
-            if args.postinst_script is None:
-                args.postinst_script = value
-        elif key == "FinalizeScript":
-            if args.finalize_script is None:
-                args.finalize_script = value
-        elif key == "WithNetwork":
-            if args.with_network is None:
-                args.with_network = parse_boolean(value)
-        elif key == "NSpawnSettings":
-            if args.nspawn_settings is None:
-                args.nspawn_settings = value
-        elif key is None:
-            return True
-        else:
-            return False
-    elif section == "Partitions":
-        if key == "RootSize":
-            if args.root_size is None:
-                args.root_size = value
-        elif key == "ESPSize":
-            if args.esp_size is None:
-                args.esp_size = value
-        elif key == "BootLoaderSize":
-            if args.xbootldr_size is None:
-                args.xbootldr_size = value
-        elif key == "SwapSize":
-            if args.swap_size is None:
-                args.swap_size = value
-        elif key == "HomeSize":
-            if args.home_size is None:
-                args.home_size = value
-        elif key == "SrvSize":
-            if args.srv_size is None:
-                args.srv_size = value
-        elif key is None:
-            return True
-        else:
-            return False
-    elif section == "Validation":
-        if key == "CheckSum":
-            if args.checksum is None:
-                args.checksum = parse_boolean(value)
-        elif key == "Sign":
-            if args.sign is None:
-                args.sign = parse_boolean(value)
-        elif key == "Key":
-            if args.key is None:
-                args.key = value
-        elif key == "Bmap":
-            if args.bmap is None:
-                args.bmap = parse_boolean(value)
-        elif key == "Password":
-            if args.password is None:
-                args.password = value
-        elif key is None:
-            return True
-        else:
-            return False
-    elif section == "Host":
-        if key == "ExtraSearchPaths":
-            list_value = value if type(value) == list else value.split()
-            for v in list_value:
-                args.extra_search_paths.extend(v.split(":"))
-    else:
-        return False
-
-    return True
-
-
-def load_defaults_file(fname: str, options: Dict[str, Dict[str, Any]]) -> Optional[Dict[str, Dict[str, Any]]]:
-    try:
-        f = open(fname)
-    except FileNotFoundError:
-        return None
-
-    config = configparser.ConfigParser(delimiters='=')
-    config.optionxform = str  # type: ignore
-    config.read_file(f)
-
-    # this is used only for validation
-    args = parse_args()
-
-    for section in config.sections():
-        if not process_setting(args, section, None, None):
-            sys.stderr.write(f"Unknown section in {fname!r}, ignoring: [{section}]\n")
-            continue
-        if section not in options:
-            options[section] = {}
-        for key in config[section]:
-            if not process_setting(args, section, key, config[section][key]):
-                sys.stderr.write(f'Unknown key in section [{section}] in {fname!r}, ignoring: {key}=\n')
-                continue
-            if section == "Packages" and key in ["Packages", "ExtraTrees", "BuildPackages"]:
-                if key in options[section]:
-                    options[section][key].extend(config[section][key].split())
-                else:
-                    options[section][key] = config[section][key].split()
-            else:
-                options[section][key] = config[section][key]
-    return options
-
-
-def load_defaults(args: CommandLineArguments) -> None:
-    fname = "mkosi.default" if args.default_path is None else args.default_path
-
-    config: Dict[str, Dict[str, str]] = {}
-    load_defaults_file(fname, config)
-
-    defaults_dir = fname + '.d'
-    if os.path.isdir(defaults_dir):
-        for defaults_file in sorted(os.listdir(defaults_dir)):
-            defaults_path = os.path.join(defaults_dir, defaults_file)
-            if os.path.isfile(defaults_path):
-                load_defaults_file(defaults_path, config)
-
-    for section in config.keys():
-        for key in config[section]:
-            process_setting(args, section, key, config[section][key])
-
-
 def find_nspawn_settings(args: CommandLineArguments) -> None:
     if args.nspawn_settings is not None:
         return
@@ -3748,11 +3692,9 @@ def build_root_hash_file_path(path: str) -> str:
     return strip_suffixes(path) + ".roothash"
 
 
-def load_args(args) -> CommandLineArguments:
+def load_args(args: CommandLineArguments) -> CommandLineArguments:
     global arg_debug
     arg_debug = args.debug
-
-    load_defaults(args)
 
     args_find_path(args, 'nspawn_settings', "mkosi.nspawn")
     args_find_path(args, 'build_script',    "mkosi.build")
@@ -4596,24 +4538,21 @@ def run_verb(args):
 
 
 def main() -> None:
-    args = parse_args()
+    try:
+        args = parse_args()
+    except MkosiParseException as exp:
+        die(str(exp))
 
-    if args.directory is not None:
-        os.chdir(args.directory)
-
-    if args.all:
-        for f in os.scandir(args.all_directory):
-
-            if not f.name.startswith("mkosi."):
-                continue
-
-            a = copy.deepcopy(args)
-            a.default_path = f.path
-
-            with complete_step('Processing ' + f.path):
-                run_verb(a)
-    else:
-        run_verb(args)
+    for job_name, a in args.items():
+        # Change working directory if --directory is passed
+        if hasattr(args, 'directory'):
+            work_dir = args.directory
+            if os.path.isdir(work_dir):
+                os.chdir(work_dir)
+            else:
+                die("Error: %s is not a directory!" % work_dir)
+        with complete_step('Processing ' + job_name):
+            run_verb(a)
 
 
 if __name__ == "__main__":

--- a/mkosi
+++ b/mkosi
@@ -2971,6 +2971,10 @@ class ListAction(argparse.Action):
         if ary is None:
             ary = []
 
+        # Support list syntax for comma separated lists as well
+        if self.delimiter == ',' and values.startswith("[") and values.endswith("]"):
+            values = values[1:-1]
+
         new = values.split(self.delimiter)
 
         for x in new:

--- a/mkosi
+++ b/mkosi
@@ -2963,11 +2963,24 @@ class ListAction(argparse.Action):
         ary = getattr(namespace, self.dest)
         if ary is None:
             ary = []
+
         new = values.split(self.delimiter)
+
         for x in new:
+            x = x.strip()
+            if not x:  # ignore empty entries
+                continue
             if self.list_choices is not None and x not in self.list_choices:
                 raise ValueError(f'Unknown value {x!r}')
-            ary.append(x)
+
+            # Remove ! prefixed list entries from list. !* removes all entries. This works for strings only now.
+            if x.startswith('!*'):
+                ary = []
+            elif x.startswith('!'):
+                if x[1:] in ary:
+                    ary.remove(x[1:])
+            else:
+                ary.append(x)
         setattr(namespace, self.dest, ary)
 
 

--- a/mkosi
+++ b/mkosi
@@ -3966,6 +3966,12 @@ def line_join_list(ary: List[str]) -> str:
 
 
 def print_summary(args: CommandLineArguments) -> None:
+    sys.stderr.write("COMMANDS:\n")
+    sys.stderr.write("                  verb: " + args.verb + "\n")
+    try:
+        sys.stderr.write("               cmdline: " + ' '.join(args.cmdline) + "\n")
+    except AttributeError:
+        pass
     sys.stderr.write("DISTRIBUTION:\n")
     sys.stderr.write("          Distribution: " + args.distribution.name + "\n")
     sys.stderr.write("               Release: " + none_to_na(args.release) + "\n")

--- a/mkosi.md
+++ b/mkosi.md
@@ -180,7 +180,8 @@ details see the table below.
 : Additional package repositories to use during installation. Expects
   one or more URLs as argument, separated by commas. This option may
   be used multiple times, in which case the list of repositories to
-  use is combined.
+  use is combined. Use "!*" to remove all repositories from to the list
+  or use e.g. "!repo-url" to remove just one specific repository.
 
 `--architecture=`
 
@@ -247,12 +248,20 @@ details see the table below.
   comma-separated list of `uefi` or `bios`. May be specified more than
   once in which case the specified lists are merged. If `uefi` is
   specified the `sd-boot` UEFI boot loader is used, if `bios` is
-  specified the GNU Grub boot loader is used.
+  specified the GNU Grub boot loader is used. Use "!*" to remove all
+  previously added protocols or "!protocol" to remove one protocol.
 
 `--kernel-command-line=`
 
-: Use the specified kernel command line for when building bootable
-  images.
+: Use the specified kernel command line when building bootable
+  images. By default command line arguments get appended. To remove all
+  arguments from the current list pass "!*". To remove specific arguments
+  add a space separated list of "!" prefixed arguments.
+  For example adding "!* console=ttyS0 rw" to a mkosi.default file or the
+  command line arguments passes "console=ttyS0 rw" to the kernel in any
+  case. Just adding "console=ttyS0 rw" would append these two arguments
+  to the kernel command line created by lower priority configuration
+  files or previous --kernel-command-line command line arguments.
 
 `--secure-boot`
 
@@ -366,6 +375,11 @@ details see the table below.
   (see below) to specify packages that shall only be used for the
   image generated in the build image, but that shall not appear in the
   final image.
+  To remove a package e.g. added by a mkosi.default configuration file
+  prepend the package name with a ! letter. For example -p "!apache2"
+  would remove the apache2 package. To replace the apache2 package by
+  the httpd package just add -p "!apache2,httpd" to the command line
+  arguments. To remove all packages use "!*".
 
 `--with-docs`
 
@@ -460,6 +474,8 @@ details see the table below.
   here are only included in the image created during the first phase
   of the build, and are absent in the final image. use `--package=` to
   list packages that shall be included in both.
+  Packages are appended to the list. Packages prefixed with "!" are
+  removed from the list. "!*" removes all packages from the list.
 
 `--postinst-script=`
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
+import sys
+import os 
+dir_path = os.path.dirname(os.path.realpath(__file__))
+
+import importlib.util
+spec = importlib.util.spec_from_file_location('mkosi', os.path.join(dir_path, '../mkosi.py'))
+mkosi_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mkosi_module)
+sys.modules['mkosi'] = mkosi_module
+
+from tests.test_config_parser import MkosiConfig
+
+
+class DictDiffer(object):
+    def __init__(self, expected_dict, current_dict):
+        self.current_dict = current_dict
+        self.expected_dict = expected_dict
+        self.set_current, self.set_past = set(current_dict.keys()), set(expected_dict.keys())
+        self.intersect = self.set_current.intersection(self.set_past)
+
+    @property
+    def unexpected(self):
+        return [ '%s=%s' % (k, self.current_dict[k]) for k in self.set_current - self.intersect ]
+
+    @property 
+    def missing(self):
+        return [ str(k) for k in self.set_past - self.intersect ]
+ 
+    @property
+    def invalid(self):
+        inva = set(o for o in self.intersect if self.expected_dict[o] != self.current_dict[o])
+        return [ '%s=%s (exp: %s)' % (k, self.current_dict[k], self.expected_dict[k]) for k in inva ]
+
+    @property
+    def valid(self):
+        return set(o for o in self.intersect if self.expected_dict[o] == self.current_dict[o])
+
+
+def pytest_assertrepr_compare(op, left, right):
+    if not isinstance(left, MkosiConfig):
+        return
+    if not isinstance(right, dict):
+        return
+    for r in right.values():
+        if not isinstance(vars(r), dict):
+            return ["Invalid datatype"]
+    if op == "==":
+        def compare_job_args(job, l_a, r_a):
+            ddiff = DictDiffer(l_a, r_a)
+            ret.append('Comparing parsed configuration %s against expected configuration:' % job)
+            ret.append('unexpected:')
+            ret.extend([ '- %s' % i for i in ddiff.unexpected])
+            ret.append('missing:')
+            ret.extend([ '- %s' % i for i in ddiff.missing])
+            ret.append('invalid:')
+            ret.extend([ '- %s' % i for i in ddiff.invalid])
+
+        verified_keys = []
+        ret = ["MkosiConfig is not equal to parsed args"]
+        for right_job, right_args in right.items():
+            try:
+                left_args = left.reference_config[right_job]
+            except KeyError:
+                ret.append('Unexpected job: %s' % right_job)
+                continue
+            r_v = vars(right_args)
+            compare_job_args(right_job, left_args, r_v)
+            verified_keys.append(right_job)
+        for left_job in left.reference_config:
+            if not left_job in verified_keys:
+                ret.append('Missing job: %s' % left_job)
+        return ret

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1,0 +1,920 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
+import os
+dir_path = os.path.dirname(os.path.realpath(__file__))
+
+import importlib.util
+spec = importlib.util.spec_from_file_location('mkosi', os.path.join(dir_path, '../mkosi.py'))
+mkosi = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mkosi)
+
+import pytest
+import configparser
+import copy
+
+
+class ChangeCwd(object):
+    """Change working directory temporarily"""
+    def __init__(self, path):
+        self.old_dir = os.getcwd()
+        self.new_dir = path
+
+    def __enter__(self):
+        os.chdir(self.new_dir)
+
+    def __exit__(self, *args):
+        os.chdir(self.old_dir)
+
+
+DEFAULT_JOB_NAME = 'default'
+
+class MkosiConfig(object):
+    """Base class for mkosi test and reference configuration generators
+    """
+
+    def __init__(self):
+        self.cli_arguments = []
+        self.reference_config = {}
+
+    def add_reference_config(self, job_name=DEFAULT_JOB_NAME):
+        """create one initial reference configuration
+
+        This default reference configuration is equal to the configuration returned by parse_args
+        function without default files and without any command line arguments.
+        """
+        self.reference_config[job_name] = {
+            'all': False,
+            'all_directory': None,
+            'architecture': None,
+            'bmap': False,
+            'boot_protocols': [],
+            'bootable': False,
+            'build_dir': None,
+            'build_packages': [],
+            'build_script': None,
+            'build_sources': None,
+            'cache_path': None,
+            'checksum': False,
+            'cmdline': [],
+            'compress': None,
+            'debug': [],
+            'default_path': None,
+            'directory': None,
+            'distribution': None,
+            'encrypt': None,
+            'esp_size': None,
+            'extra_search_paths': [],
+            'extra_trees': [],
+            'finalize_script': None,
+            'force_count': 0,
+            'home_size': None,
+            'hostname': None,
+            'incremental': False,
+            'kernel_command_line': ['rhgb', 'quiet', 'selinux=0', 'audit=0', 'rw'],
+            'key': None,
+            'mirror': None,
+            'mksquashfs_tool': None,
+            'no_chown': False,
+            'nspawn_settings': None,
+            'output': None,
+            'output_dir': None,
+            'output_format': None,
+            'packages': [],
+            'password': None,
+            'postinst_script': None,
+            'qcow2': False,
+            'read_only': False,
+            'release': None,
+            'repositories': [],
+            'root_size': None,
+            'secure_boot': False,
+            'secure_boot_certificate': None,
+            'secure_boot_key': None,
+            'sign': False,
+            'skeleton_trees': [],
+            'source_file_transfer': None,
+            'srv_size': None,
+            'swap_size': None,
+            'verb': 'build',
+            'verity': False,
+            'with_docs': False,
+            'with_network': False,
+            'with_tests': True,
+            'xbootldr_size': None,
+            'xz': False,
+        }
+
+    def __eq__(self, other: [mkosi.CommandLineArguments]) -> bool:
+        """Compare the configuration returned by parse_args against self.reference_config
+        """
+        if len(self.reference_config) != len(other):
+            return False
+
+        is_eq = True
+        for other_job, other_args in other.items():
+            try:
+                this_args = self.reference_config[other_job]
+            except KeyError:
+                return False
+            other_args_v = vars(other_args)
+            if this_args != other_args_v:
+                is_eq = False
+        return is_eq
+
+    def _append_list(self, ref_entry, new_args, job_name=DEFAULT_JOB_NAME, separator=','):
+        """Helper function handling comma separated list as supported by mkosi
+        """
+        args_list = []
+        if isinstance(new_args, str):
+            args_list = new_args.split(separator)
+        else:
+            for arg in new_args:
+                args_list.extend(arg.split(separator))
+        for arg in args_list:
+            if isinstance(arg, str) and arg.startswith('!'):
+                if arg[1:] in self.reference_config[job_name][ref_entry]:
+                    self.reference_config[job_name][ref_entry].remove(arg[1:])
+            else:
+                self.reference_config[job_name][ref_entry].append(arg)
+
+    @staticmethod
+    def write_ini(dname: str, fname: str, config: dict, prio=1000) -> None:
+        """Write mkosi.default(.d/*) files
+        """
+        if not os.path.exists(dname):
+            os.makedirs(dname)
+        if prio < 1000:
+            fname = '{:03d}_{}'.format(prio, fname)
+        config_parser = configparser.ConfigParser()
+        config_parser.optionxform=str
+
+        # Replace lists in dict before calling config_parser write file
+        config_all_normalized = copy.deepcopy(config)
+        for section, key_val in config_all_normalized.items():
+            for key, val in key_val.items():
+                if isinstance(val, list):
+                    config_all_normalized[section][key] = os.linesep.join(val)
+
+        config_parser.read_dict(config_all_normalized)
+        with open(os.path.join(dname, fname), 'w') as f_ini:
+            config_parser.write(f_ini)
+
+    def _update_ref_from_file(self, mk_config: dict, job_name=DEFAULT_JOB_NAME) -> None:
+        """Update reference_config from a dict as needed to write an ini file using configparser
+
+        This is basically a conversion from snake case to - separated format.
+        """
+        if 'Distribution' in mk_config:
+            mk_config_distro = mk_config['Distribution']
+            if 'Distribution' in mk_config_distro:
+                self.reference_config[job_name]['distribution'] = mk_config_distro['Distribution']
+            if 'Release' in mk_config_distro:
+                self.reference_config[job_name]['release'] = mk_config_distro['Release']
+            if 'Repositories' in mk_config_distro:
+                self._append_list('repositories', mk_config_distro['Repositories'], job_name)
+            if 'Mirror' in mk_config_distro:
+                self.reference_config[job_name]['mirror'] = mk_config_distro['Mirror']
+            if 'Architecture' in mk_config_distro:
+                self.reference_config[job_name]['architecture'] = mk_config_distro['Architecture']
+        if 'Output' in mk_config:
+            mk_config_output = mk_config['Output']
+            if 'Format' in mk_config_output:
+                self.reference_config[job_name]['output_format'] = mkosi.OutputFormat.from_string(mk_config_output['Format'])
+            if 'Output' in mk_config_output:
+                self.reference_config[job_name]['output'] = mk_config_output['Output']
+            if 'Force' in mk_config_output:
+                self.reference_config[job_name]['force_count'] += 1
+            if 'Bootable' in mk_config_output:
+                self.reference_config[job_name]['bootable'] = mk_config_output['Bootable']
+            if 'BootProtocols' in mk_config_output:
+                self._append_list('boot_protocols', mk_config_output['BootProtocols'], job_name)
+            if 'KernelCommandLine' in mk_config_output:
+                self._append_list('kernel_command_line', mk_config_output['KernelCommandLine'], job_name, ' ')
+            if 'SecureBoot' in mk_config_output:
+                self.reference_config[job_name]['secure_boot'] = mk_config_output['SecureBoot']
+            if 'SecureBootKey' in mk_config_output:
+                self.reference_config[job_name]['secure_boot_key'] = mk_config_output['SecureBootKey']
+            if 'SecureBootCertificate' in mk_config_output:
+                self.reference_config[job_name]['secure_boot_certificate'] = mk_config_output['SecureBootCertificate']
+            if 'ReadOnly' in mk_config_output:
+                self.reference_config[job_name]['read_only'] = mk_config_output['ReadOnly']
+            if 'Encrypt' in mk_config_output:
+                self.reference_config[job_name]['encrypt'] = mk_config_output['Encrypt']
+            if 'Verity' in mk_config_output:
+                self.reference_config[job_name]['verity'] = mk_config_output['Verity']
+            if 'Compress' in mk_config_output:
+                self.reference_config[job_name]['compress'] = mk_config_output['Compress']
+            if 'Mksquashfs' in mk_config_output:
+                self.reference_config[job_name]['mksquashfs_tool'] = mk_config_output['Mksquashfs'].split()
+            if 'XZ' in mk_config_output:
+                self.reference_config[job_name]['xz'] = mk_config_output['XZ']
+            if 'QCow2' in mk_config_output:
+                self.reference_config[job_name]['qcow2'] = mk_config_output['QCow2']
+            if 'Hostname' in mk_config_output:
+                self.reference_config[job_name]['hostname'] = mk_config_output['Hostname']
+        if 'Packages' in mk_config:
+            mk_config_packages = mk_config['Packages']
+            if 'Packages' in mk_config_packages:
+                self._append_list('packages', mk_config_packages['Packages'], job_name)
+            if 'WithDocs' in mk_config_packages:
+                self.reference_config[job_name]['with_docs'] = mk_config_packages['WithDocs']
+            if 'WithTests' in mk_config_packages:
+                self.reference_config[job_name]['with_tests'] = mk_config_packages['WithTests']
+            if 'Cache' in mk_config_packages:
+                self.reference_config[job_name]['cache_path'] = mk_config_packages['Cache']
+            if 'ExtraTrees' in mk_config_packages:
+                self._append_list('extra_trees', mk_config_packages['ExtraTrees'], job_name)
+            if 'SkeletonTrees' in mk_config_packages:
+                self._append_list('skeleton_trees', mk_config_packages['SkeletonTrees'], job_name)
+            if 'BuildScript' in mk_config_packages:
+                self.reference_config[job_name]['build_script'] = mk_config_packages['BuildScript']
+            if 'BuildSources' in mk_config_packages:
+                self.reference_config[job_name]['build_sources'] = mk_config_packages['BuildSources']
+            if 'SourceFileTransfer' in mk_config_packages:
+                self.reference_config[job_name]['source_file_transfer'] = mk_config_packages['SourceFileTransfer']
+            if 'BuildDirectory' in mk_config_packages:
+                self.reference_config[job_name]['build_dir'] = mk_config_packages['BuildDirectory']
+            if 'BuildPackages' in mk_config_packages:
+                self._append_list('build_packages', mk_config_packages['BuildPackages'], job_name)
+            if 'PostInstallationScript' in mk_config_packages:
+                self.reference_config[job_name]['postinst_script'] = mk_config_packages['PostInstallationScript']
+            if 'FinalizeScript' in mk_config_packages:
+                self.reference_config[job_name]['finalize_script'] = mk_config_packages['FinalizeScript']
+            if 'WithNetwork' in mk_config_packages:
+                self.reference_config[job_name]['with_network'] = mk_config_packages['WithNetwork']
+            if 'NSpawnSettings' in mk_config_packages:
+                self.reference_config[job_name]['nspawn_settings'] = mk_config_packages['NSpawnSettings']
+        if 'Partitions' in mk_config:
+            mk_config_partitions = mk_config['Partitions']
+            if 'RootSize' in mk_config_partitions:
+                self.reference_config[job_name]['root_size'] = mk_config_partitions['RootSize']
+            if 'ESPSize' in mk_config_partitions:
+                self.reference_config[job_name]['esp_size'] = mk_config_partitions['ESPSize']
+            if 'SwapSize' in mk_config_partitions:
+                self.reference_config[job_name]['swap_size'] = mk_config_partitions['SwapSize']
+            if 'HomeSize' in mk_config_partitions:
+                self.reference_config[job_name]['home_size'] = mk_config_partitions['HomeSize']
+            if 'SrvSize' in mk_config_partitions:
+                self.reference_config[job_name]['srv_size'] = mk_config_partitions['SrvSize']
+        if 'Validation' in mk_config:
+            mk_config_validation = mk_config['Validation']
+            if 'CheckSum' in mk_config_validation:
+                self.reference_config[job_name]['checksum'] = mk_config_validation['CheckSum']
+            if 'Sign' in mk_config_validation:
+                self.reference_config[job_name]['sign'] = mk_config_validation['Sign']
+            if 'Key' in mk_config_validation:
+                self.reference_config[job_name]['key'] = mk_config_validation['Key']
+            if 'BMap' in mk_config_validation:
+                self.reference_config[job_name]['bmap'] = mk_config_validation['BMap']
+            if 'Password' in mk_config_validation:
+                self.reference_config[job_name]['password'] = mk_config_validation['Password']
+        if 'Host' in mk_config:
+            mk_config_host = mk_config['Host']
+            if 'ExtraSearchPaths' in mk_config_host:
+                self._append_list('extra_search_paths', mk_config_host['ExtraSearchPaths'], job_name, ':')
+
+
+class MkosiConfigOne(MkosiConfig):
+    """Classes derived from this class are magically instantiated by pytest
+
+    Each test_ function with a parameter named "tested_config" gets
+    called by pytest for each class derived from this class. These test cases
+    verify the parse_args function in single image (not --all) mode.
+    This class implements four functions:
+    - prepare_mkosi_default
+    - prepare_mkosi_default_d_1
+    - prepare_mkosi_default_d_2
+    - prepare_args or prepare_args_short
+
+    The purpose of these function is to generate configuration files and sets of command line
+    arguments processed by the parse_args function of mkosi. Additionally each of these four functions
+    alters the reference_config to be consistent with the expected values returned by the parse_args
+    function under test.
+
+    This allows to write test cases with four steps. The first step generates a reference configuration
+    consisting of mkosi.default file only. Therefore prepare_mkosi_default function is is called to
+    generate the test configuration. Finally parse_args is called and the configuration returned by
+    parse_args is compared against the reference_config. The second test step generates a test
+    configuration by calling prepare_mkosi_default and prepare_mkosi_default_d_1. This verifies the
+    behavior of parse_args is fine for mkosi.default plus one override file. The third test case verifies
+    that mkosi.default with two files in mkosi.default.d folder works as expected. The fourth test case
+    additionally overrides some default values with command line arguments.
+
+    Classes derived from this base class should override the mentioned functions to implement specific
+    test cases.
+    """
+
+    def __init__(self):
+        """Add the default mkosi.default config
+        """
+        super().__init__()
+        self.add_reference_config()
+
+    def _prepare_mkosi_default(self, directory: str, config: dict) -> None:
+        __class__.write_ini(directory, 'mkosi.default', config)
+
+    def _prepare_mkosi_default_d(self, directory: str, config: dict, prio=1000, fname='mkosi.conf') -> None:
+        __class__.write_ini(os.path.join(directory, 'mkosi.default.d'), fname, config, prio)
+
+    def prepare_mkosi_default(self, directory: str) -> None:
+        """Generate a mkosi.default defaults file in the working directory"""
+        pass
+
+    def prepare_mkosi_default_d_1(self, directory: str) -> None:
+        """Generate a prio 1 config file in mkosi.default.d
+
+        The file name should be prefixed with 001_.
+        """
+        pass
+
+    def prepare_mkosi_default_d_2(self, directory: str) -> None:
+        """Generate a prio 2 config file in mkosi.default.d
+
+        The file name should be prefixed with 002_.
+        """
+        pass
+
+    def prepare_args(self) -> None:
+        """Add some command line arguments to this test run"""
+        pass
+
+    def prepare_args_short(self) -> None:
+        """Add some command line arguments to this test run, in short form"""
+        pass
+
+
+class MkosiConfigSummary(MkosiConfigOne):
+    """Test configuration for mkosi summary
+
+    This test checks if the default parameter set of these tests is in sync
+    with the default parameters implemented in mkosi. No config files or command
+    line arguments are in place.
+    """
+    def __init__(self):
+        super().__init__()
+        for ref_c in self.reference_config.values():
+            ref_c['verb'] = 'summary'
+        self.cli_arguments = ['summary']
+
+
+class MkosiConfigDistro(MkosiConfigOne):
+    """Minimal test configuration for the distribution parameter
+
+    This tests defines the distribution parameter on several configuration priorities:
+    - mkosi.default
+    - mkosi.default.d/001_mkosi.conf
+    - mkosi.default.d/002_mkosi.conf
+    - --distribution
+    """
+
+    def __init__(self, subdir_name=None, alldir_name=None):
+        super().__init__()
+        self.subdir_name = subdir_name
+        if subdir_name:
+            for ref_c in self.reference_config.values():
+                ref_c['directory'] = self.subdir_name
+            self.cli_arguments = ['--directory', self.subdir_name, 'summary']
+
+    def prepare_mkosi_default(self, directory: str) -> None:
+        mk_config = { 'Distribution': { 'Distribution': 'fedora'}}
+        self._prepare_mkosi_default(directory, mk_config)
+        for ref_c in self.reference_config.values():
+            ref_c['distribution'] = 'fedora'
+            if self.subdir_name:
+                ref_c['directory'] = self.subdir_name
+        if self.subdir_name:
+            self.cli_arguments = ['--directory', self.subdir_name, 'summary']
+
+    def prepare_mkosi_default_d_1(self, directory: str) -> None:
+        mk_config = { 'Distribution': { 'Distribution': 'ubuntu'}}
+        self._prepare_mkosi_default_d(directory, mk_config, 1)
+        for ref_c in self.reference_config.values():
+            ref_c['distribution'] = 'ubuntu'
+
+    def prepare_mkosi_default_d_2(self, directory: str) -> None:
+        mk_config = { 'Distribution': { 'Distribution': 'debian'}}
+        self._prepare_mkosi_default_d(directory, mk_config, 2)
+        for ref_c in self.reference_config.values():
+            ref_c['distribution'] = 'debian'
+
+    def prepare_args(self) -> None:
+        if not self.cli_arguments:
+            self.cli_arguments = ['build']
+        self.cli_arguments[0:0] = ['--distribution', 'arch']
+        for ref_c in self.reference_config.values():
+            ref_c['distribution'] = 'arch'
+
+    def prepare_args_short(self) -> None:
+        if not self.cli_arguments:
+            self.cli_arguments = ['build']
+        self.cli_arguments[0:0] = ['-d', 'arch']
+        for ref_c in self.reference_config.values():
+            ref_c['distribution'] = 'arch'
+
+
+class MkosiConfigDistroDir(MkosiConfigDistro):
+    """Same as Distro, but gets --directory passed and sets verb to summary
+    """
+    def __init__(self):
+        super().__init__('a_sub_dir')
+        for ref_c in self.reference_config.values():
+            ref_c['verb'] = 'summary'
+
+
+class MkosiConfigManyParams(MkosiConfigOne):
+    """Test configuration for most parameters"""
+
+    def prepare_mkosi_default(self, directory: str) -> None:
+        mk_config = {
+            'Distribution': {
+                'Distribution': 'fedora',
+                'Release': '28',
+                'Repositories': 'http://fedora/repos',
+                'Mirror': 'http://fedora/mirror',
+                'Architecture': 'i386',
+                },
+            'Output': {
+                'Format': 'gpt_ext4',
+                'Output': 'test_image.raw',
+#                 # 'OutputDirectory': '',
+                'Bootable': False,
+                'BootProtocols': 'uefi',
+                'KernelCommandLine': ['console=ttyS0'],
+                'SecureBoot': False,
+                'SecureBootKey': '/foo.pem',
+                'SecureBootCertificate': 'bar.crt',
+                'ReadOnly': False,
+                'Encrypt': 'all',
+                'Verity': False,
+                'Compress': 'lz4',
+                'Mksquashfs': 'my/fo/sq-tool',
+                'XZ': False,
+                'QCow2': False,
+                'Hostname': 'myhost1',
+                 },
+            'Packages': {
+                'Packages': ['pkg-foo', 'pkg-bar', 'pkg-foo1,pkg-bar1'],
+                'WithDocs': False,
+                'WithTests': True,
+                'Cache': 'the/cache/dir',
+                'ExtraTrees': 'another/tree',
+                'SkeletonTrees': 'a/skeleton',
+                'BuildScript': 'fancy_build.sh',
+                'BuildSources': 'src',
+                'SourceFileTransfer': mkosi.SourceFileTransfer.copy_all,
+                'BuildDirectory': 'here/we/build',
+                'BuildPackages': ['build-me', 'build-me2'],
+                'PostInstallationScript': 'post-script.sh',
+                'FinalizeScript': 'final.sh',
+                'WithNetwork': False,
+                'NSpawnSettings': 'foo.nspawn'
+                },
+            'Partitions': {
+                'RootSize': '2G',
+                'ESPSize': '128M',
+                'SwapSize': '1024M',
+                'HomeSize': '3G'
+                },
+            'Validation': {
+                'CheckSum': True,
+                'Sign': False,
+                'Key': 'mykey.gpg',
+                'BMap': False,
+                'Password': "secret1234",
+                },
+            'Host': {
+                'ExtraSearchPaths': 'search/here:search/there',
+                }
+            }
+        self._prepare_mkosi_default(directory, mk_config)
+        for j in self.reference_config:
+            self._update_ref_from_file(mk_config, j)
+
+    def prepare_mkosi_default_d_1(self, directory: str) -> None:
+        mk_config = {
+            'Distribution': {
+                'Distribution': 'ubuntu',
+                'Release': '18.04',
+                'Repositories': 'http://ubuntu/repos',
+                'Mirror': 'http://ubuntu/mirror',
+                'Architecture': 'x86_64',
+                },
+            'Output': {
+                'Format': 'gpt_btrfs',
+                'Output': 'test_image.raw.xz',
+#                 # 'OutputDirectory': '',
+                'Bootable': True,
+                'BootProtocols': 'bios',
+                'KernelCommandLine': ['console=ttyS1'],
+                'SecureBoot': True,
+                'SecureBootKey': '/foo-ubu.pem',
+                'SecureBootCertificate': 'bar-bub.crt',
+                'ReadOnly': True,
+                'Encrypt': 'data',
+                'Verity': True,
+                'Compress': 'zstd',
+                'Mksquashfs': 'my/fo/sq-tool-ubu',
+                'XZ': True,
+                'QCow2': True,
+                'Hostname': 'myubuhost1',
+                 },
+            'Packages': {
+                'Packages': ['add-ubu-1', 'add-ubu-2'],
+                'WithDocs': True,
+                'WithTests': False,
+                'Cache': 'the/cache/dir/ubu',
+                'ExtraTrees': 'another/tree/ubu',
+                'SkeletonTrees': 'a/skeleton/ubu',
+                'BuildScript': 'ubu_build.sh',
+                'BuildSources': 'src/ubu',
+                'SourceFileTransfer': mkosi.SourceFileTransfer.copy_git_cached,
+                'BuildDirectory': 'here/we/build/ubu',
+                'BuildPackages': ['build-me', 'build-me2-ubu'],
+                'PostInstallationScript': 'post-ubu-script.sh',
+                'FinalizeScript': 'final-ubu.sh',
+                'WithNetwork': True,
+                'NSpawnSettings': 'foo-ubu.nspawn'
+                },
+            'Partitions': {
+                'RootSize': '4G',
+                'ESPSize': '148M',
+                'SwapSize': '1536M',
+                'HomeSize': '5G'
+                },
+            'Validation': {
+                'CheckSum': False,
+                'Sign': True,
+                'Key': 'mykey-ubu.gpg',
+                'BMap': True,
+                'Password': "secret12345",
+                },
+            'Host': {
+                'ExtraSearchPaths': 'search/ubu',
+                }
+            }
+        self._prepare_mkosi_default_d(directory, mk_config, 1)
+        for j in self.reference_config:
+            self._update_ref_from_file(mk_config, j)
+
+    def prepare_mkosi_default_d_2(self, directory: str) -> None:
+        mk_config = {
+            'Distribution': {
+                'Distribution': 'debian',
+                'Release': 'unstable',
+                'Repositories': 'http://debian/repos',
+                'Mirror': 'http://ubuntu/mirror',
+                'Architecture': 'x86_64',
+                },
+            'Output': {
+                'Format': 'gpt_btrfs',
+                'Output': 'test_image.raw.xz',
+#                 # 'OutputDirectory': '',
+                'Bootable': True,
+                'BootProtocols': 'bios',
+                'KernelCommandLine': ['console=ttyS1'],
+                'SecureBoot': True,
+                'SecureBootKey': '/foo-debi.pem',
+                'SecureBootCertificate': 'bar-bub.crt',
+                'ReadOnly': True,
+                'Encrypt': 'data',
+                'Verity': True,
+                'Compress': 'zstd',
+                'Mksquashfs': 'my/fo/sq-tool-debi',
+                'XZ': True,
+                'QCow2': True,
+                'Hostname': 'mydebihost1',
+                 },
+            'Packages': {
+                'Packages': ['!add-ubu-1', '!add-ubu-2', 'add-debi-1', 'add-debi-2'],
+                'WithDocs': True,
+                'WithTests': False,
+                'Cache': 'the/cache/dir/debi',
+                'ExtraTrees': 'another/tree/debi',
+                'SkeletonTrees': 'a/skeleton/debi',
+                'BuildScript': 'debi_build.sh',
+                'BuildSources': 'src/debi',
+                'SourceFileTransfer': mkosi.SourceFileTransfer.copy_git_cached,
+                'BuildDirectory': 'here/we/build/debi',
+                'BuildPackages': ['build-me', 'build-me2-debi'],
+                'PostInstallationScript': 'post-debi-script.sh',
+                'FinalizeScript': 'final-debi.sh',
+                'WithNetwork': True,
+                'NSpawnSettings': 'foo-debi.nspawn'
+                },
+            'Partitions': {
+                'RootSize': '4G',
+                'ESPSize': '148M',
+                'SwapSize': '1536M',
+                'HomeSize': '5G'
+                },
+            'Validation': {
+                'CheckSum': False,
+                'Sign': True,
+                'Key': 'mykey-debi.gpg',
+                'BMap': True,
+                'Password': "secret12345",
+                },
+            'Host': {
+                'ExtraSearchPaths': 'search/debi',
+                }
+            }
+        self._prepare_mkosi_default_d(directory, mk_config, 2)
+        for j in self.reference_config:
+            self._update_ref_from_file(mk_config, j)
+
+    def prepare_args(self) -> None:
+        if not self.cli_arguments:
+            self.cli_arguments = ['build']
+        self.cli_arguments[0:0] = ['--distribution', 'arch']
+        self.cli_arguments[0:0] = ['--release', '7']
+        self.cli_arguments[0:0] = ['--repositories', 'centos/repos']
+        self.cli_arguments[0:0] = ['--force']
+        self.cli_arguments[0:0] = ['--read-only', 'no']
+        self.cli_arguments[0:0] = ['--incremental']
+
+        for j, ref_c in self.reference_config.items():
+            ref_c['distribution'] = 'arch'
+            ref_c['release'] = '7'
+            self._append_list('repositories', 'centos/repos', j)
+            ref_c['force_count'] += 1
+            ref_c['read_only'] = False
+            ref_c['incremental'] = True
+
+    def prepare_args_short(self) -> None:
+        if not self.cli_arguments:
+            self.cli_arguments = ['build']
+        self.cli_arguments[0:0] = ['-d', 'centos']
+        for ref_c in self.reference_config.values():
+            ref_c['distribution'] = 'centos'
+
+
+class MkosiConfigIniLists1(MkosiConfigOne):
+    """Manually written ini files with advanced list syntax."""
+
+    def prepare_mkosi_default(self, directory: str) -> None:
+        ini_lines = [
+            "[Distribution]",
+            "Distribution=fedora",
+            "",
+            "[Packages]",
+            "Packages=openssh-clients",
+            "  httpd",
+            "  tar"
+            ]
+        with open(os.path.join(directory, 'mkosi.default'), 'w') as f_ini:
+            f_ini.write(os.linesep.join(ini_lines))
+        self.reference_config[DEFAULT_JOB_NAME]['distribution'] = 'fedora'
+        self.reference_config[DEFAULT_JOB_NAME]['packages'] = ['openssh-clients', 'httpd', 'tar']
+
+    def prepare_mkosi_default_d_1(self, directory: str) -> None:
+        ini_lines = [
+            "[Distribution]",
+            "Distribution=ubuntu",
+            "",
+            "[Packages]",
+            "Packages=   ",
+            "          !httpd",
+            "           apache2",
+            "",
+            "[Output]",
+            "KernelCommandLine=console=ttyS0"
+            ]
+        dname = os.path.join(directory, 'mkosi.default.d')
+        if not os.path.exists(dname):
+            os.makedirs(dname)
+        with open(os.path.join(dname, '1_ubuntu.conf'), 'w') as f_ini:
+            f_ini.write(os.linesep.join(ini_lines))
+        self.reference_config[DEFAULT_JOB_NAME]['distribution'] = 'ubuntu'
+        if 'httpd' in self.reference_config[DEFAULT_JOB_NAME]['packages']:
+            self.reference_config[DEFAULT_JOB_NAME]['packages'].remove('httpd')
+        self.reference_config[DEFAULT_JOB_NAME]['packages'].append('apache2')
+        self.reference_config[DEFAULT_JOB_NAME]['kernel_command_line'].extend(['console=ttyS0'])
+
+    def prepare_mkosi_default_d_2(self, directory: str) -> None:
+        ini_lines = [
+            "[Packages]",
+            "Packages=[ vim,!vi",
+            "  ca-certificates, bzip ]"
+            "",
+            "[Output]",
+            "KernelCommandLine=console=ttyS1",
+            "  driver.feature=1"
+            ]
+        dname = os.path.join(directory, 'mkosi.default.d')
+        if not os.path.exists(dname):
+            os.makedirs(dname)
+        with open(os.path.join(dname, '2_additional_stuff.conf'), 'w') as f_ini:
+            f_ini.write(os.linesep.join(ini_lines))
+        if 'vi' in self.reference_config[DEFAULT_JOB_NAME]['packages']:
+            self.reference_config[DEFAULT_JOB_NAME]['packages'].remove('vi')
+        self.reference_config[DEFAULT_JOB_NAME]['packages'].extend(['vim', 'ca-certificates', 'bzip'])
+        self.reference_config[DEFAULT_JOB_NAME]['kernel_command_line'].extend(['console=ttyS1', 'driver.feature=1'])
+
+
+class MkosiConfigIniLists2(MkosiConfigIniLists1):
+    """Same as MkosiConfigIniLists2 but with clean KernelCommandLine"""
+
+    def prepare_mkosi_default(self, directory: str) -> None:
+        ini_lines = [
+            "[Output]",
+            "KernelCommandLine=!*"
+            ]
+        with open(os.path.join(directory, 'mkosi.default'), 'w') as f_ini:
+            f_ini.write(os.linesep.join(ini_lines))
+        self.reference_config[DEFAULT_JOB_NAME]['kernel_command_line'] = []
+
+
+# pytest magic: run each test function with each class derived from MkosiConfigOne
+@pytest.fixture(params=MkosiConfigOne.__subclasses__())
+def tested_config(request):
+    return request.param()
+
+def test_verb_none(tmpdir):
+    with ChangeCwd(tmpdir.strpath):
+        args = mkosi.parse_args([])
+        assert args['default'].verb == 'build'
+
+def test_verb_build(tmpdir):
+    with ChangeCwd(tmpdir.strpath):
+        args = mkosi.parse_args(['build'])
+        assert args['default'].verb == 'build'
+
+def test_verb_boot_no_cli_args1(tmpdir):
+    with ChangeCwd(tmpdir.strpath):
+        cmdline_ref = ['boot', '--par-for-sub', '--pom', '--for_sub', '1234']
+        args = mkosi.parse_args(cmdline_ref)
+        assert args['default'].verb == 'boot'
+        assert args['default'].cmdline == cmdline_ref[1:]
+
+def test_verb_boot_no_cli_args2(tmpdir):
+    with ChangeCwd(tmpdir.strpath):
+        cmdline_ref = ['-pa-package', 'boot', '--par-for-sub', '--popenssl', '--for_sub', '1234']
+        args = mkosi.parse_args(cmdline_ref)
+        assert args['default'].verb == 'boot'
+        assert 'a-package' in args['default'].packages
+        assert args['default'].cmdline == cmdline_ref[2:]
+
+def test_verb_boot_no_cli_args3(tmpdir):
+    with ChangeCwd(tmpdir.strpath):
+        cmdline_ref = ['-pa-package', '-p', 'another-package', 'build']
+        args = mkosi.parse_args(cmdline_ref)
+        assert args['default'].verb == 'build'
+        assert args['default'].packages == ['a-package', 'another-package']
+
+def test_verb_summary_no_cli_args4(tmpdir):
+    with ChangeCwd(tmpdir.strpath):
+        cmdline_ref = ['-pa-package', '-p', 'another-package', 'summary']
+        args = mkosi.parse_args(cmdline_ref)
+        assert args['default'].verb == 'summary'
+        assert args['default'].packages == ['a-package', 'another-package']
+
+def test_verb_shell_cli_args5(tmpdir):
+    with ChangeCwd(tmpdir.strpath):
+        cmdline_ref = ['-pa-package', '-p', 'another-package', 'shell', 'python3 -foo -bar;', 'ls --inode']
+        args = mkosi.parse_args(cmdline_ref)
+        assert args['default'].verb == 'shell'
+        assert args['default'].packages == ['a-package', 'another-package']
+        assert args['default'].cmdline == cmdline_ref[4:]
+
+def test_verb_shell_cli_args6(tmpdir):
+    with ChangeCwd(tmpdir.strpath):
+        cmdline_ref = ['-i', 'yes', 'summary']
+        args = mkosi.parse_args(cmdline_ref)
+        assert args['default'].verb == 'summary'
+        assert args['default'].incremental == True
+
+def test_verb_shell_cli_args7(tmpdir):
+    with ChangeCwd(tmpdir.strpath):
+        cmdline_ref = ['-i', 'summary']
+        args = mkosi.parse_args(cmdline_ref)
+        assert args['default'].verb == 'summary'
+        assert args['default'].incremental == True
+
+def test_builtin(tested_config, tmpdir):
+    """Test if builtin config and reference config match"""
+    with ChangeCwd(tmpdir.strpath):
+        if '--all' in tested_config.cli_arguments:
+            with pytest.raises(mkosi.MkosiParseException):
+                args = mkosi.parse_args(tested_config.cli_arguments)
+        else:
+            args = mkosi.parse_args(tested_config.cli_arguments)
+            assert tested_config == args
+
+def test_def(tested_config, tmpdir):
+    """Generate the mkosi.default file only"""
+    with ChangeCwd(tmpdir.strpath):
+        tested_config.prepare_mkosi_default(tmpdir.strpath)
+        args = mkosi.parse_args(tested_config.cli_arguments)
+        assert tested_config == args
+
+def test_def_1(tested_config, tmpdir):
+    """Generate the mkosi.default file plus one config file"""
+    with ChangeCwd(tmpdir.strpath):
+        tested_config.prepare_mkosi_default(tmpdir.strpath)
+        tested_config.prepare_mkosi_default_d_1(tmpdir.strpath)
+        args = mkosi.parse_args(tested_config.cli_arguments)
+        assert tested_config == args
+
+def test_def_2(tested_config, tmpdir):
+    """Generate the mkosi.default file plus another config file"""
+    with ChangeCwd(tmpdir.strpath):
+        tested_config.prepare_mkosi_default(tmpdir.strpath)
+        tested_config.prepare_mkosi_default_d_2(tmpdir.strpath)
+        args = mkosi.parse_args(tested_config.cli_arguments)
+        assert tested_config == args
+
+def test_def_1_2(tested_config, tmpdir):
+    """Generate the mkosi.default file plus two config files"""
+    with ChangeCwd(tmpdir.strpath):
+        tested_config.prepare_mkosi_default(tmpdir.strpath)
+        tested_config.prepare_mkosi_default_d_1(tmpdir.strpath)
+        tested_config.prepare_mkosi_default_d_2(tmpdir.strpath)
+        args = mkosi.parse_args(tested_config.cli_arguments)
+        assert tested_config == args
+
+def test_def_args(tested_config, tmpdir):
+    """Generate the mkosi.default plus command line arguments"""
+    with ChangeCwd(tmpdir.strpath):
+        tested_config.prepare_args()
+        args = mkosi.parse_args(tested_config.cli_arguments)
+        assert tested_config == args
+
+def test_def_1_args(tested_config, tmpdir):
+    """Generate the mkosi.default plus a config file plus command line arguments"""
+    with ChangeCwd(tmpdir.strpath):
+        tested_config.prepare_mkosi_default(tmpdir.strpath)
+        tested_config.prepare_mkosi_default_d_1(tmpdir.strpath)
+        tested_config.prepare_args()
+        args = mkosi.parse_args(tested_config.cli_arguments)
+        assert tested_config == args
+
+def test_def_1_2_args(tested_config, tmpdir):
+    """Generate the mkosi.default plus two config files plus command line arguments"""
+    with ChangeCwd(tmpdir.strpath):
+        tested_config.prepare_mkosi_default(tmpdir.strpath)
+        tested_config.prepare_mkosi_default_d_1(tmpdir.strpath)
+        tested_config.prepare_mkosi_default_d_2(tmpdir.strpath)
+        tested_config.prepare_args()
+        args = mkosi.parse_args(tested_config.cli_arguments)
+        assert tested_config == args
+
+def test_def_1_2_argssh(tested_config, tmpdir):
+    """Generate the mkosi.default plus two config files plus short command line arguments"""
+    with ChangeCwd(tmpdir.strpath):
+        tested_config.prepare_mkosi_default(tmpdir.strpath)
+        tested_config.prepare_mkosi_default_d_1(tmpdir.strpath)
+        tested_config.prepare_mkosi_default_d_2(tmpdir.strpath)
+        tested_config.prepare_args_short()
+        args = mkosi.parse_args(tested_config.cli_arguments)
+        assert tested_config == args
+
+
+class MkosiConfigAll(MkosiConfig):
+    """Classes derived from this class are magically instantiated by pytest
+
+    Each test_ function with a parameter named "tested_config_all" gets
+    called by pytest for each class derived from this class.
+    """
+
+
+class MkosiConfigAllHost(MkosiConfigAll):
+    """Test --all option with two simple configs
+    """
+
+    def __init__(self):
+        """Add two default mkosi.default configs
+        """
+        super().__init__()
+        for hostname in ['test1.example.org', 'test2.example.org']:
+            job_name = 'mkosi.' + hostname
+            self.add_reference_config(job_name)
+            self.reference_config[job_name]['all'] = True
+            self.reference_config[job_name]['hostname'] = hostname
+        self.cli_arguments = ['--all', 'build']
+
+    def prepare_mkosi_files(self, directory: str, all_directory=None) -> None:
+        if all_directory is None:
+            all_dir = os.path.abspath('mkosi.files')
+        else:
+            all_dir = os.path.join(directory, all_directory)
+
+        for job_name, config in self.reference_config.items():
+            mk_config = { 'Output': { 'Hostname': config['hostname']}}
+            __class__.write_ini(all_dir, job_name, mk_config)
+
+        if all_directory:
+            self.cli_arguments[0:0] = ['--all-directory', 'all_dir']
+
+
+# pytest magic: run each test function with each class derived from MkosiConfigAll
+@pytest.fixture(params=MkosiConfigAll.__subclasses__())
+def tested_config_all(request):
+    return request.param()
+
+
+def test_all_1(tested_config_all, tmpdir):
+    """Generate the mkosi.default plus two config files plus short command line arguments"""
+    with ChangeCwd(tmpdir.strpath):
+        tested_config_all.prepare_mkosi_files(tmpdir.strpath)
+        args = mkosi.parse_args(tested_config_all.cli_arguments)
+        assert tested_config_all == args


### PR DESCRIPTION
Improve argument parsing and mkosi.default files loading as already dicussed in [#295](https://github.com/systemd/mkosi/pull/295).

Bugfix: This PR delegates mkosi.default file loading to python's ArgumentParser. This allows to override settings from unlimited number of mkosi.default.d files as well as from command line arguments. This approach also fixes some issues with type conversion for settings loaded from mkosi.default files.

Add pytest based tests for command line arguments and mkosi.default files parsing. pytest is called by ci/semaphore.sh.

Feature: It's possible to remove items from a comma separated list argument (e.g. a package).