### PR TITLE
assorted housekeeping

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5693,7 +5693,7 @@ def load_args(args: argparse.Namespace) -> CommandLineArguments:
 
     if args.release is None:
         if args.distribution == Distribution.fedora:
-            args.release = "33"
+            args.release = "34"
         elif args.distribution in (Distribution.centos, Distribution.centos_epel):
             args.release = "8"
         elif args.distribution == Distribution.mageia:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5964,10 +5964,6 @@ def load_args(args: argparse.Namespace) -> CommandLineArguments:
             )
         )
 
-    if args.bootable and args.distribution == Distribution.mageia:
-        # TODO: Remove once dracut 045 is available in mageia.
-        args.kernel_command_line.append("root=/dev/gpt-auto-root")
-
     if not args.read_only:
         args.kernel_command_line.append("rw")
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -524,6 +524,7 @@ FEDORA_KEYS_MAP = {
     "31": "3C3359C4",
     "32": "12C944D0",
     "33": "9570FF31",
+    "34": "45719A39",
 }
 
 # 1 MB at the beginning of the disk for the GPT disk label, and


### PR DESCRIPTION
Since Fedora 34 has been released now, this bumps the default Fedora version to that and adds it's key.

I also noticed, that there was a todo to remove a check for Mageia once they have a recent enough dracut (younger than 045) and if I haven't [missed anything](https://pkgs.org/search/?q=dracut) then the oldest dracut in Mageia right now is 046.