### PR TITLE
qemu: Use q35 machine

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -6182,7 +6182,7 @@ def run_qemu(args: CommandLineArguments) -> None:
     arch_binary = ARCH_BINARIES.get(platform.machine(), None)
     accel = "kvm" if has_kvm else "tcg"
     if arch_binary is not None:
-        cmdlines += [[arch_binary, "-machine", f"accel={accel}"]]
+        cmdlines += [[arch_binary, "-machine", f"type=q35,accel={accel}"]]
     cmdlines += [
         ["qemu", "-machine", f"accel={accel}"],
         ["qemu-kvm"],
@@ -6260,7 +6260,15 @@ def run_qemu(args: CommandLineArguments) -> None:
         else:
             fname = args.output
 
-        cmdline += ["-drive", f"format={'qcow2' if args.qcow2 else 'raw'},file={fname},if=virtio"]
+        cmdline += [
+            "-drive",
+            f"if=none,id=hd,file={fname},format={'qcow2' if args.qcow2 else 'raw'}",
+            "-device",
+            "virtio-scsi-pci,id=scsi",
+            "-device",
+            "scsi-hd,drive=hd,bootindex=1",
+        ]
+
         cmdline += args.cmdline
 
         print_running_cmd(cmdline)


### PR DESCRIPTION
This is necessary for booting with secure boot enabled in QEMU.
Switching to q35 somehow changed the boot order causing us to drop
into the EFI shell at boot. To fix this, I switched from virtio-blk
to virtio-scsci-pci (which is supposed to be the future anyway)
which allows us to set bootindex to override the boot order.