### PR TITLE
Allow overriding the SSH key pair

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -812,6 +812,12 @@ details see the table below.
   with this  option and running the image using `mkosi boot` or `mkosi qemu`,
   the `mkosi ssh` command can be used to connect to the container/VM via SSH.
 
+`--ssh-key=`
+: If specified, use the given private key when connecting to the guest machine
+  via `mkosi ssh`. This requires the public key counterpart to be present at
+  the same location, suffixed with `.pub` (as done by `ssh-keygen`). If this
+  option is not present `mkosi` generates a new key pair automatically.
+
 ## Command Line Parameters and their Settings File Counterparts
 
 Most command line parameters may also be placed in an `mkosi.default`
@@ -891,6 +897,7 @@ which settings file options.
 | `--network-veth`                  | `[Host]`                | `NetworkVeth=`                |
 | `--ephemeral`                     | `[Host]`                | `Ephemeral=`                  |
 | `--ssh`                           | `[Host]`                | `Ssh=`                        |
+| `--ssh-key=`                      | `[Host]`                | `SshKey=`                     |
 
 Command line options that take no argument are not suffixed with a `=`
 in their long version in the table above. In the `mkosi.default` file

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -121,6 +121,7 @@ class MkosiConfig(object):
             "with_unified_kernel_images": True,
             "hostonly_initrd": False,
             "ssh": False,
+            "ssh_key": None,
             "minimize": False,
         }
 


### PR DESCRIPTION
Allow using a pre-defined SSH key pair instead of generating a new one.
This should be useful, for example, in CI environments, where the images
are built and used at different times, and using the same SSH key pair
across multiple images is more convenient.

---

I'm not completely sure about correctness of the `unlink`-related shenanigans, so please feel free to kick me in the right direction if needed.