### PR TITLE
Give prepare scripts access to SRCDIR.

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -913,10 +913,12 @@ local directory:
   This script has network access and may be used to install packages
   from other sources than the distro's package manager (e.g. pip, npm, ...),
   after all software packages are installed but before the image is
-  cached (if incremental mode is enabled).
-  Note that this script is executed directly in the image context with
-  the final root directory in place, without any `$SRCDIR`/`$DESTDIR`
-  setup.
+  cached (if incremental mode is enabled). This script is executed within
+  `$SRCDIR`. In contrast to a general purpose installation, it is safe to
+  install packages to the system (`pip install`, `npm install -g`) instead
+  of in `$SRCDIR` itself because the build image is only used for a single
+  project and can easily be thrown away and rebuilt so there's no risk of
+  conflicting dependencies and no risk of polluting the host system.
 
 * `mkosi.postinst` may be an executable script. If it exists it is
   invoked as the penultimate step of preparing an image, from within

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2738,6 +2738,23 @@ def set_serial_terminal(args: CommandLineArguments, root: str, do_run_build_scri
         )
 
 
+def nspawn_params_for_build_sources(args: CommandLineArguments, sft: SourceFileTransfer) -> List[str]:
+    params = []
+
+    if args.build_sources is not None:
+        params.append("--setenv=SRCDIR=/root/src")
+        params.append("--chdir=/root/src")
+        if sft == SourceFileTransfer.mount:
+            params.append("--bind=" + args.build_sources + ":/root/src")
+
+        if args.read_only:
+            params.append("--overlay=+/root/src::/root/src")
+    else:
+        params.append("--chdir=/root")
+
+    return params
+
+
 def run_prepare_script(args: CommandLineArguments, root: str, do_run_build_script: bool, cached: bool) -> None:
     if args.prepare_script is None:
         return
@@ -2755,7 +2772,11 @@ def run_prepare_script(args: CommandLineArguments, root: str, do_run_build_scrip
 
         shutil.copy2(args.prepare_script, os.path.join(root, "root/prepare"))
 
-        run_workspace_command(args, root, ["/root/prepare", verb], network=True)
+        nspawn_params = nspawn_params_for_build_sources(args, SourceFileTransfer.mount)
+        run_workspace_command(args, root, ["/root/prepare", verb], network=True, nspawn_params=nspawn_params)
+
+        if os.path.exists(os.path.join(root, "root/src")):
+            os.rmdir(os.path.join(root, "root/src"))
         os.unlink(os.path.join(root, "root/prepare"))
 
 
@@ -5096,16 +5117,7 @@ def run_build_script(args: CommandLineArguments, root: str, raw: Optional[Binary
         if args.default_path is not None:
             cmdline.append("--setenv=MKOSI_DEFAULT=" + args.default_path)
 
-        if args.build_sources is not None:
-            cmdline.append("--setenv=SRCDIR=/root/src")
-            cmdline.append("--chdir=/root/src")
-            if args.source_file_transfer == SourceFileTransfer.mount:
-                cmdline.append("--bind=" + args.build_sources + ":/root/src")
-
-            if args.read_only:
-                cmdline.append("--overlay=+/root/src::/root/src")
-        else:
-            cmdline.append("--chdir=/root")
+        cmdline += nspawn_params_for_build_sources(args, args.source_file_transfer)
 
         if args.build_dir is not None:
             cmdline.append("--setenv=BUILDDIR=/root/build")


### PR DESCRIPTION
There are often project specific files that contain the dependencies
necessary to be installed. Make sure the prepare script has access to
these files so the logic doesn't have to be repeated in the prepare
script itself.