### PR TITLE
ignore return code of fstrim

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3167,7 +3167,7 @@ def invoke_fstrim(args: CommandLineArguments, root: str, do_run_build_script: bo
         return
 
     with complete_step("Trimming File System"):
-        run(["fstrim", "-v", root])
+        run(["fstrim", "-v", root], check=False)
 
 
 def pam_add_autologin(root: str, tty: str) -> None:


### PR DESCRIPTION
devices (i.e. virtualized) may not support fstrim operations.