### PR TITLE
Unified kernel images improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,14 +104,9 @@ jobs:
         sudo pacman-key --init
         sudo pacman-key --populate archlinux
 
-        wget https://git.archlinux.org/arch-install-scripts.git/snapshot/arch-install-scripts-$ARCH_INSTALL_SCRIPTS_VERSION.tar.gz
-        tar xf arch-install-scripts-$ARCH_INSTALL_SCRIPTS_VERSION.tar.gz
-
-        sudo make -C arch-install-scripts-$ARCH_INSTALL_SCRIPTS_VERSION PREFIX=/usr install
       env:
         PACMAN_VERSION: "5.2.2"
         ARCHLINUX_KEYRING_VERSION: "20200622"
-        ARCH_INSTALL_SCRIPTS_VERSION: "23"
 
     - name: Build dnf
       if: startsWith(matrix.distro, 'centos') ||

--- a/mkosi
+++ b/mkosi
@@ -2322,7 +2322,8 @@ def install_arch(args: CommandLineArguments, root: str, do_run_build_script: boo
         if args.bios_partno:
             packages.add("grub")
 
-        packages.add("mkinitcpio")
+        packages.add("dracut")
+        packages.add("binutils")
 
     def run_pacstrap(packages: Set[str]) -> None:
         cmdline = ["pacstrap", "-C", pacman_conf, "-GM", root]
@@ -2331,37 +2332,6 @@ def install_arch(args: CommandLineArguments, root: str, do_run_build_script: boo
 
     # Set up system with packages from the base group
     run_pacstrap(packages)
-
-    if not do_run_build_script and args.bootable:
-        # Patch mkinitcpio configuration so:
-        # 1) we remove autodetect and
-        # 2) we add the modules needed for encrypt.
-        def jj(line: str) -> str:
-            if line.startswith("HOOKS="):
-                if args.encrypt == "all":
-                    return 'HOOKS="systemd modconf block sd-encrypt filesystems keyboard fsck"\n'
-                else:
-                    return 'HOOKS="systemd modconf block filesystems fsck"\n'
-            return line
-        patch_file(os.path.join(root, "etc/mkinitcpio.conf"), jj)
-
-        # Disable fallback images to save time. We override the preset files
-        # before installing any kernels to have the updated config available
-        # when the mkinitcpio pacman hook is run during installation.
-        presetdir = os.path.join(root, "etc/mkinitcpio.d")
-        for kernel in kernel_packages:
-            preset = os.path.join(presetdir, f"{kernel}.preset")
-            with open(preset, "w") as f:
-                f.write(
-                    dedent(
-                        f"""
-                        ALL_config="/etc/mkinitcpio.conf"
-                        ALL_kver="/boot/vmlinuz-{kernel}"
-                        PRESETS=('default')
-                        default_image="/boot/initramfs-{kernel}.img"
-                        """
-                    )
-                )
 
     # Install the user-specified packages and kernel
     packages = set(args.packages)
@@ -2372,16 +2342,14 @@ def install_arch(args: CommandLineArguments, root: str, do_run_build_script: boo
         packages.update(args.build_packages)
 
     if not do_run_build_script and args.bootable:
-        # Replace mkinitcpio and depmod hooks by kernel-install hooks which additionally creates systemd-boot
-        # loader entries.
         hooks_dir = os.path.join(root, "etc/pacman.d/hooks")
         scripts_dir = os.path.join(root, "etc/pacman.d/scripts")
 
         os.makedirs(hooks_dir, 0o755, exist_ok=True)
         os.makedirs(scripts_dir, 0o755, exist_ok=True)
 
-        for hook in ["60-depmod.hook", "90-mkinitcpio-install.hook"]:
-            os.symlink("/dev/null", os.path.join(hooks_dir, hook))
+        # Disable depmod pacman hook as depmod is handled by kernel-install as well.
+        os.symlink("/dev/null", os.path.join(hooks_dir, "60-depmod.hook"))
 
         kernel_add_hook = os.path.join(hooks_dir, "90-mkosi-kernel-add.hook")
         with open(kernel_add_hook, 'w') as f:

--- a/mkosi
+++ b/mkosi
@@ -2384,10 +2384,6 @@ def install_arch(args: CommandLineArguments, root: str, do_run_build_script: boo
         finally:
             stop_gpg_agent()
 
-    # Remove already installed packages
-    c = run_pacman(['-Qq'], stdout=PIPE, universal_newlines=True)
-    packages.difference_update(c.stdout.split())
-
     if packages:
         # Disable mkinitcpio hook because we manually install the kernel image
         # to /boot using kernel-install in install_boot_loader_arch.

--- a/mkosi
+++ b/mkosi
@@ -2375,7 +2375,6 @@ def install_arch(args: CommandLineArguments, root: str, do_run_build_script: boo
         cmdline = [
             "pacman",
             "--noconfirm",
-            "--color", "never",
             "--config", pacman_conf,
         ]
 

--- a/mkosi
+++ b/mkosi
@@ -1525,7 +1525,7 @@ def disable_kernel_install(args: CommandLineArguments, root: str) -> None:
     # off any kernel installation beforehand.
     #
     # For BIOS mode, we don't have that option, so do not mask the units.
-    if not args.bootable or args.bios_partno is not None:
+    if not args.bootable or args.bios_partno is not None or not args.with_unified_kernel_images:
         return
 
     for d in ("etc", "etc/kernel", "etc/kernel/install.d"):
@@ -1537,7 +1537,7 @@ def disable_kernel_install(args: CommandLineArguments, root: str) -> None:
 
 
 def reenable_kernel_install(args: CommandLineArguments, root: str) -> None:
-    if not args.bootable or args.bios_partno is not None:
+    if not args.bootable or args.bios_partno is not None or not args.with_unified_kernel_images:
         return
 
     hook_path = os.path.join(root, "etc/kernel/install.d/50-mkosi-dracut-unified-kernel.install")
@@ -3298,7 +3298,7 @@ def install_unified_kernel(args: CommandLineArguments,
     # benefit that they can be signed like normal EFI binaries, and can encode everything necessary to boot a
     # specific root device, including the root hash.
 
-    if not args.bootable or args.esp_partno is None:
+    if not args.bootable or args.esp_partno is None or not args.with_unified_kernel_images:
         return
     if for_cache:
         return
@@ -3892,6 +3892,9 @@ def create_parser() -> ArgumentParserMkosi:
                        help='Make use of and generate intermediary cache images')
     group.add_argument('-M', "--minimize", action=BooleanAction,
                        help='Minimize root file system size')
+    group.add_argument("--without-unified-kernel-images", action=BooleanAction,
+                       dest='with_unified_kernel_images', default=True,
+                       help="Do not install unified kernel images")
 
     group = parser.add_argument_group("Packages")
     group.add_argument('-p', "--package", action=CommaDelimitedListAction, dest='packages', default=[],
@@ -4688,6 +4691,13 @@ def load_args(args: CommandLineArguments) -> CommandLineArguments:
     if args.generated_root() and "bios" in args.boot_protocols:
         die("Sorry, BIOS cannot be combined with --minimize or squashfs filesystems")
 
+    if args.with_unified_kernel_images and args.distribution == Distribution.clear:
+        warn("Using --without-unified-kernel-images as Clear Linux does not support unified kernel images.")
+        args.with_unified_kernel_images = False
+
+    if args.verity and not args.with_unified_kernel_images:
+        die("Sorry, --verity can only be used with unified kernel images")
+
     return args
 
 
@@ -4801,6 +4811,7 @@ def print_summary(args: CommandLineArguments) -> None:
                 sys.stderr.write(" UEFI SecureBoot Cert.: " + args.secure_boot_certificate + "\n")
 
             sys.stderr.write("        Boot Protocols: " + line_join_list(args.boot_protocols) + "\n")
+            sys.stderr.write(" Unified Kernel Images: " + yes_no(args.with_unified_kernel_images))
 
     sys.stderr.write("\nPACKAGES:\n")
     sys.stderr.write("              Packages: " + line_join_list(args.packages) + "\n")

--- a/mkosi
+++ b/mkosi
@@ -207,8 +207,8 @@ def die(message: str) -> NoReturn:
     raise MkosiException(message)
 
 
-def warn(message: str, *args: Any, **kwargs: Any) -> None:
-    sys.stderr.write('WARNING: ' + message.format(*args, **kwargs) + '\n')
+def warn(message: str) -> None:
+    sys.stderr.write(f"‣ \033[33;1mWarning: {message}\033[0m\n")
 
 
 def tmp_dir() -> str:
@@ -4326,9 +4326,14 @@ def find_cache(args: CommandLineArguments) -> None:
 def require_private_file(name: str, description: str) -> None:
     mode = os.stat(name).st_mode & 0o777
     if mode & 0o007:
-        warn("Permissions of '{}' of '{}' are too open.\n" +
-             "When creating {} files use an access mode that restricts access to the owner only.",
-             name, oct(mode), description)
+        warn(
+            dedent(
+                f"""
+                Permissions of '{name}' of '{mode:04o}' are too open.
+                When creating {description} files use an access mode that restricts access to the owner only.\
+                """
+            )
+        )
 
 
 def find_passphrase(args: CommandLineArguments) -> None:

--- a/mkosi
+++ b/mkosi
@@ -2646,7 +2646,9 @@ def set_serial_terminal(args: CommandLineArguments, root: str, do_run_build_scri
     if do_run_build_script or for_cache or not args.qemu_headless:
         return
 
-    override_dir = mkdir_last(os.path.join(root, "etc/systemd/system/serial-getty@ttyS0.service.d"))
+    override_dir = os.path.join(root, "etc/systemd/system/serial-getty@ttyS0.service.d")
+    os.makedirs(override_dir, mode=0o755, exist_ok=True)
+
     with open(os.path.join(override_dir, "override.conf"), 'w') as f:
         f.write(
             dedent(

--- a/mkosi
+++ b/mkosi
@@ -2270,77 +2270,6 @@ def install_arch(args: CommandLineArguments, root: str, do_run_build_script: boo
                     )
                 )
 
-    def stop_gpg_agent() -> None:
-        # Kill the gpg-agent used by pacman and pacman-key
-        run(['gpgconf', '--homedir', os.path.join(root, 'etc/pacman.d/gnupg'), '--kill', 'all'])
-
-    def run_pacman_key(args: List[str]) -> CompletedProcess:
-        cmdline = [
-            "pacman-key",
-            "--nocolor",
-            "--config", pacman_conf,
-        ]
-
-        try:
-            return run(cmdline + args, check=True)
-        finally:
-            stop_gpg_agent()
-
-    keyring = "archlinux"
-    if platform.machine() == "aarch64":
-        keyring += "arm"
-    run_pacman_key(["--init"])
-    run_pacman_key(["--populate", keyring])
-
-    # the base metapackage is mandatory
-    packages = {"base"}
-
-    official_kernel_packages = {
-        "linux",
-        "linux-lts",
-        "linux-hardened",
-        "linux-zen",
-    }
-
-    kernel_packages = official_kernel_packages.intersection(args.packages)
-    if len(kernel_packages) > 1:
-        warn('More than one kernel will be installed: {}', ' '.join(kernel_packages))
-
-    if not do_run_build_script and args.bootable:
-        if args.output_format == OutputFormat.gpt_ext4:
-            packages.add("e2fsprogs")
-        elif args.output_format == OutputFormat.gpt_btrfs:
-            packages.add("btrfs-progs")
-        elif args.output_format == OutputFormat.gpt_xfs:
-            packages.add("xfsprogs")
-        if args.encrypt:
-            packages.add("cryptsetup")
-            packages.add("device-mapper")
-        if not kernel_packages:
-            # No user-specified kernel
-            kernel_packages.add("linux")
-        if args.bios_partno:
-            packages.add("grub")
-
-        packages.add("dracut")
-        packages.add("binutils")
-
-    def run_pacstrap(packages: Set[str]) -> None:
-        cmdline = ["pacstrap", "-C", pacman_conf, "-GM", root]
-        # pacstrap handles gpg-agent on its own
-        run(cmdline + list(packages), check=True)
-
-    # Set up system with packages from the base group
-    run_pacstrap(packages)
-
-    # Install the user-specified packages and kernel
-    packages = set(args.packages)
-    if not do_run_build_script and args.bootable:
-        packages |= kernel_packages
-
-    if do_run_build_script:
-        packages.update(args.build_packages)
-
     if not do_run_build_script and args.bootable:
         hooks_dir = os.path.join(root, "etc/pacman.d/hooks")
         scripts_dir = os.path.join(root, "etc/pacman.d/scripts")
@@ -2454,19 +2383,62 @@ def install_arch(args: CommandLineArguments, root: str, do_run_build_script: boo
 
         make_executable(kernel_remove_script)
 
-    def run_pacman(packages: List[str]) -> CompletedProcess:
-        if len(packages) == 0:
-            return
-
-        cmdline = ["pacman", "--noconfirm", "--config", pacman_conf, "-S", *packages]
+    def run_pacman_key(args: List[str]) -> CompletedProcess:
+        cmdline = ["pacman-key", "--nocolor", "--config", pacman_conf]
 
         try:
-            return run(cmdline, check=True)
+            return run(cmdline + args, check=True)
         finally:
-            stop_gpg_agent()
+            # Kill the gpg-agent started by pacman-key
+            run(['gpgconf', '--homedir', os.path.join(root, 'etc/pacman.d/gnupg'), '--kill', 'all'])
 
-    with mount_api_vfs(args, root):
-        run_pacman(packages)
+    keyring = "archlinux"
+    if platform.machine() == "aarch64":
+        keyring += "arm"
+    run_pacman_key(["--init"])
+    run_pacman_key(["--populate", keyring])
+
+    packages = {"base"}
+
+    if not do_run_build_script and args.bootable:
+        if args.output_format == OutputFormat.gpt_ext4:
+            packages.add("e2fsprogs")
+        elif args.output_format == OutputFormat.gpt_btrfs:
+            packages.add("btrfs-progs")
+        elif args.output_format == OutputFormat.gpt_xfs:
+            packages.add("xfsprogs")
+        if args.encrypt:
+            packages.add("cryptsetup")
+            packages.add("device-mapper")
+        if args.bios_partno:
+            packages.add("grub")
+
+        packages.add("dracut")
+        packages.add("binutils")
+
+    packages.update(args.packages)
+
+    official_kernel_packages = {
+        "linux",
+        "linux-lts",
+        "linux-hardened",
+        "linux-zen",
+    }
+
+    has_kernel_package = official_kernel_packages.intersection(args.packages)
+    if not do_run_build_script and args.bootable and not has_kernel_package:
+        # No user-specified kernel
+        packages.add("linux")
+
+    if do_run_build_script:
+        packages.update(args.build_packages)
+
+    def run_pacstrap(packages: Set[str]) -> None:
+        cmdline = ["pacstrap", "-C", pacman_conf, "-GM", root]
+        # pacstrap handles gpg-agent on its own
+        run(cmdline + list(packages), check=True)
+
+    run_pacstrap(packages)
 
     if "networkmanager" in args.packages:
         enable_networkmanager(root)

--- a/mkosi
+++ b/mkosi
@@ -2379,6 +2379,25 @@ def install_arch(args: CommandLineArguments, root: str, do_run_build_script: boo
 
         make_executable(kernel_remove_script)
 
+        if args.esp_partno is not None:
+            bootctl_update_hook = os.path.join(hooks_dir, "91-mkosi-bootctl-update-hook")
+            with open(bootctl_update_hook, 'w') as f:
+                f.write(
+                    dedent(
+                        """\
+                        [Trigger]
+                        Operation = Upgrade
+                        Type = Package
+                        Target = systemd
+
+                        [Action]
+                        Description = Updating systemd-boot...
+                        When = PostTransaction
+                        Exec = /usr/bin/bootctl update
+                        """
+                    )
+                )
+
     keyring = "archlinux"
     if platform.machine() == "aarch64":
         keyring += "arm"

--- a/mkosi
+++ b/mkosi
@@ -78,6 +78,73 @@ MKOSI_COMMANDS_NEED_BUILD = MKOSI_COMMANDS_CMDLINE
 MKOSI_COMMANDS_SUDO = ("build", "clean") + MKOSI_COMMANDS_CMDLINE
 MKOSI_COMMANDS = ("build", "clean", "help", "summary") + MKOSI_COMMANDS_CMDLINE
 
+DRACUT_SYSTEMD_EXTRAS = [
+    "/usr/lib/systemd/systemd-veritysetup",
+    "/usr/lib/systemd/system-generators/systemd-veritysetup-generator",
+    "/usr/bin/systemd-repart",
+    "/usr/lib/systemd/system/systemd-repart.service",
+    "/usr/lib/systemd/system/initrd-root-fs.target.wants/systemd-repart.service",
+]
+
+DRACUT_UNIFIED_KERNEL_INSTALL = """\
+#!/bin/bash -e
+
+COMMAND="$1"
+KERNEL_VERSION="$2"
+BOOT_DIR_ABS="$3"
+KERNEL_IMAGE="$4"
+ROOTHASH="${5:-}"
+
+# If KERNEL_INSTALL_MACHINE_ID is defined but empty, BOOT_DIR_ABS is a fake directory so let's skip creating
+# the unified kernel image.
+if [[ -z "${KERNEL_INSTALL_MACHINE_ID-unset}" ]]; then
+    exit 0
+fi
+
+# Strip machine ID and kernel version to get the boot directory.
+PREFIX=$(dirname $(dirname "$BOOT_DIR_ABS"))
+
+if [[ -n "$ROOTHASH" ]]; then
+    BOOT_BINARY="${PREFIX}/EFI/Linux/linux-${KERNEL_VERSION}-${ROOTHASH}.efi"
+else
+    BOOT_BINARY="${PREFIX}/EFI/Linux/linux-${KERNEL_VERSION}.efi"
+fi
+
+case "$COMMAND" in
+    add)
+        if [[ -f /etc/kernel/cmdline ]]; then
+            read -r -d '' BOOT_OPTIONS < /etc/kernel/cmdline || true
+        elif [[ -f /usr/lib/kernel/cmdline ]]; then
+            read -r -d '' BOOT_OPTIONS < /usr/lib/kernel/cmdline || true
+        else
+            read -r -d '' BOOT_OPTIONS < /proc/cmdline || true
+        fi
+
+        if [[ -n "$ROOTHASH" ]]; then
+            BOOT_OPTIONS="${BOOT_OPTIONS} roothash=${ROOTHASH}"
+        fi
+
+        if [[ -n "$KERNEL_IMAGE" ]]; then
+            DRACUT_KERNEL_IMAGE_OPTION="--kernel-image ${KERNEL_IMAGE}"
+        else
+            DRACUT_KERNEL_IMAGE_OPTION=""
+        fi
+
+        dracut \\
+            --verbose \\
+            --uefi \\
+            --kver "$KERNEL_VERSION" \\
+            $DRACUT_KERNEL_IMAGE_OPTION \\
+            --kernel-cmdline "$BOOT_OPTIONS" \\
+            --force \\
+            "$BOOT_BINARY"
+        ;;
+    remove)
+        rm -f -- "$BOOT_BINARY"
+        ;;
+esac
+"""
+
 
 # This global should be initialized after parsing arguments
 arg_debug = ()
@@ -1329,6 +1396,24 @@ def prepare_tree(args: CommandLineArguments, root: str, do_run_build_script: boo
             cmdline.write(' '.join(args.kernel_command_line))
             cmdline.write("\n")
 
+        dracut_dir = os.path.join(root, "etc/dracut.conf.d")
+        os.mkdir(dracut_dir, 0o755)
+
+        with open(os.path.join(dracut_dir, "30-mkosi-hostonly.conf"), "w") as f:
+            f.write("hostonly=no\n")
+
+        with open(os.path.join(dracut_dir, "30-mkosi-systemd-extras.conf"), "w") as f:
+            for extra in DRACUT_SYSTEMD_EXTRAS:
+                f.write(f"install_optional_items+=\" {extra} \"\n")
+
+        with open(os.path.join(dracut_dir, "30-mkosi-qemu.conf"), "w") as f:
+            f.write("add_dracutmodules+=\" qemu \"\n")
+
+        # These distros need uefi_stub configured explicitly for dracut to find the systemd-boot uefi stub.
+        if args.distribution in (Distribution.ubuntu, Distribution.mageia, Distribution.openmandriva):
+            with open(os.path.join(dracut_dir, "30-mkosi-uefi-stub.conf"), "w") as f:
+                f.write("uefi_stub=/usr/lib/systemd/boot/efi/linuxx64.efi.stub\n")
+
     if do_run_build_script:
         os.mkdir(os.path.join(root, "root"), 0o750)
         os.mkdir(os.path.join(root, "root/dest"), 0o755)
@@ -1428,40 +1513,38 @@ def check_if_url_exists(url: str) -> bool:
         return False
 
 
-def disable_kernel_install(args: CommandLineArguments, root: str) -> List[str]:
-    # Let's disable the automatic kernel installation done by the
-    # kernel RPMs. After all, we want to built our own unified kernels
-    # that include the root hash in the kernel command line and can be
-    # signed as a single EFI executable. Since the root hash is only
-    # known when the root file system is finalized we turn off any
-    # kernel installation beforehand.
+def make_executable(path: str) -> None:
+    st = os.stat(path)
+    os.chmod(path, st.st_mode | stat.S_IEXEC)
+
+
+def disable_kernel_install(args: CommandLineArguments, root: str) -> None:
+    # Let's disable the automatic kernel installation done by the kernel RPMs. After all, we want to built
+    # our own unified kernels that include the root hash in the kernel command line and can be signed as a
+    # single EFI executable. Since the root hash is only known when the root file system is finalized we turn
+    # off any kernel installation beforehand.
     #
-    # For BIOS mode, we don't have that option, so do not mask the units
+    # For BIOS mode, we don't have that option, so do not mask the units.
     if not args.bootable or args.bios_partno is not None:
-        return []
+        return
 
     for d in ("etc", "etc/kernel", "etc/kernel/install.d"):
         mkdir_last(os.path.join(root, d), 0o755)
 
-    masked: List[str] = []
-
     for f in ("50-dracut.install", "51-dracut-rescue.install", "90-loaderentry.install"):
         path = os.path.join(root, "etc/kernel/install.d", f)
         os.symlink("/dev/null", path)
-        masked += [path]
-
-    return masked
 
 
-def reenable_kernel_install(args: CommandLineArguments, root: str, masked: List[str]) -> None:
-    # Undo disable_kernel_install() so the final image can be used
-    # with scripts installing a kernel following the Bootloader Spec
-
-    if not args.bootable:
+def reenable_kernel_install(args: CommandLineArguments, root: str) -> None:
+    if not args.bootable or args.bios_partno is not None:
         return
 
-    for f in masked:
-        os.unlink(f)
+    hook_path = os.path.join(root, "etc/kernel/install.d/50-mkosi-dracut-unified-kernel.install")
+    with open(hook_path, "w") as f:
+        f.write(DRACUT_UNIFIED_KERNEL_INSTALL)
+
+    make_executable(hook_path)
 
 
 def make_rpm_list(args: argparse.Namespace, packages: List[str]) -> List[str]:
@@ -1664,8 +1747,6 @@ def setup_dnf(args: CommandLineArguments, root: str, repos: List[Repo] = []) -> 
 
 @completestep('Installing Photon')
 def install_photon(args: CommandLineArguments, root: str, do_run_build_script: bool) -> None:
-    masked = disable_kernel_install(args, root)
-
     release_url = "baseurl=https://dl.bintray.com/vmware/photon_release_$releasever_$basearch"
     updates_url = "baseurl=https://dl.bintray.com/vmware/photon_updates_$releasever_$basearch"
     gpgpath='/etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY'
@@ -1680,7 +1761,6 @@ def install_photon(args: CommandLineArguments, root: str, do_run_build_script: b
         packages += ["linux", "initramfs"]
 
     invoke_tdnf(args, root, args.repositories or ["photon", "photon-updates"], packages, os.path.exists(gpgpath))
-    reenable_kernel_install(args, root, masked)
 
 
 @completestep('Installing Clear Linux')
@@ -1749,8 +1829,6 @@ def install_fedora(args: CommandLineArguments, root: str, do_run_build_script: b
     else:
         args.releasever = args.release
 
-    masked = disable_kernel_install(args, root)
-
     arch = args.architecture or platform.machine()
 
     if args.mirror:
@@ -1785,13 +1863,9 @@ def install_fedora(args: CommandLineArguments, root: str, do_run_build_script: b
     with open(os.path.join(root, 'etc/locale.conf'), 'w') as f:
         f.write('LANG=C.UTF-8\n')
 
-    reenable_kernel_install(args, root, masked)
-
 
 @completestep('Installing Mageia')
 def install_mageia(args: CommandLineArguments, root: str, do_run_build_script: bool) -> None:
-    masked = disable_kernel_install(args, root)
-
     if args.mirror:
         baseurl = f"{args.mirror}/distrib/{args.release}/x86_64/media/core/"
         release_url = f"baseurl={baseurl}/release/"
@@ -1816,13 +1890,10 @@ def install_mageia(args: CommandLineArguments, root: str, do_run_build_script: b
         packages += args.build_packages or []
     invoke_dnf(args, root, args.repositories or ["mageia", "updates"], packages)
 
-    reenable_kernel_install(args, root, masked)
-
 
 @completestep('Installing OpenMandriva')
 def install_openmandriva(args: CommandLineArguments, root: str, do_run_build_script: bool) -> None:
     release = args.release.strip("'")
-    masked = disable_kernel_install(args, root)
 
     if release[0].isdigit():
         release_model = "rock"
@@ -1854,8 +1925,6 @@ def install_openmandriva(args: CommandLineArguments, root: str, do_run_build_scr
     if do_run_build_script:
         packages += args.build_packages or []
     invoke_dnf(args, root, args.repositories or ["openmandriva", "updates"], packages)
-
-    reenable_kernel_install(args, root, masked)
 
 
 def invoke_yum(args: CommandLineArguments,
@@ -1963,8 +2032,6 @@ def install_centos_new(args: CommandLineArguments, root: str, epel_release: str)
 
 @completestep('Installing CentOS')
 def install_centos(args: CommandLineArguments, root: str, do_run_build_script: bool) -> None:
-    masked = disable_kernel_install(args, root)
-
     epel_release = args.release.split('.')[0]
 
     # Centos Repositories were changed between 7 and 8
@@ -1997,7 +2064,6 @@ def install_centos(args: CommandLineArguments, root: str, do_run_build_script: b
         packages += args.build_packages or []
 
     invoke_dnf_or_yum(args, root, repos, packages)
-    reenable_kernel_install(args, root, masked)
 
 
 def debootstrap_knows_arg(arg: str) -> bool:
@@ -2468,7 +2534,9 @@ def install_distribution(args: CommandLineArguments,
         Distribution.openmandriva: install_openmandriva,
     }
 
+    disable_kernel_install(args, root)
     install[args.distribution](args, root, do_run_build_script)
+    reenable_kernel_install(args, root)
 
 
 def reset_machine_id(args: CommandLineArguments, root: str, do_run_build_script: bool, for_cache: bool) -> None:
@@ -2686,12 +2754,6 @@ def install_boot_loader_arch(args: CommandLineArguments, root: str, loopdev: str
 
 
 def install_boot_loader_debian(args: CommandLineArguments, root: str, loopdev: str) -> None:
-    if "uefi" in args.boot_protocols:
-        kernel_version = next(filter(lambda x: x[0].isdigit(), os.listdir(os.path.join(root, "lib/modules"))))
-
-        run_workspace_command(args, root,
-                              "/usr/bin/kernel-install", "add", kernel_version, "/boot/vmlinuz-" + kernel_version)
-
     if "bios" in args.boot_protocols:
         grub = "grub" if args.distribution in (Distribution.ubuntu, Distribution.debian) else "grub2"
         # TODO: Just use "grub" once https://github.com/systemd/systemd/pull/16645 is widely available.
@@ -3218,76 +3280,44 @@ def install_unified_kernel(args: CommandLineArguments,
                            do_run_build_script: bool,
                            for_cache: bool,
                            root_hash: Optional[str]) -> None:
-    # Iterates through all kernel versions included in the image and
-    # generates a combined kernel+initrd+cmdline+osrelease EFI file
-    # from it and places it in the /EFI/Linux directory of the
-    # ESP. sd-boot iterates through them and shows them in the
-    # menu. These "unified" single-file images have the benefit that
-    # they can be signed like normal EFI binaries, and can encode
-    # everything necessary to boot a specific root device, including
-    # the root hash.
+    # Iterates through all kernel versions included in the image and generates a combined
+    # kernel+initrd+cmdline+osrelease EFI file from it and places it in the /EFI/Linux directory of the ESP.
+    # sd-boot iterates through them and shows them in the menu. These "unified" single-file images have the
+    # benefit that they can be signed like normal EFI binaries, and can encode everything necessary to boot a
+    # specific root device, including the root hash.
 
     if not args.bootable or args.esp_partno is None:
         return
     if for_cache:
         return
 
-    # Don't bother running dracut if this is a development
-    # build. Strictly speaking it would probably be a good idea to run
-    # it, so that the development environment differs as little as
-    # possible from the final build, but then again the initrd should
-    # not be relevant for building, and dracut is simply very slow,
-    # hence let's avoid it invoking it needlessly, given that we never
-    # actually invoke the boot loader on the development image.
+    # Don't bother running dracut if this is a development build. Strictly speaking it would probably be a
+    # good idea to run it, so that the development environment differs as little as possible from the final
+    # build, but then again the initrd should not be relevant for building, and dracut is simply very slow,
+    # hence let's avoid it invoking it needlessly, given that we never actually invoke the boot loader on the
+    # development image.
     if do_run_build_script:
-        return
-    if args.distribution not in (Distribution.fedora, Distribution.mageia, Distribution.ubuntu, Distribution.debian, Distribution.centos, Distribution.centos_epel):
         return
 
     with complete_step("Generating combined kernel + initrd boot file"):
+        # Apparently openmandriva hasn't yet completed its usrmerge so we use lib here instead of usr/lib.
+        with os.scandir(os.path.join(root, "lib/modules")) as d:
+            for kver in d:
+                if not kver.is_dir():
+                    continue
 
-        cmdline = ' '.join(args.kernel_command_line)
-        if root_hash is not None:
-            cmdline += " roothash=" + root_hash
+                prefix = "/boot" if args.xbootldr_partno is not None else "/efi"
+                # While the kernel version can generally be found as a directory under /usr/lib/modules, the
+                # kernel image files can be found either in /usr/lib/modules/<kernel-version>/vmlinuz or in
+                # /boot depending on the distro. By invoking the kernel-install script directly, we can pass
+                # the empty string as the kernel image which causes the script to not pass the --kernel-image
+                # option to dracut so it searches the image for us.
+                cmdline = ["/etc/kernel/install.d/50-mkosi-dracut-unified-kernel.install", "add", kver.name,
+                           f"{prefix}/{args.machine_id}/{kver.name}", ""]
+                if root_hash is not None:
+                    cmdline.append(root_hash)
 
-        for kver in os.scandir(os.path.join(root, "usr/lib/modules")):
-            if not kver.is_dir():
-                continue
-
-            # Place kernel in XBOOTLDR partition if it is turned on, otherwise in the ESP
-            prefix = "/efi" if args.xbootldr_size is None else "/boot"
-
-            boot_binary = prefix + "/EFI/Linux/linux-" + kver.name
-            if root_hash is not None:
-                boot_binary += "-" + root_hash
-            boot_binary += ".efi"
-
-            dracut = ["/usr/bin/dracut",
-                      "-v",
-                      "--no-hostonly",
-                      "--uefi",
-                      "--uefi-stub", "/usr/lib/systemd/boot/efi/linuxx64.efi.stub",
-                      "--kver", kver.name,
-                      "--kernel-cmdline", cmdline]
-
-            # Temporary fix until dracut includes these in the image anyway
-            dracut += ("-i",) + ("/usr/lib/systemd/system/systemd-volatile-root.service",)*2 + \
-                      ("-i",) + ("/usr/lib/systemd/systemd-volatile-root",)*2 + \
-                      ("-i",) + ("/usr/lib/systemd/systemd-veritysetup",)*2 + \
-                      ("-i",) + ("/usr/lib/systemd/system-generators/systemd-veritysetup-generator",)*2 + \
-                      ("-i",) + ("/usr/bin/systemd-repart",)*2 + \
-                      ("-i",) + ("/usr/lib/systemd/system/systemd-repart.service",)*2 + \
-                      ("-i",) + ("/usr/lib/systemd/system/initrd-root-fs.target.wants/systemd-repart.service",)*2 + \
-                      ("-i",) + ("/usr/lib/systemd/system-generators/systemd-debug-generator",)*2
-
-            if args.output_format.is_squashfs:
-                dracut += ['--add-drivers', 'squashfs']
-
-            dracut += ['--add', 'qemu']
-
-            dracut += [boot_binary]
-
-            run_workspace_command(args, root, *dracut)
+                run_workspace_command(args, root, *cmdline)
 
 
 def secure_boot_sign(args: CommandLineArguments, root: str, do_run_build_script: bool, for_cache: bool) -> None:

--- a/mkosi
+++ b/mkosi
@@ -2403,7 +2403,7 @@ def install_opensuse(args: CommandLineArguments, root: str, do_run_build_script:
         packages += ["patterns-base-minimal_base"]
 
     if not do_run_build_script and args.bootable:
-        packages += ["kernel-default"]
+        packages += ["kernel-default", "binutils"]
         if args.bios_partno is not None:
             packages += ["grub2"]
 

--- a/mkosi
+++ b/mkosi
@@ -2371,32 +2371,134 @@ def install_arch(args: CommandLineArguments, root: str, do_run_build_script: boo
     if do_run_build_script:
         packages.update(args.build_packages)
 
-    def run_pacman(args: List[str], **kwargs: Any) -> CompletedProcess:
-        cmdline = [
-            "pacman",
-            "--noconfirm",
-            "--config", pacman_conf,
-        ]
+    if not do_run_build_script and args.bootable:
+        # Replace mkinitcpio and depmod hooks by kernel-install hooks which additionally creates systemd-boot
+        # loader entries.
+        hooks_dir = os.path.join(root, "etc/pacman.d/hooks")
+        scripts_dir = os.path.join(root, "etc/pacman.d/scripts")
+
+        os.makedirs(hooks_dir, 0o755, exist_ok=True)
+        os.makedirs(scripts_dir, 0o755, exist_ok=True)
+
+        for hook in ["60-depmod.hook", "90-mkinitcpio-install.hook"]:
+            os.symlink("/dev/null", os.path.join(hooks_dir, hook))
+
+        kernel_add_hook = os.path.join(hooks_dir, "90-mkosi-kernel-add.hook")
+        with open(kernel_add_hook, 'w') as f:
+            f.write(
+                dedent(
+                    """\
+                    [Trigger]
+                    Operation = Install
+                    Operation = Upgrade
+                    Type = Path
+                    Target = usr/lib/modules/*/vmlinuz
+
+                    [Trigger]
+                    Operation = Install
+                    Operation = Upgrade
+                    Operation = Remove
+                    Type = Package
+                    Target = systemd
+                    Target = dracut
+                    Target = intel-ucode
+                    Target = amd-ucode
+
+                    [Action]
+                    Description = Adding kernel and initramfs images to /boot...
+                    When = PostTransaction
+                    Exec = /etc/pacman.d/scripts/mkosi-kernel-add
+                    NeedsTargets
+                    """
+                )
+            )
+
+        kernel_add_script = os.path.join(scripts_dir, "mkosi-kernel-add")
+        with open(kernel_add_script, 'w') as f:
+            f.write(
+                dedent(
+                    """\
+                    #!/bin/bash -e
+
+                    declare -a kernel_version
+
+                    # Check the targets passed by the pacman hook.
+                    while read -r line
+                    do
+                        if [[ "$line" =~ usr/lib/modules/([^/]+)/vmlinuz ]]
+                        then
+                            kernel_version+=( "${BASH_REMATCH[1]}" )
+                        else
+                            # If a non-matching line is passed, just rebuild all kernels.
+                            kernel_version=()
+                            for f in /usr/lib/modules/*/vmlinuz
+                            do
+                                kernel_version+=( "$(basename "$(dirname "$f")")" )
+                            done
+                            break
+                        fi
+                    done
+
+                    # (re)build the kernel images.
+                    for kv in "${kernel_version[@]}"
+                    do
+                        kernel-install add "$kv" "/usr/lib/modules/${kv}/vmlinuz"
+                    done
+                    """
+                )
+            )
+
+        make_executable(kernel_add_script)
+
+        kernel_remove_hook = os.path.join(hooks_dir, "60-mkosi-kernel-remove.hook")
+        with open(kernel_remove_hook, 'w') as f:
+            f.write(
+                dedent(
+                    """\
+                    [Trigger]
+                    Operation = Upgrade
+                    Operation = Remove
+                    Type = Path
+                    Target = usr/lib/modules/*/vmlinuz
+
+                    [Action]
+                    Description = Removing kernel and initramfs images from /boot...
+                    When = PreTransaction
+                    Exec = /etc/pacman.d/mkosi-kernel-remove
+                    NeedsTargets
+                    """
+                )
+            )
+
+        kernel_remove_script = os.path.join(scripts_dir, "mkosi-kernel-remove")
+        with open(kernel_remove_script, 'w') as f:
+            f.write(
+                dedent(
+                    """\
+                    #!/bin/bash -e
+
+                    while read -r f; do
+                        kernel-install remove $(basename $(dirname $f))
+                    done
+                    """
+                )
+            )
+
+        make_executable(kernel_remove_script)
+
+    def run_pacman(packages: List[str]) -> CompletedProcess:
+        if len(packages) == 0:
+            return
+
+        cmdline = ["pacman", "--noconfirm", "--config", pacman_conf, "-S", *packages]
 
         try:
-            return run(cmdline + args, **kwargs, check=True)
+            return run(cmdline, check=True)
         finally:
             stop_gpg_agent()
 
-    if packages:
-        # Disable mkinitcpio hook because we manually install the kernel image
-        # to /boot using kernel-install in install_boot_loader_arch.
-        hooks = os.path.join(root, "etc/pacman.d/hooks")
-        os.makedirs(hooks, 0o755, exist_ok=True)
-
-        mkinitcpio_override = os.path.join(hooks, "90-mkinitcpio-install.hook")
-        os.symlink("/dev/null", mkinitcpio_override)
-
-        run_pacman(["-S", *packages])
-
-        # Re-enable mkinitcpio hook so updating the kernel in the image via
-        # pacman still works.
-        os.remove(mkinitcpio_override)
+    with mount_api_vfs(args, root):
+        run_pacman(packages)
 
     if "networkmanager" in args.packages:
         enable_networkmanager(root)
@@ -2676,23 +2778,6 @@ def run_finalize_script(args: CommandLineArguments, root: str, do_run_build_scri
         run([args.finalize_script, verb], env=env, check=True)
 
 
-def find_kernel_file(root: str, pattern: str) -> Optional[str]:
-    # Look for the vmlinuz file in the workspace
-    workspace_pattern = os.path.join(root, pattern.lstrip('/'))
-    kernel_files = sorted(glob.glob(workspace_pattern))
-    kernel_file = kernel_files[0]
-    # The path the kernel-install script expects is within the
-    # workspace reference as it is run from within the container
-    if kernel_file.startswith(root):
-        kernel_file = kernel_file[len(root):]
-    else:
-        sys.stderr.write(f'Error, kernel file {kernel_file} cannot be used as it is not in the workspace\n')
-        return None
-    if len(kernel_files) > 1:
-        warn('More than one kernel file found, will use {}', kernel_file)
-    return kernel_file
-
-
 def install_grub(args: CommandLineArguments, root: str, loopdev: str, grub: str) -> None:
     if args.bios_partno is None:
         return
@@ -2737,13 +2822,6 @@ def install_boot_loader_centos(args:CommandLineArguments, root: str, loopdev: st
 
 
 def install_boot_loader_arch(args: CommandLineArguments, root: str, loopdev: str) -> None:
-    if "uefi" in args.boot_protocols:
-        # add loader entries and copy kernel/initrd under that entry
-        kernel_version = next(filter(lambda x: x[0].isdigit(), os.listdir(os.path.join(root, "lib/modules"))))
-        kernel_file = find_kernel_file(root, "/lib/modules/*/vmlinuz")
-        if kernel_file is not None:
-            run_workspace_command(args, root, "/usr/bin/kernel-install", "add", kernel_version, kernel_file)
-
     if "bios" in args.boot_protocols:
         install_grub(args, root, loopdev, "grub")
 

--- a/mkosi
+++ b/mkosi
@@ -163,10 +163,6 @@ def print_running_cmd(cmdline: Iterable[str]) -> None:
     sys.stderr.write(" ".join(shlex.quote(x) for x in cmdline) + "\n")
 
 
-def print_error(text: str) -> None:
-    sys.stderr.write(f"‣ \033[31;1m{text}\033[0m\n")
-
-
 @contextlib.contextmanager
 def delay_interrupt() -> Generator[None, None, None]:
     # CTRL+C is sent to the entire process group. We delay its handling in mkosi itself so the subprocess can
@@ -207,7 +203,7 @@ def run(cmdline: List[str], execvp: bool = False, **kwargs: Any) -> CompletedPro
 
 
 def die(message: str) -> NoReturn:
-    print_error(f"Error: {message}")
+    sys.stderr.write(f"‣ \033[31;1mError: {message}\033[0m\n")
     raise MkosiException(message)
 
 

--- a/mkosi
+++ b/mkosi
@@ -4860,6 +4860,7 @@ def print_summary(args: CommandLineArguments) -> None:
 
     sys.stderr.write("\nHOST CONFIGURATION:\n")
     sys.stderr.write("    Extra search paths: " + line_join_list(args.extra_search_paths) + "\n")
+    sys.stderr.write("         QEMU Headless: " + yes_no(args.qemu_headless) + "\n")
 
 
 def reuse_cache_tree(args: CommandLineArguments,

--- a/mkosi
+++ b/mkosi
@@ -2212,6 +2212,7 @@ def install_arch(args: CommandLineArguments, root: str, do_run_build_script: boo
         "var/cache": 0o755,
         "var/cache/pacman": 0o755,
         "var/tmp": 0o1777,
+        "run": 0o755,
     }
 
     for dir, permissions in fix_permissions_dirs.items():
@@ -2378,20 +2379,9 @@ def install_arch(args: CommandLineArguments, root: str, do_run_build_script: boo
 
         make_executable(kernel_remove_script)
 
-    def run_pacman_key(args: List[str]) -> CompletedProcess:
-        cmdline = ["pacman-key", "--nocolor", "--config", pacman_conf]
-
-        try:
-            return run(cmdline + args, check=True)
-        finally:
-            # Kill the gpg-agent started by pacman-key
-            run(['gpgconf', '--homedir', os.path.join(root, 'etc/pacman.d/gnupg'), '--kill', 'all'])
-
     keyring = "archlinux"
     if platform.machine() == "aarch64":
         keyring += "arm"
-    run_pacman_key(["--init"])
-    run_pacman_key(["--populate", keyring])
 
     packages = {"base"}
 
@@ -2428,12 +2418,19 @@ def install_arch(args: CommandLineArguments, root: str, do_run_build_script: boo
     if do_run_build_script:
         packages.update(args.build_packages)
 
-    def run_pacstrap(packages: Set[str]) -> None:
-        cmdline = ["pacstrap", "-C", pacman_conf, "-GM", root]
-        # pacstrap handles gpg-agent on its own
-        run(cmdline + list(packages), check=True)
+    def run_pacman(packages: Set[str]) -> None:
+        conf = ["--config", pacman_conf]
 
-    run_pacstrap(packages)
+        try:
+            run(["pacman-key", *conf, "--init"], check=True)
+            run(["pacman-key", *conf, "--populate"], check=True)
+            run(["pacman", *conf, "--noconfirm", "-Sy", *packages], check=True)
+        finally:
+            # Kill the gpg-agent started by pacman and pacman-key.
+            run(['gpgconf', '--homedir', os.path.join(root, 'etc/pacman.d/gnupg'), '--kill', 'all'])
+
+    with mount_api_vfs(args, root):
+        run_pacman(packages)
 
     if "networkmanager" in args.packages:
         enable_networkmanager(root)

--- a/mkosi
+++ b/mkosi
@@ -2750,34 +2750,6 @@ def install_grub(args: CommandLineArguments, root: str, loopdev: str, grub: str)
         nspawn_params=nspawn_params)
 
 
-def install_boot_loader_fedora(args: CommandLineArguments, root: str, loopdev: str) -> None:
-    install_grub(args, root, loopdev, "grub2")
-
-
-def install_boot_loader_centos(args:CommandLineArguments, root: str, loopdev: str) -> None:
-    install_grub(args, root, loopdev, "grub2")
-
-
-def install_boot_loader_arch(args: CommandLineArguments, root: str, loopdev: str) -> None:
-    if "bios" in args.boot_protocols:
-        install_grub(args, root, loopdev, "grub")
-
-
-def install_boot_loader_debian(args: CommandLineArguments, root: str, loopdev: str) -> None:
-    if "bios" in args.boot_protocols:
-        grub = "grub" if args.distribution in (Distribution.ubuntu, Distribution.debian) else "grub2"
-        # TODO: Just use "grub" once https://github.com/systemd/systemd/pull/16645 is widely available.
-        install_grub(args, root, loopdev, f"/usr/sbin/{grub}")
-
-
-def install_boot_loader_ubuntu(args: CommandLineArguments, root: str, loopdev: str) -> None:
-    install_boot_loader_debian(args, root, loopdev)
-
-
-def install_boot_loader_opensuse(args: CommandLineArguments, root: str, loopdev: str) -> None:
-    install_boot_loader_debian(args, root, loopdev)
-
-
 def install_boot_loader_clear(args: CommandLineArguments, root: str, loopdev: str) -> None:
     nspawn_params = [
         # clr-boot-manager uses blkid in the device backing "/" to
@@ -2796,14 +2768,6 @@ def install_boot_loader_clear(args: CommandLineArguments, root: str, loopdev: st
     run_workspace_command(args, root, "/usr/bin/clr-boot-manager", "update", "-i", nspawn_params=nspawn_params)
 
 
-def install_boot_loader_photon(args: CommandLineArguments, root: str, loopdev: str) -> None:
-    install_grub(args, root, loopdev, "grub2")
-
-
-def install_boot_loader_openmandriva(args: CommandLineArguments, root: str, loopdev: str) -> None:
-    install_grub(args, root, loopdev, "grub2")
-
-
 def install_boot_loader(args: CommandLineArguments, root: str, loopdev: Optional[str], do_run_build_script: bool, cached: bool) -> None:
     if not args.bootable or do_run_build_script:
         return
@@ -2820,32 +2784,16 @@ def install_boot_loader(args: CommandLineArguments, root: str, loopdev: Optional
             shutil.copyfile(os.path.join(root, "usr/lib/systemd/boot/efi/systemd-bootx64.efi"),
                             os.path.join(root, "efi/EFI/BOOT/bootx64.efi"))
 
-        if args.distribution == Distribution.fedora:
-            install_boot_loader_fedora(args, root, loopdev)
+        if args.bios_partno and args.distribution != Distribution.clear:
+            grub = "grub" if args.distribution in (Distribution.ubuntu, Distribution.debian, Distribution.arch) else "grub2"
+            # TODO: Just use "grub" once https://github.com/systemd/systemd/pull/16645 is widely available.
+            if args.distribution in (Distribution.ubuntu, Distribution.debian, Distribution.opensuse):
+                grub = f"/usr/sbin/{grub}"
 
-        if args.distribution == Distribution.arch:
-            install_boot_loader_arch(args, root, loopdev)
-
-        if args.distribution == Distribution.debian:
-            install_boot_loader_debian(args, root, loopdev)
-
-        if args.distribution == Distribution.ubuntu:
-            install_boot_loader_ubuntu(args, root, loopdev)
-
-        if args.distribution == Distribution.opensuse:
-            install_boot_loader_opensuse(args, root, loopdev)
+            install_grub(args, root, loopdev, grub)
 
         if args.distribution == Distribution.clear:
             install_boot_loader_clear(args, root, loopdev)
-
-        if args.distribution == Distribution.photon:
-            install_boot_loader_photon(args, root, loopdev)
-
-        if args.distribution in (Distribution.centos, Distribution.centos_epel):
-            install_boot_loader_centos(args, root, loopdev)
-
-        if args.distribution == Distribution.openmandriva:
-            install_boot_loader_openmandriva(args, root, loopdev)
 
 
 def install_extra_trees(args: CommandLineArguments, root: str, for_cache: bool) -> None:

--- a/mkosi
+++ b/mkosi
@@ -2775,11 +2775,7 @@ def install_boot_loader(args: CommandLineArguments, root: str, loopdev: Optional
 
     with complete_step("Installing boot loader"):
         if args.esp_partno and args.distribution != Distribution.clear:
-            shutil.copyfile(os.path.join(root, "usr/lib/systemd/boot/efi/systemd-bootx64.efi"),
-                            os.path.join(root, "efi/EFI/systemd/systemd-bootx64.efi"))
-
-            shutil.copyfile(os.path.join(root, "usr/lib/systemd/boot/efi/systemd-bootx64.efi"),
-                            os.path.join(root, "efi/EFI/BOOT/bootx64.efi"))
+            run_workspace_command(args, root, "bootctl", "install")
 
         if args.bios_partno and args.distribution != Distribution.clear:
             grub = "grub" if args.distribution in (Distribution.ubuntu, Distribution.debian, Distribution.arch) else "grub2"

--- a/mkosi
+++ b/mkosi
@@ -2236,7 +2236,6 @@ def install_arch(args: CommandLineArguments, root: str, do_run_build_script: boo
                 HookDir     = {root}/etc/pacman.d/hooks/
                 HoldPkg     = pacman glibc
                 Architecture = auto
-                UseSyslog
                 Color
                 CheckSpace
                 SigLevel    = Required DatabaseOptional TrustAll

--- a/mkosi.md
+++ b/mkosi.md
@@ -499,14 +499,14 @@ details see the table below.
 
 : Takes a path to an executable that is invoked inside the image
   right after installing the software packages. It is
-  the last step before the image is cached (if incremental mode is 
+  the last step before the image is cached (if incremental mode is
   enabled).
   This script is invoked inside a `systemd-nspawn` container
   environment, and thus does not have access to host resources.
   If this option is not used, but an executable script `mkosi.prepare`
   is found in the local directory, it is automatically used for this
   purpose (also see below).
-  
+
 `--postinst-script=`
 
 : Takes a path to an executable that is invoked inside the final image
@@ -906,8 +906,8 @@ local directory:
   time for the *final* image with the "final" command line parameter.
   This script has network access and may be used to install packages
   from other sources than the distro's package manager (e.g. pip, npm, ...),
-  after all software packages are installed but before the image is 
-  cached (if incremental mode is enabled). 
+  after all software packages are installed but before the image is
+  cached (if incremental mode is enabled).
   Note that this script is executed directly in the image context with
   the final root directory in place, without any `$SRCDIR`/`$DESTDIR`
   setup.

--- a/mkosi.md
+++ b/mkosi.md
@@ -352,6 +352,11 @@ details see the table below.
 
 : Set the image's hostname to the specified name.
 
+`--without-unified-kernel-images`
+
+: If specified, mkosi does not build unified kernel images and instead installs kernels with a separate
+  initrd and boot loader config to the efi or bootloader partition.
+
 `--no-chown`
 
 : By default, if `mkosi` is run inside a `sudo` environment all
@@ -690,60 +695,61 @@ settings file (or any other file `--default=` is used on). The
 following table shows which command lines parameters correspond with
 which settings file options.
 
-| Command Line Parameter       | `mkosi.default` section | `mkosi.default` setting   |
-|------------------------------|-------------------------|---------------------------|
-| `--distribution=`, `-d`      | `[Distribution]`        | `Distribution=`           |
-| `--release=`, `-r`           | `[Distribution]`        | `Release=`                |
-| `--repositories=`            | `[Distribution]`        | `Repositories=`           |
-| `--mirror=`, `-m`            | `[Distribution]`        | `Mirror=`                 |
-| `--architecture=`            | `[Distribution]`        | `Architecture=`           |
-| `--format=`, `-t`            | `[Output]`              | `Format=`                 |
-| `--output=`, `-o`            | `[Output]`              | `Output=`                 |
-| `--output-dir=`, `-O`        | `[Output]`              | `OutputDirectory=`        |
-| `--force`, `-f`              | `[Output]`              | `Force=`                  |
-| `--bootable`, `-b`           | `[Output]`              | `Bootable=`               |
-| `--boot-protocols=`          | `[Output]`              | `BootProtocols=`          |
-| `--kernel-command-line=`     | `[Output]`              | `KernelCommandLine=`      |
-| `--secure-boot`              | `[Output]`              | `SecureBoot=`             |
-| `--secure-boot-key=`         | `[Output]`              | `SecureBootKey=`          |
-| `--secure-boot-certificate=` | `[Output]`              | `SecureBootCertificate=`  |
-| `--read-only`                | `[Output]`              | `ReadOnly=`               |
-| `--encrypt=`                 | `[Output]`              | `Encrypt=`                |
-| `--verity=`                  | `[Output]`              | `Verity=`                 |
-| `--compress=`                | `[Output]`              | `Compress=`               |
-| `--mksquashfs=`              | `[Output]`              | `Mksquashfs=`             |
-| `--xz`                       | `[Output]`              | `XZ=`                     |
-| `--qcow2`                    | `[Output]`              | `QCow2=`                  |
-| `--hostname=`                | `[Output]`              | `Hostname=`               |
-| `--package=`                 | `[Packages]`            | `Packages=`               |
-| `--with-docs`                | `[Packages]`            | `WithDocs=`               |
-| `--without-tests`, `-T`      | `[Packages]`            | `WithTests=`              |
-| `--cache=`                   | `[Packages]`            | `Cache=`                  |
-| `--extra-tree=`              | `[Packages]`            | `ExtraTrees=`             |
-| `--skeleton-tree=`           | `[Packages]`            | `SkeletonTrees=`          |
-| `--build-script=`            | `[Packages]`            | `BuildScript=`            |
-| `--build-sources=`           | `[Packages]`            | `BuildSources=`           |
-| `--source-file-transfer=`    | `[Packages]`            | `SourceFileTransfer=`     |
-| `--build-directory=`         | `[Packages]`            | `BuildDirectory=`         |
-| `--build-packages=`          | `[Packages]`            | `BuildPackages=`          |
-| `--skip-final-phase=`        | `[Packages]`            | `SkipFinalPhase=`         |
-| `--postinst-script=`         | `[Packages]`            | `PostInstallationScript=` |
-| `--finalize-script=`         | `[Packages]`            | `FinalizeScript=`         |
-| `--with-network`             | `[Packages]`            | `WithNetwork=`            |
-| `--settings=`                | `[Packages]`            | `NSpawnSettings=`         |
-| `--root-size=`               | `[Partitions]`          | `RootSize=`               |
-| `--esp-size=`                | `[Partitions]`          | `ESPSize=`                |
-| `--swap-size=`               | `[Partitions]`          | `SwapSize=`               |
-| `--home-size=`               | `[Partitions]`          | `HomeSize=`               |
-| `--srv-size=`                | `[Partitions]`          | `SrvSize=`                |
-| `--checksum`                 | `[Validation]`          | `CheckSum=`               |
-| `--sign`                     | `[Validation]`          | `Sign=`                   |
-| `--key=`                     | `[Validation]`          | `Key=`                    |
-| `--bmap`                     | `[Validation]`          | `BMap=`                   |
-| `--password=`                | `[Validation]`          | `Password=`               |
-| `--password-is-hashed`       | `[Validation]`          | `PasswordIsHashed=`       |
-| `--extra-search-paths=`      | `[Host]`                | `ExtraSearchPaths=`       |
-| `--qemu-headless`            | `[Host]`                | `QemuHeadless=`           |
+| Command Line Parameter            | `mkosi.default` section | `mkosi.default` setting       |
+|-----------------------------------|-------------------------|-------------------------------|
+| `--distribution=`, `-d`           | `[Distribution]`        | `Distribution=`               |
+| `--release=`, `-r`                | `[Distribution]`        | `Release=`                    |
+| `--repositories=`                 | `[Distribution]`        | `Repositories=`               |
+| `--mirror=`, `-m`                 | `[Distribution]`        | `Mirror=`                     |
+| `--architecture=`                 | `[Distribution]`        | `Architecture=`               |
+| `--format=`, `-t`                 | `[Output]`              | `Format=`                     |
+| `--output=`, `-o`                 | `[Output]`              | `Output=`                     |
+| `--output-dir=`, `-O`             | `[Output]`              | `OutputDirectory=`            |
+| `--force`, `-f`                   | `[Output]`              | `Force=`                      |
+| `--bootable`, `-b`                | `[Output]`              | `Bootable=`                   |
+| `--boot-protocols=`               | `[Output]`              | `BootProtocols=`              |
+| `--kernel-command-line=`          | `[Output]`              | `KernelCommandLine=`          |
+| `--secure-boot`                   | `[Output]`              | `SecureBoot=`                 |
+| `--secure-boot-key=`              | `[Output]`              | `SecureBootKey=`              |
+| `--secure-boot-certificate=`      | `[Output]`              | `SecureBootCertificate=`      |
+| `--read-only`                     | `[Output]`              | `ReadOnly=`                   |
+| `--encrypt=`                      | `[Output]`              | `Encrypt=`                    |
+| `--verity=`                       | `[Output]`              | `Verity=`                     |
+| `--compress=`                     | `[Output]`              | `Compress=`                   |
+| `--mksquashfs=`                   | `[Output]`              | `Mksquashfs=`                 |
+| `--xz`                            | `[Output]`              | `XZ=`                         |
+| `--qcow2`                         | `[Output]`              | `QCow2=`                      |
+| `--hostname=`                     | `[Output]`              | `Hostname=`                   |
+| `--without-unified-kernel-images` | `[Output]`              | `WithUnifiedKernelImages=`    |
+| `--package=`                      | `[Packages]`            | `Packages=`                   |
+| `--with-docs`                     | `[Packages]`            | `WithDocs=`                   |
+| `--without-tests`, `-T`           | `[Packages]`            | `WithTests=`                  |
+| `--cache=`                        | `[Packages]`            | `Cache=`                      |
+| `--extra-tree=`                   | `[Packages]`            | `ExtraTrees=`                 |
+| `--skeleton-tree=`                | `[Packages]`            | `SkeletonTrees=`              |
+| `--build-script=`                 | `[Packages]`            | `BuildScript=`                |
+| `--build-sources=`                | `[Packages]`            | `BuildSources=`               |
+| `--source-file-transfer=`         | `[Packages]`            | `SourceFileTransfer=`         |
+| `--build-directory=`              | `[Packages]`            | `BuildDirectory=`             |
+| `--build-packages=`               | `[Packages]`            | `BuildPackages=`              |
+| `--skip-final-phase=`             | `[Packages]`            | `SkipFinalPhase=`             |
+| `--postinst-script=`              | `[Packages]`            | `PostInstallationScript=`     |
+| `--finalize-script=`              | `[Packages]`            | `FinalizeScript=`             |
+| `--with-network`                  | `[Packages]`            | `WithNetwork=`                |
+| `--settings=`                     | `[Packages]`            | `NSpawnSettings=`             |
+| `--root-size=`                    | `[Partitions]`          | `RootSize=`                   |
+| `--esp-size=`                     | `[Partitions]`          | `ESPSize=`                    |
+| `--swap-size=`                    | `[Partitions]`          | `SwapSize=`                   |
+| `--home-size=`                    | `[Partitions]`          | `HomeSize=`                   |
+| `--srv-size=`                     | `[Partitions]`          | `SrvSize=`                    |
+| `--checksum`                      | `[Validation]`          | `CheckSum=`                   |
+| `--sign`                          | `[Validation]`          | `Sign=`                       |
+| `--key=`                          | `[Validation]`          | `Key=`                        |
+| `--bmap`                          | `[Validation]`          | `BMap=`                       |
+| `--password=`                     | `[Validation]`          | `Password=`                   |
+| `--password-is-hashed`            | `[Validation]`          | `PasswordIsHashed=`           |
+| `--extra-search-paths=`           | `[Host]`                | `ExtraSearchPaths=`           |
+| `--qemu-headless`                 | `[Host]`                | `QemuHeadless=`               |
 
 Command line options that take no argument are not suffixed with a `=`
 in their long version in the table above. In the `mkosi.default` file

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -108,6 +108,7 @@ class MkosiConfig(object):
             'xbootldr_size': None,
             'xz': False,
             'qemu_headless': False,
+            'with_unified_kernel_images': True,
         }
 
     def __eq__(self, other: [mkosi.CommandLineArguments]) -> bool:
@@ -218,6 +219,8 @@ class MkosiConfig(object):
                 self.reference_config[job_name]['qcow2'] = mk_config_output['QCow2']
             if 'Hostname' in mk_config_output:
                 self.reference_config[job_name]['hostname'] = mk_config_output['Hostname']
+            if 'WithUnifiedKernelImages' in mk_config_output:
+                self.reference_config[job_name]['with_unified_kernel_images'] =  mk_config_output['WithUnifiedKernelImages']
         if 'Packages' in mk_config:
             mk_config_packages = mk_config['Packages']
             if 'Packages' in mk_config_packages:


### PR DESCRIPTION
Doing the initial kernel installs with kernel-install and the rest with mkinitcpio is weird. Let's just use kernel-install all the time. Rest of the commits are simplification of the existing logic.

I also want to add unified kernel images support for Arch but I want to accompany that with a flag to disable unified kernel images (which I really think should be the default but that breaks backwards compat)