### PR TITLE
use /usr/bin/env to get bash path instead of hardwiring it

### DIFF
--- a/bin/mkosi
+++ b/bin/mkosi
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 # This script calls the main function of the internal mkosi module, which is
 # functionally equivalent to calling "python3 -m mkosi".


### PR DESCRIPTION
Fixes #532