### PR TITLE
Commit empty `mkosi.cache` and `mkosi.output` directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,13 +7,7 @@
 /__pycache__
 /build
 /dist
-/image
-/image.raw
-/image.raw.xz
-/image.roothash
-/image.tar.xz
 /mkosi.build
-/mkosi.cache
 /mkosi.egg-info
 /mkosi.extra
 /mkosi.nspawn

--- a/ci/semaphore.sh
+++ b/ci/semaphore.sh
@@ -10,8 +10,8 @@ testimg()
 {
 	img="$1"
 	sudo python3.6 ./mkosi --default ./mkosi.files/mkosi."$img"
-	test -f "$img".raw
-	rm "$img".raw
+	test -f mkosi.output/"$img".raw
+	rm mkosi.output/"$img".raw
 }
 
 # Only test ubuntu images for now, as semaphore is based on Ubuntu

--- a/mkosi.cache/.gitignore
+++ b/mkosi.cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!/.gitignore

--- a/mkosi.output/.gitignore
+++ b/mkosi.output/.gitignore
@@ -1,0 +1,2 @@
+*
+!/.gitignore


### PR DESCRIPTION
The goal is to benefit from a package cache right after having checked `mkosi` out.