### PR TITLE
Exchange --password-is-hashed for --password-hashed=

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -2503,25 +2503,29 @@ def set_root_password(args: CommandLineArguments, root: str, do_run_build_script
     if for_cache:
         return
 
-    if args.password == '':
-        with complete_step("Deleting root password"):
-            def jj(line: str) -> str:
-                if line.startswith('root:'):
-                    return ':'.join(['root', ''] + line.split(':')[2:])
-                return line
-            patch_file(os.path.join(root, 'etc/passwd'), jj)
+    if args.password_hashed == "" or args.password == "":
+        msg = "Deleting root password"
+        password = ""
+        target = "etc/passwd"
+    elif args.password_hashed:
+        msg = "Setting hashed root password"
+        password = args.password_hashed
+        target = "etc/shadow"
     elif args.password:
-        with complete_step("Setting root password"):
-            if args.password_is_hashed:
-                password = args.password
-            else:
-                password = crypt.crypt(args.password, crypt.mksalt(crypt.METHOD_SHA512))
+        msg = "Setting root password"
+        password = crypt.crypt(args.password, crypt.mksalt(crypt.METHOD_SHA512))
+        target = "etc/shadow"
+    else:
+        return
 
-            def jj(line: str) -> str:
-                if line.startswith('root:'):
-                    return ':'.join(['root', password] + line.split(':')[2:])
-                return line
-            patch_file(os.path.join(root, 'etc/shadow'), jj)
+    def jj(line: str) -> str:
+        nonlocal password
+        if line.startswith('root:'):
+            return ':'.join(['root', password] + line.split(':')[2:])
+        return line
+
+    with complete_step(msg):
+        patch_file(os.path.join(root, target), jj)
 
 
 def run_postinst_script(args: CommandLineArguments, root: str, do_run_build_script: bool, for_cache: bool) -> None:
@@ -3830,8 +3834,7 @@ def create_parser() -> ArgumentParserMkosi:
     group.add_argument("--bmap", action=BooleanAction,
                        help='Write block map file (.bmap) for bmaptool usage (only gpt_ext4, gpt_btrfs)')
     group.add_argument("--password", help='Set the root password')
-    group.add_argument("--password-is-hashed", action=BooleanAction,
-                       help='Indicate that the root password has already been hashed')
+    group.add_argument("--password-hashed", help='Set the root password (prehashed)')
 
     group = parser.add_argument_group("Host configuration")
     group.add_argument("--extra-search-path", dest='extra_search_paths', action=ColonDelimitedListAction, default=[],
@@ -4239,7 +4242,20 @@ def find_passphrase(args: CommandLineArguments) -> None:
 
 
 def find_password(args: CommandLineArguments) -> None:
-    if args.password is not None:
+    if args.password_hashed is not None or args.password is not None:
+        return
+
+    try:
+        require_private_file('mkosi.rootpw_hashed', 'root password (prehashed)')
+
+        with open('mkosi.rootpw_hashed') as f:
+            args.password_hashed = f.read().strip()
+
+    except FileNotFoundError:
+        pass
+    else:
+        # Let's not handle a cleartext root password if we have already found a
+        # hashed one
         return
 
     try:

--- a/mkosi.md
+++ b/mkosi.md
@@ -598,17 +598,19 @@ details see the table below.
 : Generate a `bmap` file for usage with `bmaptool` from the generated
   image file.
 
+`--password-hashed=`
+
+: Set the password hash of the `root` user, that will be written to
+  `/etc/shadow` literally. By default the `root` account is locked. If
+  neither this option nor `--password=` is used but a file
+  `mkosi.rootpw_hashed` exists in the local directory the root
+  password hash is automatically read from it.
+
 `--password=`
 
 : Set the password of the `root` user. By default the `root` account
   is locked. If this option is not used but a file `mkosi.rootpw` exists
   in the local directory the root password is automatically read from it.
-
-`--password-is-hashed`
-
-: Indicate that the password supplied for the `root` user has already been
-  hashed, so that the string supplied with `--password` or `mkosi.rootpw` will
-  be written to `/etc/shadow` literally.
 
 `--extra-search-paths=`
 
@@ -712,8 +714,8 @@ which settings file options.
 | `--sign`                     | `[Validation]`          | `Sign=`                   |
 | `--key=`                     | `[Validation]`          | `Key=`                    |
 | `--bmap`                     | `[Validation]`          | `BMap=`                   |
+| `--password-hashed=`         | `[Validation]`          | `PasswordHashed=`         |
 | `--password=`                | `[Validation]`          | `Password=`               |
-| `--password-is-hashed`       | `[Validation]`          | `PasswordIsHashed=`       |
 | `--extra-search-paths=`      | `[Host]`                | `ExtraSearchPaths=`       |
 
 Command line options that take no argument are not suffixed with a `=`
@@ -922,13 +924,19 @@ local directory:
   set, and it is up to build script to decide whether to do in in-tree
   or an out-of-tree build, and which build directory to use.
 
-* `mkosi.rootpw` may be a file containing the password or hashed
-  password (if `--password-is-hashed` is set) for the root user of the
-  image to set. The password may optionally be followed by a newline
-  character which is implicitly removed. The file must have an access
-  mode of 0600 or less. If this file does not exist the distribution's
-  default root password is set (which usually means access to the root
-  user is blocked).
+* `mkosi.rootpw_hashed` may be a file containing the hashed password
+  for the root user of the image to set. The hashed password may
+  optionally be followed by a newline character which is implicitly
+  removed. The string will be written to `/etc/shadow` literally. The
+  file must have an access mode of 0600 or less. If this file does not
+  exist the file `mkosi.rootpw` will be tried.
+
+* `mkosi.rootpw` may be a file containing the password for the root
+  user of the image to set. The password may optionally be followed by
+  a newline character which is implicitly removed. The file must have
+  an access mode of 0600 or less. If this file does not exist the
+  distribution's default root password is set (which usually means
+  access to the root user is blocked).
 
 * `mkosi.passphrase` may be a passphrase file to use when LUKS
   encryption is selected. It should contain the passphrase literally,

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -80,8 +80,8 @@ class MkosiConfig(object):
             'output_dir': None,
             'output_format': None,
             'packages': [],
+            'password_hashed': None,
             'password': None,
-            'password_is_hashed': False,
             'skip_final_phase': False,
             'postinst_script': None,
             'qcow2': False,
@@ -270,10 +270,10 @@ class MkosiConfig(object):
                 self.reference_config[job_name]['key'] = mk_config_validation['Key']
             if 'BMap' in mk_config_validation:
                 self.reference_config[job_name]['bmap'] = mk_config_validation['BMap']
+            if 'PasswordHashed' in mk_config_validation:
+                self.reference_config[job_name]['password_hashed'] = mk_config_validation['PasswordHashed']
             if 'Password' in mk_config_validation:
                 self.reference_config[job_name]['password'] = mk_config_validation['Password']
-            if 'PasswordIsHashed' in mk_config_validation:
-                self.reference_config[job_name]['password_is_hashed'] = mk_config_validation['PasswordIsHashed']
 
         if 'Host' in mk_config:
             mk_config_host = mk_config['Host']


### PR DESCRIPTION
This is more of an RFC than an outright PR. 

This change brings mkosi in line with the similar systemd-firstboot option introduced by @DaanDeMeyer in systemd/systemd#15893. The change is a bigger than `--root-password-is-hashed` was, but I think there is value in having systemd-firstboot's behaviour mirrored. 

Also, the change to `set_root_password` introduces the `nonlocal` keyword, which might be regarded as a code smell. This could also be done with `functools.partial`, but I wanted a to hear a comment first, whether this change would be regarded positively, since it does break backward compatibility (although `--root-password-is-hashed` has never been in a tagged release).