### PR TITLE
Include `systemd.volatile` infrastructure in initrd

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -86,6 +86,8 @@ DRACUT_SYSTEMD_EXTRAS = [
     "/usr/bin/systemd-repart",
     "/usr/lib/systemd/system/systemd-repart.service",
     "/usr/lib/systemd/system/initrd-root-fs.target.wants/systemd-repart.service",
+    "/usr/lib/systemd/systemd-volatile-root",
+    "/usr/lib/systemd/system/systemd-volatile-root.service",
 ]
 
 DRACUT_UNIFIED_KERNEL_INSTALL = """\


### PR DESCRIPTION
For the `systemd.volatile=...` feature to work, the
`systemd-volatile-root` generator and `systemd-volatile-root.service`
service are required to be present. Booting a read-only image generated
by `mkosi` (e.g., `gpt_ext4` built with the `--read-only` flag, or a
`gpt_squashfs` image) with a volatile but mutable overlay is useful, so
we need to provide these files in the `initrd` Dracut generates.

Hence, adding both files to `DRACUT_SYSTEMD_EXTRAS`.

Fixes: #674
See: https://github.com/systemd/mkosi/issues/674