### PR TITLE
Empty include directory before installing to it

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5189,7 +5189,8 @@ def build_image(args: CommandLineArguments,
             with mount_image(args, root, loopdev, None if args.generated_root() else encrypted_root,
                              encrypted_home, encrypted_srv, encrypted_var, encrypted_tmp):
                 prepare_tree(args, root, do_run_build_script, cached)
-                if do_run_build_script and args.include_dir:
+                if do_run_build_script and args.include_dir and not cached:
+                    empty_directory(args.include_dir)
                     # We do a recursive unmount of root so we don't need to explicitly unmount this mount
                     # later.
                     mount_bind(args.include_dir, os.path.join(root, "usr/include"))

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1442,6 +1442,10 @@ def prepare_tree(args: CommandLineArguments, root: str, do_run_build_script: boo
         os.mkdir(os.path.join(root, "root"), 0o750)
         os.mkdir(os.path.join(root, "root/dest"), 0o755)
 
+        if args.include_dir is not None:
+            os.mkdir(os.path.join(root, "usr"), 0o755)
+            os.mkdir(os.path.join(root, "usr/include"), 0o755)
+
         if args.build_dir is not None:
             os.mkdir(os.path.join(root, "root/build"), 0o755)
 


### PR DESCRIPTION
Pacman (and probably other package managers as well) expect
/usr/include to be empty when we're bootstrapping so let's make
sure we empty the directory before installing to it.