### PR TITLE
Add --hostonly-initrd option

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -365,6 +365,12 @@ details see the table below.
 : If specified, mkosi does not build unified kernel images and instead installs kernels with a separate
   initrd and boot loader config to the efi or bootloader partition.
 
+`--hostonly-initrd`
+
+: If specified, mkosi will run the tool to create the initrd such that a non-generic initrd is created that
+  will only be able to run on the system mkosi is run on. Currently mkosi uses dracut for all supported
+  distributions except Clear Linux and this option translates to enabling dracut's hostonly option.
+
 `--no-chown`
 
 : By default, if `mkosi` is run inside a `sudo` environment all
@@ -740,6 +746,7 @@ which settings file options.
 | `--qcow2`                         | `[Output]`              | `QCow2=`                      |
 | `--hostname=`                     | `[Output]`              | `Hostname=`                   |
 | `--without-unified-kernel-images` | `[Output]`              | `WithUnifiedKernelImages=`    |
+| `--hostonly-initrd`               | `[Output]`              | `HostonlyInitrd=`             |
 | `--package=`                      | `[Packages]`            | `Packages=`                   |
 | `--with-docs`                     | `[Packages]`            | `WithDocs=`                   |
 | `--without-tests`, `-T`           | `[Packages]`            | `WithTests=`                  |

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1359,7 +1359,7 @@ def configure_dracut(args: CommandLineArguments, root: str) -> None:
     os.mkdir(dracut_dir, 0o755)
 
     with open(os.path.join(dracut_dir, "30-mkosi-hostonly.conf"), "w") as f:
-        f.write("hostonly=no\n")
+        f.write(f"hostonly={'yes' if args.hostonly_initrd else 'no'}\n")
 
     with open(os.path.join(dracut_dir, "30-mkosi-systemd-extras.conf"), "w") as f:
         for extra in DRACUT_SYSTEMD_EXTRAS:
@@ -4079,6 +4079,7 @@ def create_parser() -> ArgumentParserMkosi:
     group.add_argument("--with-unified-kernel-images", action=BooleanAction, default=True,
                        help=argparse.SUPPRESS)
     group.add_argument("--gpt-first-lba", type=int, help='Set the first LBA within GPT Header', metavar='FIRSTLBA')
+    group.add_argument("--hostonly-initrd", action=BooleanAction, help="Enable dracut hostonly option")
 
     group = parser.add_argument_group("Packages")
     group.add_argument('-p', "--package", action=CommaDelimitedListAction, dest='packages', default=[],

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -108,6 +108,7 @@ class MkosiConfig(object):
             'qemu_headless': False,
             'network_veth': False,
             'with_unified_kernel_images': True,
+            'hostonly_initrd': False,
         }
 
     def __eq__(self, other: [mkosi.CommandLineArguments]) -> bool:
@@ -220,6 +221,8 @@ class MkosiConfig(object):
                 self.reference_config[job_name]['hostname'] = mk_config_output['Hostname']
             if 'WithUnifiedKernelImages' in mk_config_output:
                 self.reference_config[job_name]['with_unified_kernel_images'] =  mk_config_output['WithUnifiedKernelImages']
+            if 'HostonlyInitrd' in mk_config_output:
+                self.reference_config[job_name]['hostonly_initrd'] = mk_config_output['HostonlyInitrd']
         if 'Packages' in mk_config:
             mk_config_packages = mk_config['Packages']
             if 'Packages' in mk_config_packages:


### PR DESCRIPTION
Enabling --hostonly speeds up QEMU boots by roughly 2 seconds on
my machine.