### PR TITLE
mkosi: add Fedora 32

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -244,6 +244,7 @@ FEDORA_KEYS_MAP = {
     '29': '429476B4',
     '30': 'CFC659B9',
     '31': '3C3359C4',
+    '32': '12C944D0',
 }
 
 # 1 MB at the beginning of the disk for the GPT disk label, and

--- a/mkosi.files/mkosi.fedora
+++ b/mkosi.files/mkosi.fedora
@@ -3,7 +3,7 @@
 
 [Distribution]
 Distribution=fedora
-Release=31
+Release=32
 
 [Output]
 Format=gpt_ext4


### PR DESCRIPTION
Add the Fedora 32 GPG key to the list, and update mkosi.fedora to 32.