### PR TITLE
Revert "Call pacman-key --refresh-keys in Arch CI"

### DIFF
--- a/.github/workflows/ci-arch.yml
+++ b/.github/workflows/ci-arch.yml
@@ -61,7 +61,6 @@ jobs:
         sudo make PREFIX=/usr install
         sudo pacman-key --init
         sudo pacman-key --populate archlinux
-        sudo pacman-key --refresh-keys
         popd
     - name: Download arch-install-scripts
       run: |


### PR DESCRIPTION
This reverts commit 1eff6aa2bc3d4c1df4d05d25876f67547d14248b.

pacman-key --refresh-keys seems to be extremely flaky. It's less hassle to update the keyring package once in a while compared to having to check Arch CI flakes all the time.