### PR TITLE
Attempt to retry the SSH connection if the veth/SSH server is not up yet

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -828,6 +828,12 @@ details see the table below.
   the same location, suffixed with `.pub` (as done by `ssh-keygen`). If this
   option is not present `mkosi` generates a new key pair automatically.
 
+`--ssh-timeout=`
+: When used with the ssh verb, `mkosi` will attempt to retry the SSH connection
+  up to given timeout (in seconds) in case it fails. This option is useful mainly
+  in scripted environments where the qemu and ssh verbs are used in a quick
+  succession and the veth device might not get enough time to configure itself.
+
 ## Command Line Parameters and their Settings File Counterparts
 
 Most command line parameters may also be placed in an `mkosi.default`
@@ -909,6 +915,7 @@ which settings file options.
 | `--ephemeral`                     | `[Host]`                | `Ephemeral=`                  |
 | `--ssh`                           | `[Host]`                | `Ssh=`                        |
 | `--ssh-key=`                      | `[Host]`                | `SshKey=`                     |
+| `--ssh-timeout=`                  | `[Host]`                | `SshTimeout=`                 |
 
 Command line options that take no argument are not suffixed with a `=`
 in their long version in the table above. In the `mkosi.default` file

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -123,6 +123,7 @@ class MkosiConfig(object):
             "hostonly_initrd": False,
             "ssh": False,
             "ssh_key": None,
+            "ssh_timeout": 0,
             "minimize": False,
         }
 


### PR DESCRIPTION
This commit introduces a new option `--ssh-timeout=` to allow setting
a timeout for which `mkosi` will attempt to retry the SSH connection in
case the link not properly set up yet (e.g. when running `mkosi qemu` and
`mkosi ssh` in a script, the veth may not be configured yet, causing the
ssh connection to fail).

Fixes: #684

---

My attempt at fixing #684. It behaved as expected when I tested it, but I still have a feeling it could be written much nicer. PTAL!