### PR TITLE
Keep commented locales in /etc/locale.gen

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2678,8 +2678,20 @@ def install_arch(args: CommandLineArguments, root: str, do_run_build_script: boo
     with mount_api_vfs(args, root):
         run_pacman(packages)
 
-    with open(os.path.join(root, "etc/locale.gen"), "w") as f:
-        f.write("en_US.UTF-8 UTF-8\n")
+    # If /etc/locale.gen exists, uncomment the desired locale and leave the rest of the file untouched.
+    # If it doesn’t exist, just write the desired locale in it.
+    try:
+
+        def _enable_locale(line: str) -> str:
+            if line.startswith("#en_US.UTF-8"):
+                return line.replace("#", "")
+            return line
+
+        patch_file(os.path.join(root, "etc/locale.gen"), _enable_locale)
+
+    except FileNotFoundError:
+        with open(os.path.join(root, "etc/locale.gen"), "x") as f:
+            f.write("en_US.UTF-8 UTF-8\n")
 
     run_workspace_command(args, root, ["/usr/bin/locale-gen"])
 


### PR DESCRIPTION
`/etc/locale.gen` contains the list of supported locales.
In order to enable one, it needs to be uncommented.

The issue with removing all the commented locales and that this PR addresses is the fact that some tools might rely on the commented locales to know what are the valid ones.

For ex., here is the [Ansible module `locale_gen`](https://docs.ansible.com/ansible/latest/collections/community/general/locale_gen_module.html#ansible-collections-community-general-locale-gen-module) [error](https://github.com/ansible-collections/community.general/blob/2.0.0/plugins/modules/system/locale_gen.py#L66) that this PR fixes:
```
TASK [post_install : Enable locale] ******************************************************************************************************************************************************************************************************************************************
fatal: [archlinux]: FAILED! => {"changed": false, "msg": "The locale you've entered is not available on your system."}
```