### PR TITLE
mkosi: add UsrOnly= setting for generating images with only a /usr/ p…

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -401,6 +401,16 @@ details see the table below.
   will only be able to run on the system mkosi is run on. Currently mkosi uses dracut for all supported
   distributions except Clear Linux and this option translates to enabling dracut's hostonly option.
 
+`--usr-only`
+
+: If specified, `mkosi` will only add the `/usr/` directory tree
+  (instead of the whole root file system) to the image. This is useful
+  for fully stateless systems that come up pristine on every single
+  boot, where `/etc/` and `/var/` are populated by
+  `systemd-tmpfiles`/`systemd-sysusers` and related calls, or systems
+  that are originally shipped without root file system, but where
+  `systemd-repart` adds one in on first boot.
+
 `--no-chown`
 
 : By default, if `mkosi` is run inside a `sudo` environment all
@@ -851,6 +861,7 @@ which settings file options.
 | `--hostname=`                     | `[Output]`              | `Hostname=`                   |
 | `--without-unified-kernel-images` | `[Output]`              | `WithUnifiedKernelImages=`    |
 | `--hostonly-initrd`               | `[Output]`              | `HostonlyInitrd=`             |
+| `--usr-only`                      | `[Output]`              | `UsrOnly=`                    |
 | `--package=`                      | `[Packages]`            | `Packages=`                   |
 | `--with-docs`                     | `[Packages]`            | `WithDocs=`                   |
 | `--without-tests`, `-T`           | `[Packages]`            | `WithTests=`                  |

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -105,6 +105,7 @@ class MkosiConfig(object):
             "srv_size": None,
             "swap_size": None,
             "tmp_size": None,
+            "usr_only": False,
             "var_size": None,
             "verb": "build",
             "verity": False,
@@ -509,6 +510,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
                 "XZ": False,
                 "QCow2": False,
                 "Hostname": "myhost1",
+                "UsrOnly": False,
             },
             "Packages": {
                 "Packages": ["pkg-foo", "pkg-bar", "pkg-foo1,pkg-bar1"],
@@ -573,6 +575,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
                 "XZ": True,
                 "QCow2": True,
                 "Hostname": "myubuhost1",
+                "UsrOnly": False,
             },
             "Packages": {
                 "Packages": ["add-ubu-1", "add-ubu-2"],
@@ -637,6 +640,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
                 "XZ": True,
                 "QCow2": True,
                 "Hostname": "mydebihost1",
+                "UsrOnly": False,
             },
             "Packages": {
                 "Packages": ["!add-ubu-1", "!add-ubu-2", "add-debi-1", "add-debi-2"],


### PR DESCRIPTION
…artition

This adds a new boolean option that changes our image layout slightly:
instead of include the whole root fs in the image, we just pack up the
/usr/ subtree.

This has two usecases:

1. Truly stateless systems that come up pristine on every single boot,
   where /etc and /var are populated by tmpfiles/sysusers and related
   calls

2. Systems that are shipped without root fs, but where systemd-repart
   adds one in, with a locally generated encryption key and so on. (this
   doesn't work fully yet, because of some initrd issues, will look at
   this later.)

A companion PR on the systemd side is: https://github.com/systemd/systemd/pull/18958

Fixes: #634