### PR TITLE
Fix default source file transfer

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -2916,13 +2916,11 @@ def install_build_src(args: CommandLineArguments, root: str, do_run_build_script
         if args.build_sources is not None:
             target = os.path.join(root, "root/src")
 
-            source_file_transfer = args.source_file_transfer
-            if source_file_transfer is None and (os.path.exists('.git') or os.path.exists(os.path.join(args.build_sources, '.git'))):
-                source_file_transfer = SourceFileTransfer.copy_git_cached
-
-            if source_file_transfer in (SourceFileTransfer.copy_git_others, SourceFileTransfer.copy_git_cached, SourceFileTransfer.copy_git_more):
-                copy_git_files(args.build_sources, target, source_file_transfer=source_file_transfer)
-            elif source_file_transfer == SourceFileTransfer.copy_all:
+            if args.source_file_transfer in (SourceFileTransfer.copy_git_others,
+                                             SourceFileTransfer.copy_git_cached,
+                                             SourceFileTransfer.copy_git_more):
+                copy_git_files(args.build_sources, target, source_file_transfer=args.source_file_transfer)
+            elif args.source_file_transfer == SourceFileTransfer.copy_all:
                 ignore = shutil.ignore_patterns('.git',
                                                 '.mkosi-*',
                                                 '*.cache-pre-dev',
@@ -4678,6 +4676,12 @@ def load_args(args: CommandLineArguments) -> CommandLineArguments:
 
     if args.verity and not args.with_unified_kernel_images:
         die("Sorry, --verity can only be used with unified kernel images")
+
+    if args.source_file_transfer is None:
+        if os.path.exists('.git') or os.path.exists(os.path.join(args.build_sources, '.git')):
+            args.source_file_transfer = SourceFileTransfer.copy_git_cached
+        else:
+            args.source_file_transfer = SourceFileTransfer.copy_all
 
     return args
 


### PR DESCRIPTION
According to the man page, `--source-file-transfer` "defaults to copy-git-cached if a git source tree is detected, otherwise copy-all". However the existing code only sets it to copy-git-cached if a .git folder exists and leaves it at None otherwise, meaning a non-Git source is never transferred.