### PR TITLE
Fix unsupported operand type error

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1868,7 +1868,7 @@ def install_clear(args: CommandLineArguments, root: str, do_run_build_script: bo
 
     packages = {"os-core-plus", *args.packages}
     if do_run_build_script:
-        packages |= args.build_packages
+        packages.update(args.build_packages)
     if not do_run_build_script and args.bootable:
         packages.add("kernel-native")
 
@@ -1960,7 +1960,7 @@ def install_fedora(args: CommandLineArguments, root: str, do_run_build_script: b
         packages |= {"kernel-core", "kernel-modules", "systemd-udev", "binutils", "dracut"}
         configure_dracut(args, root)
     if do_run_build_script:
-        packages |= args.build_packages
+        packages.update(args.build_packages)
     invoke_dnf(args, root, args.repositories or ["fedora", "updates"], packages)
 
     with open(os.path.join(root, "etc/locale.conf"), "w") as f:
@@ -2000,7 +2000,7 @@ def install_mageia(args: CommandLineArguments, root: str, do_run_build_script: b
             f.write("hostonly=no\n")
             f.write('omit_dracutmodules=""\n')
     if do_run_build_script:
-        packages |= args.build_packages
+        packages.update(args.build_packages)
     invoke_dnf(args, root, args.repositories or ["mageia", "updates"], packages)
 
     disable_pam_securetty(root)
@@ -2043,7 +2043,7 @@ def install_openmandriva(args: CommandLineArguments, root: str, do_run_build_scr
         packages |= {"kernel-release-server", "binutils", "systemd-boot", "dracut", "timezone", "systemd-cryptsetup"}
         configure_dracut(args, root)
     if do_run_build_script:
-        packages |= args.build_packages
+        packages.update(args.build_packages)
     invoke_dnf(args, root, args.repositories or ["openmandriva", "updates"], packages)
 
     disable_pam_securetty(root)
@@ -2200,7 +2200,7 @@ def install_centos(args: CommandLineArguments, root: str, do_run_build_script: b
             packages.add("systemd-udev")
 
     if do_run_build_script:
-        packages |= args.build_packages
+        packages.update(args.build_packages)
 
     repos = args.repositories or default_repos
 
@@ -2209,7 +2209,7 @@ def install_centos(args: CommandLineArguments, root: str, do_run_build_script: b
         packages.add("epel-release")
 
     if do_run_build_script:
-        packages |= args.build_packages
+        packages.update(args.build_packages)
 
     invoke_dnf_or_yum(args, root, repos, packages)
 


### PR DESCRIPTION
Packages is a set, and on some version of Python it complains when |= is
used with a list. Use .update instead.

https://github.com/systemd/systemd/pull/18088/checks?check_run_id=1612112943

```
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.8/dist-packages/mkosi/__main__.py", line 31, in <module>
    main()
  File "/usr/local/lib/python3.8/dist-packages/mkosi/__main__.py", line 25, in main
    run_verb(a)
  File "/usr/local/lib/python3.8/dist-packages/mkosi/__init__.py", line 6104, in run_verb
    build_stuff(args)
  File "/usr/local/lib/python3.8/dist-packages/mkosi/__init__.py", line 5863, in build_stuff
    raw, tar, root_hash = build_image(args, root, do_run_build_script=True)
  File "/usr/local/lib/python3.8/dist-packages/mkosi/__init__.py", line 5655, in build_image
    install_distribution(args, root, do_run_build_script=do_run_build_script, cached=cached_tree)
  File "/usr/local/lib/python3.8/dist-packages/mkosi/__init__.py", line 2778, in install_distribution
    install[args.distribution](args, root, do_run_build_script)
  File "/usr/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/usr/local/lib/python3.8/dist-packages/mkosi/__init__.py", line 1963, in install_fedora
    packages |= args.build_packages
TypeError: unsupported operand type(s) for |=: 'set' and 'list'
Error: Process completed with exit code 1.
```