### PR TITLE
Enabling console autologin

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2945,6 +2945,7 @@ def set_autologin(args: CommandLineArguments, root: str, do_run_build_script: bo
         os.chmod(override_file, 0o644)
 
         pam_add_autologin(root, f"{device_prefix}tty1")
+        pam_add_autologin(root, f"{device_prefix}console")
 
 
 def set_serial_terminal(args: CommandLineArguments, root: str, do_run_build_script: bool, cached: bool) -> None:


### PR DESCRIPTION
When installing centos_epel from my centos VPS it still asks for a password even though `--autologin` was used. No problem when installing centos under fedora. Apparently it is using console instead of tty1 or pty/0.  Adding `auth sufficient pam_succeed_if.so tty = console` fixed it.
