### PR TITLE
Add --include-directory option

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -494,6 +494,17 @@ details see the table below.
   but a directory `mkosi.builddir/` exists in the local directory it
   is automatically used for this purpose (also see below).
 
+`--include-directory`
+
+: Takes a path of a directory to use as the include directory. This
+  directory is mounted at /usr/include when building the build image
+  and when running the build script. This means all include files
+  installed to /usr/include will be stored in this directory. This is
+  useful to make include files available on the host system for use by
+  language servers to provide code completion. If this option is not
+  specified, but a directory `mkosi.includedir/` exists in the local
+  directory, it is automatically used for this purpose (also see below).
+
 `--build-package=`
 
 : Similar to `--package=`, but configures packages to install only in
@@ -757,6 +768,7 @@ which settings file options.
 | `--build-sources=`                | `[Packages]`            | `BuildSources=`               |
 | `--source-file-transfer=`         | `[Packages]`            | `SourceFileTransfer=`         |
 | `--build-directory=`              | `[Packages]`            | `BuildDirectory=`             |
+| `--include-directory=`            | `[Packages]`            | `IncludeDirectory=`           |
 | `--build-packages=`               | `[Packages]`            | `BuildPackages=`              |
 | `--skip-final-phase=`             | `[Packages]`            | `SkipFinalPhase=`             |
 | `--postinst-script=`              | `[Packages]`            | `PostInstallationScript=`     |
@@ -1002,6 +1014,14 @@ local directory:
   directory does not exist the `$BUILDDIR` environment variable is not
   set, and it is up to build script to decide whether to do in in-tree
   or an out-of-tree build, and which build directory to use.
+
+* `mkosi.includedir/` may be a directory. If so, it is automatically
+  used as out-of-tree include directory. Specifically, this directory
+  will be mounted into the build container at /usr/include when building
+  the build image and when running the build script. After building the
+  (cached) build image, this directory will contain all the files installed
+  to /usr/include. Language servers or other tools can use these files to
+  provide a better editing experience for developers working on a project.
 
 * `mkosi.rootpw` may be a file containing the password or hashed
   password (if `--password-is-hashed` is set) for the root user of the

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -66,6 +66,7 @@ class MkosiConfig(object):
             'gpt_first_lba': None,
             'home_size': None,
             'hostname': None,
+            'include_dir': None,
             'incremental': False,
             'kernel_command_line': ['rhgb', 'quiet', 'selinux=0', 'audit=0'],
             'key': None,
@@ -245,6 +246,8 @@ class MkosiConfig(object):
                 self.reference_config[job_name]['source_file_transfer'] = mk_config_packages['SourceFileTransfer']
             if 'BuildDirectory' in mk_config_packages:
                 self.reference_config[job_name]['build_dir'] = mk_config_packages['BuildDirectory']
+            if 'IncludeDirectory' in mk_config_packages:
+                self.reference_config[job_name]['include_dir'] = mk_config_packages['IncludeDirectory']
             if 'BuildPackages' in mk_config_packages:
                 self._append_list('build_packages', mk_config_packages['BuildPackages'], job_name)
             if 'PostInstallationScript' in mk_config_packages:


### PR DESCRIPTION
--include-directory makes the header files installed in the container
available on the host. This is useful when running a language server
such as clangd in the mkosi container. If we define a path mapping
in clangd from /usr/include to the include directory, we can jump
to all the header files of external dependencies in the include
directory right from the editor.

Without this, we can't actually use jump to declaration for any third-party
library headers whose packages are not installed on the host system. By
making the include files from the container available on the host and defining
a path mapping, clangd will jump right into the specified --include-directory
when using go to declaration on any symbol belonging to a third-party library
we're using.

Updated clangd config that makes this work:

```
#!/usr/bin/env sh
exec clangd \
        --compile-commands-dir=/root/build \
        --path-mappings=/home/daan/projects/systemd=/root/src,/home/daan/projects/systemd/mkosi.builddir=/root/build,/home/daan/projects/systemd/mkosi.includedir=/usr/include \
        --header-insertion=never
```