### PR TITLE
mkosi: do RNG pass-through automatically for qemu

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -4482,6 +4482,7 @@ def run_qemu(args: CommandLineArguments) -> None:
                 "-m", "1024",
                 "-drive", "if=pflash,format=raw,readonly,file=" + firmware,
                 "-drive", "format=" + ("qcow2" if args.qcow2 else "raw") + ",file=" + args.output,
+                "-object", "rng-random,filename=/dev/urandom,id=rng0", "-device", "virtio-rng-pci,rng=rng0,id=rng-device0",
                 *args.cmdline]
 
     print_running_cmd(cmdline)


### PR DESCRIPTION
Let's not starve our instances of entropy needlessly, if it's easy to fix.