### PR TITLE
add support for building "minimized" file system images

### DIFF
--- a/ci/semaphore.sh
+++ b/ci/semaphore.sh
@@ -3,7 +3,7 @@
 set -ex
 
 # Build an image
-sudo add-apt-repository --yes ppa:jonathonf/python-3.6
+sudo add-apt-repository --yes ppa:deadsnakes/ppa
 sudo apt --yes update
 sudo apt --yes install python3.6 python3-pip debootstrap systemd-container squashfs-tools
 

--- a/ci/semaphore.sh
+++ b/ci/semaphore.sh
@@ -4,22 +4,31 @@ set -ex
 
 # Build an image
 sudo add-apt-repository --yes ppa:deadsnakes/ppa
+sudo add-apt-repository --yes ppa:ubuntu-iremonger/e2fsprogs-xenial
 sudo apt --yes update
-sudo apt --yes install python3.6 python3-pip debootstrap systemd-container squashfs-tools
+sudo apt --yes install python3.6 python3-pip debootstrap systemd-container squashfs-tools e2fsprogs xfsprogs
 
 testimg()
 {
-	img="$1"
-	sudo python3.6 ./mkosi --default ./mkosi.files/mkosi."$img"
-	test -f mkosi.output/"$img".raw
-	rm mkosi.output/"$img".raw
+        img="$1"
+        sudo python3.6 ./mkosi --no-chown --default ./mkosi.files/mkosi."$img"
+        if test -f mkosi.output/"$img".raw ; then
+                sudo rm -f mkosi.output/"$img".raw
+        elif test -d mkosi.output/"$img" ; then
+                sudo rm -rf mkosi.output/"$img"
+        elif test -f mkosi.output/"$img".tar.xz ; then
+                sudo rm -f mkosi.output/"$img".tar.xz
+        else
+                echo "Couldn't find generated image." >&2
+                exit 1
+        fi
 }
 
 # Only test ubuntu images for now, as semaphore is based on Ubuntu
 for i in ./mkosi.files/mkosi.ubuntu*
 do
-	imgname="$(basename "$i" | cut -d. -f 2-)"
-	testimg "$imgname"
+        imgname="$(basename "$i" | cut -d. -f 2-)"
+        testimg "$imgname"
 done
 
 # Run unit tests

--- a/mkosi
+++ b/mkosi
@@ -4524,32 +4524,35 @@ def build_stuff(args: CommandLineArguments) -> None:
 
         # There is no point generating a pre-dev cache image if no build script is provided
         if args.build_script:
-            # Generate the cache version of the build image, and store it as "cache-pre-dev"
-            raw, tar, root_hash = build_image(args, workspace, do_run_build_script=True, for_cache=True)
-            save_cache(args,
-                       workspace.name,
-                       raw.name if raw is not None else None,
-                       args.cache_pre_dev)
+            with complete_step("Running first (development) stage to generate cached copy"):
+                # Generate the cache version of the build image, and store it as "cache-pre-dev"
+                raw, tar, root_hash = build_image(args, workspace, do_run_build_script=True, for_cache=True)
+                save_cache(args,
+                           workspace.name,
+                           raw.name if raw is not None else None,
+                           args.cache_pre_dev)
 
-            remove_artifacts(args, workspace.name, raw, tar, do_run_build_script=True)
+                remove_artifacts(args, workspace.name, raw, tar, do_run_build_script=True)
 
-        # Generate the cache version of the build image, and store it as "cache-pre-inst"
-        raw, tar, root_hash = build_image(args, workspace, do_run_build_script=False, for_cache=True)
-        if raw:
-            save_cache(args,
-                       workspace.name,
-                       raw.name,
-                       args.cache_pre_inst)
-            remove_artifacts(args, workspace.name, raw, tar, do_run_build_script=False)
+        with complete_step("Running second (final) stage to generate cached copy"):
+            # Generate the cache version of the build image, and store it as "cache-pre-inst"
+            raw, tar, root_hash = build_image(args, workspace, do_run_build_script=False, for_cache=True)
+            if raw:
+                save_cache(args,
+                           workspace.name,
+                           raw.name,
+                           args.cache_pre_inst)
+                remove_artifacts(args, workspace.name, raw, tar, do_run_build_script=False)
 
     run_finalize_script(args, workspace.name, verb='build')
 
     if args.build_script:
