### PR TITLE
Call pacman-key --refresh-keys in Arch CI

### DIFF
--- a/.github/workflows/ci-arch.yml
+++ b/.github/workflows/ci-arch.yml
@@ -61,6 +61,7 @@ jobs:
         sudo make PREFIX=/usr install
         sudo pacman-key --init
         sudo pacman-key --populate archlinux
+        sudo pacman-key --refresh-keys
         popd
     - name: Download arch-install-scripts
       run: |


### PR DESCRIPTION
This refreshes local keys from the upstream keyserver. This should
mitigate having to update archlinux-keyring all the time somewhat.

It might not work for new keys that aren't in the local keyring installed via archlinux-keyring though. 