### PR TITLE
Arch: Switch back to using a single call to pacman

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2508,7 +2508,7 @@ def install_arch(args: CommandLineArguments, root: str, do_run_build_script: boo
     if platform.machine() == "aarch64":
         keyring += "arm"
 
-    packages = set()
+    packages = {"base"}
 
     if not do_run_build_script and args.bootable:
         if args.output_format == OutputFormat.gpt_btrfs:
@@ -2549,11 +2549,7 @@ def install_arch(args: CommandLineArguments, root: str, do_run_build_script: boo
         try:
             run(["pacman-key", *conf, "--init"])
             run(["pacman-key", *conf, "--populate"])
-            # Dependencies on packages from base are implicit so pacman doesn't know it has to install the
-            # packages from base before anything else. To circumvent this we explicitly install base first.
-            run(["pacman", *conf, "--noconfirm", "-Sy", "base"])
-            if packages:
-                run(["pacman", *conf, "--noconfirm", "--needed", "-S", *packages])
+            run(["pacman", *conf, "--noconfirm", "-Sy", *packages])
         finally:
             # Kill the gpg-agent started by pacman and pacman-key.
             run(['gpgconf', '--homedir', os.path.join(root, 'etc/pacman.d/gnupg'), '--kill', 'all'])


### PR DESCRIPTION
We shouldn't be working around dependency issues in Arch. I'm not
getting any failures using this anymore right now but if any turn
up, we should file bug reports for the relevant Arch packages to
add the necessary dependencies. Now that base is a metapackage and
not a group, the burden to add it as a dependency should be very
minimal.