### PR TITLE
Cache unified kernel images and secure boot when not doing verity

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5271,7 +5271,7 @@ def run_shell(args: CommandLineArguments) -> None:
     if args.verb == "boot":
         cmdline += ('--boot',)
 
-    if args.generated_root():
+    if args.generated_root() or args.verity:
         cmdline += ('--volatile=overlay',)
 
     if args.cmdline:


### PR DESCRIPTION
There's no need to re-generate these every time if we're not embedding
the root hash.