### PR TITLE
RFC UEFI boot: make sure efivarfs loaded in initrd

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1416,6 +1416,10 @@ def configure_dracut(args: CommandLineArguments, root: str) -> None:
     ):
         with open(os.path.join(dracut_dir, "30-mkosi-uefi-stub.conf"), "w") as f:
             f.write("uefi_stub=/usr/lib/systemd/boot/efi/linuxx64.efi.stub\n")
+
+    # efivarfs must be present in order to GPT root discovery work
+    if args.esp_partno is not None:
+        with open(os.path.join(dracut_dir, "30-mkosi-efivarfs.conf"), "w") as f:
             f.write('add_drivers+=" efivarfs "\n')
 
 


### PR DESCRIPTION
The efivarfs is needed in order to GPT root partition discovery work.
Without efivarfs initrd won't be able to switch to the real root.

(Make module inclusion distro specific in case it's included by other
reasons.) -- **this is why the patch is RFC**. I guess #562 it can be problem on any distro when the build host is not UEFI-booted itself (i.e. `efivarfs` won't be loaded with hostonly=1). So I'd be inclined to drop the distro-guard, OTOH, I don't know if there are any distros that have `efivarfs` built in in the kernel (which would break initrd creation).

Fixes #562