### PR TITLE
Add support for Photon OS

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -171,6 +171,7 @@ class Distribution(enum.Enum):
     centos = 7
     centos_epel = 8
     clear = 9
+    photon = 10
 
 
 GPT_ROOT_X86           = uuid.UUID("44479540f29741b29af7d131d5f0458a")  # NOQA: E221
@@ -1036,6 +1037,8 @@ def mount_cache(args: CommandLineArguments, workspace: str) -> Generator[None, N
             mount_bind(args.cache_path, os.path.join(workspace, "root", "var/cache/pacman/pkg"))
         elif args.distribution == Distribution.opensuse:
             mount_bind(args.cache_path, os.path.join(workspace, "root", "var/cache/zypp/packages"))
+        elif args.distribution == Distribution.photon:
+            mount_bind(os.path.join(args.cache_path, "tdnf"), os.path.join(workspace, "root", "var/cache/tdnf"))
     try:
         yield
     finally:
@@ -1313,8 +1316,18 @@ def clean_package_manager_metadata(workspace: str) -> None:
     clean_dnf_metadata(root)
     clean_yum_metadata(root)
     clean_rpm_metadata(root)
+    clean_tdnf_metadata(root)
     # FIXME: implement cleanup for other package managers
 
+def clean_tdnf_metadata(root: str) -> None:
+	    """Removes tdnf metadata iff /bin/tdnf is not present in the image"""
+	    tdnf_path = root + '/usr/bin/tdnf'
+	    keep_tdnf_data = os.access(tdnf_path, os.F_OK, follow_symlinks=False)
+
+	    if not keep_tdnf_data:
+	        print_step('Cleaning tdnf metadata...')
+	        remove_glob(root + '/var/log/tdnf.*',
+	                    root + '/var/cache/tdnf')
 
 def invoke_dnf(args: CommandLineArguments,
                workspace: str,
@@ -1348,6 +1361,83 @@ def invoke_dnf(args: CommandLineArguments,
 
     with mount_api_vfs(args, workspace):
         run(cmdline, check=True)
+
+def invoke_tdnf(args: CommandLineArguments,
+	            workspace: str,
+	            root: str,
+	            repositories: List[str],
+	            packages: List[str],
+	            config_file: str) -> None:
+	repos = ["--enablerepo=" + repo for repo in repositories]
+
+	packages = make_rpm_list(args, packages)
+
+	cmdline = ["tdnf",
+	           "-y",
+	           "--config=" + config_file,
+	           "--releasever=" + args.release,
+	           "--installroot=" + root,
+	           "--disablerepo=*",
+	           *repos
+    ]
+
+	cmdline += ['install', *packages]
+
+	with mount_api_vfs(args, workspace):
+	    run(cmdline, check=True)
+
+@completestep('Installing Photon')
+def install_photon(args: CommandLineArguments, workspace: str, do_run_build_script: bool) -> None:
+    masked = disable_kernel_install(args, workspace)
+
+    gpg_key = '/etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY'
+    gpg_key_string = f'file://{gpg_key}'
+    root = os.path.join(workspace, "root")
+
+    if os.path.exists(gpg_key):
+	    gpgcheck = "gpgcheck=1"
+	    cmdline = ["rpm", "--import", gpg_key, "--root", root]
+	    run(cmdline, check=True)
+
+    else:
+	    gpgcheck = "gpgcheck=0"
+
+    release_url = "https://dl.bintray.com/vmware/photon_release_$releasever_$basearch"
+    updates_url = "https://dl.bintray.com/vmware/photon_updates_$releasever_$basearch"
+
+    config_file = os.path.join(workspace, "tdnf.conf")
+    repo_file = os.path.join(workspace, "temp.repo")
+    with open(config_file, "w") as f:
+	        f.write(f"""\
+[main]
+{gpgcheck}
+repodir={workspace}
+""")
+
+    with open(repo_file, "w") as f:
+	    f.write(f"""\
+[photon]
+name=VMware Photon OS {args.release} Release
+baseurl={release_url}
+enabled=1
+gpgkey={gpg_key_string}
+
+[photon-updates]
+name=VMware Photon OS {args.release} Updates
+baseurl={updates_url}
+enabled=1
+gpgkey={gpg_key_string}
+""")
+
+    packages = ["minimal"]
+    if args.bootable:
+	    packages += ["linux", "initramfs"]
+
+    invoke_tdnf(args, workspace, root,
+	                args.repositories if args.repositories else ["photon", "photon-updates"],
+	                packages,
+	                config_file)
+    reenable_kernel_install(args, workspace, masked)
 
 
 @completestep('Installing Clear Linux')
@@ -2043,6 +2133,7 @@ def install_distribution(args: CommandLineArguments,
         Distribution.arch: install_arch,
         Distribution.opensuse: install_opensuse,
         Distribution.clear: install_clear,
+        Distribution.photon: install_photon,
     }
 
     install[args.distribution](args, workspace, do_run_build_script)
@@ -2255,6 +2346,10 @@ def install_boot_loader_clear(args: CommandLineArguments, workspace: str, loopde
     run_workspace_command(args, workspace, "/usr/bin/clr-boot-manager", "update", "-i", nspawn_params=nspawn_params)
 
 
+def install_boot_loader_photon(args: CommandLineArguments, workspace: str, loopdev: str) -> None:
+	    install_grub(args, workspace, loopdev, "grub2")
+
+
 def install_boot_loader(args: CommandLineArguments, workspace: str, loopdev: Optional[str], cached: bool) -> None:
     if not args.bootable:
         return
@@ -2289,6 +2384,8 @@ def install_boot_loader(args: CommandLineArguments, workspace: str, loopdev: Opt
         if args.distribution == Distribution.clear:
             install_boot_loader_clear(args, workspace, loopdev)
 
+        if args.distribution == Distribution.photon:
+            install_boot_loader_photon(args, workspace, loopdev)
 
 def install_extra_trees(args: CommandLineArguments, workspace: str, for_cache: bool) -> None:
     if not args.extra_trees:
@@ -3823,6 +3920,8 @@ def load_args(args: CommandLineArguments) -> CommandLineArguments:
             args.release = "tumbleweed"
         elif args.distribution == Distribution.clear:
             args.release = "latest"
+        elif args.release == Distribution.photon:
+            args.release = "3.0"
 
     find_cache(args)
 
@@ -3848,13 +3947,21 @@ def load_args(args: CommandLineArguments) -> CommandLineArguments:
 
         if not args.boot_protocols:
             args.boot_protocols = ["uefi"]
+
+            if args.distribution == Distribution.photon:
+                args.boot_protocols = ["bios"]
+
         if not {"uefi", "bios"}.issuperset(args.boot_protocols):
             die("Not a valid boot protocol")
         if "bios" in args.boot_protocols and args.distribution not in (Distribution.fedora,
                                                                        Distribution.arch,
                                                                        Distribution.debian,
-                                                                       Distribution.ubuntu):
+                                                                       Distribution.ubuntu,
+                                                                       Distribution.photon):
             die(f"bios boot not implemented yet for {args.distribution}")
+
+            if "uefi" in args.boot_protocols and args.distribution == Distribution.photon:
+	            die(f"uefi boot not supported for {args.distribution}")
 
     if args.encrypt is not None:
         if not args.output_format.is_disk():

--- a/mkosi.md
+++ b/mkosi.md
@@ -156,7 +156,7 @@ details see the table below.
 `--distribution=`, `-d`
 : The distribution to install in the image. Takes one of the following
   arguments: `fedora`, `debian`, `ubuntu`, `arch`, `opensuse`,
-  `mageia`, `centos`, `clear`. If not specified, defaults to the
+  `mageia`, `centos`, `clear`, `photon`. If not specified, defaults to the
   distribution of the host.
 
 `--release=`, `-r`
@@ -709,6 +709,8 @@ following *OS*es.
 * *CentOS*
 
 * *Clear Linux*
+
+* *Photon*
 
 In theory, any distribution may be used on the host for building
 images containing any other distribution, as long as the necessary


### PR DESCRIPTION
Please see https://vmware.github.io/photon/

Known limitations:

1. The gpg key is not published on the web, so VMWARE-RPM-GPG-KEY should be present in the host
2. No uefi boot supported yet

```

initramfs 2.0-4.ph3 posttrans
Creating /boot/initrd.img-4.19.65-2.ph3

Complete!
‣ Unmounting API VFS...
‣ Unmounting API VFS complete.
‣ Installing Photon complete.
‣ Assigning hostname...
‣ Assigning hostname complete.
‣ Installing boot loader...
Installing for i386-pc platform.
Installation finished. No error reported.
Generating grub configuration file ...
Found linux image: /boot/vmlinuz-4.19.65-2.ph3
Found initrd image: /boot/initrd.img-4.19.65-2.ph3
done
‣ Installing boot loader complete.
‣ Unmounting Package Cache...
‣ Unmounting Package Cache complete.
‣ Cleaning dnf metadata...
‣ Resetting machine ID...
‣ Resetting machine ID complete.
‣ Removing random seed...
‣ Removing random seed complete.
‣ Unmounting image...
‣ Unmounting image complete.
‣ Mounting image...
‣ Mounting image complete.
‣ Unmounting image...
‣ Unmounting image complete.
‣ Detaching image file...
‣ Detaching image file complete.
‣ Linking image file...
‣ Changing ownership of output file /home/sus/photon-mkosi/mkosi.output/fedora.raw to user sus (acquired from sudo)...
‣ Successfully changed ownership of /home/sus/photon-mkosi/mkosi.output/fedora.raw.
‣ Successfully linked /home/sus/photon-mkosi/mkosi.output/fedora.raw.
‣ Resulting image size is 1.0G, consumes 503.0M.
‣ Processing default complete.

```