### PR TITLE
Make --autologin work even when a root password is set

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -383,7 +383,7 @@ details see the table below.
 : If running on a SELinux-enabled system (Fedora, CentOS), files inside
   the container are tagged with SELinux context extended attributes
   (`xattrs`), which may interfere with host SELinux rules in building
-  or further container import stages.  
+  or further container import stages.
   This option strips SELinux context attributes from the resulting
   tar archive.
 
@@ -674,7 +674,8 @@ details see the table below.
 
 `--autologin`
 
-: Enable autologin for the `root` user.
+: Enable autologin for the `root` user on pts/0 (nspawn), tty1 (QEMU) and
+  ttyS0 (QEMU with --qemu-headless) by patching /etc/pam.d/login.
 
 `--extra-search-paths=`
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2907,6 +2907,25 @@ def set_autologin(args: CommandLineArguments, root: str, do_run_build_script: bo
 
     pam_add_autologin(root, "ttyS0")
 
+    override_dir = os.path.join(root, "etc/systemd/system/getty@tty1.service.d")
+    os.makedirs(override_dir, mode=0o755, exist_ok=True)
+
+    override_file = os.path.join(override_dir, "autologin.conf")
+    with open(override_file, "w") as f:
+        f.write(
+            dedent(
+                r"""
+                [Service]
+                ExecStart=
+                ExecStart=-/sbin/agetty -o '-p -- \\u' --autologin root --noclear %I $TERM
+                """
+            )
+        )
+
+    os.chmod(override_file, 0o644)
+
+    pam_add_autologin(root, "tty1")
+
 
 def set_serial_terminal(args: CommandLineArguments, root: str, do_run_build_script: bool, for_cache: bool) -> None:
     """Override TERM for the serial console with the terminal type from the host."""

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2857,6 +2857,14 @@ def set_root_password(args: CommandLineArguments, root: str, do_run_build_script
             patch_file(os.path.join(root, "etc/shadow"), jj)
 
 
+def pam_add_autologin(root: str, tty: str) -> None:
+    with open(os.path.join(root, "etc/pam.d/login"), "r+") as f:
+        original = f.read()
+        f.seek(0)
+        f.write(f"auth sufficient pam_succeed_if.so tty = {tty}\n")
+        f.write(original)
+
+
 def set_autologin(args: CommandLineArguments, root: str, do_run_build_script: bool, for_cache: bool) -> None:
     if do_run_build_script or for_cache or not args.autologin:
         return
@@ -2878,6 +2886,8 @@ def set_autologin(args: CommandLineArguments, root: str, do_run_build_script: bo
 
     os.chmod(override_file, 0o644)
 
+    pam_add_autologin(root, "pts/0")
+
     override_dir = os.path.join(root, "etc/systemd/system/serial-getty@ttyS0.service.d")
     os.makedirs(override_dir, mode=0o755, exist_ok=True)
 
@@ -2894,6 +2904,8 @@ def set_autologin(args: CommandLineArguments, root: str, do_run_build_script: bo
         )
 
     os.chmod(override_file, 0o644)
+
+    pam_add_autologin(root, "ttyS0")
 
 
 def set_serial_terminal(args: CommandLineArguments, root: str, do_run_build_script: bool, for_cache: bool) -> None:


### PR DESCRIPTION
Currently, --autologin still asks for a password if the root
password is not explicitly deleted. By adding some PAM short circuit
rules for the relevant TTYs, we avoid PAM asking for the root password
when a user logs in on either pts/0 (nspawn) or ttyS0 (QEMU with
--qemu-headless).

Also includes a commit that enables autologin for QEMU boots without
--qemu-headless.