### PR TITLE
Fix mount squashfs on kernel 5.4

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -941,18 +941,22 @@ def prepare_srv(args: CommandLineArguments, dev: Optional[str], cached: bool) ->
 def mount_loop(args: CommandLineArguments, dev: str, where: str, read_only: bool = False) -> None:
     os.makedirs(where, 0o755, True)
 
-    options = "-odiscard"
+    options = []
+    if not args.output_format.is_squashfs():
+        options.append("discard")
 
     if args.compress and args.output_format == OutputFormat.gpt_btrfs:
         if isinstance(args.compress, bool):
-            options += ",compress"
+            options.append("compress")
         else:
-            options += f",compress={args.compress}"
+            options.append(f",compress={args.compress}")
 
     if read_only:
-        options += ",ro"
+        options.append("ro")
 
-    run(["mount", "-n", dev, where, options], check=True)
+    options_arg = "-o" + ",".join(options) if options else ""
+
+    run(["mount", "-n", dev, where, options_arg], check=True)
 
 
 def mount_bind(what: str, where: str) -> None:


### PR DESCRIPTION
kernel 5.4 failed to mount squashfs

[764311.251432] squashfs: Unknown parameter 'discard'