### PR TITLE
Drop networkd not running to a warning instead of a fatal error

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -6092,10 +6092,15 @@ def has_networkd_vm_vt() -> bool:
 def ensure_networkd(args: CommandLineArguments) -> None:
     networkd_is_running = run(["systemctl", "is-active", "--quiet", "systemd-networkd"], check=False).returncode == 0
     if not networkd_is_running:
-        die("--network-veth requires systemd-networkd to be running (`systemctl enable --now systemd-networkd`)")
+        warn(
+            """
+            --network-veth requires systemd-networkd to be running to initialize the host interface of the
+            veth link (`systemctl enable --now systemd-networkd`)")
+            """
+        )
 
     if args.verb == "qemu" and not has_networkd_vm_vt():
-        die(
+        warn(
             r"""
             mkosi didn't find 80-vm-vt.network. This is one of systemd's built-in systemd-networkd config
             files which configures vt-* interfaces. mkosi needs this file in order for --network-veth to work


### PR DESCRIPTION
Without networkd, the veth link won't come up properly on the host
but that doesn't prevent mkosi boot or mkosi qemu from working so
let's drop those messages to warnings instead of fatal errors.

cc: @Werkov @bluca 