### PR TITLE
GPT_Squashfs fix

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -548,15 +548,18 @@ def determine_partition_table(args: CommandLineArguments) -> Tuple[str, bool]:
             args.srv_partno = pn
             pn += 1
             run_sfdisk = True
-
+    
+    args.root_partno = None
+    
     if args.output_format != OutputFormat.gpt_squashfs:
         table += 'type={}, attrs={}, name="Root Partition"\n'.format(
             gpt_root_native(args.architecture).root,
             "GUID:60" if args.read_only and args.output_format != OutputFormat.gpt_btrfs else "")
+        args.root_partno = pn
+        pn += 1
+
         run_sfdisk = True
 
-    args.root_partno = pn
-    pn += 1
 
     if args.verity:
         args.verity_partno = pn

--- a/mkosi
+++ b/mkosi
@@ -557,9 +557,7 @@ def determine_partition_table(args: CommandLineArguments) -> Tuple[str, bool]:
             "GUID:60" if args.read_only and args.output_format != OutputFormat.gpt_btrfs else "")
         args.root_partno = pn
         pn += 1
-
         run_sfdisk = True
-
 
     if args.verity:
         args.verity_partno = pn


### PR DESCRIPTION
Before this change, gpt_squashfs would just fail to build on my systems (Ubuntu 18.04 LTS and Fedora 30). Tested it against gpt_ext4 and that built. 


Within determine_partition_table, `args.root_partno` should be set to `None` and checked against the OutputFormat being not gpt_squashfs.