### PR TITLE
Various CentOS 7 fixes and some features/changes

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -237,6 +237,14 @@ details see the table below.
   run, when specified once the incremental cache files are deleted
   too, and when specified twice the package cache is also removed.
 
+`--gpt-first-lba`
+
+: Override the first usable LBA (Logical Block Address) within the
+  GPT header. This defaults to `2048` which is actually the desired value.
+  However, some tools, e.g. the `prl_disk_tool` utility from the
+  Parallels virtualization suite require this to be set to `34`, otherwise
+  they might fail to resize the disk image and/or partitions inside it.
+
 `--bootable`, `-b`
 
 : Generate a bootable image. By default this will generate an image
@@ -708,6 +716,7 @@ which settings file options.
 | `--force`, `-f`                   | `[Output]`              | `Force=`                      |
 | `--bootable`, `-b`                | `[Output]`              | `Bootable=`                   |
 | `--boot-protocols=`               | `[Output]`              | `BootProtocols=`              |
+| `--gpt-first-lba=`                | `[Output]`              | `GPTFirstLBA=`                |
 | `--kernel-command-line=`          | `[Output]`              | `KernelCommandLine=`          |
 | `--secure-boot`                   | `[Output]`              | `SecureBoot=`                 |
 | `--secure-boot-key=`              | `[Output]`              | `SecureBootKey=`              |

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -675,6 +675,8 @@ def disable_cow(path: str) -> None:
 def determine_partition_table(args: CommandLineArguments) -> Tuple[str, bool]:
     pn = 1
     table = "label: gpt\n"
+    if args.gpt_first_lba is not None:
+        table += f"first-lba: {args.gpt_first_lba:d}\n"
     run_sfdisk = False
     args.esp_partno = None
     args.bios_partno = None
@@ -3223,6 +3225,8 @@ def insert_partition(args: CommandLineArguments,
     print_step(f'Inserting partition of {format_bytes(blob_size)}...')
 
     table = "label: gpt\n"
+    if args.gpt_first_lba is not None:
+        table += f"first-lba: {args.gpt_first_lba:d}\n"
 
     for t in old_table:
         table += t + "\n"
@@ -3833,6 +3837,7 @@ class ArgumentParserMkosi(argparse.ArgumentParser):
         'SkeletonTrees': '--skeleton-tree',
         'BuildPackages': '--build-package',
         'PostInstallationScript': '--postinst-script',
+        'GPTFirstLBA': '--gpt-first-lba',
     }
 
     fromfile_prefix_chars = '@'
@@ -3970,6 +3975,7 @@ def create_parser() -> ArgumentParserMkosi:
                        help="Do not install unified kernel images")
     group.add_argument("--with-unified-kernel-images", action=BooleanAction, default=True,
                        help=argparse.SUPPRESS)
+    group.add_argument("--gpt-first-lba", type=int, help='Set the first LBA within GPT Header', metavar='FIRSTLBA')
 
     group = parser.add_argument_group("Packages")
     group.add_argument('-p', "--package", action=CommaDelimitedListAction, dest='packages', default=[],

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -360,7 +360,7 @@ GPT_HEADER_SIZE = 1024*1024
 GPT_FOOTER_SIZE = 1024*1024
 
 
-# Debian calls their architectures differently, so when calling debbootstrap we
+# Debian calls their architectures differently, so when calling debootstrap we
 # will have to map to their names
 DEBIAN_ARCHITECTURES = {
     'x86_64': 'amd64',

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -63,6 +63,7 @@ class MkosiConfig(object):
             'extra_trees': [],
             'finalize_script': None,
             'force_count': 0,
+            'gpt_first_lba': None,
             'home_size': None,
             'hostname': None,
             'incremental': False,


### PR DESCRIPTION
This PR is the result of quite intensive debugging and fixing CentOS 7 compatibility.

It consists of:
 - optionally override GPT `first-lba` header
 - disable `metadata_csum` ext4 feature for CentOS 7 images (not supported by their old `e2fsprogs` version)
 - enable `64bit` ext4 feature on supported architectures
 - switch to `grub2-efi` for efi-bootable CentOS 7 images (their `bootctl`/`systemd-boot` is broken / too old)
 - run the postinstall script with nspawn blockdev access for bootable images

I have tried to group the changes into individual logical commits as best as possible, so reviewing should probably done commit-by-commit.

If you want, I can also split this into multiple PRs, just say so.

Any feedback is welcome and I'm happy to adjust it to meet your requirements.