### PR TITLE
Fix errors in mypy's strict mode

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -409,7 +409,7 @@ def copy_path(oldpath: str, newpath: str) -> None:
             symlink_f(target, newentry)
             shutil.copystat(entry.path, newentry, follow_symlinks=False)
         else:
-            st = entry.stat(follow_symlinks=False)  # type: ignore  # mypy 0.641 doesn't know about follow_symlinks
+            st = entry.stat(follow_symlinks=False)
             if stat.S_ISREG(st.st_mode):
                 copy_file(entry.path, newentry)
             else:

--- a/mkosi
+++ b/mkosi
@@ -3270,7 +3270,7 @@ class ArgumentParserMkosi(argparse.ArgumentParser):
         self._ini_file_list_mode = False
 
         # Add config files to be parsed
-        kwargs['fromfile_prefix_chars'] = __class__.fromfile_prefix_chars
+        kwargs['fromfile_prefix_chars'] = ArgumentParserMkosi.fromfile_prefix_chars
         super().__init__(*kargs, **kwargs)
 
     def _read_args_from_files(self, arg_strings: List[str]) -> List[str]:
@@ -3295,7 +3295,7 @@ class ArgumentParserMkosi(argparse.ArgumentParser):
 
         def ini_key_to_cli_arg(key: str) -> str:
             try:
-                return __class__.SPECIAL_MKOSI_DEFAULT_PARAMS[key]
+                return ArgumentParserMkosi.SPECIAL_MKOSI_DEFAULT_PARAMS[key]
             except KeyError:
                 return '--' + camel_to_arg(key)
 

--- a/mkosi
+++ b/mkosi
@@ -48,12 +48,21 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    TYPE_CHECKING,
 )
 
 __version__ = '5'
 
 if sys.version_info < (3, 6):
     sys.exit("Sorry, we need at least Python 3.6.")
+
+
+if TYPE_CHECKING:
+    CompletedProcess = subprocess.CompletedProcess[Any]
+    TempDir = tempfile.TemporaryDirectory[str]
+else:
+    CompletedProcess = subprocess.CompletedProcess
+    TempDir = tempfile.TemporaryDirectory
 
 
 MKOSI_COMMANDS_CMDLINE = ("shell", "boot", "qemu")
@@ -66,7 +75,7 @@ MKOSI_COMMANDS = ("build", "clean", "help", "summary") + MKOSI_COMMANDS_CMDLINE
 arg_debug = ()
 
 
-def run(cmdline: List[str], execvp: bool = False, **kwargs: Any) -> subprocess.CompletedProcess:
+def run(cmdline: List[str], execvp: bool = False, **kwargs: Any) -> CompletedProcess:
     if 'run' in arg_debug:
         sys.stderr.write('+ ' + ' '.join(shlex.quote(x) for x in cmdline) + '\n')
     if execvp:
@@ -108,7 +117,7 @@ class SourceFileTransfer(enum.Enum):
         return cast(str, self.value)
 
     @classmethod
