### PR TITLE
[unified_kernel_install] Really pick a default prefix name

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -109,7 +109,7 @@ fi
 PREFIX=$(dirname $(dirname "$BOOT_DIR_ABS"))
 
 # Pick a default prefix name for the unified kernel binary
-if [[ -n "$IMAGE_ID" ]] ; then
+if [[ -z "$IMAGE_ID" ]] ; then
     IMAGE_ID=linux
 fi
 


### PR DESCRIPTION
with empty string for args.image_id we end up with an odd looking
BOOT_BINARY which results in calling dracut as such:

dracut: Executing: /usr/bin/dracut --uefi --kver 5.11.17-gentoo-dist
--kernel-image /usr/src/linux-5.11.17-gentoo-dist/arch/x86/boot/bzImage
--kernel-cmdline "rhgb selinux=0 audit=0 rw" --force
/efi/EFI/Linux/-5.11.17-gentoo-dist.efi

-n test's for _none_ empty string; -z for an empty one.