### PR TITLE
Fix literal asterisks in markdown documentation

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -180,7 +180,7 @@ details see the table below.
 : Additional package repositories to use during installation. Expects
   one or more URLs as argument, separated by commas. This option may
   be used multiple times, in which case the list of repositories to
-  use is combined. Use "!*" to remove all repositories from to the list
+  use is combined. Use "!\*" to remove all repositories from to the list
   or use e.g. "!repo-url" to remove just one specific repository.
 
 `--architecture=`
@@ -248,16 +248,16 @@ details see the table below.
   comma-separated list of `uefi` or `bios`. May be specified more than
   once in which case the specified lists are merged. If `uefi` is
   specified the `sd-boot` UEFI boot loader is used, if `bios` is
-  specified the GNU Grub boot loader is used. Use "!*" to remove all
+  specified the GNU Grub boot loader is used. Use "!\*" to remove all
   previously added protocols or "!protocol" to remove one protocol.
 
 `--kernel-command-line=`
 
 : Use the specified kernel command line when building bootable
   images. By default command line arguments get appended. To remove all
-  arguments from the current list pass "!*". To remove specific arguments
+  arguments from the current list pass "!\*". To remove specific arguments
   add a space separated list of "!" prefixed arguments.
-  For example adding "!* console=ttyS0 rw" to a mkosi.default file or the
+  For example adding "!\* console=ttyS0 rw" to a mkosi.default file or the
   command line arguments passes "console=ttyS0 rw" to the kernel in any
   case. Just adding "console=ttyS0 rw" would append these two arguments
   to the kernel command line created by lower priority configuration
@@ -379,7 +379,7 @@ details see the table below.
   prepend the package name with a ! letter. For example -p "!apache2"
   would remove the apache2 package. To replace the apache2 package by
   the httpd package just add -p "!apache2,httpd" to the command line
-  arguments. To remove all packages use "!*".
+  arguments. To remove all packages use "!\*".
 
 `--with-docs`
 
@@ -475,7 +475,7 @@ details see the table below.
   of the build, and are absent in the final image. use `--package=` to
   list packages that shall be included in both.
   Packages are appended to the list. Packages prefixed with "!" are
-  removed from the list. "!*" removes all packages from the list.
+  removed from the list. "!\*" removes all packages from the list.
 
 `--skip-final-phase=`
 


### PR DESCRIPTION
Otherwise, if a second such asterisk is present on the line, the asterisks delimit emphasised text and they are not shown in the rendered markdown. This occurred with `--kernel-command-line`.

Alternatively, one could mark the example arguments that are currently wrapped in " as code.