### PR TITLE
Allow build script to read from stdin when running in a script

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5232,6 +5232,8 @@ def run_build_script(args: CommandLineArguments, root: str, raw: Optional[Binary
         target = "--directory=" + root if raw is None else "--image=" + raw.name
 
         cmdline = ["systemd-nspawn",
+                   # TODO: Use --autopipe once systemd v247 is widely available.
+                   f"--console={'interactive' if sys.stdout.isatty() else 'pipe'}",
                    '--quiet',
                    target,
                    "--uuid=" + args.machine_id,


### PR DESCRIPTION
When running language servers like clangd via a mkosi build-script,
we need clangd to be able to read from stdin to interact with the
editor. By default, systemd-nspawn doesn't do this for security
issues but in this case we trust the build script so we can specify
--pipe to enable the build script to read from stdin.