### PR TITLE
mkosi: use threads for .tar.xz creation

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -2557,6 +2557,7 @@ def make_tar(args: CommandLineArguments,
         f: BinaryIO = cast(BinaryIO, tempfile.NamedTemporaryFile(dir=os.path.dirname(args.output), prefix=".mkosi-"))
         run(["tar", "-C", os.path.join(workspace, "root"),
              "-c", "-J", "--xattrs", "--xattrs-include=*", "."],
+            env={"XZ_OPT": "-T0"},
             stdout=f, check=True)
 
     return f


### PR DESCRIPTION
Could also be used in `xz_output()` instead of / in absence of pxz. (cf. c905b07ba3624465ddd38fd9eedb684836d5e1d9 )

Note that files compressed in multi-threaded mode are a bit larger than their single-thread counterparts. 