### PR TITLE
Debian: Use btrfs-progs instead of btrfs-tools

### DIFF
--- a/ci/semaphore.sh
+++ b/ci/semaphore.sh
@@ -6,6 +6,17 @@ sudo add-apt-repository --yes ppa:jonathonf/python-3.6
 sudo apt --yes update
 sudo apt --yes install python3.6 debootstrap systemd-container squashfs-tools
 
-sudo python3.6 ./mkosi --default ./mkosi.files/mkosi.ubuntu
+testimg()
+{
+	img="$1"
+	sudo python3.6 ./mkosi --default ./mkosi.files/mkosi."$img"
+	test -f "$img".raw
+	rm "$img".raw
+}
 
-test -f ubuntu.raw
+# Only test ubuntu images for now, as semaphore is based on Ubuntu
+for i in ./mkosi.files/mkosi.ubuntu*
+do
+	imgname="$(basename "$i" | cut -d. -f 2-)"
+	testimg "$imgname"
+done

--- a/mkosi
+++ b/mkosi
@@ -1590,7 +1590,7 @@ def install_debian_or_ubuntu(args: CommandLineArguments,
                 mirror]
 
     if args.bootable and args.output_format == OutputFormat.gpt_btrfs:
-        cmdline[4] += ",btrfs-tools"
+        cmdline[4] += ",btrfs-progs"
 
     run(cmdline, check=True)
 

--- a/mkosi.files/mkosi.ubuntu-btrfs
+++ b/mkosi.files/mkosi.ubuntu-btrfs
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
+[Distribution]
+Distribution=ubuntu
+Release=xenial
+
+[Output]
+Format=raw_btrfs
+Output=ubuntu-btrfs.raw
+
+[Packages]
+Packages=
+        tzdata


### PR DESCRIPTION
The package was [renamed](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=780081) some time ago (around March 2016). The package btrfs-progs is [available from Stretch](https://packages.debian.org/stretch/btrfs-progs) but it's also [in Jessie backports](https://packages.debian.org/jessie-backports/btrfs-progs); in Ubuntu it was introduced [in Bionic](https://packages.ubuntu.com/bionic/btrfs-progs), so it's probably more appropriate to use the new name.

Ideally a way to select which package to use should be provided, but I'm not sure it is worth the effort.