### PR TITLE
Add --ephemeral option

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -734,6 +734,13 @@ details see the table below.
   in systemd-nspawn's man page:
   https://www.freedesktop.org/software/systemd/man/systemd-nspawn.html#-n
 
+`--ephemeral`
+: When used with the shell, boot or qemu verbs, this option runs the specified
+  verb on a temporary snapshot of the output image that is removed immediately
+  when the container terminates. Taking the temporary snapshot is more efficient
+  on file systems that support subvolume snapshots or 'reflinks' natively ("btrfs"
+  or new "xfs") than on more traditional file systems that do not ("ext4").
+
 ## Command Line Parameters and their Settings File Counterparts
 
 Most command line parameters may also be placed in an `mkosi.default`
@@ -802,6 +809,7 @@ which settings file options.
 | `--extra-search-paths=`           | `[Host]`                | `ExtraSearchPaths=`           |
 | `--qemu-headless`                 | `[Host]`                | `QemuHeadless=`               |
 | `--network-veth`                  | `[Host]`                | `NetworkVeth=`                |
+| `--ephemeral`                     | `[Host]`                | `Ephemeral=`                  |
 
 Command line options that take no argument are not suffixed with a `=`
 in their long version in the table above. In the `mkosi.default` file

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -187,7 +187,6 @@ _FILE = Union[None, int, IO[Any]]
 
 def run(
     cmdline: List[str],
-    execvp: bool = False,
     check: bool = True,
     stdout: _FILE = None,
     stderr: _FILE = None,
@@ -202,12 +201,8 @@ def run(
         stdout = sys.stderr
 
     try:
-        if execvp:
-            assert not kwargs
-            os.execvp(cmdline[0], cmdline)
-        else:
-            with delay_interrupt():
-                return subprocess.run(cmdline, check=check, stdout=stdout, stderr=stderr, **kwargs)
+        with delay_interrupt():
+            return subprocess.run(cmdline, check=check, stdout=stdout, stderr=stderr, **kwargs)
     except FileNotFoundError:
         die(f"{cmdline[0]} not found in PATH.")
 
@@ -5864,7 +5859,7 @@ def run_shell(args: CommandLineArguments) -> None:
             cmdline.append("--")
         cmdline += args.cmdline
 
-    run(cmdline, execvp=True)
+    run(cmdline, stdout=sys.stdout, stderr=sys.stderr)
 
 
 def run_qemu(args: CommandLineArguments) -> None:
@@ -5951,7 +5946,7 @@ def run_qemu(args: CommandLineArguments) -> None:
 
     print_running_cmd(cmdline)
 
-    run(cmdline, execvp=True)
+    run(cmdline, stdout=sys.stdout, stderr=sys.stderr)
 
 
 def expand_paths(paths: List[str]) -> List[str]:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5835,33 +5835,33 @@ def check_native(args: CommandLineArguments) -> None:
 
 def run_shell(args: CommandLineArguments) -> None:
     if args.output_format in (OutputFormat.directory, OutputFormat.subvolume):
-        target = "--directory=" + args.output
+        target = f"--directory={args.output}"
     else:
-        target = "--image=" + args.output
+        target = f"--image={args.output}"
 
     cmdline = ["systemd-nspawn", target]
 
     if args.read_only:
-        cmdline += ("--read-only",)
+        cmdline.append("--read-only")
 
     # If we copied in a .nspawn file, make sure it's actually honoured
     if args.nspawn_settings is not None:
-        cmdline += ("--settings=trusted",)
+        cmdline.append("--settings=trusted")
 
     if args.verb == "boot":
-        cmdline += ("--boot",)
+        cmdline.append("--boot")
 
     if args.generated_root() or args.verity:
-        cmdline += ("--volatile=overlay",)
+        cmdline.append("--volatile=overlay")
 
     if args.network_veth:
-        cmdline += ("--network-veth",)
+        cmdline.append("--network-veth")
 
     if args.cmdline:
         # If the verb is shell, args.cmdline contains the command to run. Otherwise (boot), we assume
         # args.cmdline contains nspawn arguments.
         if args.verb == "shell":
-            cmdline += ("--",)
+            cmdline.append("--")
         cmdline += args.cmdline
 
     run(cmdline, execvp=True)

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -110,6 +110,7 @@ class MkosiConfig(object):
             "xz": False,
             "qemu_headless": False,
             "network_veth": False,
+            "ephemeral": False,
             "with_unified_kernel_images": True,
             "hostonly_initrd": False,
         }
@@ -300,6 +301,8 @@ class MkosiConfig(object):
                 self.reference_config[job_name]["qemu_headless"] = mk_config_host["QemuHeadless"]
             if "NetworkVeth" in mk_config_host:
                 self.reference_config[job_name]["network_veth"] = mk_config_host["NetworkVeth"]
+            if "Ephemeral" in mk_config_host:
+                self.reference_config[job_name]["ephemeral"] = mk_config_host["Ephemeral"]
 
 
 class MkosiConfigOne(MkosiConfig):


### PR DESCRIPTION
Identical to systemd-nspawn's --ephemeral option (and that's what how
we implement this for mkosi boot) but also implemented for qemu.

Also includes  a small commit to clean up `run_shell`.
