### PR TITLE
Arch: Use Arch mirrorlist generator to get a list of mirrors.

### DIFF
--- a/mkosi
+++ b/mkosi
@@ -2195,10 +2195,23 @@ def install_arch(args: CommandLineArguments, root: str, do_run_build_script: boo
     if args.release is not None:
         sys.stderr.write("Distribution release specification is not supported for Arch Linux, ignoring.\n")
 
-    if platform.machine() == "aarch64":
-        server = f"Server = {args.mirror}/$arch/$repo"
+    if args.mirror:
+        if platform.machine() == "aarch64":
+            server = f"Server = {args.mirror}/$arch/$repo"
+        else:
+            server = f"Server = {args.mirror}/$repo/os/$arch"
     else:
-        server = f"Server = {args.mirror}/$repo/os/$arch"
+        # Instead of harcoding a single mirror, we retrieve a list of mirrors from Arch's mirrorlist
+        # generator ordered by mirror score. This usually results in a solid mirror and also ensures that we
+        # have fallback mirrors available if necessary. Finally, the mirrors will be more likely to be up to
+        # date and we won't end up with a stable release that hardcodes a broken mirror.
+        mirrorlist = os.path.join(workspace(root), "mirrorlist")
+        with urllib.request.urlopen("https://www.archlinux.org/mirrorlist/?country=all&protocol=https&ip_version=4&use_mirror_status=on") as r:
+            with open(mirrorlist, 'w') as f:
+                mirrors = r.readlines()
+                uncommented = [line.decode('utf-8')[1:] for line in mirrors]
+                f.writelines(uncommented)
+                server = f"Include = {mirrorlist}"
 
     # Create base layout for pacman and pacman-key
     os.makedirs(os.path.join(root, "var/lib/pacman"), 0o755, exist_ok=True)
@@ -4467,10 +4480,8 @@ def load_args(args: CommandLineArguments) -> CommandLineArguments:
             args.mirror = "http://archive.ubuntu.com/ubuntu"
             if platform.machine() == "aarch64":
                 args.mirror = "http://ports.ubuntu.com/"
-        elif args.distribution == Distribution.arch:
-            args.mirror = "https://mirrors.kernel.org/archlinux"
-            if platform.machine() == "aarch64":
-                args.mirror = "http://mirror.archlinuxarm.org"
+        elif args.distribution == Distribution.arch and platform.machine() == "aarch64":
+            args.mirror = "http://mirror.archlinuxarm.org"
         elif args.distribution == Distribution.opensuse:
             args.mirror = "http://download.opensuse.org"
 


### PR DESCRIPTION
Fixes #467 and puts us in a good spot for when pacman 6.0 releases with
parallel download support.

@behrmann We should still add a --mirrorlist option but I think this is an improvement over the current situation. I did a few runs on my machine and I always got a solid mirror with this approach. I considered trying to get the country from somewhere on the system to filter the list a bit but I think we're guaranteed to run into annoying edge cases if we take that approach so let's start with this.

cc @mrc0mmand. I've seen a few comments from you about looking into mkosi for systemd centos CI and I definitely want to get it into a spot where it can be used for that so if there's anything else missing that we can fix it would be great if you could make issues for that. Most of the work I'm doing for Github Actions CI with mkosi should apply to centos CI as well but there might be some specifics that need special attention.