### PR TITLE
Add flag to skip (second) final image build phase

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -3385,6 +3385,7 @@ def create_parser() -> ArgumentParserMkosi:
     group.add_argument("--build-directory", dest='build_dir', help='Path to use as persistent build directory', metavar='PATH')
     group.add_argument("--build-package", action=CommaDelimitedListAction, dest='build_packages', default=[],
                        help='Additional packages needed for build script', metavar='PACKAGE')
+    group.add_argument("--skip-final-phase", action=BooleanAction, help='Skip the (second) final image building phase.', default=False)
     group.add_argument("--postinst-script", help='Postinstall script to run inside image', metavar='PATH')
     group.add_argument("--finalize-script", help='Postinstall script to run outside image', metavar='PATH')
     group.add_argument("--source-file-transfer", type=SourceFileTransfer, choices=list(SourceFileTransfer), default=None,
@@ -4248,6 +4249,7 @@ def print_summary(args: CommandLineArguments) -> None:
     sys.stderr.write("  Source File Transfer: " + none_to_none(args.source_file_transfer) + "\n")
     sys.stderr.write("       Build Directory: " + none_to_none(args.build_dir) + "\n")
     sys.stderr.write("        Build Packages: " + line_join_list(args.build_packages) + "\n")
+    sys.stderr.write("      Skip final phase: " + yes_no(args.skip_final_phase) + "\n")
     sys.stderr.write("    Postinstall Script: " + none_to_none(args.postinst_script) + "\n")
     sys.stderr.write("       Finalize Script: " + none_to_none(args.finalize_script) + "\n")
     sys.stderr.write("  Scripts with network: " + yes_no(args.with_network) + "\n")
@@ -4548,7 +4550,11 @@ def build_stuff(args: CommandLineArguments) -> None:
     run_finalize_script(args, workspace.name, verb='final')
 
     # Run the image builder for the second (final) stage
-    raw, tar, root_hash = build_image(args, workspace, do_run_build_script=False, cleanup=True)
+    if args.skip_final_phase:
+        print_step('Skipping (second) final image build phase.')
+        raw, tar, root_hash = None, None, None
+    else:
+        raw, tar, root_hash = build_image(args, workspace, do_run_build_script=False, cleanup=True)
 
     raw = qcow2_output(args, raw)
     raw = xz_output(args, raw)

--- a/mkosi.md
+++ b/mkosi.md
@@ -477,6 +477,13 @@ details see the table below.
   Packages are appended to the list. Packages prefixed with "!" are
   removed from the list. "!*" removes all packages from the list.
 
+`--skip-final-phase=`
+
+: Causes the (second) final image build stage to be skipped. This is
+  useful in combination with a build script, for when you care about
+  the artifacts that were created locally in `$BUILDDIR`, but
+  ultimately plan to discard the final image.
+
 `--postinst-script=`
 
 : Takes a path to an executable that is invoked inside the final image
@@ -674,6 +681,7 @@ which settings file options.
 | `--source-file-transfer=`    | `[Packages]`            | `SourceFileTransfer=`     |
 | `--build-directory=`         | `[Packages]`            | `BuildDirectory=`         |
 | `--build-packages=`          | `[Packages]`            | `BuildPackages=`          |
+| `--skip-final-phase=`        | `[Packages]`            | `SkipFinalPhase=`         |
 | `--postinst-script=`         | `[Packages]`            | `PostInstallationScript=` |
 | `--finalize-script=`         | `[Packages]`            | `FinalizeScript=`         |
 | `--with-network`             | `[Packages]`            | `WithNetwork=`            |

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -82,6 +82,7 @@ class MkosiConfig(object):
             'packages': [],
             'password': None,
             'password_is_hashed': False,
+            'skip_final_phase': False,
             'postinst_script': None,
             'qcow2': False,
             'read_only': False,


### PR DESCRIPTION
This adds a new flag to cause the (second) final stage to be skipped.
This is useful for when you're more interested in the build artifacts
being built in the correct environment, and less interested in the final
image.