### PR TITLE
qemu: Enable -vga virtio when not using --qemu-headless

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5541,8 +5541,9 @@ def run_qemu(args: CommandLineArguments) -> None:
         cmdline += ["-nographic", "-nodefaults", "-serial", "mon:stdio"]
         # Fix for https://github.com/systemd/mkosi/issues/559. QEMU gets stuck in a boot loop when using BIOS
         # if there's no vga device.
-        if "bios" in args.boot_protocols:
-            cmdline += ["-vga", "virtio"]
+
+    if not args.qemu_headless or (args.qemu_headless and "bios" in args.boot_protocols):
+        cmdline += ["-vga", "virtio"]
 
     if args.network_veth:
         # On Linux, interface names are limited to 16 characters so we do the same.


### PR DESCRIPTION
Supports higher resolutions than the default driver. Probably
is more performant as well.