### PR TITLE
Add the ability to set pre-hashed root passwords

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -2105,7 +2105,10 @@ def set_root_password(args: CommandLineArguments, workspace: str, do_run_build_s
             patch_file(os.path.join(workspace, 'root', 'etc/passwd'), jj)
     elif args.password:
         with complete_step("Setting root password"):
-            password = crypt.crypt(args.password, crypt.mksalt(crypt.METHOD_SHA512))
+            if args.password_is_hashed:
+                password = args.password
+            else:
+                password = crypt.crypt(args.password, crypt.mksalt(crypt.METHOD_SHA512))
 
             def jj(line: str) -> str:
                 if line.startswith('root:'):
@@ -3302,6 +3305,8 @@ def create_parser() -> ArgumentParserMkosi:
     group.add_argument("--bmap", action=BooleanAction,
                        help='Write block map file (.bmap) for bmaptool usage (only gpt_ext4, gpt_btrfs)')
     group.add_argument("--password", help='Set the root password')
+    group.add_argument("--password-is-hashed", action=BooleanAction,
+                       help='Indicate that the root password has already been hashed')
 
     group = parser.add_argument_group("Host configuration")
     group.add_argument("--extra-search-path", dest='extra_search_paths', action=ColonDelimitedListAction, default=[],

--- a/mkosi.md
+++ b/mkosi.md
@@ -580,6 +580,12 @@ details see the table below.
   is locked. If this option is not used but a file `mkosi.rootpw` exists
   in the local directory the root password is automatically read from it.
 
+`--password-is-hashed`
+
+: Indicate that the password supplied for the `root` user has already been
+  hashed, so that the string supplied with `--password` or `mkosi.rootpw` will
+  be written to `/etc/shadow` literally.
+
 `--extra-search-paths=`
 
 : List of colon-separated paths to look for tools in, before using the
@@ -682,6 +688,7 @@ which settings file options.
 | `--key=`                     | `[Validation]`          | `Key=`                    |
 | `--bmap`                     | `[Validation]`          | `BMap=`                   |
 | `--password=`                | `[Validation]`          | `Password=`               |
+| `--password-is-hashed`       | `[Validation]`          | `PasswordIsHashed=`       |
 | `--extra-search-paths=`      | `[Host]`                | `ExtraSearchPaths=`       |
 
 Command line options that take no argument are not suffixed with a `=`
@@ -885,12 +892,13 @@ local directory:
   set, and it is up to build script to decide whether to do in in-tree
   or an out-of-tree build, and which build directory to use.
 
-* `mkosi.rootpw` may be a file containing the password for the root
-  user of the image to set. The password may optionally be followed by
-  a newline character which is implicitly removed. The file must have
-  an access mode of 0600 or less. If this file does not exist the
-  distribution's default root password is set (which usually means
-  access to the root user is blocked).
+* `mkosi.rootpw` may be a file containing the password or hashed
+  password (if `--password-is-hashed` is set) for the root user of the
+  image to set. The password may optionally be followed by a newline
+  character which is implicitly removed. The file must have an access
+  mode of 0600 or less. If this file does not exist the distribution's
+  default root password is set (which usually means access to the root
+  user is blocked).
 
 * `mkosi.passphrase` may be a passphrase file to use when LUKS
   encryption is selected. It should contain the passphrase literally,

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -81,6 +81,7 @@ class MkosiConfig(object):
             'output_format': None,
             'packages': [],
             'password': None,
+            'password_is_hashed': False,
             'postinst_script': None,
             'qcow2': False,
             'read_only': False,
@@ -268,6 +269,9 @@ class MkosiConfig(object):
                 self.reference_config[job_name]['bmap'] = mk_config_validation['BMap']
             if 'Password' in mk_config_validation:
                 self.reference_config[job_name]['password'] = mk_config_validation['Password']
+            if 'PasswordIsHashed' in mk_config_validation:
+                self.reference_config[job_name]['password_is_hashed'] = mk_config_validation['PasswordIsHashed']
+
         if 'Host' in mk_config:
             mk_config_host = mk_config['Host']
             if 'ExtraSearchPaths' in mk_config_host:


### PR DESCRIPTION
This PR introduces a new commandline switch `--password-is-hashed` such that the supplied root password will not be hashed, but written to `/etc/shadow` literally.

Closes #360 