### PR TITLE
Check if btrfs is available before trying to unlink a subvolume

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,20 @@ jobs:
         NetworkVeth=yes
         EOF
 
+    # Ubuntu's systemd-nspawn doesn't support faccessat2() syscall, which is
+    # required, since current Arch's glibc implements faccessat() via faccessat2().
+    - name: Update systemd-nspawn
+      if: ${{ matrix.distro == 'arch' }}
+      run: |
+        echo "deb-src http://archive.ubuntu.com/ubuntu/ $(lsb_release -cs) main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
+        sudo apt update
+        sudo apt build-dep systemd
+        git clone https://github.com/systemd/systemd --depth=1 && cd systemd
+        meson build
+        ninja -C build
+        sudo ln -svf $PWD/build/systemd-nspawn `which systemd-nspawn`
+        systemd-nspawn --version
+
     - name: Build ${{ matrix.distro }}/${{ matrix.format }}
       run: |
         sudo python3 -m mkosi build

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5074,10 +5074,11 @@ def unlink_try_hard(path: Optional[str]) -> None:
     except:  # NOQA: E722
         pass
 
-    try:
-        btrfs_subvol_delete(path)
-    except:  # NOQA: E722
-        pass
+    if shutil.which("btrfs"):
+        try:
+            btrfs_subvol_delete(path)
+        except:  # NOQA: E722
+            pass
 
     try:
         shutil.rmtree(path)


### PR DESCRIPTION
otherwise the output is full of pointless errors on certain systems
(like CentOS 8, which doesn't support btrfs):

```
# mkosi --force --debug run --qemu-headless=true build
‣ Removing output files...
+ btrfs subvol show /home/vagrant/mkosi/mkosi.output/fedora.raw
‣ Error: btrfs not found in PATH.
...
‣ Configuring serial tty (ttyS0)...
‣ Cleaning dnf metadata......
+ btrfs subvol show /var/tmp/mkosi-polqexiq/root/var/log/dnf.log
‣ Error: btrfs not found in PATH.
+ btrfs subvol show /var/tmp/mkosi-polqexiq/root/var/cache/dnf
‣ Error: btrfs not found in PATH.
+ btrfs subvol show /var/tmp/mkosi-polqexiq/root/var/log/dnf.librepo.log
‣ Error: btrfs not found in PATH.
+ btrfs subvol show /var/tmp/mkosi-polqexiq/root/var/log/hawkey.log
‣ Error: btrfs not found in PATH.
+ btrfs subvol show /var/tmp/mkosi-polqexiq/root/var/lib/dnf
‣ Error: btrfs not found in PATH.
+ btrfs subvol show /var/tmp/mkosi-polqexiq/root/var/log/dnf.rpm.log
‣ Error: btrfs not found in PATH.
‣ Cleaning rpm metadata......
+ btrfs subvol show /var/tmp/mkosi-polqexiq/root/var/lib/rpm
‣ Error: btrfs not found in PATH.
‣ Resetting machine ID...
...
```