### PR TITLE
Replace "legacy-free" with "bespoke" in descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# mkosi - Create legacy-free OS images
+# mkosi — Build Bespoke OS Images
 
-A fancy wrapper around `dnf --installroot`, `debootstrap`,
-`pacstrap` and `zypper` that may generate disk images with a number of
+A fancy wrapper around `dnf --installroot`, `debootstrap`, `pacstrap`
+and `zypper` that generates customized disk images with a number of
 bells and whistles.
 
 For a longer description and available features and options, see the

--- a/man/mkosi.1
+++ b/man/mkosi.1
@@ -5,7 +5,7 @@
 .hy
 .SH NAME
 .PP
-mkosi - Build Legacy-Free OS Images
+mkosi - Build Bespoke OS Images
 .SH SYNOPSIS
 .PP
 \f[C]mkosi [options\&...] build\f[R]
@@ -21,7 +21,7 @@ mkosi - Build Legacy-Free OS Images
 \f[C]mkosi [options\&...] qemu\f[R]
 .SH DESCRIPTION
 .PP
-\f[C]mkosi\f[R] is a tool for easily building legacy-free OS images.
+\f[C]mkosi\f[R] is a tool for easily building customized OS images.
 It\[cq]s a fancy wrapper around \f[C]dnf --installroot\f[R],
 \f[C]debootstrap\f[R], \f[C]pacstrap\f[R] and \f[C]zypper\f[R] that may
 generate disk images with a number of bells and whistles.
@@ -1292,9 +1292,9 @@ Any distribution that packages \f[C]yum\f[R] (or the newer replacement
 Currently, \f[I]Fedora\f[R] packages all relevant tools as of Fedora 28.
 .SS Compatibility
 .PP
-Generated images are \f[I]legacy-free\f[R].
-This means only \f[I]GPT\f[R] disk labels (and no \f[I]MBR\f[R] disk
-labels) are supported, and only systemd based images may be generated.
+Legacy concepts are avoided: generated images use \f[I]GPT\f[R] disk
+labels (and no \f[I]MBR\f[R] labels), and only systemd-based images
+may be generated.
 .PP
 All generated \f[I]GPT\f[R] disk images may be booted in a local
 container directly with:

--- a/mkosi.md
+++ b/mkosi.md
@@ -4,7 +4,7 @@
 
 # NAME
 
-mkosi - Build Legacy-Free OS Images
+mkosi — Build Bespoke OS Images
 
 # SYNOPSIS
 
@@ -22,7 +22,7 @@ mkosi - Build Legacy-Free OS Images
 
 # DESCRIPTION
 
-`mkosi` is a tool for easily     building legacy-free OS images. It's a
+`mkosi` is a tool for easily building customized OS images. It's a
 fancy wrapper around `dnf --installroot`, `debootstrap`, `pacstrap`
 and `zypper` that may generate disk images with a number of bells and
 whistles.
@@ -1035,9 +1035,8 @@ Currently, *Fedora* packages all relevant tools as of Fedora 28.
 
 ## Compatibility
 
-Generated images are *legacy-free*. This means only *GPT* disk labels
-(and no *MBR* disk labels) are supported, and only systemd based
-images may be generated.
+Legacy concepts are avoided: generated images use *GPT* disk labels
+(and no *MBR* labels), and only systemd-based images may be generated.
 
 All generated *GPT* disk images may be booted in a local
 container directly with:

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ class BuildManpage(Command):
 setup(
     name="mkosi",
     version="9",
-    description="Create legacy-free OS images",
+    description="Create Bespoke OS Images",
     url="https://github.com/systemd/mkosi",
     maintainer="mkosi contributors",
     maintainer_email="systemd-devel@lists.freedesktop.org",


### PR DESCRIPTION
Since the introduction of grub2 support, legacy-free is not really true.

  bespoke
    adj 1: (of clothing) custom-made [syn: {bespoke}, {bespoken},
           {made-to-order}, {tailored}, {tailor-made}]

    Any product that is special in some way, individually created for
    a specific user or system, as opposed to generic or off-the-shelf.

In the test, say "customized" to avoid repeating the same word.