-    def doc(cls) -> Dict[SourceFileTransfer, str]:
+    def doc(cls) -> Dict["SourceFileTransfer", str]:
         return {cls.copy_all: "normal file copy",
                 cls.copy_git_cached: "use git-ls-files --cached, ignoring any file that git itself ignores",
                 cls.copy_git_others: "use git-ls-files --others, ignoring any file that git itself ignores",
@@ -440,7 +449,7 @@ def init_namespace(args: CommandLineArguments) -> None:
     run(["mount", "--make-rslave", "/"], check=True)
 
 
-def setup_workspace(args: CommandLineArguments) -> tempfile.TemporaryDirectory:
+def setup_workspace(args: CommandLineArguments) -> TempDir:
     print_step("Setting up temporary workspace.")
     if args.output_format in (OutputFormat.directory, OutputFormat.subvolume):
         d = tempfile.TemporaryDirectory(dir=os.path.dirname(args.output), prefix='.mkosi-')
@@ -1914,7 +1923,7 @@ SigLevel    = Required DatabaseOptional TrustAll
 {server}
 """)
 
-    def run_pacman(args: List[str], **kwargs: Any) -> subprocess.CompletedProcess:
+    def run_pacman(args: List[str], **kwargs: Any) -> CompletedProcess:
         cmdline = [
             "pacman",
             "--noconfirm",
@@ -1923,7 +1932,7 @@ SigLevel    = Required DatabaseOptional TrustAll
         ]
         return run(cmdline + args, **kwargs, check=True)
 
-    def run_pacman_key(args: List[str]) -> subprocess.CompletedProcess:
+    def run_pacman_key(args: List[str]) -> CompletedProcess:
         cmdline = [
             "pacman-key",
             "--nocolor",
@@ -3124,8 +3133,8 @@ def print_output_size(args: CommandLineArguments) -> None:
         print_step("Resulting image size is " + format_bytes(st.st_size) + ", consumes " + format_bytes(st.st_blocks * 512) + ".")  # NOQA: E501
 
 
-def setup_package_cache(args: CommandLineArguments) -> Optional[tempfile.TemporaryDirectory]:
-    d: Optional[tempfile.TemporaryDirectory] = None
+def setup_package_cache(args: CommandLineArguments) -> Optional[TempDir]:
+    d = None
     with complete_step('Setting up package cache',
                        'Setting up package cache {} complete') as output:
         if args.cache_path is None:
@@ -4347,7 +4356,7 @@ def make_build_dir(args: CommandLineArguments) -> None:
 
 
 def build_image(args: CommandLineArguments,
-                workspace: tempfile.TemporaryDirectory,
+                workspace: TempDir,
                 *,
                 do_run_build_script: bool,
                 for_cache: bool = False,

--- a/mkosi
+++ b/mkosi
@@ -104,11 +104,11 @@ class SourceFileTransfer(enum.Enum):
     copy_git_more = "copy-git-more"
     mount = "mount"
 
-    def __str__(self):
-        return self.value
+    def __str__(self) -> str:
+        return cast(str, self.value)
 
     @classmethod
-    def doc(cls):
+    def doc(cls) -> Dict[SourceFileTransfer, str]:
         return {cls.copy_all: "normal file copy",
                 cls.copy_git_cached: "use git-ls-files --cached, ignoring any file that git itself ignores",
                 cls.copy_git_others: "use git-ls-files --others, ignoring any file that git itself ignores",
@@ -3198,12 +3198,22 @@ class BooleanAction(argparse.Action):
     or implicitly --foo. If the parameter name starts with "not-" or "without-" the value gets
     inverted.
     """
-    def __init__(self, option_strings, dest, nargs=None, const=True, default=False, **kwargs):
+    def __init__(self, # These type-hints are copied from argparse.pyi
+                 option_strings: Sequence[str],
+                 dest: str,
+                 nargs: Optional[Union[int, str]]=None,
+                 const: Any=True,
+                 default: Any=False,
+                 **kwargs: Any) -> None:
         if nargs is not None:
             raise ValueError("nargs not allowed")
         super(BooleanAction, self).__init__(option_strings, dest, nargs='?', const=const, default=default, **kwargs)
 
-    def __call__(self, parser, namespace, values, option_string=None):
+    def __call__(self, # These type-hints are copied from argparse.pyi
+                 parser: argparse.ArgumentParser,
+                 namespace: argparse.Namespace,
+                 values: Union[str, Sequence[Any], None],
+                 option_string: Optional[str] = None) -> None:
         new_value = self.default
         if isinstance(values, str):
             try:
@@ -3254,7 +3264,7 @@ class ArgumentParserMkosi(argparse.ArgumentParser):
 
     fromfile_prefix_chars = '@'
 
-    def __init__(self, *kargs, **kwargs):
+    def __init__(self, *kargs: Any, **kwargs: Any) -> None:
         self._ini_file_section = ""
         self._ini_file_key = ""  # multi line list processing
         self._ini_file_list_mode = False
@@ -3263,7 +3273,7 @@ class ArgumentParserMkosi(argparse.ArgumentParser):
         kwargs['fromfile_prefix_chars'] = __class__.fromfile_prefix_chars
         super().__init__(*kargs, **kwargs)
 
-    def _read_args_from_files(self, arg_strings):
+    def _read_args_from_files(self, arg_strings: List[str]) -> List[str]:
         """Convert @ prefixed command line arguments with corresponding file content
 
         Regular arguments are just returned. Arguments prefixed with @ are considered as
@@ -3279,11 +3289,11 @@ class ArgumentParserMkosi(argparse.ArgumentParser):
           arg_strings: ['@mkosi.default', '-p', 'httpd']
           return value: ['--distribution', 'fedora', '-p', 'httpd']
         """
-        def camel_to_arg(camel):
+        def camel_to_arg(camel: str) -> str:
             s1 = re.sub('(.)([A-Z][a-z]+)', r'\1-\2', camel)
             return re.sub('([a-z0-9])([A-Z])', r'\1-\2', s1).lower()
 
-        def ini_key_to_cli_arg(key):
+        def ini_key_to_cli_arg(key: str) -> str:
             try:
                 return __class__.SPECIAL_MKOSI_DEFAULT_PARAMS[key]
             except KeyError:
@@ -3461,7 +3471,7 @@ class MkosiParseException(Exception):
     """Leads to sys.exit"""
 
 
-def parse_args(argv=None) -> Dict[str, CommandLineArguments]:
+def parse_args(argv: Optional[List[str]]=None) -> Dict[str, CommandLineArguments]:
     """Load default values from files and parse command line arguments
 
     Do all about default files and command line arguments parsing. If --all argument is passed
@@ -3558,7 +3568,7 @@ def parse_args_file(argv_post_parsed: List[str], default_path: str) -> CommandLi
     return args
 
 
-def parse_args_file_group(argv_post_parsed, default_path) -> CommandLineArguments:
+def parse_args_file_group(argv_post_parsed: List[str], default_path: str) -> CommandLineArguments:
     """Parse a set of mkosi.default and mkosi.default.d/* files.
     """
     # Add the @ prefixed filenames to current argument list in inverse priority order.
@@ -4723,7 +4733,7 @@ def prepend_to_environ_path(paths: List[str]) -> None:
         os.environ["PATH"] = new_path + ":" + original_path
 
 
-def run_verb(args):
+def run_verb(args: CommandLineArguments) -> None:
     load_args(args)
 
     prepend_to_environ_path(args.extra_search_paths)

--- a/mkosi
+++ b/mkosi
@@ -3601,9 +3601,9 @@ def parse_bytes(num_bytes: Optional[str]) -> Optional[int]:
         return num_bytes
 
     if num_bytes.endswith('G'):
-        factor = 1024**3
+        factor = 1024 * 1024 * 1024
     elif num_bytes.endswith('M'):
-        factor = 1024**2
+        factor = 1024 * 1024
     elif num_bytes.endswith('K'):
         factor = 1024
     else:

--- a/mkosi
+++ b/mkosi
@@ -3563,9 +3563,7 @@ def parse_args_file(argv_post_parsed: List[str], default_path: str) -> CommandLi
     argv_post_parsed.insert(1, ArgumentParserMkosi.fromfile_prefix_chars+default_path)
     parser = create_parser()
     # parse all parameters handled by mkosi. Parameters forwarded to subprocesses such as nspawn or qemu end up in cmdline_argv.
-    parsed_args = parser.parse_args(argv_post_parsed, CommandLineArguments())
-    args = cast(CommandLineArguments, parsed_args)
-    return args
+    return parser.parse_args(argv_post_parsed, CommandLineArguments())
 
 
 def parse_args_file_group(argv_post_parsed: List[str], default_path: str) -> CommandLineArguments:
@@ -3586,9 +3584,7 @@ def parse_args_file_group(argv_post_parsed: List[str], default_path: str) -> Com
     parser = create_parser()
 
     # parse all parameters handled by mkosi. Parameters forwarded to subprocesses such as nspawn or qemu end up in cmdline_argv.
-    parsed_args = parser.parse_args(argv_post_parsed, CommandLineArguments())
-    args = cast(CommandLineArguments, parsed_args)
-    return args
+    return parser.parse_args(argv_post_parsed, CommandLineArguments())
 
 
 def parse_bytes(num_bytes: Optional[str]) -> Optional[int]:


### PR DESCRIPTION
Most of these changes should be fairly uncontroversial, they only add missing type hints or remove type comments and casts that are no longer needed, when using a recent mypy.

Some additions are a bit busy work, as they silence warnings about generics (mostly return values of `CompletedSubprocess` or `TemporaryDirectory`), or are somewhat stylistic (usage of `__class__`) and some work around limitations in mypy (values in enums having type `Any` or the weird power issue in `parse_bytes`)

```mkosi:432: error: Missing type parameters for generic type "Callable"``` (the typing for the `complete_step` decorator) is left open, as this is an open mypy issue and I haven't found a way to work around it yet.