### PR TITLE
Make CommandLineArguments fully typed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## v10 (unreleased)
 
+- Minimum Python version is now Python 3.7.
 - Remove Arch Linux network automatic configuration to bring the different
   distros more in line with each other. To add it back, add a postinstall
   script to configure your network manager of choice.

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     maintainer="mkosi contributors",
     maintainer_email="systemd-devel@lists.freedesktop.org",
     license="LGPLv2+",
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     packages = ["mkosi"],
     scripts = ["bin/mkosi"],
     cmdclass = { "man": BuildManpage },

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -74,7 +74,7 @@ class MkosiConfig(object):
             "kernel_command_line": ["rhgb", "selinux=0", "audit=0"],
             "key": None,
             "mirror": None,
-            "mksquashfs_tool": None,
+            "mksquashfs_tool": [],
             "no_chown": False,
             "nspawn_settings": None,
             "output": None,
@@ -119,6 +119,7 @@ class MkosiConfig(object):
             "with_unified_kernel_images": True,
             "hostonly_initrd": False,
             "ssh": False,
+            "minimize": False,
         }
 
     def __eq__(self, other: [mkosi.CommandLineArguments]) -> bool:


### PR DESCRIPTION
This commit extends CommandLineArguments with all necessary fields
from the argument parser, removes the inheritance from argparse.Namespace
and fixes all resulting typing errors.

We try to stick to typing only changes as much as possible to reduce the
chance of breaking something (although there are a few non-typing changes
where doing so made things easier).

Because we use a dataclass now for the CommandLineArguments class, we
up the required python version to 3.7.