### PR TITLE
Add usrmerge for ubuntu previous to 18.04

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1806,7 +1806,7 @@ def install_debian_or_ubuntu(args: CommandLineArguments,
     # Debootstrap is not smart enough to deal correctly with alternative dependencies
     # Installing libpam-systemd via debootstrap results in systemd-shim being installed
     # Therefore, prefer to install via apt from inside the container
-    extra_packages = ['dbus', 'libpam-systemd', 'binutils']
+    extra_packages = ['dbus', 'libpam-systemd', 'binutils', 'usrmerge']
 
     # Also install extra packages via the secondary APT run, because it is smarter and
     # can deal better with any conflicts

--- a/mkosi
+++ b/mkosi
@@ -1806,7 +1806,7 @@ def install_debian_or_ubuntu(args: CommandLineArguments,
     # Debootstrap is not smart enough to deal correctly with alternative dependencies
     # Installing libpam-systemd via debootstrap results in systemd-shim being installed
     # Therefore, prefer to install via apt from inside the container
-    extra_packages = ['dbus', 'libpam-systemd', 'binutils', 'usrmerge']
+    extra_packages = ['dbus', 'libpam-systemd', 'binutils']
 
     # Also install extra packages via the secondary APT run, because it is smarter and
     # can deal better with any conflicts
@@ -1821,7 +1821,7 @@ def install_debian_or_ubuntu(args: CommandLineArguments,
         f.write("hostonly=no")
 
     if args.bootable:
-        extra_packages += ["dracut"]
+        extra_packages += ["dracut", "usrmerge"]
         if args.distribution == Distribution.ubuntu:
             extra_packages += ["linux-generic"]
         else:


### PR DESCRIPTION
This change is a follow up to this PR:

https://github.com/systemd/mkosi/pull/402  - This introduced the unified kernel EFI for debian and ubuntu distros. 

Looking at this [issue](https://github.com/systemd/mkosi/issues/410), ubuntu 18.04 and below require usrmerge for those paths to work. The PR originally special cased 18.04, but I moved away from it and forgot to add usrmerge. 
 
