### PR TITLE
qemu: Add secure boot support

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -6182,7 +6182,7 @@ def run_qemu(args: CommandLineArguments) -> None:
     arch_binary = ARCH_BINARIES.get(platform.machine(), None)
     accel = "kvm" if has_kvm else "tcg"
     if arch_binary is not None:
-        cmdlines += [[arch_binary, "-machine", f"accel={accel}"]]
+        cmdlines += [[arch_binary, "-machine", f"type=q35,accel={accel}"]]
     cmdlines += [
         ["qemu", "-machine", f"accel={accel}"],
         ["qemu-kvm"],
@@ -6260,7 +6260,15 @@ def run_qemu(args: CommandLineArguments) -> None:
         else:
             fname = args.output
 
-        cmdline += ["-drive", f"format={'qcow2' if args.qcow2 else 'raw'},file={fname},if=virtio"]
+        cmdline += [
+            "-drive",
+            f"if=none,id=hd,file={fname},format={'qcow2' if args.qcow2 else 'raw'}",
+            "-device",
+            "virtio-scsi-pci,id=scsi",
+            "-device",
+            "scsi-hd,drive=hd,bootindex=1",
+        ]
+
         cmdline += args.cmdline
 
         print_running_cmd(cmdline)

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -6183,7 +6183,7 @@ def run_shell(args: CommandLineArguments) -> None:
 
 def find_qemu_binary() -> str:
     ARCH_BINARIES = {"x86_64": "qemu-system-x86_64", "i386": "qemu-system-i386"}
-    arch_binary = ARCH_BINARIES.get(platform.machine(), None)
+    arch_binary = ARCH_BINARIES.get(platform.machine())
 
     binaries: List[str] = []
     if arch_binary is not None:


### PR DESCRIPTION
So I'm trying to get this working so I can use it to test secure boot enrollement in sd-boot which I'm working on atm. Just using OVMF_CODE.secboot.fd causes qemu to enter a busy loop on startup. Adding `-global ICH9-LPC.disable_s3=1` causes the following error:

```
daan@archlinux ~/p/systemd (sd-boot-no-include)> sudo mkosi -i qemu
‣ Running command:
‣ qemu-system-x86_64 -machine type=q35,smm=on,accel=kvm -smp 2 -m 1024 -cpu host -drive if=pflash,format=raw,readonly,file=/usr/share/ovmf/x64/OVMF_CODE.secboot.fd -global driver=cfi.pflash01,property=secure,value=on -global ICH9-LPC.disable_s3=1 -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0,id=rng-device0 -nographic -nodefaults -serial mon:stdio -nic tap,script=no,downscript=no,ifname=vt-image,model=virtio-net-pci -drive if=none,id=hd,file=/home/daan/projects/systemd/mkosi.output/image.raw,format=raw -device virtio-scsi-pci,id=scsi -device scsi-hd,drive=hd,bootindex=1

!!!! X64 Exception Type - 06(#UD - Invalid Opcode)  CPU Apic ID - 00000000 !!!!
RIP  - 0000000000030000, CS  - 0000000000000038, RFLAGS - 0000000000010246
RAX  - 0000000000000000, RCX - 0000000000000000, RDX - 0000000000000000
RBX  - FFFFFFFFFFFFFFFF, RSP - 000000003EFB3E38, RBP - 000000003EFB3EA8
RSI  - 000000003E8ED798, RDI - 000000003EFCA378
R8   - 0000000000000000, R9  - 0000000003041001, R10 - 000000000000003A
R11  - 000000003E8E9988, R12 - 000000003E8E9018, R13 - 0000000000000001
R14  - 000000008000F880, R15 - 000000008000F844
DS   - 0000000000000030, ES  - 0000000000000030, FS  - 0000000000000030
GS   - 0000000000000030, SS  - 0000000000000030
CR0  - 0000000080010033, CR2 - 0000000000000000, CR3 - 000000003EC01000
CR4  - 0000000000000668, CR8 - 0000000000000000
DR0  - 0000000000000000, DR1 - 0000000000000000, DR2 - 0000000000000000
DR3  - 0000000000000000, DR6 - 00000000FFFF0FF0, DR7 - 0000000000000400
GDTR - 000000003E9EEA98 0000000000000047, LDTR - 0000000000000000
IDTR - 000000003E5BB018 0000000000000FFF,   TR - 0000000000000000
FXSAVE_STATE - 000000003EFB3A90
!!!! Can't find image information. !!!!
```

I wonder if this is a bug in ovmf itself. Can anyone give this a test run to see if the problem is specific to my machine? I guess it could also be due to the fact that the UEFI bootloader can't find a signed image since secure boot should be enabled but this seems like a super weird error to raise if that's the case.