### PR TITLE
Change QEMU boot order so it doesn't try the CD-ROM

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5423,6 +5423,7 @@ def run_qemu(args: CommandLineArguments) -> None:
         "-drive", f"format={'qcow2' if args.qcow2 else 'raw'},file={args.output}",
         "-object", "rng-random,filename=/dev/urandom,id=rng0",
         "-device", "virtio-rng-pci,rng=rng0,id=rng-device0",
+        "-boot", "c"
     ]
 
     if args.qemu_headless:


### PR DESCRIPTION
Currently, when booting with QEMU, there's a log message about
QEMU trying to boot from the CD-ROM device but not finding anything
there. By changing the boot order, QEMU skips the CD-ROM device and
immediately boots our image.