### PR TITLE
Fix BootProtocols parsing

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -3208,7 +3208,7 @@ def create_parser() -> ArgumentParserMkosi:
                        help='Do not run tests as part of build script, if supported')
     group.add_argument("--with-tests", action=BooleanAction, default=True, help=argparse.SUPPRESS)  # Compatibility option
     group.add_argument("--cache", dest='cache_path', help='Package cache path', metavar='PATH')
-    group.add_argument("--extra-tree", action='append', dest='extra_trees', default=[],
+    group.add_argument("--extra-tree", action=CommaDelimitedListAction, dest='extra_trees', default=[],
                        help='Copy an extra tree on top of image', metavar='PATH')
     group.add_argument("--skeleton-tree", action='append', dest='skeleton_trees', default=[],
                        help='Use a skeleton tree to bootstrap the image before installing anything', metavar='PATH')


### PR DESCRIPTION
Mark it with the same action as other lists, otherwise its parsing from
a config file is broken.