### PR TITLE
CI: Install mkosi explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,12 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ./
 
-    - name: Install
+    - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install --no-install-recommends python3-pexpect
+
+    # Do a manual install so we have the latest changes from the pull request available.
+    - name: Install
+      run: sudo python3 -m pip install .
 
     - name: Build ${{ matrix.distro }}/${{ matrix.format }}
       run: |


### PR DESCRIPTION
Since we'll soon be installing the latest stable version with the
action, let's modify CI already to do an explicit install that
installs mkosi with the latest changes from the PR.