### PR TITLE
Only print summary when summary verb is used

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5550,7 +5550,7 @@ def run_verb(args: CommandLineArguments) -> None:
     if args.verb == "build":
         check_output(args)
 
-    if args.verb == "summary" or needs_build(args):
+    if args.verb == "summary" or (needs_build(args) and need_cache_images(args)):
         print_summary(args)
 
     if needs_build(args):


### PR DESCRIPTION
Printing the entire summary every time we're building the image
is unnecessarily verbose. Let's only print the summary when the
user asks for it.