### PR TITLE
tree-wide: change tagline to "Build Bespoke OS Images"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mkosi - Create legacy-free OS images
+# mkosi - Build Bespoke OS Images
 
 A fancy wrapper around `dnf --installroot`, `debootstrap`,
 `pacstrap` and `zypper` that may generate disk images with a number of

--- a/man/mkosi.1
+++ b/man/mkosi.1
@@ -5,7 +5,7 @@
 .hy
 .SH NAME
 .PP
-mkosi - Build Legacy-Free OS Images
+mkosi - Build Bespoke OS Images
 .SH SYNOPSIS
 .PP
 \f[C]mkosi [options\&...] build\f[R]
@@ -21,7 +21,7 @@ mkosi - Build Legacy-Free OS Images
 \f[C]mkosi [options\&...] qemu\f[R]
 .SH DESCRIPTION
 .PP
-\f[C]mkosi\f[R] is a tool for easily building legacy-free OS images.
+\f[C]mkosi\f[R] is a tool for easily building bespoke OS images.
 It\[cq]s a fancy wrapper around \f[C]dnf --installroot\f[R],
 \f[C]debootstrap\f[R], \f[C]pacstrap\f[R] and \f[C]zypper\f[R] that may
 generate disk images with a number of bells and whistles.

--- a/mkosi.md
+++ b/mkosi.md
@@ -4,7 +4,7 @@
 
 # NAME
 
-mkosi - Build Legacy-Free OS Images
+mkosi - Build Bespoke OS Images
 
 # SYNOPSIS
 
@@ -22,9 +22,9 @@ mkosi - Build Legacy-Free OS Images
 
 # DESCRIPTION
 
-`mkosi` is a tool for easily     building legacy-free OS images. It's a
-fancy wrapper around `dnf --installroot`, `debootstrap`, `pacstrap`
-and `zypper` that may generate disk images with a number of bells and
+`mkosi` is a tool for easily building bespoke OS images. It's a fancy
+wrapper around `dnf --installroot`, `debootstrap`, `pacstrap` and
+`zypper` that may generate disk images with a number of bells and
 whistles.
 
 ## Supported output formats

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4667,7 +4667,7 @@ def parse_source_file_transfer(value: str) -> Optional[SourceFileTransfer]:
 
 
 def create_parser() -> ArgumentParserMkosi:
-    parser = ArgumentParserMkosi(prog="mkosi", description="Build Legacy-Free OS Images", add_help=False)
+    parser = ArgumentParserMkosi(prog="mkosi", description="Build Bespoke OS Images", add_help=False)
 
     group = parser.add_argument_group("Commands")
     group.add_argument("verb", choices=MKOSI_COMMANDS, default="build", help="Operation to execute")

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ class BuildManpage(Command):
 setup(
     name="mkosi",
     version="9",
-    description="Create legacy-free OS images",
+    description="Build Bespoke OS Images",
     url="https://github.com/systemd/mkosi",
     maintainer="mkosi contributors",
     maintainer_email="systemd-devel@lists.freedesktop.org",


### PR DESCRIPTION
@keszybz suggested we should drop the "legacy-free" tag, and he's right:
since we added support for BIOS supports we aren't really legacy-free
anymore.

Let's use a nice word less focussed on computer history instead: 🔥 bespoke 🔥