### PR TITLE
arch: use base package instead of base group

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1943,24 +1943,8 @@ SigLevel    = Required DatabaseOptional TrustAll
     run_pacman_key(["--populate", keyring])
 
     run_pacman(["-Sy"])
-    # determine base packages list from base group
-    c = run_pacman(["-Sqg", "base"], stdout=PIPE, universal_newlines=True)
-    packages = set(c.stdout.split())
-    packages -= {
-        "cryptsetup",
-        "device-mapper",
-        "dhcpcd",
-        "e2fsprogs",
-        "jfsutils",
-        "linux",
-        "lvm2",
-        "man-db",
-        "man-pages",
-        "mdadm",
-        "netctl",
-        "reiserfsprogs",
-        "xfsprogs",
-    }
+    # the base metapackage is mandatory
+    packages = {"base"}
 
     official_kernel_packages = {
         "linux",


### PR DESCRIPTION
Arch has changed its base package group to a meta package that pulls in several
other packages as dependencies. It is slimmer than the package group was before
and necessary to request support, so we can (and should) install it in full.

https://www.archlinux.org/news/base-group-replaced-by-mandatory-base-package-manual-intervention-required/

Original-Author: @keur
Closes: #377