### PR TITLE
Add option to strip SELinux file context from tar'ed files

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -378,6 +378,15 @@ details see the table below.
   the user which invoked `sudo`. With this option this may be turned
   off and all generated files are owned by `root`.
 
+`--tar-strip-selinux-context`
+
+: If running on a SELinux-enabled system (Fedora, CentOS), files inside
+  the container are tagged with SELinux context extended attributes
+  (`xattrs`), which may interfere with host SELinux rules in building
+  or further container import stages.  
+  This option strips SELinux context attributes from the resulting
+  tar archive.
+
 `--incremental`, `-i`
 
 : Enable incremental build mode. This only applies if the two-phase
@@ -767,6 +776,7 @@ which settings file options.
 | `--xz`                            | `[Output]`              | `XZ=`                         |
 | `--qcow2`                         | `[Output]`              | `QCow2=`                      |
 | `--no-chown`                      | `[Output]`              | `NoChown=`                    |
+| `--tar-strip-selinux-context`     | `[Output]`              | `TarStripSELinuxContext=`     |
 | `--hostname=`                     | `[Output]`              | `Hostname=`                   |
 | `--without-unified-kernel-images` | `[Output]`              | `WithUnifiedKernelImages=`    |
 | `--hostonly-initrd`               | `[Output]`              | `HostonlyInitrd=`             |

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -84,6 +84,7 @@ class MkosiConfig(object):
             "password_is_hashed": False,
             "autologin": False,
             "skip_final_phase": False,
+            "tar_strip_selinux_context": False,
             "prepare_script": None,
             "postinst_script": None,
             "qcow2": False,
@@ -219,6 +220,10 @@ class MkosiConfig(object):
                 self.reference_config[job_name]["xz"] = mk_config_output["XZ"]
             if "QCow2" in mk_config_output:
                 self.reference_config[job_name]["qcow2"] = mk_config_output["QCow2"]
+            if "TarStripSELinuxContext" in mk_config_output:
+                self.reference_config[job_name]["tar_strip_selinux_context"] = mk_config_output[
+                    "TarStripSELinuxContext"
+                ]
             if "Hostname" in mk_config_output:
                 self.reference_config[job_name]["hostname"] = mk_config_output["Hostname"]
             if "WithUnifiedKernelImages" in mk_config_output:


### PR DESCRIPTION
This option removes (or not includes) SELinux xattrs into output tar archive.
This is a hack as mkosi does not properly support SELinux contexts. See #130.

The patch adds `--tar-strip-selinux-context` flag and `TarStripSELinuxContext` configuration file option.