### PR TITLE
add firstboot parameter

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -2483,7 +2483,8 @@ def reset_machine_id(args: CommandLineArguments, root: str, do_run_build_script:
             os.unlink(machine_id)
         except FileNotFoundError:
             pass
-        open(machine_id, "w+b").close()
+        if not args.firstboot:
+            open(machine_id, "w+b").close()
         dbus_machine_id = os.path.join(root, 'var/lib/dbus/machine-id')
         try:
             os.unlink(dbus_machine_id)
@@ -3661,6 +3662,7 @@ class ArgumentParserMkosi(argparse.ArgumentParser):
         'QCow2': '--qcow2',
         'OutputDirectory': '--output-dir',
         'XZ': '--xz',
+        'Firstboot': '--firstboot',
         'NSpawnSettings': '--settings',
         'ESPSize': '--esp-size',
         'CheckSum': '--checksum',
@@ -3782,6 +3784,7 @@ def create_parser() -> ArgumentParserMkosi:
                        help='Sign the resulting kernel/initrd image for UEFI SecureBoot')
     group.add_argument("--secure-boot-key", help="UEFI SecureBoot private key in PEM format", metavar='PATH')
     group.add_argument("--secure-boot-certificate", help="UEFI SecureBoot certificate in X509 format", metavar='PATH')
+    group.add_argument("--firstboot", action=BooleanAction, help="Do not add /etc/machine-id to the image")
     group.add_argument("--read-only", action=BooleanAction,
                        help='Make root volume read-only (only gpt_ext4, gpt_xfs, gpt_btrfs, subvolume, implied with gpt_squashfs and plain_squashfs)')
     group.add_argument("--encrypt", choices=("all", "data"),
@@ -4662,6 +4665,7 @@ def print_summary(args: CommandLineArguments) -> None:
     sys.stderr.write("        FS Compression: " + yes_no(args.compress) + detail + "\n")
 
     sys.stderr.write("        XZ Compression: " + yes_no(args.xz) + "\n")
+    sys.stderr.write("             FirstBoot: " + yes_no(args.firstboot) + "\n")
     if args.mksquashfs_tool:
         sys.stderr.write("       Mksquashfs tool: " + ' '.join(args.mksquashfs_tool) + "\n")
 

--- a/mkosi.md
+++ b/mkosi.md
@@ -265,6 +265,11 @@ details see the table below.
   to the kernel command line created by lower priority configuration
   files or previous --kernel-command-line command line arguments.
 
+`--firstboot`
+
+: Do not generate /etc/machine-id file. This is useful, for images that 
+  shall trigger systemd-firstboot.service.
+
 `--secure-boot`
 
 : Sign the resulting kernel/initrd image for UEFI SecureBoot
@@ -692,6 +697,7 @@ which settings file options.
 | `--bootable`, `-b`           | `[Output]`              | `Bootable=`               |
 | `--boot-protocols=`          | `[Output]`              | `BootProtocols=`          |
 | `--kernel-command-line=`     | `[Output]`              | `KernelCommandLine=`      |
+| `--firstboot`                | `[Output]`              | `FirstBoot=`              |
 | `--secure-boot`              | `[Output]`              | `SecureBoot=`             |
 | `--secure-boot-key=`         | `[Output]`              | `SecureBootKey=`          |
 | `--secure-boot-certificate=` | `[Output]`              | `SecureBootCertificate=`  |

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -89,6 +89,7 @@ class MkosiConfig(object):
             'release': None,
             'repositories': [],
             'root_size': None,
+            'firstboot': False,
             'secure_boot': False,
             'secure_boot_certificate': None,
             'secure_boot_key': None,
@@ -195,6 +196,8 @@ class MkosiConfig(object):
                 self._append_list('boot_protocols', mk_config_output['BootProtocols'], job_name)
             if 'KernelCommandLine' in mk_config_output:
                 self._append_list('kernel_command_line', mk_config_output['KernelCommandLine'], job_name, ' ')
+            if 'FirstBoot' in mk_config_output:
+                self.reference_config[job_name]['first_boot'] = mk_config_output['FirstBoot']
             if 'SecureBoot' in mk_config_output:
                 self.reference_config[job_name]['secure_boot'] = mk_config_output['SecureBoot']
             if 'SecureBootKey' in mk_config_output:


### PR DESCRIPTION
When generating cloud images or other images that should use
systemd-firstboot, we want to make sure that /etc/machine-id is not
existent. Creating an empty /etc/machine-id file is not enough, because
systemds `ConditionFirstBoot` will only check for the file, not its
content. Furthermore systemd will generate a new /etc/machine-id file if
the /etc/machine-id file is empty. This is supposed to fix https://github.com/systemd/mkosi/issues/384

Signed-off-by: Christian Rebischke <chris@nullday.de>