### PR TITLE
Redirect non-redirected subprocesses output to stderr except build-script

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -181,17 +181,30 @@ def delay_interrupt() -> Generator[None, None, None]:
         if interrupted:
             die("Interrupted")
 
+# Borrowed from https://github.com/python/typeshed/blob/3d14016085aed8bcf0cf67e9e5a70790ce1ad8ea/stdlib/3/subprocess.pyi#L24
+_FILE = Union[None, int, IO[Any]]
 
-def run(cmdline: List[str], execvp: bool = False, check: bool = True, **kwargs: Any) -> CompletedProcess:
+def run(cmdline: List[str],
+        execvp: bool = False,
+        check: bool = True,
+        stdout: _FILE = None,
+        stderr: _FILE = None,
+        **kwargs: Any) -> CompletedProcess:
     if 'run' in arg_debug:
         sys.stderr.write('+ ' + ' '.join(shlex.quote(x) for x in cmdline) + '\n')
+
+    if not stdout and not stderr:
+        # Unless explicit redirection is done, print all subprocess output on stderr since we do so as well
+        # for mkosi's own output.
+        stdout = sys.stderr
+
     try:
         if execvp:
             assert not kwargs
             os.execvp(cmdline[0], cmdline)
         else:
             with delay_interrupt():
-                return subprocess.run(cmdline, check=check, **kwargs)
+                return subprocess.run(cmdline, check=check, stdout=stdout, stderr=stderr, **kwargs)
     except FileNotFoundError as e:
         die(f"{cmdline[0]} not found in PATH.")
 
@@ -5264,7 +5277,9 @@ def run_build_script(args: CommandLineArguments, root: str, raw: Optional[Binary
 
         cmdline.append("/root/" + os.path.basename(args.build_script))
 
-        result = run(cmdline, check=False)
+        # build-script output goes to stdout so we can run language servers from within mkosi build-scripts.
+        # See https://github.com/systemd/mkosi/pull/566 for more information.
+        result = run(cmdline, stdout=sys.stdout, check=False)
         if result.returncode != 0:
             if 'build-script' in arg_debug:
                 run(cmdline[:-1], check=False)


### PR DESCRIPTION
When running a language server via mkosi, communication with the editor
is done via mkosi's stdin/stdout. If the client reads output from mkosi's
subprocesses instead of LSP json messages from stdout, it won't recognize
the output and crash. To make the language server integration work when the
build image needs to be built from scratch, we redirect all non-redirected
output from subprocesses to stderr except for the build-script. This way,
we can get progress output from mkosi right in the editor without breaking
the language server integration.

The split was already quite arbitrary in the first place. All of mkosi's messages
go to stderr and most subprocess output went to stdout. Instead, let's define
the split between stdout/stderr a bit more so we can take advantage of it.
Only the build script gets to write to stdout which simplifies language server
usage with mkosi.

(This should be the last language server specific change)