### PR TITLE
Allow overriding # of CPUs and amount of RAM for qemu guests

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -772,6 +772,16 @@ details see the table below.
   connects to its serial console from the current terminal instead
   of launching the VM in a separate window.
 
+`--qemu-smp=`
+
+: When used with the qemu verb, this options sets the qemu's `-smp`
+  argument which controls the number of guest's CPUs. Defaults to `2`.
+
+`--qemu-mem=`
+
+: When used with the qemu verb, this options sets the qemu's `-m`
+  argument which controls the amount of guest's RAM. Defaults to `1G`.
+
 `--network-veth`
 : When used with the boot or qemu verbs, this option creates a virtual
   ethernet link between the host and the container/VM. The host
@@ -866,6 +876,8 @@ which settings file options.
 | `--autologin`                     | `[Validation]`          | `Autologin=`                  |
 | `--extra-search-paths=`           | `[Host]`                | `ExtraSearchPaths=`           |
 | `--qemu-headless`                 | `[Host]`                | `QemuHeadless=`               |
+| `--qemu-smp`                      | `[Host]`                | `QemuSmp=`                    |
+| `--qemu-mem`                      | `[Host]`                | `QemuMem=`                    |
 | `--network-veth`                  | `[Host]`                | `NetworkVeth=`                |
 | `--ephemeral`                     | `[Host]`                | `Ephemeral=`                  |
 | `--ssh`                           | `[Host]`                | `Ssh=`                        |

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -399,7 +399,6 @@ class CommandLineArguments:
     password_is_hashed: bool
     autologin: bool
     extra_search_paths: List[str]
-    qemu_headless: bool
     network_veth: bool
     ephemeral: bool
     ssh: bool
@@ -408,6 +407,11 @@ class CommandLineArguments:
     all: bool
     all_directory: Optional[str]
     debug: List[str]
+
+    # QEMU-specific options
+    qemu_headless: bool
+    qemu_smp: str
+    qemu_mem: str
 
     # Some extra stuff that's stored in CommandLineArguments for convenience but isn't populated by arguments
     verity_size: Optional[int]
@@ -4769,6 +4773,8 @@ def create_parser() -> ArgumentParserMkosi:
         "--extra-search-paths", dest="extra_search_paths", action=ColonDelimitedListAction, help=argparse.SUPPRESS
     )  # Compatibility option
     group.add_argument("--qemu-headless", action=BooleanAction, help="Configure image for qemu's -nographic mode")
+    group.add_argument("--qemu-smp", help="Configure guest's SMP settings", metavar="SMP", default="2")
+    group.add_argument("--qemu-mem", help="Configure guest's RAM size", metavar="MEM", default="1G")
     group.add_argument(
         "--network-veth",
         action=BooleanAction,
@@ -6476,9 +6482,9 @@ def run_qemu(args: CommandLineArguments) -> None:
         "-machine",
         f"type=q35,accel={accel},smm={'on' if fw_supports_sb else 'off'}",
         "-smp",
-        "2",
+        args.qemu_smp,
         "-m",
-        "1024",
+        args.qemu_mem,
         "-object",
         "rng-random,filename=/dev/urandom,id=rng0",
         "-device",

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -114,6 +114,8 @@ class MkosiConfig(object):
             "xbootldr_size": None,
             "xz": False,
             "qemu_headless": False,
+            "qemu_smp": "2",
+            "qemu_mem": "1G",
             "network_veth": False,
             "ephemeral": False,
             "with_unified_kernel_images": True,


### PR DESCRIPTION
This commit introduces two options - `--qemu-smp` and `--qemu-mem` - which
can be used to override the default number of CPUs and amount of RAM for
guests started via the `qemu` verb.