### PR TITLE
Arch: Remove network configuration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 ### Highlighted Changes
 
+- Remove Arch Linux network automatic configuration to bring the different
+  distros more in line with each other. To add it back, add a postinstall
+  script to configure your network manager of choice.
 - The mkosi Github action now defaults to the current release of mkosi instead
   of the tip of the master branch.
 - Add a `ssh` verb and accompanying `--ssh` option. The latter sets up SSH keys


### PR DESCRIPTION
Let's pull Arch in line with the other distros and not do any network
configuration. If needed, we can add this back, but let's do it behind
an option that we implement for all distros so we at least have uniformity
between distros.