### PR TITLE
mkosi: make workspace dir configurable and discover mkosi.workspace/

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -264,6 +264,20 @@ details see the table below.
   such a directory does not exist, all output artifacts are placed
   adjacent to the output image file.
 
+`--workspace-dir=`
+
+: Path to a directory where to store data required temporarily while
+  building the image. This directory should have enough space to store
+  a full OS image, though in most modes the actually used disk space
+  is smaller. If not specified, and `mkosi.workspace/` exists, it is
+  used for this purpose. If it doesn't exist and `$TMPDIR` is set, the
+  specified directory is used. If that's not set either, `/var/tmp/`
+  is used. The data in the directory is removed automatically after
+  each build. It's safe to manually remove the contents of this
+  directories should an `mkosi` invocation be aborted abnormally (for
+  example, due to reboot/power failure). If the `btrfs` output modes
+  are selected this directory must be backed by `btrfs` too.
+
 `--force`, `-f`
 
 : Replace the output file if it already exists, when building an

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -132,6 +132,7 @@ class MkosiConfig(object):
             "image_id": None,
             "image_version": None,
             "auto_bump": False,
+            "workspace_dir": None,
         }
 
     def __eq__(self, other: [mkosi.CommandLineArguments]) -> bool:


### PR DESCRIPTION
So far we determined the workspace directory from $TMPDIR and /var/tmp
if that wasn't set. In some cases this is less than ideal though, in
particular if one wants to build a btrfs image but /var/tmp is not
btrfs. In that case it makes sense to always use a local workspace dir.
This adds support for this:

WorkspaceDirectory= + --workspace-dir= may now be used to configure it
explicitly.

if "mkosi.workspace/" exists, we use it automatically.

Otherwise we use TMPDIR and /var/tmp as fallback.