### PR TITLE
Add --build-environment option

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -490,6 +490,14 @@ details see the table below.
   `mkosi.build` file found in the local directory it is automatically
   used for this purpose (also see below).
 
+`--build-environment=`
+
+: Adds environment variables to the environment that the build script
+  is executed with. Takes a space-separated list of variable
+  assignments. This option may be  specified more than once, in which
+  case all listed variables will be set. If the same variable is set
+  twice, the later setting will override the earlier setting.
+
 `--build-sources=`
 
 : Takes a path of a source tree to copy into the development image, if
@@ -817,6 +825,7 @@ which settings file options.
 | `--extra-tree=`                   | `[Packages]`            | `ExtraTrees=`                 |
 | `--skeleton-tree=`                | `[Packages]`            | `SkeletonTrees=`              |
 | `--build-script=`                 | `[Packages]`            | `BuildScript=`                |
+| `--build-environment=`            | `[Packages]`            | `BuildEnvironment=`           |
 | `--build-sources=`                | `[Packages]`            | `BuildSources=`               |
 | `--source-file-transfer=`         | `[Packages]`            | `SourceFileTransfer=`         |
 | `--source-file-transfer-final=`   | `[Packages]`            | `SourceFileTransferFinal=`    |

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -49,6 +49,7 @@ class MkosiConfig(object):
             "build_dir": None,
             "build_packages": [],
             "build_script": None,
+            "build_env": [],
             "build_sources": None,
             "cache_path": None,
             "checksum": False,
@@ -251,6 +252,8 @@ class MkosiConfig(object):
                 self._append_list("skeleton_trees", mk_config_packages["SkeletonTrees"], job_name)
             if "BuildScript" in mk_config_packages:
                 self.reference_config[job_name]["build_script"] = mk_config_packages["BuildScript"]
+            if "BuildEnvironment" in mk_config_packages:
+                self.reference_config["build_env"] = mk_config_packages["BuildEnvironment"]
             if "BuildSources" in mk_config_packages:
                 self.reference_config[job_name]["build_sources"] = mk_config_packages["BuildSources"]
             if "SourceFileTransfer" in mk_config_packages:


### PR DESCRIPTION
Allows setting environment variables for the build script. Useful
to allow users to configure the execution of the build script.