### PR TITLE
CI: Run apt-get update before installing dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Update
+      run: sudo apt-get update
+
     - name: Install dependencies
       run: sudo apt-get --assume-yes --no-install-recommends install
             asciidoc


### PR DESCRIPTION
Let's see if this solves the CI issues.