### PR TITLE
Add env to build that specifies which "default" we're using

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -4308,6 +4308,7 @@ def run_build_script(args: CommandLineArguments, workspace: str, raw: Optional[B
                    "--setenv=WITH_DOCS=" + one_zero(args.with_docs),
                    "--setenv=WITH_TESTS=" + one_zero(args.with_tests),
                    "--setenv=WITH_NETWORK=" + one_zero(args.with_network),
+                   "--setenv=MKOSI_DEFAULT=" + args.default_path,
                    "--setenv=DESTDIR=/root/dest"]
 
         if args.build_sources is not None:

--- a/mkosi.md
+++ b/mkosi.md
@@ -830,6 +830,9 @@ local directory:
   directory (see below), which is an easy way to exclude all build
   artifacts.
 
+  The `MKOSI_DEFAULT` environment variable will be set inside of this
+  script so that you know which `mkosi.default` (if any) was passed in.
+
 * `mkosi.postinst` may be an executable script. If it exists it is
   invoked as the penultimate step of preparing an image, from within
   the image context. It is once called for the *development* image (if


### PR DESCRIPTION
It's not possible to determine which "mkosi.default" we're using, when
using a single "mkosi.build" script with `mkosi --default <file> build`
so this adds a variable that allows the build script to know which one
is being used.