### PR TITLE
Don't write .pyc files when bin/mkosi is called with sudo

### DIFF
--- a/bin/mkosi
+++ b/bin/mkosi
@@ -49,6 +49,8 @@ then
     else
         PREPEND_PYTHONPATH="$SITEDIR"
     fi
+
+    export PYTHONDONTWRITEBYTECODE=1
 fi
 
 


### PR DESCRIPTION
As @DaanDeMeyer noted in #504 
> @behrmann I just had git crash with a fatal error because it couldn't unlink one of the generated pyc files in the mkosi directory (permission error because its owned by root). Should we invoke python with -B if we're in an editable install so we don't clutter the source directory with pyc files?

Setting `PYTHONDONTWRITEBYTECODE` has the effect
> If this is set to a non-empty string it is equivalent to specifying the -B option (don't try  to write .pyc files).
which is equivalent to calling `python` with `-B`. 

I think doing this in the case were we rewrite `PYTHONPATH` should safe us from clobbering paths in a user's home with files they cannot remove without escalating privileges.