### PR TITLE
Add better CTRL+C handling when running a subprocess

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -21,6 +21,7 @@ import platform
 import re
 import shlex
 import shutil
+import signal
 import stat
 import string
 import subprocess
@@ -50,6 +51,7 @@ from typing import (
     cast,
     TYPE_CHECKING,
 )
+from types import FrameType
 
 __version__ = '5'
 
@@ -95,6 +97,31 @@ def print_error(text: str) -> None:
     sys.stderr.write(f"‣ \033[31;1m{text}\033[0m\n")
 
 
+@contextlib.contextmanager
+def delay_interrupt() -> Generator[None, None, None]:
+    # CTRL+C is sent to the entire process group. We delay its handling in mkosi itself so the subprocess can
+    # exit cleanly before doing mkosi's cleanup. If we don't do this, we get device or resource is busy
+    # errors when unmounting stuff later on during cleanup. We only delay a single CTRL+C interrupt so that a
+    # user can always exit mkosi even if a subprocess hangs by pressing CTRL+C twice.
+    interrupted = False
+    def handler(signal: int, frame: FrameType) -> None:
+        nonlocal interrupted
+        if interrupted:
+            raise KeyboardInterrupt()
+        else:
+            interrupted = True
+
+    s = signal.signal(signal.SIGINT, handler)
+
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGINT, s)
+
+        if interrupted:
+            die("Interrupted")
+
+
 def run(cmdline: List[str], execvp: bool = False, **kwargs: Any) -> CompletedProcess:
     if 'run' in arg_debug:
         sys.stderr.write('+ ' + ' '.join(shlex.quote(x) for x in cmdline) + '\n')
@@ -103,7 +130,8 @@ def run(cmdline: List[str], execvp: bool = False, **kwargs: Any) -> CompletedPro
             assert not kwargs
             os.execvp(cmdline[0], cmdline)
         else:
-            return subprocess.run(cmdline, **kwargs)
+            with delay_interrupt():
+                return subprocess.run(cmdline, **kwargs)
     except FileNotFoundError as e:
         die(f"{cmdline[0]} not found in PATH.")
 

--- a/mkosi
+++ b/mkosi
@@ -78,7 +78,7 @@ MKOSI_COMMANDS = ("build", "clean", "help", "summary") + MKOSI_COMMANDS_CMDLINE
 arg_debug = ()
 
 
-class MkosiCommandException(Exception):
+class MkosiException(Exception):
     """Leads to sys.exit"""
 
 
@@ -105,13 +105,12 @@ def run(cmdline: List[str], execvp: bool = False, **kwargs: Any) -> CompletedPro
         else:
             return subprocess.run(cmdline, **kwargs)
     except FileNotFoundError as e:
-        raise MkosiCommandException(f"{cmdline[0]} not found in PATH.") from e
+        die(f"{cmdline[0]} not found in PATH.")
 
 
-def die(message: str, status: int = 1) -> NoReturn:
-    assert status >= 1 and status < 128
+def die(message: str) -> NoReturn:
     print_error(f"Error: {message}")
-    sys.exit(status)
+    raise MkosiException(message)
 
 
 def warn(message: str, *args: Any, **kwargs: Any) -> None:
@@ -1642,7 +1641,7 @@ def install_clear(args: CommandLineArguments, root: str, do_run_build_script: bo
     swupd_extract = shutil.which("swupd-extract")
 
     if swupd_extract is None:
-        print("""
+        die("""
 Couldn't find swupd-extract program, download (or update it) it using:
 
   go get -u github.com/clearlinux/mixer-tools/swupd-extract
@@ -1650,7 +1649,6 @@ Couldn't find swupd-extract program, download (or update it) it using:
 and it will be installed by default in ~/go/bin/swupd-extract. Also
 ensure that you have openssl program in your system.
 """)
-        raise FileNotFoundError("Couldn't find swupd-extract")
 
     print(f'Using {swupd_extract}')
 
@@ -3980,10 +3978,6 @@ def create_parser() -> ArgumentParserMkosi:
     return parser
 
 
-class MkosiParseException(Exception):
-    """Leads to sys.exit"""
-
-
 def parse_args(argv: Optional[List[str]]=None) -> Dict[str, CommandLineArguments]:
     """Load default values from files and parse command line arguments
 
@@ -4050,13 +4044,13 @@ def parse_args(argv: Optional[List[str]]=None) -> Dict[str, CommandLineArguments
         default_path = os.path.join(directory, "mkosi.default")
 
     if args_pre_parsed.all and args_pre_parsed.default_path:
-        raise MkosiParseException("--all and --default= may not be combined.")
+        die("--all and --default= may not be combined.")
 
     # Parse everything in --all mode
     args_all = {}
     if args_pre_parsed.all:
         if not os.path.isdir(all_directory):
-            raise MkosiParseException("all-directory %s does not exist." % all_directory)
+            die("all-directory %s does not exist." % all_directory)
         for f in os.scandir(all_directory):
             if not f.name.startswith("mkosi."):
                 continue
@@ -5039,7 +5033,7 @@ def run_build_script(args: CommandLineArguments, root: str, raw: Optional[Binary
         if result.returncode != 0:
             if 'build-script' in arg_debug:
                 run(cmdline[:-1])
-            raise MkosiCommandException(f"Build script returned non-zero exit code {result.returncode}.")
+            die(f"Build script returned non-zero exit code {result.returncode}.")
 
 
 def need_cache_images(args: CommandLineArguments) -> bool:
@@ -5323,8 +5317,8 @@ def main() -> None:
                     die("Error: %s is not a directory!" % work_dir)
             with complete_step('Processing ' + job_name):
                 run_verb(a)
-    except (MkosiParseException, MkosiCommandException) as exp:
-        die(str(exp))
+    except MkosiException:
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We delay mkosi's cleanup until the subprocess has finished. Because
CTRL+C is sent to the entire process group, we don't have to forward
the signal to the subprocess.

This does break the use case where SIGINT is sent to only mkosi and not the entire mkosi process group. Fixing that would require forwarding the SIGINT signal to the subprocess so we'd have to figure out the pid of the subprocess in the signal handler somehow to send the signal. I'm not entirely sure how we'd do that though, python doesn't seem to have an equivalent to bash's $! which returns the pid of the last command executed.