### PR TITLE
mkosi: having a "defaults" file is optional, hence conditionalize MKOSI_DEFAULT

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -4436,8 +4436,10 @@ def run_build_script(args: CommandLineArguments, workspace: str, raw: Optional[B
                    "--setenv=WITH_DOCS=" + one_zero(args.with_docs),
                    "--setenv=WITH_TESTS=" + one_zero(args.with_tests),
                    "--setenv=WITH_NETWORK=" + one_zero(args.with_network),
-                   "--setenv=MKOSI_DEFAULT=" + args.default_path,
                    "--setenv=DESTDIR=/root/dest"]
+
+        if args.default_path is not None:
+            cmdline.append("--setenv=MKOSI_DEFAULT=" + args.default_path)
 
         if args.build_sources is not None:
             cmdline.append("--setenv=SRCDIR=/root/src")


### PR DESCRIPTION
Follow-up for b067223c0de3ca814abac0ba6459d4916fd15746