### PR TITLE
Add support for writing authenticated ESLs to /efi/loader/secure-boot

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5601,7 +5601,7 @@ def load_args(args: argparse.Namespace) -> CommandLineArguments:
     if args.secure_boot_certificate is not None:
         args.secure_boot_certificate = os.path.abspath(args.secure_boot_certificate)
 
-    if args.secure_boot:
+    if args.secure_boot and args.verb != "genkey":
         if args.secure_boot_key is None:
             die(
                 "UEFI SecureBoot enabled, but couldn't find private key. (Consider placing it in mkosi.secure-boot.key?)"

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -6645,7 +6645,7 @@ def run_ssh(args: CommandLineArguments) -> None:
         )
 
 
-def generate_secure_boot_key(args: CommandLineArguments) -> NoReturn:
+def generate_secure_boot_key(args: CommandLineArguments) -> None:
     """Generate secure boot keys using openssl"""
     args.secure_boot_key = args.secure_boot_key or "./mkosi.secure-boot.key"
     args.secure_boot_certificate = args.secure_boot_certificate or "./mkosi.secure-boot.crt"
@@ -6691,9 +6691,12 @@ def generate_secure_boot_key(args: CommandLineArguments) -> NoReturn:
         str(args.secure_boot_valid_days),
         "-subj",
         f"/CN={cn}/",
+        "-nodes",
     ]
 
-    os.execvp(cmd[0], cmd)
+    run(cmd)
+
+    os.chmod(args.secure_boot_key, 0o600)
 
 
 def expand_paths(paths: List[str]) -> List[str]:


### PR DESCRIPTION
In preparation for systemd adding secure-boot enrollment support to
sd-boot, let's have mkosi write authenticated EFI signature lists to
/efi/loader/secure-boot which sd-boot will read to enroll the host
into secure-boot.

cc @poettering 

Not tested as I still need to finish the sd-boot integration so let's wait
until that's finished before merging this.