### PR TITLE
mkosi: add explicit check for loopdev being not None to placate mypy

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -979,10 +979,10 @@ def mount_image(args: CommandLineArguments,
         if srv_dev is not None:
             mount_loop(args, srv_dev, os.path.join(root, "srv"))
 
-        if args.esp_partno is not None:
+        if args.esp_partno is not None and loopdev is not None:
             mount_loop(args, partition(loopdev, args.esp_partno), os.path.join(root, "efi"))
 
-        if args.xbootldr_partno is not None:
+        if args.xbootldr_partno is not None and loopdev is not None:
             mount_loop(args, partition(loopdev, args.xbootldr_partno), os.path.join(root, "boot"))
 
         # Make sure /tmp and /run are not part of the image


### PR DESCRIPTION
mypy throws an error on checking the mount_image function

> mkosi:969: error: Argument 1 to "partition" has incompatible type "Optional[str]"; expected "str"
> mkosi:972: error: Argument 1 to "partition" has incompatible type "Optional[str]"; expected "str"

because as of yet it cannot deduce, that loopdev will only be non-None if
args.esp_partno or args.xbootldr_partno are non-None as well, since they will
only be non-None on bootable images, which necessarily will be disk images, and
loopdev will only be None on non-disk images, i.e.

disk image -> loopdev is not None and args.esp_partno maybe None
non-disk image -> loopdev is None and args.esp_partno is None