### PR TITLE
build ubuntu on armv7l

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -261,6 +261,8 @@ def gpt_root_native(arch: str) -> GPTRootTypePair:
         return GPTRootTypePair(GPT_ROOT_X86_64, GPT_ROOT_X86_64_VERITY)
     elif arch == 'aarch64':
         return GPTRootTypePair(GPT_ROOT_ARM_64, GPT_ROOT_ARM_64_VERITY)
+    elif arch == 'armv7l':
+        return GPTRootTypePair(GPT_ROOT_ARM, GPT_ROOT_ARM_VERITY)
     else:
         die(f'Unknown architecture {arch}.')
 

--- a/mkosi
+++ b/mkosi
@@ -4310,6 +4310,8 @@ def print_summary(args: CommandLineArguments) -> None:
         sys.stderr.write("          Architecture: " + args.architecture + "\n")
     if args.mirror is not None:
         sys.stderr.write("                Mirror: " + args.mirror + "\n")
+    if args.repositories is not None and len(args.repositories) > 0:
+        sys.stderr.write("          Repositories: " + ','.join(args.repositories) + "\n")
     sys.stderr.write("\nOUTPUT:\n")
     if args.hostname:
         sys.stderr.write("              Hostname: " + args.hostname + "\n")


### PR DESCRIPTION

 - added output about the repositories enabled:

```
DISTRIBUTION:
          Distribution: ubuntu
               Release: bionic
                Mirror: http://ports.ubuntu.com/ubuntu-ports/
          Repositories: main,universe
```

 - added architecture hints which have enabled me to build on 32-bit odroid:

_before_
```
‣ Temporary workspace in /var/tmp/mkosi-i72_jc6y is now set up.
‣ Running first (development) stage...
‣ Basing off cached image ubuntu.raw.cache-pre-dev...
Unknown architecture armv7l.
```

_after_
```
‣ Temporary workspace in /var/tmp/mkosi-tboyvf5t is now set up.
‣ Running first (development) stage...
‣ Basing off cached image ubuntu.raw.cache-pre-dev...
‣ Copied cached image as /home/user/src/mkosi/build/.mkosi-gtg5dyi8.
‣ Attaching image file...
‣ Attached image file as /dev/loop0.
```