### PR TITLE
Fix encrypted gpt_squashfs

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3665,7 +3665,7 @@ def insert_partition(
         last_partition_sector = GPT_HEADER_SIZE
 
     blob_size = roundup512(os.stat(blob.name).st_size)
-    luks_extra = 2 * 1024 * 1024 if args.encrypt == "all" else 0
+    luks_extra = 16 * 1024 * 1024 if args.encrypt == "all" else 0
     new_size = last_partition_sector + blob_size + luks_extra + GPT_FOOTER_SIZE
 
     MkosiPrinter.print_step(f"Resizing disk image to {format_bytes(new_size)}...")

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3694,6 +3694,7 @@ def insert_partition(
 
     run(["sfdisk", "--color=never", loopdev], input=table.encode("utf-8"))
     run(["sync"])
+    run(["partx", "--update", loopdev])
 
     MkosiPrinter.print_step("Writing partition...")
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3699,7 +3699,7 @@ def insert_partition(
     MkosiPrinter.print_step("Writing partition...")
 
     if args.root_partno == partno:
-        luks_format_root(args, loopdev, False, True)
+        luks_format_root(args, loopdev, False, False, True)
         dev = luks_setup_root(args, loopdev, False, True)
     else:
         dev = None


### PR DESCRIPTION
Fixes #655.

https://github.com/systemd/mkosi/issues/655#issue-810610045 describes the errors.
`mkosi --encrypt=data --home-size=128M --distribution=fedora --release=33 --format=gpt_squashfs` fails because `dd` can't find the partition to write to. This is caused by /home already being mounted when the `sfdisk` modifies the partitions. `sfdisk` fails to re-read the partition table because the device is busy so a `partprobe` command had to be added.

`mkosi --encrypt=all --distribution=fedora --release=33 --format=gpt_squashfs` fails because of 2 bugs. Encrypted, minimized images are also affected.
* The wrong parameters are given to `luks_format_root` because the `cached` parameter was added (99453d9) to the function but not to all the calls.
* The LUKS overhead when creating the image isn't large enough. Increased it from 2MB to 16MB.