### PR TITLE
mkosi: provide default xbootldr_partno

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -91,6 +91,7 @@ class CommandLineArguments(argparse.Namespace):
 
     swap_partno: Optional[int] = None
     esp_partno: Optional[int] = None
+    xbootldr_partno: Optional[int] = None
 
 
 class SourceFileTransfer(enum.Enum):


### PR DESCRIPTION
xbootldr_partno might not be set if the output format is directory
or tar, because determine_partition_table is not called ofr those.

Fixes #333