### PR TITLE
ci: add openSUSE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           - fedora
           - openmandriva
           - mageia
+          - opensuse
         format:
           - directory
           - tar
@@ -225,6 +226,10 @@ jobs:
       run: |
         go get -u github.com/clearlinux/mixer-tools/swupd-extract
         sudo ln -s ~/go/bin/swupd-extract /usr/bin/swupd-extract
+
+    - name: Install zypper (OpenSuse)
+      if: matrix.distro == 'opensuse'
+      run: sudo apt-get --assume-yes --no-install-recommends install zypper
 
     - name: Build ${{ matrix.distro }}/${{ matrix.format }}
       run: sudo ./mkosi


### PR DESCRIPTION
I noticed that Debian has packaged zypper and that openSUSE is missing from the CI.