### PR TITLE
Use Ubuntu Focal in all Github Actions workflows

### DIFF
--- a/.github/workflows/ci-mypy.yml
+++ b/.github/workflows/ci-mypy.yml
@@ -10,12 +10,9 @@ on:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
-      with:
-        python-version: '3.x'
     - name: install mypy via pip
       run: python3 -m pip install 'mypy==0.770'
     - name: run mypy on mkosi with settings from setup.cfg

--- a/.github/workflows/ci-unit-test.yml
+++ b/.github/workflows/ci-unit-test.yml
@@ -10,12 +10,9 @@ on:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
-      with:
-        python-version: '3.x'
     - name: install unit tester via pip
       run: python3 -m pip install pytest
     - name: run unit test


### PR DESCRIPTION
We also stop installing Python via setup-python as the version in
Focal should be more than recent enough.