### PR TITLE
Changes to support unified kernel+initrd in Ubuntu

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1802,7 +1802,7 @@ def install_debian_or_ubuntu(args: CommandLineArguments,
     # Debootstrap is not smart enough to deal correctly with alternative dependencies
     # Installing libpam-systemd via debootstrap results in systemd-shim being installed
     # Therefore, prefer to install via apt from inside the container
-    extra_packages = ['dbus', 'libpam-systemd']
+    extra_packages = ['dbus', 'libpam-systemd', 'binutils']
 
     # Also install extra packages via the secondary APT run, because it is smarter and
     # can deal better with any conflicts
@@ -2864,7 +2864,7 @@ def install_unified_kernel(args: CommandLineArguments,
     if do_run_build_script:
         return
 
-    if args.distribution not in (Distribution.fedora, Distribution.mageia):
+    if args.distribution not in (Distribution.fedora, Distribution.mageia, Distribution.ubuntu, Distribution.debian):
         return
 
     with complete_step("Generating combined kernel + initrd boot file"):
@@ -2889,6 +2889,7 @@ def install_unified_kernel(args: CommandLineArguments,
                       "-v",
                       "--no-hostonly",
                       "--uefi",
+                      "--uefi-stub", "/usr/lib/systemd/boot/efi/linuxx64.efi.stub",
                       "--kver", kver.name,
                       "--kernel-cmdline", cmdline]
 


### PR DESCRIPTION
I need to create an Ubuntu custom image with a read only file system (+ dm verity) and secure boot. I realized mkosi has all of this but the option for a unified kernel is disabled for Linux. I realized that the changes to get it to work are minimal, just differences in paths that can be fixed with usrmerge. 
