### PR TITLE
mkosi: explicitly flush SHA256SUMS file

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4037,6 +4037,8 @@ def calculate_sha256sum(
             assert args.output_nspawn_settings is not None
             hash_file(f, nspawn_settings, os.path.basename(args.output_nspawn_settings))
 
+        f.flush()
+
     return f
 
 


### PR DESCRIPTION
Apparently we have to flush things explicitly after writing it,
otherwise things remain buffered by python IO and the SHA256SUMS file
will remain empty on disk.