### PR TITLE
mkosi: fix wrong url to get Fedora's keys

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1537,7 +1537,7 @@ def install_fedora(args: CommandLineArguments, workspace: str, do_run_build_scri
     if os.path.exists(gpg_key):
         gpg_key = f"file://{gpg_key}"
     else:
-        gpg_key = "https://getfedora.org/static/{}.txt".format(FEDORA_KEYS_MAP[args.releasever])
+        gpg_key = "https://getfedora.org/static/keys/{}.txt".format(FEDORA_KEYS_MAP[args.releasever])
 
     if args.mirror:
         baseurl = f"{args.mirror}/releases/{args.release}/Everything/$basearch/os/"


### PR DESCRIPTION
Fedora's website recently moved the keys from

    https://getfedora.org/static/[KEY]

to

    https://getfedora.org/static/keys/[KEY]

Unfortunately, they are not redirecting the URL, so it results in a 404.
It means that mkosi fails installing packages when the keys are not
stored locally, because it fails to get them from the website.