### PR TITLE
Check if image being built is bootable before checking CentOS versions

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5223,6 +5223,27 @@ def load_args(args: CommandLineArguments) -> CommandLineArguments:
         elif args.distribution == Distribution.openmandriva:
             args.release = "cooker"
 
+    if args.bootable:
+        if args.output_format in (
+            OutputFormat.directory,
+            OutputFormat.subvolume,
+            OutputFormat.tar,
+            OutputFormat.plain_squashfs,
+        ):
+            die("Directory, subvolume, tar and plain squashfs images cannot be booted.")
+
+        if not args.boot_protocols:
+            args.boot_protocols = ["uefi"]
+
+            if args.distribution == Distribution.photon:
+                args.boot_protocols = ["bios"]
+
+        if not {"uefi", "bios"}.issuperset(args.boot_protocols):
+            die("Not a valid boot protocol")
+
+        if "uefi" in args.boot_protocols and args.distribution == Distribution.photon:
+            die(f"uefi boot not supported for {args.distribution}")
+
     if args.distribution in (Distribution.centos, Distribution.centos_epel):
         epel_release = int(args.release.split(".")[0])
         if epel_release <= 8 and args.output_format == OutputFormat.gpt_btrfs:
@@ -5264,27 +5285,6 @@ def load_args(args: CommandLineArguments) -> CommandLineArguments:
 
     if args.generated_root() and args.incremental:
         die("Sorry, incremental mode is currently not supported for squashfs or minimized file systems.")
-
-    if args.bootable:
-        if args.output_format in (
-            OutputFormat.directory,
-            OutputFormat.subvolume,
-            OutputFormat.tar,
-            OutputFormat.plain_squashfs,
-        ):
-            die("Directory, subvolume, tar and plain squashfs images cannot be booted.")
-
-        if not args.boot_protocols:
-            args.boot_protocols = ["uefi"]
-
-            if args.distribution == Distribution.photon:
-                args.boot_protocols = ["bios"]
-
-        if not {"uefi", "bios"}.issuperset(args.boot_protocols):
-            die("Not a valid boot protocol")
-
-        if "uefi" in args.boot_protocols and args.distribution == Distribution.photon:
-            die(f"uefi boot not supported for {args.distribution}")
 
     if args.encrypt is not None:
         if not args.output_format.is_disk():


### PR DESCRIPTION
The CentOS specific tests need to know the final value for
boot_protocols.

Before:
 ```
   sudo mkosi -d centos -r 7 --bootable
    ...
    ‣ Generating combined kernel + initrd boot file...
    getopt: unrecognized option '--uefi'
    Usage: /usr/sbin/dracut [OPTION]... [<initramfs> [<kernel-version>]]

    Version: 033-572.el7

    Creates initial ramdisk images for preloading modules

      -h, --help  Display all options

    If a [LIST] has multiple arguments, then you have to put these in quotes.

    For example:

        # dracut --add-drivers "module1 module2"  ...

    ‣ Error: Workspace command `/etc/kernel/install.d/50-mkosi-dracut-unified-kernel.install add 3.10.0-1160.15.2.el7.x86_64 
/efi/8bb4954ccdbb43c9bb7422a279666f09/3.10.0-1160.15.2.el7.x86_64 ` returned non-zero exit code 1.
    ‣ Unmounting image...
    ‣ Detaching image file...

```
After:
```
    sudo mkosi -d centos -r 7 --bootable --force
    ‣ Error: Sorry, CentOS 7 does not support unified kernel images. You must use --without-unified-kernel-images.
```