### PR TITLE
Arch: Make pacman hooks more generic

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -2300,16 +2300,14 @@ def install_arch(args: CommandLineArguments, root: str, do_run_build_script: boo
                     Operation = Upgrade
                     Type = Path
                     Target = usr/lib/modules/*/vmlinuz
+                    Target = usr/lib/kernel/install.d/*
+                    Target = boot/*-ucode.img
 
                     [Trigger]
                     Operation = Install
                     Operation = Upgrade
-                    Operation = Remove
                     Type = Package
                     Target = systemd
-                    Target = dracut
-                    Target = intel-ucode
-                    Target = amd-ucode
 
                     [Action]
                     Description = Adding kernel and initramfs images to /boot...


### PR DESCRIPTION
It's generally good to not depend on specific packages in pacman hooks
since it doesn't take new packages into account. To get around, this we
can simply depend on the /usr/lib/kernel/install.d directory so any
package that installs a file into this directory can plug into the
pacman hook.

One annoyance we can't solve without package specific information in the
pacman hook is packages that themself support hook directories that
other packages can install to. This would require a mechanism in pacman
where packages can contribute triggers to hooks installed by other
packages.