### PR TITLE
Add --network-veth option

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -695,6 +695,12 @@ details see the table below.
   connects to its serial console from the current terminal instead
   of launching the VM in a separate window.
 
+`--network-veth`
+: When used with the boot or qemu verbs, this option creates a virtual
+  ethernet link between the host and the container/VM. The host
+  interface is automatically picked up by systemd-networkd as documented
+  in systemd-nspawn's man page:
+  https://www.freedesktop.org/software/systemd/man/systemd-nspawn.html#-n
 
 ## Command Line Parameters and their Settings File Counterparts
 
@@ -759,6 +765,7 @@ which settings file options.
 | `--password-is-hashed`            | `[Validation]`          | `PasswordIsHashed=`           |
 | `--extra-search-paths=`           | `[Host]`                | `ExtraSearchPaths=`           |
 | `--qemu-headless`                 | `[Host]`                | `QemuHeadless=`               |
+| `--network-veth`                  | `[Host]`                | `NetworkVeth=`                |
 
 Command line options that take no argument are not suffixed with a `=`
 in their long version in the table above. In the `mkosi.default` file

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -105,6 +105,7 @@ class MkosiConfig(object):
             'xbootldr_size': None,
             'xz': False,
             'qemu_headless': False,
+            'network_veth': False,
             'with_unified_kernel_images': True,
         }
 
@@ -283,6 +284,8 @@ class MkosiConfig(object):
                 self._append_list('extra_search_paths', mk_config_host['ExtraSearchPaths'], job_name, ':')
             if 'QemuHeadless' in mk_config_host:
                 self.reference_config[job_name]['qemu_headless'] = mk_config_host['QemuHeadless']
+            if 'NetworkVeth' in mk_config_host:
+                self.reference_config[job_name]['network_veth'] = mk_config_host['NetworkVeth']
 
 
 class MkosiConfigOne(MkosiConfig):
@@ -496,6 +499,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
             'Host': {
                 'ExtraSearchPaths': 'search/here:search/there',
                 'QemuHeadless': True,
+                'NetworkVeth': True,
                 }
             }
         self._prepare_mkosi_default(directory, mk_config)
@@ -563,6 +567,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
             'Host': {
                 'ExtraSearchPaths': 'search/ubu',
                 'QemuHeadless': True,
+                'NetworkVeth': True,
                 }
             }
         self._prepare_mkosi_default_d(directory, mk_config, 1)
@@ -630,6 +635,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
             'Host': {
                 'ExtraSearchPaths': 'search/debi',
                 'QemuHeadless': True,
+                'NetworkVeth': True,
                 }
             }
         self._prepare_mkosi_default_d(directory, mk_config, 2)


### PR DESCRIPTION
Sets up a virtual ethernet link between the host and the container/vm.
For boot, we just pass --network-veth to nspawn. For qemu, we set up
a TAP nic with the correct ifname so that it is picked up by
systemd-networkd on the host.