### PR TITLE
Install the boot loader after copying in the build tree.

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -4635,10 +4635,12 @@ def build_image(args: CommandLineArguments,
                     install_distribution(args, workspace.name,
                                          do_run_build_script=do_run_build_script, cached=cached)
                     install_etc_hostname(args, workspace.name)
-                    install_boot_loader(args, workspace.name, loopdev, cached)
                     install_extra_trees(args, workspace.name, for_cache)
                     install_build_src(args, workspace.name, do_run_build_script, for_cache)
                     install_build_dest(args, workspace.name, do_run_build_script, for_cache)
+                    # Install boot loader after copying in the build tree so the
+                    # built binaries are bundled in the initramfs as well.
+                    install_boot_loader(args, workspace.name, loopdev, cached)
                     set_root_password(args, workspace.name, do_run_build_script, for_cache)
                     run_postinst_script(args, workspace.name, do_run_build_script, for_cache)
 


### PR DESCRIPTION
This makes sure the binaries from the build tree are bundled in the
initramfs as well (which is mostly useful for systemd).