### PR TITLE
add basic support for --repositories option for Arch Linux

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1925,6 +1925,19 @@ SigLevel    = Required DatabaseOptional TrustAll
 {server}
 """)
 
+        if args.repositories:
+            for repository in args.repositories:
+                # repositories must be passed in the form <repo name>::<repo url>
+                repository_name, repository_server = repository.split('::', 1)
+
+                # note: for additional repositories, signature checking options are set to pacman's default values
+                f.write(f"""\
+
+[{repository_name}]
+SigLevel = Optional TrustedOnly
+Server = {repository_server}
+""")
+
     def run_pacman(args: List[str], **kwargs: Any) -> subprocess.CompletedProcess:
         cmdline = [
             "pacman",

--- a/mkosi.md
+++ b/mkosi.md
@@ -181,7 +181,9 @@ details see the table below.
   one or more URLs as argument, separated by commas. This option may
   be used multiple times, in which case the list of repositories to
   use is combined. Use "!\*" to remove all repositories from to the list
-  or use e.g. "!repo-url" to remove just one specific repository.
+  or use e.g. "!repo-url" to remove just one specific repository. For Arch
+  Linux, additional repositories must be passed in the form `<name>::<url>`
+  (e.g. `myrepo::https://myrepo.net`).
 
 `--architecture=`
 


### PR DESCRIPTION
The `--repositories` option was silently ignored for Arch Linux. This patch adds very basic support for this option.