### PR TITLE
Add --autologin option

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -635,6 +635,10 @@ details see the table below.
   hashed, so that the string supplied with `--password` or `mkosi.rootpw` will
   be written to `/etc/shadow` literally.
 
+`--autologin`
+
+: Enable autologin for the `root` user.
+
 `--extra-search-paths=`
 
 : List of colon-separated paths to look for tools in, before using the
@@ -763,6 +767,7 @@ which settings file options.
 | `--bmap`                          | `[Validation]`          | `BMap=`                       |
 | `--password=`                     | `[Validation]`          | `Password=`                   |
 | `--password-is-hashed`            | `[Validation]`          | `PasswordIsHashed=`           |
+| `--autologin`                     | `[Validation]`          | `Autologin=`                  |
 | `--extra-search-paths=`           | `[Host]`                | `ExtraSearchPaths=`           |
 | `--qemu-headless`                 | `[Host]`                | `QemuHeadless=`               |
 | `--network-veth`                  | `[Host]`                | `NetworkVeth=`                |

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -79,6 +79,7 @@ class MkosiConfig(object):
             'packages': [],
             'password': None,
             'password_is_hashed': False,
+            'autologin': False,
             'skip_final_phase': False,
             'prepare_script': None,
             'postinst_script': None,
@@ -277,6 +278,8 @@ class MkosiConfig(object):
                 self.reference_config[job_name]['password'] = mk_config_validation['Password']
             if 'PasswordIsHashed' in mk_config_validation:
                 self.reference_config[job_name]['password_is_hashed'] = mk_config_validation['PasswordIsHashed']
+            if 'Autologin' in mk_config_validation:
+                self.reference_config[job_name]['autologin'] = mk_config_validation['Autologin']
 
         if 'Host' in mk_config:
             mk_config_host = mk_config['Host']
@@ -495,6 +498,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
                 'Key': 'mykey.gpg',
                 'BMap': False,
                 'Password': "secret1234",
+                'Autologin': True,
                 },
             'Host': {
                 'ExtraSearchPaths': 'search/here:search/there',
@@ -563,6 +567,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
                 'Key': 'mykey-ubu.gpg',
                 'BMap': True,
                 'Password': "secret12345",
+                'Autologin': True,
                 },
             'Host': {
                 'ExtraSearchPaths': 'search/ubu',
@@ -631,6 +636,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
                 'Key': 'mykey-debi.gpg',
                 'BMap': True,
                 'Password': "secret12345",
+                'Autologin': True,
                 },
             'Host': {
                 'ExtraSearchPaths': 'search/debi',


### PR DESCRIPTION
This is useful when using mkosi for development as systemd does since
it removes a manual step from the testing workflow.