### PR TITLE
Ignore mypy false positives and update to latest version

### DIFF
--- a/.github/workflows/ci-unit-test.yml
+++ b/.github/workflows/ci-unit-test.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install
-      run: python3 -m pip install pytest 'mypy==0.770'
+      run: python3 -m pip install pytest mypy
 
     - name: Type Checking
       run: python3 -m mypy mkosi

--- a/mkosi
+++ b/mkosi
@@ -483,7 +483,7 @@ def copy_fd(oldfd: int, newfd: int) -> None:
     except OSError as e:
         if e.errno not in {errno.EXDEV, errno.EOPNOTSUPP}:
             raise
-        shutil.copyfileobj(open(oldfd, 'rb', closefd=False),
+        shutil.copyfileobj(open(oldfd, 'rb', closefd=False), # type: ignore # Workaround for python/mypy#8962
                            open(newfd, 'wb', closefd=False))
 
 
@@ -493,7 +493,7 @@ def copy_file_object(oldobject: BinaryIO, newobject: BinaryIO) -> None:
     except OSError as e:
         if e.errno not in {errno.EXDEV, errno.EOPNOTSUPP}:
             raise
-        shutil.copyfileobj(oldobject, newobject)
+        shutil.copyfileobj(oldobject, newobject) # type: ignore # Workaround for python/mypy#8962
 
 
 def copy_symlink(oldpath: str, newpath: str) -> None:
@@ -3927,7 +3927,7 @@ def create_parser() -> ArgumentParserMkosi:
                        help='Turn on debugging output', metavar='SELECTOR',
                        choices=('run','build-script','workspace-command'))
     try:
-        import argcomplete  # type: ignore
+        import argcomplete
         argcomplete.autocomplete(parser)
     except ImportError:
         pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,3 +26,5 @@ show_column_numbers = True
 warn_unreachable = True
 allow_redefinition = True
 strict_equality = True
+[mypy-argcomplete]
+ignore_missing_imports = True


### PR DESCRIPTION
Just ignoring the false positives until the corresponding issue is solved seems easier than pinning the version.