### PR TITLE
Increase default root size to 3G

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -4529,11 +4529,8 @@ def load_args(args: CommandLineArguments) -> CommandLineArguments:
     args.xbootldr_size = parse_bytes(args.xbootldr_size)
     args.swap_size = parse_bytes(args.swap_size)
 
-    if args.output_format in (OutputFormat.gpt_ext4, OutputFormat.gpt_btrfs) and args.root_size is None:
-        args.root_size = 1024*1024*1024
-
-    if args.output_format == OutputFormat.gpt_xfs and args.root_size is None:
-        args.root_size = 1300*1024*1024
+    if args.root_size is None:
+        args.root_size = 3*1024*1024*1024
 
     if args.bootable and args.esp_size is None:
         args.esp_size = 256*1024*1024


### PR DESCRIPTION
1G isn't sufficient for a default ubuntu focal bootable image. Let's
up the size for a better new user experience.

We also remove the special casing for XFS since it should comfortably
fit under the 3G as well.