### PR TITLE
Remove "quiet" from default kernel cmdline

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 - Change the --default option to not affect the search location of
   mkosi.default.d anymore. mkosi now always searches for mkosi.default.d
   in the working directory.
+- Drop "quiet" from the default kernel command line.
 
 ## v9
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4319,7 +4319,7 @@ def create_parser() -> ArgumentParserMkosi:
     group.add_argument(
         "--kernel-command-line",
         action=SpaceDelimitedListAction,
-        default=["rhgb", "quiet", "selinux=0", "audit=0"],
+        default=["rhgb", "selinux=0", "audit=0"],
         help="Set the kernel command line (only bootable images)",
     )
     group.add_argument(

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -70,7 +70,7 @@ class MkosiConfig(object):
             "include_dir": None,
             "incremental": False,
             "install_dir": None,
-            "kernel_command_line": ["rhgb", "quiet", "selinux=0", "audit=0"],
+            "kernel_command_line": ["rhgb", "selinux=0", "audit=0"],
             "key": None,
             "mirror": None,
             "mksquashfs_tool": None,


### PR DESCRIPTION
We seem to be running into boot issues semi-regularly in CI because
of the usage of systemd.volatile=overlay. These issues are hard to
debug because we silence boot output by default. Let's enable boot
output by default so we have an easier time debugging these issues
when they occur. Also, mkosi boot shows the same output on
container startup anyway so this brings qemu more in line with mkosi
boot as well.