### PR TITLE
prevent mounting EFI partition with compress

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1240,11 +1240,11 @@ def mount_loop(args: CommandLineArguments, dev: str, where: str, read_only: bool
     if not args.output_format.is_squashfs():
         options.append("discard")
 
-    if args.compress and args.output_format == OutputFormat.gpt_btrfs:
+    if args.compress and args.output_format == OutputFormat.gpt_btrfs and not where.endswith("/efi"):
         if isinstance(args.compress, bool):
             options.append("compress")
         else:
-            options.append(f",compress={args.compress}")
+            options.append(f"compress={args.compress}")
 
     if read_only:
         options.append("ro")

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1240,7 +1240,9 @@ def mount_loop(args: CommandLineArguments, dev: str, where: str, read_only: bool
     if not args.output_format.is_squashfs():
         options.append("discard")
 
-    if args.compress and args.output_format == OutputFormat.gpt_btrfs and not where.endswith("/efi"):
+    if args.compress and args.output_format == OutputFormat.gpt_btrfs and not (
+        where.endswith("/efi") or where.endswith("/boot")
+    ):
         if isinstance(args.compress, bool):
             options.append("compress")
         else:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1240,8 +1240,10 @@ def mount_loop(args: CommandLineArguments, dev: str, where: str, read_only: bool
     if not args.output_format.is_squashfs():
         options.append("discard")
 
-    if args.compress and args.output_format == OutputFormat.gpt_btrfs and not (
-        where.endswith("/efi") or where.endswith("/boot")
+    if (
+        args.compress
+        and args.output_format == OutputFormat.gpt_btrfs
+        and not (where.endswith("/efi") or where.endswith("/boot"))
     ):
         if isinstance(args.compress, bool):
             options.append("compress")


### PR DESCRIPTION
For bootable gpt_btrfs format output with compression enabled, mkosi would crash trying to mount the EFI partition with a compression option. This change skips adding any compression options if we are mounting the EFI partition.