### PR TITLE
debootstrap fixes with https and upgrading

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1899,6 +1899,14 @@ def install_debian_or_ubuntu(args: CommandLineArguments,
         cmdline = ["/usr/bin/apt-get", "--assume-yes", "update"]
         run_workspace_command(args, workspace, network=True, env=env, *cmdline)
 
+    if args.upgrade:
+        # Assumes correct configuration in /etc/apt/sources.list.d/ at skeleton
+        # folder as debootstrap overrides /etc/apt/sources.list provided
+        cmdline = ["/usr/bin/apt-get", "--assume-yes", "update"]
+        run_workspace_command(args, workspace, network=True, env=env, *cmdline)
+        cmdline = ["/usr/bin/apt-get", "--assume-yes", "--no-install-recommends", "dist-upgrade"]
+        run_workspace_command(args, workspace, network=True, env=env, *cmdline)
+
     cmdline = ["/usr/bin/apt-get", "--assume-yes", "--no-install-recommends", "install"] + extra_packages
     run_workspace_command(args, workspace, network=True, env=env, *cmdline)
     os.unlink(policyrcd)
@@ -3530,6 +3538,7 @@ def create_parser() -> ArgumentParserMkosi:
     group.add_argument("--with-network", action=WithNetworkAction,
                        help='Run build and postinst scripts with network access (instead of private network)')
     group.add_argument("--settings", dest='nspawn_settings', help='Add in .nspawn settings file', metavar='PATH')
+    group.add_argument('-U', "--upgrade", action=BooleanAction, help='Upgrade system (ubuntu / debian)')
 
     group = parser.add_argument_group("Partitions")
     group.add_argument("--root-size",
@@ -4099,6 +4108,9 @@ def load_args(args: CommandLineArguments) -> CommandLineArguments:
     if args.minimize and not args.output_format.can_minimize():
         die("Minimal file systems only supported for ext4 and btrfs.")
 
+    if args.upgrade and not args.distribution in [Distribution.ubuntu, Distribution.debian]:
+        die("Upgrade currently only supported on ubuntu and debian")
+
     if args.generated_root() and args.incremental:
         die("Sorry, incremental mode is currently not supported for squashfs or minimized file systems.")
 
@@ -4398,6 +4410,9 @@ def print_summary(args: CommandLineArguments) -> None:
     sys.stderr.write("       Finalize Script: " + none_to_none(args.finalize_script) + "\n")
     sys.stderr.write("  Scripts with network: " + yes_no(args.with_network) + "\n")
     sys.stderr.write("       nspawn Settings: " + none_to_none(args.nspawn_settings) + "\n")
+
+    if args.upgrade:
+        sys.stderr.write("              Upgrade:  " + yes_no(args.upgrade) + "\n")
 
     if args.output_format.is_disk():
         sys.stderr.write("\nPARTITIONS:\n")

--- a/mkosi
+++ b/mkosi
@@ -1785,6 +1785,13 @@ def install_debian_or_ubuntu(args: CommandLineArguments,
                "--exclude=sysv-rc,initscripts,startpar,lsb-base,insserv",
                "--components=" + ','.join(repos)]
 
+    # Atleast ubuntu doesn't have apt-transport-https anymore, except on xenial,
+    # but debootstrap scripting tries to install it.
+    # Not checking end-of-life releases
+    # Correct patch should be in debootstrap scripting
+    if args.distribution == Distribution.ubuntu and args.release not in ["xenial"]:
+        cmdline[4] += ",apt-transport-https"
+
     if args.architecture is not None:
         debarch = DEBIAN_ARCHITECTURES.get(args.architecture)
         cmdline += [f"--arch={debarch}"]
@@ -1869,11 +1876,30 @@ def install_debian_or_ubuntu(args: CommandLineArguments,
         with open(dpkg_conf, "w") as f:
             f.writelines(f'path-exclude {d}/*\n' for d in doc_paths)
 
-    cmdline = ["/usr/bin/apt-get", "--assume-yes", "--no-install-recommends", "install"] + extra_packages
     env = {
         'DEBIAN_FRONTEND': 'noninteractive',
         'DEBCONF_NONINTERACTIVE_SEEN': 'true',
     }
+
+    # Fix sources.list to use given apt mirror if debootstrap fails to set it
+    # This is required check if using https-mirrors with ubuntu as debootstrap
+    # doesn't correctly handle https schema when selecting final mirror to write
+    sourceslist = os.path.join(workspace, "root/etc/apt/sources.list")
+    sourceslist_correct = True
+    with open(sourceslist) as f:
+        sourceslist_correct = (mirror in f.read())
+
+    if not sourceslist_correct:
+        # debootstrap failed to write correct sources.list
+        sourceslist_components = " ".join(repos)
+        with open(sourceslist, "w") as f:
+            f.write(f"deb {mirror} {args.release} {sourceslist_components}\n")
+
+        # We have to run update here when using non-default mirror if broken
+        cmdline = ["/usr/bin/apt-get", "--assume-yes", "update"]
+        run_workspace_command(args, workspace, network=True, env=env, *cmdline)
+
+    cmdline = ["/usr/bin/apt-get", "--assume-yes", "--no-install-recommends", "install"] + extra_packages
     run_workspace_command(args, workspace, network=True, env=env, *cmdline)
     os.unlink(policyrcd)
 

--- a/mkosi.md
+++ b/mkosi.md
@@ -294,6 +294,16 @@ details see the table below.
   and thus generally leaves some free space in place. For btrfs the
   results are perfect, leaving no free space.
 
+`--upgrade` `-U`
+
+: Try to upgrade ubuntu/debian after debootstrap. This is required for
+  getting security upgrades available before installing kernel etc for
+  the first time so that old kernel isn't installed at all. Requires
+  `/etc/apt/sources.list.d/` configured with update repositories as
+  debootstrap overwrites `/etc/apt/sources.list`. Also allows using
+  packages from custom repositories with --package as side effect if
+  the repositories are configured properly.
+
 `--encrypt`
 
 : Encrypt all partitions in the file system or just the root file
@@ -703,6 +713,7 @@ which settings file options.
 | `--finalize-script=`         | `[Packages]`            | `FinalizeScript=`         |
 | `--with-network`             | `[Packages]`            | `WithNetwork=`            |
 | `--settings=`                | `[Packages]`            | `NSpawnSettings=`         |
+| `--upgrade`                  | `[Packages]`            | `Upgrade=`                |
 | `--root-size=`               | `[Partitions]`          | `RootSize=`               |
 | `--esp-size=`                | `[Partitions]`          | `ESPSize=`                |
 | `--swap-size=`               | `[Partitions]`          | `SwapSize=`               |


### PR DESCRIPTION
I needed to use https-mirror for Ubuntu and wrote some workarounds for debootstrap problems.
I also made a new flag to allow installing security upgrades directly after debootstrap if apt is configured correctly. This is mainly because Ubuntu seems to split newest updates to separate repositories instead of the main repository debootstrap uses.

I haven't tested if debian has similar problems with debootstrap and https.