### PR TITLE
mkosi: allow inline comments (but only with "#")

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4734,7 +4734,7 @@ class ArgumentParserMkosi(argparse.ArgumentParser):
                 # This used to use configparser.ConfigParser before, but
                 # ConfigParser's interpolation clashes with systemd style
                 # specifier, e.g. %u for user, since both use % as a sigil.
-                config = configparser.RawConfigParser(delimiters="=")
+                config = configparser.RawConfigParser(delimiters="=", inline_comment_prefixes=("#",))
                 config.optionxform = str  # type: ignore
                 with open(arg_string[1:]) as args_file:
                     config.read_file(args_file)


### PR DESCRIPTION
For example, it's super useful to comment on a list of packages:

Packages=
        glibc-minimal-langpack    # avoid pulling in other glibc langpacks
        less                      # this makes 'systemctl' much nicer to use ;)

;-comments are not allowed, because the colon doesn't stand out
enough. I was considering also adding comment_prefixes=('#',) to
disallow ;-comments everywhere, but that'd be a compatibility break
which I don't see enough justification for.