### PR TITLE
Fix ci-arch.yml to support zstd-compressed packages

### DIFF
--- a/.github/workflows/ci-arch.yml
+++ b/.github/workflows/ci-arch.yml
@@ -23,7 +23,18 @@ jobs:
     - name: Update package cache
       run: sudo apt-get --assume-yes update
     - name: Install dependencies
-      run: sudo apt-get --assume-yes install systemd-container squashfs-tools e2fsprogs xfsprogs libarchive-dev libgpgme-dev libcurl4-openssl-dev asciidoc
+      run: sudo apt-get --assume-yes install systemd-container squashfs-tools e2fsprogs xfsprogs libzstd1-dev libgpgme-dev libcurl4-openssl-dev asciidoc
+    - name: Download libarchive source
+      run: |
+        wget "https://github.com/libarchive/libarchive/releases/download/v3.4.2/libarchive-3.4.2.tar.gz"
+        tar -xzf libarchive-3.4.2.tar.gz   
+    - name: Build and install libarchive to /usr/local
+      run: |
+        pushd libarchive-3.4.2
+        ./configure
+        make
+        sudo make install
+        popd
     - name: Download pacman source
       run: |
         wget "https://sources.archlinux.org/other/pacman/pacman-5.2.1.tar.gz"
@@ -33,6 +44,9 @@ jobs:
         pushd pacman-5.2.1
         # GPGME_KEYLIST_MODE_LOCATE is syntactic sugar for GPGME_KEYLIST_MODE_LOCAL and GPGME_KEYLIST_MODE_EXTERN
         sed -i 's/mode |= GPGME_KEYLIST_MODE_LOCATE;/mode |= GPGME_KEYLIST_MODE_LOCAL; mode |= GPGME_KEYLIST_MODE_EXTERN;/g' lib/libalpm/signing.c
+        export LIBARCHIVE_CFLAGS=-I/usr/local/include
+        export LIBARCHIVE_LIBS="-L/usr/local/lib -larchive"
+        export LD_LIBRARY_PATH=/usr/local/lib
         ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var --disable-doc --with-scriptlet-shell=/usr/bin/bash --with-ldconfig=/usr/bin/ldconfig
         make
         sudo make install
@@ -57,4 +71,5 @@ jobs:
         make -C "arch-install-scripts-23"
         sudo make -C "arch-install-scripts-23" PREFIX=/usr install
     - name: Build Arch Linux/${{ matrix.output_type }}
-      run: sudo env PATH="$PATH" python3 ./mkosi --debug run -d arch -t ${{ matrix.output_type }} -p tzdata -b false --default /dev/null
+      run: sudo env PATH="$PATH" LD_LIBRARY_PATH=/usr/local/lib python3 ./mkosi --debug run -d arch -t ${{ matrix.output_type }} -p tzdata -b false --default /dev/null
+  


### PR DESCRIPTION
This installs libzstd1-dev as an additional package, then downloads and builds libarchive, so that the resulting library supports zstd.