### PR TITLE
always use same tagline "Build Bespoke OS Images"

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4723,7 +4723,7 @@ def parse_source_file_transfer(value: str) -> Optional[SourceFileTransfer]:
 
 
 def create_parser() -> ArgumentParserMkosi:
-    parser = ArgumentParserMkosi(prog="mkosi", description="Build Legacy-Free OS Images", add_help=False)
+    parser = ArgumentParserMkosi(prog="mkosi", description="Build Bespoke OS Images", add_help=False)
 
     group = parser.add_argument_group("Commands")
     group.add_argument("verb", choices=MKOSI_COMMANDS, default="build", help="Operation to execute")

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ class BuildManpage(Command):
 setup(
     name="mkosi",
     version="9",
-    description="Create Bespoke OS Images",
+    description="Build Bespoke OS Images",
     url="https://github.com/systemd/mkosi",
     maintainer="mkosi contributors",
     maintainer_email="systemd-devel@lists.freedesktop.org",


### PR DESCRIPTION
Follow-up for b365720596d6ec6c54b3c5fe10d793e5596eeda6: two cases were
missed.