### PR TITLE
CI: Build tar archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,6 @@ jobs:
         systemd-container
 
     - name: Build ${{ matrix.distro }}/${{ matrix.format }}
-      if: matrix.format != 'tar'
       run: |
         tee mkosi.default << EOF
         [Distribution]


### PR DESCRIPTION
We actually weren't building tar archives until now. Let's build
them but not try to boot them since that's not supported.