### PR TITLE
Require --merged-usr support in debootstrap.

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -1984,16 +1984,16 @@ def install_debian_or_ubuntu(args: CommandLineArguments,
                "--variant=minbase",
                "--include=systemd-sysv",
                "--exclude=sysv-rc,initscripts,startpar,lsb-base,insserv",
+               "--merged-usr",
                "--components=" + ','.join(repos)]
 
     if args.architecture is not None:
         debarch = DEBIAN_ARCHITECTURES.get(args.architecture)
         cmdline += [f"--arch={debarch}"]
 
-    # Let's use --merged-usr and --no-check-valid-until only if debootstrap knows it
-    for arg in ["--merged-usr", "--no-check-valid-until"]:
-        if debootstrap_knows_arg(arg):
-            cmdline += [arg]
+    # Let's use --no-check-valid-until only if debootstrap knows it
+    if debootstrap_knows_arg("--no-check-valid-until"):
+        cmdline.append("--no-check-valid-until")
 
     cmdline += [args.release, root, mirror]
 
@@ -2020,7 +2020,7 @@ def install_debian_or_ubuntu(args: CommandLineArguments,
         f.write("hostonly=no")
 
     if not do_run_build_script and args.bootable:
-        extra_packages += ["dracut", "usrmerge"]
+        extra_packages += ["dracut"]
         if args.distribution == Distribution.ubuntu:
             extra_packages += ["linux-generic"]
         else:


### PR DESCRIPTION
Let's assume debootstrap is recent enough to support --merged-usr. The
option was added in 2016 so it should be widely available now.