### PR TITLE
Add --qemu-headless option

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1264,7 +1264,7 @@ def prepare_tree(args: CommandLineArguments, root: str, do_run_build_script: boo
         os.mkdir(os.path.join(root, "etc/kernel"), 0o755)
 
         with open(os.path.join(root, "etc/kernel/cmdline"), "w") as cmdline:
-            cmdline.write(' '.join(args.kernel_command_line))
+            cmdline.write(' '.join(args.kernel_command_line + ["console=ttyS0"] if args.qemu_headless else []))
             cmdline.write("\n")
 
     if do_run_build_script:
@@ -2490,6 +2490,20 @@ def set_root_password(args: CommandLineArguments, root: str, do_run_build_script
                     return ':'.join(['root', password] + line.split(':')[2:])
                 return line
             patch_file(os.path.join(root, 'etc/shadow'), jj)
+
+
+def set_serial_terminal(args: CommandLineArguments, root: str, do_run_build_script: bool, for_cache: bool) -> None:
+    """Override TERM for the serial console with the terminal type from the host."""
+
+    if do_run_build_script or for_cache or not args.qemu_headless:
+        return
+
+    override_dir = mkdir_last(os.path.join(root, "etc/systemd/system/serial-getty@ttyS0.service.d"))
+    with open(os.path.join(override_dir, "override.conf"), 'w') as f:
+        f.write(f"""
+[Service]
+Environment=TERM={os.getenv('TERM', 'vt220')}
+""")
 
 
 def run_postinst_script(args: CommandLineArguments, root: str, do_run_build_script: bool, for_cache: bool) -> None:
@@ -3796,6 +3810,7 @@ def create_parser() -> ArgumentParserMkosi:
     group.add_argument("--extra-search-path", dest='extra_search_paths', action=ColonDelimitedListAction, default=[],
                        help="List of colon-separated paths to look for programs before looking in PATH")
     group.add_argument("--extra-search-paths", dest='extra_search_paths', action=ColonDelimitedListAction, help=argparse.SUPPRESS) # Compatibility option
+    group.add_argument("--qemu-headless", action=BooleanAction, help="Configure image for qemu's -nographic mode")
 
     group = parser.add_argument_group("Additional Configuration")
     group.add_argument('-C', "--directory", help='Change to specified directory before doing anything', metavar='PATH')
@@ -4774,6 +4789,7 @@ def build_image(args: CommandLineArguments,
                     install_build_src(args, root, do_run_build_script, for_cache)
                     install_build_dest(args, root, do_run_build_script, for_cache)
                     set_root_password(args, root, do_run_build_script, for_cache)
+                    set_serial_terminal(args, root, do_run_build_script, for_cache)
                     run_postinst_script(args, root, do_run_build_script, for_cache)
 
                 if cleanup:
@@ -5069,8 +5085,12 @@ def run_qemu(args: CommandLineArguments) -> None:
                 "-m", "1024",
                 "-drive", "if=pflash,format=raw,readonly,file=" + firmware,
                 "-drive", "format=" + ("qcow2" if args.qcow2 else "raw") + ",file=" + args.output,
-                "-object", "rng-random,filename=/dev/urandom,id=rng0", "-device", "virtio-rng-pci,rng=rng0,id=rng-device0",
-                *args.cmdline]
+                "-object", "rng-random,filename=/dev/urandom,id=rng0", "-device", "virtio-rng-pci,rng=rng0,id=rng-device0"]
+
+    if args.qemu_headless:
+        cmdline.append("-nographic")
+
+    cmdline += args.cmdline
 
     print_running_cmd(cmdline)
 

--- a/mkosi.md
+++ b/mkosi.md
@@ -655,6 +655,22 @@ details see the table below.
 `--help`, `-h`
 : Show brief usage information.
 
+`--qemu-headless=`
+
+: When used with the build verb, this option adds `console=ttyS0` to
+  the image's kernel command line and sets the terminal type of the
+  serial console in the image to the terminal type of the host (more
+  specifically, the value of the TERM environment variable passed to
+  mkosi). This makes sure that all terminal features such as colors
+  and shortcuts still work as expected when connecting to the qemu
+  VM over the serial console (for example via `-nographic`).
+
+  When used with the qemu verb, this option adds the `-nographic`
+  option to qemu's command line so qemu starts a headless vm and
+  connects to its serial console from the current terminal instead
+  of launching the VM in a separate window.
+
+
 ## Command Line Parameters and their Settings File Counterparts
 
 Most command line parameters may also be placed in an `mkosi.default`
@@ -715,6 +731,7 @@ which settings file options.
 | `--password=`                | `[Validation]`          | `Password=`               |
 | `--password-is-hashed`       | `[Validation]`          | `PasswordIsHashed=`       |
 | `--extra-search-paths=`      | `[Host]`                | `ExtraSearchPaths=`       |
+| `--qemu-headless`            | `[Host]`                | `QemuHeadless=`           |
 
 Command line options that take no argument are not suffixed with a `=`
 in their long version in the table above. In the `mkosi.default` file

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -106,6 +106,7 @@ class MkosiConfig(object):
             'with_tests': True,
             'xbootldr_size': None,
             'xz': False,
+            'qemu_headless': False,
         }
 
     def __eq__(self, other: [mkosi.CommandLineArguments]) -> bool:


### PR DESCRIPTION
This option streamlines launching headless qemu virtual machines from
the command line via mkosi's qemu verb. When this option is specified,
mkosi configures the image for headless connections and adds the
-nographic option when launching the vm via mkosi's qemu verb. Instead
of launching a separate window, qemu connects the host's terminal to the
vm via the serial console. This allows working with the vm from the
comfort of your own terminal instead of the linux console which is used
when qemu starts the vm in a separate window.

We make sure all terminal features still work by overriding the TERM
value for serial-getty@ttyS0 in the vm with the TERM value from the
host's terminal emulator which we get from the TERM environment variable
that mkosi is started with.