### PR TITLE
Disable COW (for btrfs) on qcow2 files

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -2712,7 +2712,7 @@ def qcow2_output(args: CommandLineArguments, raw: Optional[BinaryIO]) -> Optiona
 
     with complete_step('Converting image file to qcow2'):
         f: BinaryIO = cast(BinaryIO, tempfile.NamedTemporaryFile(prefix=".mkosi-", dir=os.path.dirname(args.output)))
-        run(["qemu-img", "convert", "-fraw", "-Oqcow2", raw.name, f.name], check=True)
+        run(["qemu-img", "convert", "-onocow=on", "-fraw", "-Oqcow2", raw.name, f.name], check=True)
 
     return f
 


### PR DESCRIPTION
According to [qemu-img(1)](https://manpages.ubuntu.com/manpages/bionic/man1/qemu-img.1.html#notes):

    Btrfs has low performance when hosting a VM image file,
    even more when the guest on the VM also using btrfs as file system.
    Turning off COW is a way to mitigate this bad performance.

This is the reason of the [disable_cow()](https://github.com/systemd/mkosi/blob/master/mkosi#L487) function, but this function
applies only to the raw file. So, let’s disable COW also on the qcow2
one.