-        # Run the image builder for the first (development) stage in preparation for the build script
-        raw, tar, root_hash = build_image(args, workspace, do_run_build_script=True)
+        with complete_step("Running first (development) stage"):
+            # Run the image builder for the first (development) stage in preparation for the build script
+            raw, tar, root_hash = build_image(args, workspace, do_run_build_script=True)
 
-        run_build_script(args, workspace.name, raw)
-        remove_artifacts(args, workspace.name, raw, tar, do_run_build_script=True)
+            run_build_script(args, workspace.name, raw)
+            remove_artifacts(args, workspace.name, raw, tar, do_run_build_script=True)
 
     run_finalize_script(args, workspace.name, verb='final')
 
@@ -4558,7 +4561,8 @@ def build_stuff(args: CommandLineArguments) -> None:
         print_step('Skipping (second) final image build phase.')
         raw, tar, root_hash = None, None, None
     else:
-        raw, tar, root_hash = build_image(args, workspace, do_run_build_script=False, cleanup=True)
+        with complete_step("Running second (final) stage"):
+            raw, tar, root_hash = build_image(args, workspace, do_run_build_script=False, cleanup=True)
 
     raw = qcow2_output(args, raw)
     raw = xz_output(args, raw)

--- a/mkosi
+++ b/mkosi
@@ -728,7 +728,7 @@ def prepare_xbootldr(args: CommandLineArguments, loopdev: Optional[str], cached:
 
 
 def mkfs_ext4(label: str, mount: str, dev: str) -> None:
-    run(["mkfs.ext4", "-L", label, "-M", mount, dev], check=True)
+    run(["mkfs.ext4", "-I", "256", "-L", label, "-M", mount, dev], check=True)
 
 
 def mkfs_xfs(label: str, dev: str) -> None:

--- a/mkosi
+++ b/mkosi
@@ -97,6 +97,11 @@ class CommandLineArguments(argparse.Namespace):
     esp_partno: Optional[int] = None
     xbootldr_partno: Optional[int] = None
 
+    def generated_root(self):
+        """Returns whether this configuration means we need to generate a file system from a prepared tree,
+        as needed for anything squashfs and when root minimization is required."""
+        return self.minimize or self.output_format.is_squashfs()
+
 
 class SourceFileTransfer(enum.Enum):
     copy_all = "copy-all"
@@ -165,6 +170,10 @@ class OutputFormat(enum.Enum):
     def is_squashfs(self) -> bool:
         "The output format contains a squashfs partition"
         return self in {OutputFormat.gpt_squashfs, OutputFormat.plain_squashfs}
+
+    def can_minimize(self) -> bool:
+        "The output format can be 'minimized'"
+        return self in (OutputFormat.gpt_ext4, OutputFormat.gpt_btrfs)
 
 
 class Distribution(enum.Enum):
@@ -567,7 +576,7 @@ def determine_partition_table(args: CommandLineArguments) -> Tuple[str, bool]:
             pn += 1
             run_sfdisk = True
 
-    if args.output_format != OutputFormat.gpt_squashfs:
+    if not args.generated_root():
         table += 'type={}, attrs={}, name="Root Partition"\n'.format(
             gpt_root_native(args.architecture).root,
             "GUID:60" if args.read_only and args.output_format != OutputFormat.gpt_btrfs else "")
@@ -782,12 +791,12 @@ def luks_format_root(args: CommandLineArguments,
                      loopdev: str,
                      do_run_build_script: bool,
                      cached: bool,
-                     inserting_squashfs: bool = False) -> None:
+                     inserting_generated_root: bool = False) -> None:
     if args.encrypt != "all":
         return
     if args.root_partno is None:
         return
-    if args.output_format == OutputFormat.gpt_squashfs and not inserting_squashfs:
+    if args.generated_root() and not inserting_generated_root:
         return
     if do_run_build_script:
         return
@@ -829,12 +838,12 @@ def luks_format_srv(args: CommandLineArguments, loopdev: str, do_run_build_scrip
 def luks_setup_root(args: CommandLineArguments,
                     loopdev: str,
                     do_run_build_script: bool,
-                    inserting_squashfs: bool = False) -> Optional[str]:
+                    inserting_generated_root: bool = False) -> Optional[str]:
     if args.encrypt != "all":
         return None
     if args.root_partno is None:
         return None
