### PR TITLE
Drop --verbose flag when running dracut

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -132,7 +132,6 @@ case "$COMMAND" in
         fi
 
         dracut \\
-            --verbose \\
             --uefi \\
             --kver "$KERNEL_VERSION" \\
             $DRACUT_KERNEL_IMAGE_OPTION \\


### PR DESCRIPTION
It spams the output a little bit too much.