### PR TITLE
Use console=pipe in install_grub() when calling nspawn

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -2296,6 +2296,7 @@ def install_grub(args: CommandLineArguments, workspace: str, loopdev: str, grub:
     nspawn_params = [
         "--bind-ro=/dev",
         "--property=DeviceAllow=" + loopdev,
+        "--console=pipe",
     ]
     if args.root_partno is not None:
         nspawn_params += ["--property=DeviceAllow=" + partition(loopdev, args.root_partno)]


### PR DESCRIPTION
The mount bind to /dev on the host conflicts with this patch in systemd,
which doesn't expect /dev/console to exist:
https://github.com/systemd/systemd/commit/3acc84ebd9aebe8cf1771b42644ebbfbecdfaa37

The result is that nspawn dies because it is unable to create a symlink
at /dev/console. This adds a new parameter when calling nspawn to
prevent it from attempting to create/use /dev/console since the default
behavior is to create/use /dev/console and install_grub() doesn't seem to
require an interactive console in order to install grub.

Fixes #380