### PR TITLE
Feature/prepare script

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -2547,6 +2547,27 @@ Environment=TERM={os.getenv('TERM', 'vt220')}
 """)
 
 
+def run_prepare_script(args: CommandLineArguments, root: str, do_run_build_script: bool, cached: bool) -> None:
+    if args.prepare_script is None:
+        return
+    if cached:
+        return
+
+    verb = "build" if do_run_build_script else "final"
+
+    with complete_step('Running prepare script'):
+
+        # We copy the prepare script into the build tree. We'd prefer
+        # mounting it into the tree, but for that we'd need a good
+        # place to mount it to. But if we create that we might as well
+        # just copy the file anyway.
+
+        shutil.copy2(args.prepare_script, os.path.join(root, "root/prepare"))
+
+        run_workspace_command(args, root, "/root/prepare", verb, network=True)
+        os.unlink(os.path.join(root, "root/prepare"))
+
+
 def run_postinst_script(args: CommandLineArguments, root: str, do_run_build_script: bool, for_cache: bool) -> None:
     if args.postinst_script is None:
         return
@@ -3824,6 +3845,7 @@ def create_parser() -> ArgumentParserMkosi:
                        help='Additional packages needed for build script', metavar='PACKAGE')
     group.add_argument("--skip-final-phase", action=BooleanAction, help='Skip the (second) final image building phase.', default=False)
     group.add_argument("--postinst-script", help='Postinstall script to run inside image', metavar='PATH')
+    group.add_argument("--prepare-script", help='Prepare script to run inside the image before it is cached', metavar='PATH')
     group.add_argument("--finalize-script", help='Postinstall script to run outside image', metavar='PATH')
     group.add_argument("--source-file-transfer", type=SourceFileTransfer, choices=list(SourceFileTransfer), default=None,
                        help="Method used to copy build sources to the build image." +
@@ -4327,6 +4349,7 @@ def load_args(args: CommandLineArguments) -> CommandLineArguments:
     args_find_path(args, 'build_sources',   ".")
     args_find_path(args, 'build_dir',       "mkosi.builddir/")
     args_find_path(args, 'postinst_script', "mkosi.postinst")
+    args_find_path(args, 'prepare_script',  "mkosi.prepare")
     args_find_path(args, 'finalize_script', "mkosi.finalize")
     args_find_path(args, 'output_dir',      "mkosi.output/")
     args_find_path(args, 'mksquashfs_tool', "mkosi.mksquashfs-tool", type_call=lambda x: [x])
@@ -4505,6 +4528,9 @@ def load_args(args: CommandLineArguments) -> CommandLineArguments:
 
     if args.postinst_script is not None:
         args.postinst_script = os.path.abspath(args.postinst_script)
+
+    if args.prepare_script is not None:
+        args.prepare_script = os.path.abspath(args.prepare_script)
 
     if args.finalize_script is not None:
         args.finalize_script = os.path.abspath(args.finalize_script)
@@ -4704,6 +4730,7 @@ def print_summary(args: CommandLineArguments) -> None:
     sys.stderr.write("        Build Packages: " + line_join_list(args.build_packages) + "\n")
     sys.stderr.write("      Skip final phase: " + yes_no(args.skip_final_phase) + "\n")
     sys.stderr.write("    Postinstall Script: " + none_to_none(args.postinst_script) + "\n")
+    sys.stderr.write("        Prepare Script: " + none_to_none(args.prepare_script) + "\n")
     sys.stderr.write("       Finalize Script: " + none_to_none(args.finalize_script) + "\n")
     sys.stderr.write("  Scripts with network: " + yes_no(args.with_network) + "\n")
     sys.stderr.write("       nspawn Settings: " + none_to_none(args.nspawn_settings) + "\n")
@@ -4835,6 +4862,7 @@ def build_image(args: CommandLineArguments,
                     install_distribution(args, root, do_run_build_script=do_run_build_script, cached=cached)
                     install_etc_hostname(args, root)
                     install_boot_loader(args, root, loopdev, do_run_build_script, cached)
+                    run_prepare_script(args, root, do_run_build_script, cached)
                     install_extra_trees(args, root, for_cache)
                     install_build_src(args, root, do_run_build_script, for_cache)
                     install_build_dest(args, root, do_run_build_script, for_cache)

--- a/mkosi.md
+++ b/mkosi.md
@@ -495,6 +495,18 @@ details see the table below.
   the artifacts that were created locally in `$BUILDDIR`, but
   ultimately plan to discard the final image.
 
+`--prepare-script=`
+
+: Takes a path to an executable that is invoked inside the image
+  right after installing the software packages. It is
+  the last step before the image is cached (if incremental mode is 
+  enabled).
+  This script is invoked inside a `systemd-nspawn` container
+  environment, and thus does not have access to host resources.
+  If this option is not used, but an executable script `mkosi.prepare`
+  is found in the local directory, it is automatically used for this
+  purpose (also see below).
+  
 `--postinst-script=`
 
 : Takes a path to an executable that is invoked inside the final image
@@ -883,6 +895,20 @@ local directory:
 
   The `MKOSI_DEFAULT` environment variable will be set inside of this
   script so that you know which `mkosi.default` (if any) was passed in.
+
+* `mkosi.prepare` may be an executable script. If it exists it is
+  invoked directly after the software packages are installed,
+  from within the image context. It is once called for the *development*
+  image (if this is enabled, see above) with the "build" command line
+  parameter, right before copying the extra tree. It is called a second
+  time for the *final* image with the "final" command line parameter.
+  This script has network access and may be used to install packages
+  from other sources than the distro's package manager (e.g. pip, npm, ...),
+  after all software packages are installed but before the image is 
+  cached (if incremental mode is enabled). 
+  Note that this script is executed directly in the image context with
+  the final root directory in place, without any `$SRCDIR`/`$DESTDIR`
+  setup.
 
 * `mkosi.postinst` may be an executable script. If it exists it is
   invoked as the penultimate step of preparing an image, from within

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -83,6 +83,7 @@ class MkosiConfig(object):
             'password': None,
             'password_is_hashed': False,
             'skip_final_phase': False,
+            'prepare_script': None,
             'postinst_script': None,
             'qcow2': False,
             'read_only': False,


### PR DESCRIPTION
Added prepare script hook as proposed in #391.

The prepare script has always network access and is run before the image is cached for incremental mode. Just like the postinst script it is called twice, once with "build" and once with "final" as command line argument.