### PR TITLE
Add --root-size-build option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # mkosi Changelog
 
+## v10
+
+- Add `--root-size-build=` option to set the root partition size of the build
+  image independently of the root partition size of the final image.
+
 ## v9 (unreleased)
 
 ### Highlighted Changes

--- a/mkosi.md
+++ b/mkosi.md
@@ -635,6 +635,11 @@ details see the table below.
   output formats `gpt_ext4`, `gpt_xfs`, `gpt_btrfs`. Defaults to 1G,
   except for `gpt_xfs` where it defaults to 1.3G.
 
+`--root-size-build=`
+
+: If specified, sets the build image root partition size to the given
+  value instead of the value from `--root-size`.
+
 `--esp-size=`
 
 : Similar, and configures the size of the UEFI System Partition
@@ -830,6 +835,7 @@ which settings file options.
 | `--with-network`                  | `[Packages]`            | `WithNetwork=`                |
 | `--settings=`                     | `[Packages]`            | `NSpawnSettings=`             |
 | `--root-size=`                    | `[Partitions]`          | `RootSize=`                   |
+| `--root-size-build=`              | `[Partitions]`          | `RootSizeBuild=`              |
 | `--esp-size=`                     | `[Partitions]`          | `ESPSize=`                    |
 | `--swap-size=`                    | `[Partitions]`          | `SwapSize=`                   |
 | `--home-size=`                    | `[Partitions]`          | `HomeSize=`                   |

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -92,6 +92,7 @@ class MkosiConfig(object):
             "release": None,
             "repositories": [],
             "root_size": None,
+            "root_size_build": None,
             "secure_boot": False,
             "secure_boot_certificate": None,
             "secure_boot_key": None,
@@ -279,6 +280,8 @@ class MkosiConfig(object):
             mk_config_partitions = mk_config["Partitions"]
             if "RootSize" in mk_config_partitions:
                 self.reference_config[job_name]["root_size"] = mk_config_partitions["RootSize"]
+            if "RootSizeBuild" in mk_config_partitions:
+                self.reference_config[job_name]["root_size_build"] = mk_config_partitions["RootSizeBuild"]
             if "ESPSize" in mk_config_partitions:
                 self.reference_config[job_name]["esp_size"] = mk_config_partitions["ESPSize"]
             if "SwapSize" in mk_config_partitions:


### PR DESCRIPTION
Allows independently setting the build image root partition size.
This is useful when the build image is much larger than the final
image due to the extra tools that need to be installed.

Fixed #611.