### PR TITLE
mkosi: don't make efivarfs.ko a hard dep

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1597,7 +1597,9 @@ def configure_dracut(args: CommandLineArguments, root: str) -> None:
     # efivarfs must be present in order to GPT root discovery work
     if args.esp_partno is not None:
         with open(os.path.join(dracut_dir, "30-mkosi-efivarfs.conf"), "w") as f:
-            f.write('add_drivers+=" efivarfs "\n')
+            f.write(
+                '[[ $(modinfo -k "$kernel" -F filename efivarfs 2>/dev/null) == /* ]] && add_drivers+=" efivarfs "\n'
+            )
 
 
 def prepare_tree_root(args: CommandLineArguments, root: str) -> None:


### PR DESCRIPTION
Some distros build this as kmod, others build it in. Hence only package
it up if it exists, i.e. pull it in weakly only.

(Quite frankly, distros that don't build it in are stupid, they should
fix that, it's needed almost always and is tiny.)

Follow-up for 9244e1dcdc056a7e9c457222a858a852a7965078