### PR TITLE
Arch: Fix autologin on nspawn --boot and qemu

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2918,8 +2918,8 @@ def set_autologin(args: CommandLineArguments, root: str, do_run_build_script: bo
         return
 
     with complete_step("Setting up autologin"):
-        # On Debian, PAM wants the full path to the console device or it will refuse access
-        device_prefix = "/dev/" if args.distribution is Distribution.debian else ""
+        # On Arch, Debian, PAM wants the full path to the console device or it will refuse access
+        device_prefix = "/dev/" if args.distribution in [Distribution.arch, Distribution.debian] else ""
 
         override_dir = os.path.join(root, "etc/systemd/system/console-getty.service.d")
         os.makedirs(override_dir, mode=0o755, exist_ok=True)


### PR DESCRIPTION
This PR fixes auto-login for Arch guests when run with `systemd-nspawn --boot` or by qemu with the same change as in #596.

For an image `mkosi --bootable --distribution=arch --autologin`:

Before:
- `systemd-nspawn -i image.raw` boots to root bash prompt (as always)
- `systemd-nspawn -bi image.raw` boots to a password prompt
- `qemu-system-x86_64 -m 512 -bios /usr/share/ovmf/x64/OVMF.fd -drive format=raw,file=image.raw` boots to password prompt

After: all three boot to root bash prompt.