### PR TITLE
Cosmetics

### DIFF
--- a/.github/workflows/ci-unit-test.yml
+++ b/.github/workflows/ci-unit-test.yml
@@ -15,10 +15,13 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install
-      run: python3 -m pip install pytest mypy black
+      run: python3 -m pip install pytest mypy black isort
 
     - name: Check formatting
       run: python3 -m black --check mkosi/ tests/
+
+    - name: Check that imports are sorted
+      run: python3 -m isort --verbose --check-only mkosi/
 
     - name: Type Checking
       run: python3 -m mypy mkosi

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -36,11 +36,14 @@ import urllib.request
 import uuid
 from subprocess import DEVNULL, PIPE
 from textwrap import dedent
+from types import FrameType
 from typing import (
     IO,
+    TYPE_CHECKING,
     Any,
     BinaryIO,
     Callable,
+    ContextManager,
     Dict,
     Generator,
     Iterable,
@@ -54,13 +57,9 @@ from typing import (
     Tuple,
     Union,
     cast,
-    TYPE_CHECKING,
-    ContextManager,
 )
-from types import FrameType
 
 from .printer import MkosiPrinter
-
 
 __version__ = "9"
 

--- a/mkosi/__main__.py
+++ b/mkosi/__main__.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-from . import parse_args, complete_step, run_verb, die, MkosiException
+from . import MkosiException, complete_step, die, parse_args, run_verb
 
 
 def main() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 119
-target-version = ['py36']
+target-version = ['py37']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
 [tool.black]
 line-length = 119
 target-version = ['py37']
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+py_version = "37"


### PR DESCRIPTION
Add isort to CI to keep the imports in a canonical order.

Also bump the black code version to 3.7, since we use that now. 