### PR TITLE
Remove mkosi.default from repo and add it to .gitignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,4 +229,3 @@ jobs:
             --debug run
             --distribution ${{ matrix.distro }}
             --format ${{ matrix.format }}
-            --default /dev/null

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@
 /mkosi.extra
 /mkosi.nspawn
 /mkosi.rootpw
+/mkosi.default
 __pycache__

--- a/mkosi.default
+++ b/mkosi.default
@@ -1,1 +1,0 @@
-mkosi.files/mkosi.fedora


### PR DESCRIPTION
Causes more issues that it solves. Currently, one always has to be
careful to specify --default /dev/null when running in the mkosi project
directory to avoid options from the mkosi.default file taking effect.
The mkosi.default file also only works on distros with dnf. Removing it
and putting it into the .gitignore also makes it easier for developers
to put their own symlink to their distro of choice in place.

A similar change was done in systemd recently (https://github.com/systemd/systemd/pull/16497)