-    if args.output_format == OutputFormat.gpt_squashfs and not inserting_squashfs:
+    if args.generated_root() and not inserting_generated_root:
         return None
     if do_run_build_script:
         return None
@@ -900,7 +909,7 @@ def luks_setup_all(args: CommandLineArguments,
 def prepare_root(args: CommandLineArguments, dev: Optional[str], cached: bool) -> None:
     if dev is None:
         return
-    if args.output_format == OutputFormat.gpt_squashfs:
+    if args.generated_root():
         return
     if cached:
         return
@@ -1075,11 +1084,8 @@ def prepare_tree(args: CommandLineArguments, workspace: str, do_run_build_script
     else:
         mkdir_last(os.path.join(workspace, "root"), 0o755)
 
-    if args.output_format in (OutputFormat.subvolume, OutputFormat.gpt_btrfs):
-
-        if cached and args.output_format is OutputFormat.gpt_btrfs:
-            return
-
+    if args.output_format is OutputFormat.subvolume or \
+       (args.output_format is OutputFormat.gpt_btrfs and not (args.minimize or cached)):
         btrfs_subvol_create(os.path.join(workspace, "root", "home"))
         btrfs_subvol_create(os.path.join(workspace, "root", "srv"))
         btrfs_subvol_create(os.path.join(workspace, "root", "var"))
@@ -2576,6 +2582,54 @@ def make_squashfs(args: CommandLineArguments, workspace: str, for_cache: bool) -
     return f
 
 
+def make_minimal_ext4(args: CommandLineArguments, workspace: str, for_cache: bool) -> Optional[BinaryIO]:
+    if args.output_format != OutputFormat.gpt_ext4:
+        return None
+    if not args.minimize:
+        return None
+    if for_cache:
+        return None
+
+    with complete_step('Creating ext4 root file system'):
+        f: BinaryIO = cast(BinaryIO, tempfile.NamedTemporaryFile(prefix=".mkosi-mkfs-ext4",
+                                                                 dir=os.path.dirname(args.output)))
+        f.truncate(args.root_size)
+        run(["mkfs.ext4", "-I", "256", "-L", "root", "-M", "/", "-d", os.path.join(workspace, "root"), f.name], check=True)
+
+    with complete_step('Minimizing ext4 root file system'):
+        run(["resize2fs", "-M", f.name])
+
+    return f
+
+
+def make_minimal_btrfs(args: CommandLineArguments, workspace: str, for_cache: bool) -> Optional[BinaryIO]:
+    if args.output_format != OutputFormat.gpt_btrfs:
+        return None
+    if not args.minimize:
+        return None
+    if for_cache:
+        return None
+
+    with complete_step('Creating minimal btrfs root file system'):
+        f: BinaryIO = cast(BinaryIO, tempfile.NamedTemporaryFile(prefix=".mkosi-mkfs-btrfs",
+                                                                 dir=os.path.dirname(args.output)))
+        f.truncate(args.root_size)
+        run(["mkfs.btrfs", "-L", "root", "-d", "single", "-m", "single", "--shrink", "--rootdir", os.path.join(workspace, "root"), f.name], check=True)
+
+    return f
+
+
+def make_generated_root(args: CommandLineArguments, workspace: str, for_cache: bool) -> Optional[BinaryIO]:
+
+    if args.output_format == OutputFormat.gpt_ext4:
+        return make_minimal_ext4(args, workspace, for_cache)
+    if args.output_format == OutputFormat.gpt_btrfs:
+        return make_minimal_btrfs(args, workspace, for_cache)
+    if args.output_format.is_squashfs():
+        return make_squashfs(args, workspace, for_cache)
+
+    return None
+
 def read_partition_table(loopdev: str) -> Tuple[List[str], int]:
     table = []
     last_sector = 0
@@ -2624,6 +2678,7 @@ def insert_partition(args: CommandLineArguments,
                      blob: BinaryIO,
                      name: str,
                      type_uuid: uuid.UUID,
+                     read_only: bool,
                      uuid_opt: Optional[uuid.UUID] = None) -> int:
     if args.ran_sfdisk:
         old_table, last_partition_sector = read_partition_table(loopdev)
@@ -2651,8 +2706,12 @@ def insert_partition(args: CommandLineArguments,
     if uuid_opt is not None:
         table += "uuid=" + str(uuid_opt) + ", "
 
-    n_sectores = (blob_size + luks_extra) // 512
-    table += f'size={n_sectores}, type={type_uuid}, attrs=GUID:60, name="{name}"\n'
+    n_sectors = (blob_size + luks_extra) // 512
+    table += 'size={}, type={}, attrs={}, name="{}"\n'.format(
+        n_sectors,
+        type_uuid,
+        "GUID:60" if read_only else "",
+        name)
 
     print(table)
 
@@ -2678,23 +2737,25 @@ def insert_partition(args: CommandLineArguments,
     return blob_size
 
 
-def insert_squashfs(args: CommandLineArguments,
-                    workspace: str,
-                    raw: Optional[BinaryIO],
-                    loopdev: Optional[str],
-                    squashfs: Optional[BinaryIO],
-                    for_cache: bool) -> None:
-    if args.output_format != OutputFormat.gpt_squashfs:
+def insert_generated_root(args: CommandLineArguments,
+                          workspace: str,
+                          raw: Optional[BinaryIO],
+                          loopdev: Optional[str],
+                          image: Optional[BinaryIO],
+                          for_cache: bool) -> None:
+    if not args.generated_root():
+        return
+    if not args.output_format.is_disk():
         return
     if for_cache:
         return
     assert raw is not None
     assert loopdev is not None
-    assert squashfs is not None
+    assert image is not None
 
-    with complete_step('Inserting squashfs root partition'):
-        args.root_size = insert_partition(args, workspace, raw, loopdev, args.root_partno, squashfs,
-                                          "Root Partition", gpt_root_native(args.architecture).root)
+    with complete_step('Inserting generated root partition'):
+        args.root_size = insert_partition(args, workspace, raw, loopdev, args.root_partno, image,
+                                          "Root Partition", gpt_root_native(args.architecture).root, args.output_format.is_squashfs())
 
 
 def make_verity(args: CommandLineArguments,
@@ -2740,7 +2801,7 @@ def insert_verity(args: CommandLineArguments,
 
     with complete_step('Inserting verity partition'):
         insert_partition(args, workspace, raw, loopdev, args.verity_partno, verity,
-                         "Verity Partition", gpt_root_native(args.architecture).verity, u)
+                         "Verity Partition", gpt_root_native(args.architecture).verity, True, u)
 
 
 def patch_root_uuid(args: CommandLineArguments,
@@ -2825,7 +2886,7 @@ def install_unified_kernel(args: CommandLineArguments,
                       ("-i",) + ("/usr/lib/systemd/systemd-veritysetup",)*2 + \
                       ("-i",) + ("/usr/lib/systemd/system-generators/systemd-veritysetup-generator",)*2
 
-            if args.output_format == OutputFormat.gpt_squashfs:
+            if args.output_format.is_squashfs:
                 dracut += ['--add-drivers', 'squashfs']
 
             dracut += ['--add', 'qemu']
@@ -3367,6 +3428,8 @@ def create_parser() -> ArgumentParserMkosi:
                        help='When running with sudo, disable reassignment of ownership of the generated files to the original user')  # NOQA: E501
     group.add_argument('-i', "--incremental", action=BooleanAction,
                        help='Make use of and generate intermediary cache images')
+    group.add_argument('-M', "--minimize", action=BooleanAction,
+                       help='Minimize root file system size')
 
     group = parser.add_argument_group("Packages")
     group.add_argument('-p', "--package", action=CommaDelimitedListAction, dest='packages', default=[],
@@ -3962,6 +4025,9 @@ def load_args(args: CommandLineArguments) -> CommandLineArguments:
         elif args.distribution == Distribution.opensuse:
             args.mirror = "http://download.opensuse.org"
 
+    if args.minimize and not args.output_format.can_minimize():
+        die("Minimal file systems only supported for ext4 and btrfs.")
+
     if args.bootable:
         if args.output_format in (OutputFormat.directory, OutputFormat.subvolume, OutputFormat.tar):
             die("Directory, subvolume and tar images cannot be booted.")
@@ -4197,6 +4263,8 @@ def print_summary(args: CommandLineArguments) -> None:
     if args.hostname:
         sys.stderr.write("              Hostname: " + args.hostname + "\n")
     sys.stderr.write("         Output Format: " + args.output_format.name + "\n")
+    if args.output_format.can_minimize():
+        sys.stderr.write("              Minimize: " + yes_no(args.minimize) + "\n")
     if args.output_dir:
         sys.stderr.write("      Output Directory: " + args.output_dir + "\n")
     sys.stderr.write("                Output: " + args.output + "\n")
@@ -4365,7 +4433,10 @@ def build_image(args: CommandLineArguments,
             prepare_home(args, encrypted_home, cached)
             prepare_srv(args, encrypted_srv, cached)
 
-            with mount_image(args, workspace.name, loopdev, encrypted_root, encrypted_home, encrypted_srv):
+            # Mount everything together, but let's not mount the root
+            # dir if we still have to generate the root image here
+            with mount_image(args, workspace.name, loopdev, None if args.generated_root() else encrypted_root,
+                             encrypted_home, encrypted_srv):
                 prepare_tree(args, workspace.name, do_run_build_script, cached)
 
                 with mount_cache(args, workspace.name):
@@ -4387,8 +4458,8 @@ def build_image(args: CommandLineArguments,
                 reset_random_seed(args, workspace.name)
                 make_read_only(args, workspace.name, for_cache)
 
-            squashfs = make_squashfs(args, workspace.name, for_cache)
-            insert_squashfs(args, workspace.name, raw, loopdev, squashfs, for_cache)
+            generated_root = make_generated_root(args, workspace.name, for_cache)
+            insert_generated_root(args, workspace.name, raw, loopdev, generated_root, for_cache)
 
             verity, root_hash = make_verity(args, workspace.name, encrypted_root, do_run_build_script, for_cache)
             patch_root_uuid(args, loopdev, root_hash, for_cache)
@@ -4398,13 +4469,13 @@ def build_image(args: CommandLineArguments,
             # the verity data, and hence really shouldn't modify the
             # image anymore.
             with mount_image(args, workspace.name, loopdev,
-                             encrypted_root, encrypted_home, encrypted_srv, root_read_only=True):
+                             None if args.generated_root() and for_cache else encrypted_root, encrypted_home, encrypted_srv, root_read_only=True):
                 install_unified_kernel(args, workspace.name, do_run_build_script, for_cache, root_hash)
                 secure_boot_sign(args, workspace.name, do_run_build_script, for_cache)
 
     tar = make_tar(args, workspace.name, do_run_build_script, for_cache)
 
-    return raw or squashfs, tar, root_hash
+    return raw or generated_root, tar, root_hash
 
 
 def var_tmp(workspace: str) -> str:

--- a/mkosi
+++ b/mkosi
@@ -97,10 +97,10 @@ class CommandLineArguments(argparse.Namespace):
     esp_partno: Optional[int] = None
     xbootldr_partno: Optional[int] = None
 
-    def generated_root(self):
+    def generated_root(self) -> bool:
         """Returns whether this configuration means we need to generate a file system from a prepared tree,
         as needed for anything squashfs and when root minimization is required."""
-        return self.minimize or self.output_format.is_squashfs()
+        return cast(bool, self.minimize) or self.output_format.is_squashfs()
 
 
 class SourceFileTransfer(enum.Enum):
@@ -3285,14 +3285,18 @@ class BooleanAction(argparse.Action):
 
 class WithNetworkAction(BooleanAction):
 
-    def __call__(self, parser, namespace, values, option_strings=None):
+    def __call__(self,
+                 parser: argparse.ArgumentParser,
+                 namespace: argparse.Namespace,
+                 values: Union[str, Sequence[Any], None, bool],
+                 option_string: Optional[str] = None) -> None:
 
         if isinstance(values, str):
             if values == "strict":
                 setattr(namespace, self.dest, "strict")
                 return
 
-        super().__call__(parser, namespace, values, option_strings)
+        super().__call__(parser, namespace, values, option_string)
 
 
 class ArgumentParserMkosi(argparse.ArgumentParser):

--- a/mkosi
+++ b/mkosi
@@ -4028,6 +4028,9 @@ def load_args(args: CommandLineArguments) -> CommandLineArguments:
     if args.minimize and not args.output_format.can_minimize():
         die("Minimal file systems only supported for ext4 and btrfs.")
 
+    if args.generated_root() and args.incremental:
+        die("Sorry, incremental mode is currently not supported for squashfs or minimized file systems.")
+
     if args.bootable:
         if args.output_format in (OutputFormat.directory, OutputFormat.subvolume, OutputFormat.tar):
             die("Directory, subvolume and tar images cannot be booted.")

--- a/mkosi
+++ b/mkosi
@@ -2617,7 +2617,15 @@ def make_minimal_btrfs(args: CommandLineArguments, workspace: str, for_cache: bo
         f: BinaryIO = cast(BinaryIO, tempfile.NamedTemporaryFile(prefix=".mkosi-mkfs-btrfs",
                                                                  dir=os.path.dirname(args.output)))
         f.truncate(args.root_size)
-        run(["mkfs.btrfs", "-L", "root", "-d", "single", "-m", "single", "--shrink", "--rootdir", os.path.join(workspace, "root"), f.name], check=True)
+
+        command = ["mkfs.btrfs", "-L", "root", "-d", "single", "-m", "single", "--shrink", "--rootdir", os.path.join(workspace, "root"), f.name]
+        try:
+            run(command, check=True)
+        except subprocess.CalledProcessError as e:
+            # The --shrink option was added in btrfs-tools 4.14.1, before that it was the default behaviour.
+            # If the above fails, let's see if things work if we drop it
+            command.remove("--shrink")
+            run(command, check=True)
 
     return f
 

--- a/mkosi
+++ b/mkosi
@@ -1376,6 +1376,9 @@ def invoke_dnf(args: CommandLineArguments,
     if args.architecture is not None:
         cmdline += [f'--forcearch={args.architecture}']
 
+    if args.with_network == "strict":
+        cmdline += ['--cacheonly']
+
     if not args.with_docs:
         cmdline += ['--nodocs']
 
@@ -3272,6 +3275,18 @@ class BooleanAction(argparse.Action):
         setattr(namespace, self.dest, new_value)
 
 
+class WithNetworkAction(BooleanAction):
+
+    def __call__(self, parser, namespace, values, option_strings=None):
+
+        if isinstance(values, str):
+            if values == "strict":
+                setattr(namespace, self.dest, "strict")
+                return
+
+        super().__call__(parser, namespace, values, option_strings)
+
+
 class ArgumentParserMkosi(argparse.ArgumentParser):
     """ArgumentParser with support for mkosi.defaults file(s)
 
@@ -3456,7 +3471,7 @@ def create_parser() -> ArgumentParserMkosi:
     group.add_argument("--source-file-transfer", type=SourceFileTransfer, choices=list(SourceFileTransfer), default=None,
                        help="Method used to copy build sources to the build image." +
                        "; ".join([f"'{k}': {v}" for k, v in SourceFileTransfer.doc().items()]) + " (default: copy-git-cached if in a git repository, otherwise copy-all)")
-    group.add_argument("--with-network", action=BooleanAction,
+    group.add_argument("--with-network", action=WithNetworkAction,
                        help='Run build and postinst scripts with network access (instead of private network)')
     group.add_argument("--settings", dest='nspawn_settings', help='Add in .nspawn settings file', metavar='PATH')
 

--- a/mkosi
+++ b/mkosi
@@ -85,6 +85,7 @@ def die(message: str, status: int = 1) -> NoReturn:
 def warn(message: str, *args: Any, **kwargs: Any) -> None:
     sys.stderr.write('WARNING: ' + message.format(*args, **kwargs) + '\n')
 
+
 def tmp_dir() -> str:
     return os.environ.get('TMPDIR') or '/var/tmp'
 

--- a/mkosi.files/mkosi.ubuntu
+++ b/mkosi.files/mkosi.ubuntu
@@ -2,7 +2,7 @@
 
 [Distribution]
 Distribution=ubuntu
-Release=xenial
+Release=bionic
 
 [Output]
 Format=gpt_ext4

--- a/mkosi.files/mkosi.ubuntu-btrfs-minimal
+++ b/mkosi.files/mkosi.ubuntu-btrfs-minimal
@@ -6,7 +6,8 @@ Release=bionic
 
 [Output]
 Format=gpt_btrfs
-Output=ubuntu-btrfs.raw
+Minimize=yes
+Output=ubuntu-btrfs-minimal.raw
 
 [Packages]
 Packages=

--- a/mkosi.files/mkosi.ubuntu-directory
+++ b/mkosi.files/mkosi.ubuntu-directory
@@ -5,8 +5,8 @@ Distribution=ubuntu
 Release=bionic
 
 [Output]
-Format=gpt_btrfs
-Output=ubuntu-btrfs.raw
+Format=directory
+Output=ubuntu-directory
 
 [Packages]
 Packages=

--- a/mkosi.files/mkosi.ubuntu-ext4-minimal
+++ b/mkosi.files/mkosi.ubuntu-ext4-minimal
@@ -5,8 +5,9 @@ Distribution=ubuntu
 Release=bionic
 
 [Output]
-Format=gpt_btrfs
-Output=ubuntu-btrfs.raw
+Format=gpt_ext4
+Minimize=yes
+Output=ubuntu-ext4-minimal.raw
 
 [Packages]
 Packages=

--- a/mkosi.files/mkosi.ubuntu-squashfs
+++ b/mkosi.files/mkosi.ubuntu-squashfs
@@ -5,8 +5,8 @@ Distribution=ubuntu
 Release=bionic
 
 [Output]
-Format=gpt_btrfs
-Output=ubuntu-btrfs.raw
+Format=gpt_squashfs
+Output=ubuntu-squashfs.raw
 
 [Packages]
 Packages=

--- a/mkosi.files/mkosi.ubuntu-squashfs-plain
+++ b/mkosi.files/mkosi.ubuntu-squashfs-plain
@@ -5,8 +5,8 @@ Distribution=ubuntu
 Release=bionic
 
 [Output]
-Format=gpt_btrfs
-Output=ubuntu-btrfs.raw
+Format=plain_squashfs
+Output=ubuntu-squashfs-plain.raw
 
 [Packages]
 Packages=

--- a/mkosi.files/mkosi.ubuntu-tar
+++ b/mkosi.files/mkosi.ubuntu-tar
@@ -5,8 +5,8 @@ Distribution=ubuntu
 Release=bionic
 
 [Output]
-Format=gpt_btrfs
-Output=ubuntu-btrfs.raw
+Format=tar
+Output=ubuntu-tar.tar.xz
 
 [Packages]
 Packages=

--- a/mkosi.files/mkosi.ubuntu-xfs
+++ b/mkosi.files/mkosi.ubuntu-xfs
@@ -5,8 +5,8 @@ Distribution=ubuntu
 Release=bionic
 
 [Output]
-Format=gpt_btrfs
-Output=ubuntu-btrfs.raw
+Format=gpt_xfs
+Output=ubuntu-xfs.raw
 
 [Packages]
 Packages=

--- a/mkosi.md
+++ b/mkosi.md
@@ -280,8 +280,17 @@ details see the table below.
 `--read-only`
 
 : Make root file system read-only. Only applies to `gpt_ext4`,
-  `gpt_xfs`, `gpt-btrfs`, `subvolume` output formats, and implied on
+  `gpt_xfs`, `gpt_btrfs`, `subvolume` output formats, and implied on
   `gpt_squashfs` and `plain_squashfs`.
+
+`--minimize`
+
+: Attempt to make the resulting root file system as small as possible,
+  reducing free space on the file system as much as possible. Only
+  supported for `gpt_ext4` and `gpt_btrfs`. For ext4 this relies on
+  `resize2fs -M`, which reduces the free disk space but is not perfect
+  and thus generally leaves some free space in place. For btrfs the
+  results are perfect, leaving no free space.
 
 `--encrypt`
 
@@ -524,7 +533,11 @@ details see the table below.
   invoked. By default, the build script runs with networking turned
   off. The `$WITH_NETWORK` environment variable is passed to the
   `mkosi.build` build script indicating whether the build is done with
-  or without this option.
+  or without this option. If specified as `--with-network=strict` the
+  package manager is instructed not to contact the network for
+  updating package data. This provides a minimal level of
+  reproducibility, as long as the package data cache is already fully
+  populated.
 
 `--settings=`
 

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -72,6 +72,7 @@ class MkosiConfig(object):
             'incremental': False,
             'kernel_command_line': ['rhgb', 'quiet', 'selinux=0', 'audit=0', 'rw'],
             'key': None,
+            'minimize': False,
             'mirror': None,
             'mksquashfs_tool': None,
             'no_chown': False,


### PR DESCRIPTION
This adds support for images that have files systems that are as short as possible. This is implemented on ext4 via resize2fs -M (which isn't perfect, the images are still larger than necessary) and on btrfs via mkfs.btrfs --shrink (which works really well).

Also, beef up CI to test images of this type and all others.

(And while we are at it also add a "strict" mode without network. It just passes --nocache to dnf, thus permitting a modicum of reproducibility, as long as the cache is fully populated)