### PR TITLE
mkosi: UsrOnly= btrfs fixups

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1669,7 +1669,7 @@ def configure_dracut(args: CommandLineArguments, root: str) -> None:
 
 
 def prepare_tree_root(args: CommandLineArguments, root: str) -> None:
-    if args.output_format == OutputFormat.subvolume:
+    if args.output_format == OutputFormat.subvolume and not is_generated_root(args):
         with complete_step("Setting up OS tree root"):
             btrfs_subvol_create(root)
 
@@ -1693,9 +1693,7 @@ def prepare_tree(args: CommandLineArguments, root: str, do_run_build_script: boo
         return
 
     with complete_step("Setting up basic OS tree"):
-        if args.output_format is OutputFormat.subvolume or (
-            args.output_format is OutputFormat.gpt_btrfs and not args.minimize
-        ):
+        if args.output_format in (OutputFormat.subvolume, OutputFormat.gpt_btrfs) and not is_generated_root(args):
             btrfs_subvol_create(os.path.join(root, "home"))
             btrfs_subvol_create(os.path.join(root, "srv"))
             btrfs_subvol_create(os.path.join(root, "var"))
@@ -3615,6 +3613,8 @@ def make_read_only(args: CommandLineArguments, root: str, for_cache: bool, b: bo
         return
 
     if args.output_format not in (OutputFormat.gpt_btrfs, OutputFormat.subvolume):
+        return
+    if is_generated_root(args):
         return
 
     with complete_step("Marking root subvolume read-only"):

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -957,7 +957,7 @@ def determine_partition_table(args: CommandLineArguments) -> Tuple[str, bool]:
             pn += 1
             run_sfdisk = True
 
-    if args.usr_only or not is_generated_root(args):
+    if not is_generated_root(args):
         table += 'type={}, attrs={}, name="{}"\n'.format(
             gpt_root_native(args.architecture, args.usr_only).root,
             "GUID:60" if args.read_only and args.output_format != OutputFormat.gpt_btrfs else "",
@@ -1410,7 +1410,7 @@ def luks_setup_all(
 def prepare_root(args: CommandLineArguments, dev: Optional[str], cached: bool) -> None:
     if dev is None:
         return
-    if is_generated_root(args) and not args.usr_only:
+    if is_generated_root(args):
         return
     if cached:
         return
@@ -1696,13 +1696,12 @@ def prepare_tree(args: CommandLineArguments, root: str, do_run_build_script: boo
         if args.output_format is OutputFormat.subvolume or (
             args.output_format is OutputFormat.gpt_btrfs and not args.minimize
         ):
-            if not is_generated_root(args):
-                btrfs_subvol_create(os.path.join(root, "home"))
-                btrfs_subvol_create(os.path.join(root, "srv"))
-                btrfs_subvol_create(os.path.join(root, "var"))
-                btrfs_subvol_create(os.path.join(root, "var/tmp"), 0o1777)
-                os.mkdir(os.path.join(root, "var/lib"))
-                btrfs_subvol_create(os.path.join(root, "var/lib/machines"), 0o700)
+            btrfs_subvol_create(os.path.join(root, "home"))
+            btrfs_subvol_create(os.path.join(root, "srv"))
+            btrfs_subvol_create(os.path.join(root, "var"))
+            btrfs_subvol_create(os.path.join(root, "var/tmp"), 0o1777)
+            os.mkdir(os.path.join(root, "var/lib"))
+            btrfs_subvol_create(os.path.join(root, "var/lib/machines"), 0o700)
 
         # We need an initialized machine ID for the build & boot logic to work
         os.mkdir(os.path.join(root, "etc"), 0o755)


### PR DESCRIPTION
I put this together als alternative to f0386b00cfd2c897cbbaad50b0e717e7221676bc which got merged by now. 

Compared to what was merged it drops two explicit usr_only checks (since redundant, as 
is_generated_root() checks this internally anyway.

It also fixes the root partition situation. The idea of UsrOnly= was to not have a root partition, so that repart can create it at boot. The merged patch undid that, which defeated the whole point.