### PR TITLE
allow both uefi and bios build with unified kernel images

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1596,8 +1596,11 @@ def disable_kernel_install(args: CommandLineArguments, root: str) -> None:
 
 
 def reenable_kernel_install(args: CommandLineArguments, root: str) -> None:
-    if not args.bootable or args.bios_partno is not None or not args.with_unified_kernel_images:
+    if not args.bootable or not args.with_unified_kernel_images:
         return
+
+    for d in ("etc", "etc/kernel", "etc/kernel/install.d"):
+        mkdir_last(os.path.join(root, d), 0o755)
 
     hook_path = os.path.join(root, "etc/kernel/install.d/50-mkosi-dracut-unified-kernel.install")
     with open(hook_path, "w") as f:


### PR DESCRIPTION
i attempted to make an (ubuntu bionic) image that would work with both bios and uefi boot i.e. `BootProtocols=bios,uefi` and ran into a problem where it attempts to run a dracut install script that never gets made in `reenable_kernel_install` because of the presence of a bios boot partition number (`args.bios_partno`):

```
‣ Generating combined kernel + initrd boot file...
execv(/etc/kernel/install.d/50-mkosi-dracut-unified-kernel.install) failed: No such file or directory
‣ Error: Workspace command `/etc/kernel/install.d/50-mkosi-dracut-unified-kernel.install add 4.15.0-20-generic /efi/01c7c30962f14b1b942ed4a9cfeea4e2/4.15.0-20-generic ` returned non-zero exit code 1.
```