### PR TITLE
mkosi: stop automatically inserting packages

### DIFF
--- a/man/mkosi.1
+++ b/man/mkosi.1
@@ -523,6 +523,25 @@ In order to force rebuilding of these cached images, combined
 \f[C]-i\f[R] with \f[C]-ff\f[R], which ensures the cached images are
 removed first, and then re-created.
 .TP
+\f[B]\f[CB]--base-packages\f[B]\f[R]
+If true, automatically install packages to ensure basic functionality,
+as appropriate for the given image type.
+For example, \f[C]systemd\f[R] is always included,
+\f[C]systemd-udev\f[R] if the image is bootable, and so on.
+If false, only packages specified with
+\f[C]--package\f[R]/\f[C]Packages\f[R] will be installed.
+If \f[C]conditional\f[R], the list of packages to install will be
+extended with boolean dependencies (c.f.
+https://rpm.org/user_doc/boolean_dependencies.html), to install specific
+packages when \f[I]other\f[R] packages are in the list.
+For example, \f[C]systemd-udev\f[R] may be automatically included if the
+image is bootable and \f[C]systemd\f[R] is installed.
+With this, various \[lq]base\[rq] packages still need to be specified if
+they should be included, but the corresponding \[lq]extension\[rq]
+packages will be added automatically when appropriate.
+This feature depends on support in the package manager, so it is not
+implemented for all distributions.
+.TP
 \f[B]\f[CB]--package=\f[B]\f[R], \f[B]\f[CB]-p\f[B]\f[R]
 Install the specified distribution packages (i.e.\ RPM, DEB, \&...) in
 the image.
@@ -1208,6 +1227,13 @@ T}@T{
 \f[C][Output]\f[R]
 T}@T{
 \f[C]SplitArtifacts=\f[R]
+T}
+T{
+\f[C]--base-packages=\f[R]
+T}@T{
+\f[C][Packages]\f[R]
+T}@T{
+\f[C]BasePackages=\f[R]
 T}
 T{
 \f[C]--package=\f[R]

--- a/mkosi.md
+++ b/mkosi.md
@@ -518,6 +518,27 @@ details see the table below.
   cached images, combined `-i` with `-ff`, which ensures the cached
   images are removed first, and then re-created.
 
+`--base-packages`
+
+: If true, automatically install packages to ensure basic
+  functionality, as appropriate for the given image type. For example,
+  `systemd` is always included, `systemd-udev` and `dracut` if the
+  image is bootable, and so on.
+
+: If false, only packages specified with `--package`/`Packages` will
+  be installed.
+
+: If `conditional`, the list of packages to install will be extended
+  with boolean dependencies
+  (c.f. https://rpm.org/user_doc/boolean_dependencies.html), to
+  install specific packages when *other* packages are in the list. For
+  example, `systemd-udev` may be automatically included if the image
+  is bootable and `systemd` is installed. With this, various "base"
+  packages still need to be specified if they should be included, but
+  the corresponding "extension" packages will be added automatically
+  when appropriate. This feature depends on support in the package
+  manager, so it is not implemented for all distributions.
+
 `--package=`, `-p`
 
 : Install the specified distribution packages (i.e. RPM, DEB, …) in
@@ -528,7 +549,8 @@ details see the table below.
   (see below) to specify packages that shall only be used for the
   image generated in the build image, but that shall not appear in the
   final image.
-  To remove a package e.g. added by a mkosi.default configuration file
+
+: To remove a package e.g. added by a mkosi.default configuration file
   prepend the package name with a ! letter. For example -p "!apache2"
   would remove the apache2 package. To replace the apache2 package by
   the httpd package just add -p "!apache2,httpd" to the command line
@@ -961,6 +983,7 @@ which settings file options.
 | `--hostonly-initrd`               | `[Output]`              | `HostonlyInitrd=`             |
 | `--usr-only`                      | `[Output]`              | `UsrOnly=`                    |
 | `--split-artifacts`               | `[Output]`              | `SplitArtifacts=`             |
+| `--base-packages=`                | `[Packages]`            | `BasePackages=`               |
 | `--package=`                      | `[Packages]`            | `Packages=`                   |
 | `--with-docs`                     | `[Packages]`            | `WithDocs=`                   |
 | `--without-tests`, `-T`           | `[Packages]`            | `WithTests=`                  |

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3053,7 +3053,7 @@ def install_opensuse(args: CommandLineArguments, root: str, do_run_build_script:
         packages.update(args.build_packages)
 
     if not do_run_build_script and args.ssh:
-        packages.update("openssh-server")
+        packages.add("openssh-server")
 
     cmdline = [
         "zypper",

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2140,7 +2140,7 @@ def install_photon(args: CommandLineArguments, root: str, do_run_build_script: b
         ],
     )
 
-    packages = {"minimal"}
+    packages = {"minimal", *args.packages}
     if not do_run_build_script and args.bootable:
         packages |= {"linux", "initramfs"}
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -409,6 +409,7 @@ class CommandLineArguments:
     with_unified_kernel_images: bool
     gpt_first_lba: Optional[int]
     hostonly_initrd: bool
+    base_packages: Union[str, bool]
     packages: List[str]
     with_docs: bool
     with_tests: bool
@@ -1902,31 +1903,47 @@ def reenable_kernel_install(args: CommandLineArguments, root: str) -> None:
     make_executable(hook_path)
 
 
+def add_packages(
+    args: CommandLineArguments, packages: Set[str], *names: str, conditional: Optional[str] = None
+) -> None:
+    """Add packages in @names to @packages, if enabled by --base-packages.
+
+    If @conditional is specifed, rpm-specific syntax for boolean
+    dependencies will be used to include @names if @conditional is
+    satisfied.
+    """
+    assert args.base_packages is True or args.base_packages is False or args.base_packages == "conditional"
+
+    if args.base_packages is True or (args.base_packages == "conditional" and conditional):
+        for name in names:
+            packages.add(f"({name} if {conditional})" if conditional else name)
+
+
 def make_rpm_list(args: CommandLineArguments, packages: Set[str], do_run_build_script: bool) -> Set[str]:
     packages = packages.copy()
 
     if args.bootable:
         # Temporary hack: dracut only adds crypto support to the initrd, if the cryptsetup binary is installed
         if args.encrypt or args.verity:
-            packages.add("cryptsetup")
+            add_packages(args, packages, "cryptsetup", conditional="dracut")
 
         if args.output_format == OutputFormat.gpt_ext4:
-            packages.add("e2fsprogs")
+            add_packages(args, packages, "e2fsprogs")
 
         if args.output_format == OutputFormat.gpt_xfs:
-            packages.add("xfsprogs")
+            add_packages(args, packages, "xfsprogs")
 
         if args.output_format == OutputFormat.gpt_btrfs:
-            packages.add("btrfs-progs")
+            add_packages(args, packages, "btrfs-progs")
 
         if args.bios_partno:
             if args.distribution in (Distribution.mageia, Distribution.openmandriva):
-                packages.add("grub2")
+                add_packages(args, packages, "grub2")
             else:
-                packages.add("grub2-pc")
+                add_packages(args, packages, "grub2-pc")
 
     if not do_run_build_script and args.ssh:
-        packages.add("openssh-server")
+        add_packages(args, packages, "openssh-server")
 
     return packages
 
@@ -2140,9 +2157,10 @@ def install_photon(args: CommandLineArguments, root: str, do_run_build_script: b
         ],
     )
 
-    packages = {"minimal", *args.packages}
+    packages = {*args.packages}
+    add_packages(args, packages, "minimal")
     if not do_run_build_script and args.bootable:
-        packages |= {"linux", "initramfs"}
+        add_packages(args, packages, "linux", "initramfs")
 
     invoke_tdnf(
         args,
@@ -2161,13 +2179,14 @@ def install_clear(args: CommandLineArguments, root: str, do_run_build_script: bo
     else:
         release = "clear/" + args.release
 
-    packages = {"os-core-plus", *args.packages}
+    packages = {*args.packages}
+    add_packages(args, packages, "os-core-plus")
     if do_run_build_script:
         packages.update(args.build_packages)
     if not do_run_build_script and args.bootable:
-        packages.add("kernel-native")
+        add_packages(args, packages, "kernel-native")
     if not do_run_build_script and args.ssh:
-        packages.add("openssh-server")
+        add_packages(args, packages, "openssh-server")
 
     swupd_extract = shutil.which("swupd-extract")
 
@@ -2255,14 +2274,17 @@ def install_fedora(args: CommandLineArguments, root: str, do_run_build_script: b
         ],
     )
 
-    packages = {"fedora-release", "glibc-minimal-langpack", "systemd", *args.packages}
+    packages = {*args.packages}
+    add_packages(args, packages, "fedora-release", "systemd")
+    add_packages(args, packages, "glibc-minimal-langpack", conditional="glibc")
     if not do_run_build_script and args.bootable:
-        packages |= {"kernel-core", "kernel-modules", "systemd-udev", "binutils", "dracut"}
+        add_packages(args, packages, "kernel-core", "kernel-modules", "binutils", "dracut")
+        add_packages(args, packages, "systemd-udev", conditional="systemd")
         configure_dracut(args, root)
     if do_run_build_script:
         packages.update(args.build_packages)
     if not do_run_build_script and args.network_veth:
-        packages.add("systemd-networkd")
+        add_packages(args, packages, "systemd-networkd", conditional="systemd")
     invoke_dnf(args, root, args.repositories or ["fedora", "updates"], packages, do_run_build_script)
 
     with open(os.path.join(root, "etc/locale.conf"), "w") as f:
@@ -2291,10 +2313,10 @@ def install_mageia(args: CommandLineArguments, root: str, do_run_build_script: b
         ],
     )
 
-    packages = {"basesystem-minimal", *args.packages}
+    packages = {*args.packages}
+    add_packages(args, packages, "basesystem-minimal")
     if not do_run_build_script and args.bootable:
-        packages |= {"kernel-server-latest", "binutils", "dracut"}
-
+        add_packages(args, packages, "kernel-server-latest", "binutils", "dracut")
         configure_dracut(args, root)
         # Mageia ships /etc/50-mageia.conf that omits systemd from the initramfs and disables hostonly.
         # We override that again so our defaults get applied correctly on Mageia as well.
@@ -2340,13 +2362,16 @@ def install_openmandriva(args: CommandLineArguments, root: str, do_run_build_scr
         ],
     )
 
+    packages = {*args.packages}
     # well we may use basesystem here, but that pulls lot of stuff
-    packages = {"basesystem-minimal", "systemd", *args.packages}
+    add_packages(args, packages, "basesystem-minimal", "systemd")
     if not do_run_build_script and args.bootable:
-        packages |= {"kernel-release-server", "binutils", "systemd-boot", "dracut", "timezone", "systemd-cryptsetup"}
+        add_packages(args, packages, "systemd-boot", "systemd-cryptsetup", conditional="systemd")
+        add_packages(args, packages, "kernel-release-server", "binutils", "dracut", "timezone")
         configure_dracut(args, root)
     if args.network_veth:
-        packages |= {"systemd-networkd"}
+        add_packages(args, packages, "systemd-networkd", conditional="systemd")
+
     if do_run_build_script:
         packages.update(args.build_packages)
     invoke_dnf(args, root, args.repositories or ["openmandriva", "updates"], packages, do_run_build_script)
@@ -2498,15 +2523,25 @@ def install_centos(args: CommandLineArguments, root: str, do_run_build_script: b
     else:
         default_repos = install_centos_new(args, root, epel_release)
 
-    packages = {"centos-release", "systemd", *args.packages}
+    packages = {*args.packages}
+    add_packages(args, packages, "centos-release", "systemd")
     if not do_run_build_script and args.bootable:
-        packages |= {"kernel", "dracut", "binutils"}
+        add_packages(args, packages, "kernel", "dracut", "binutils")
         configure_dracut(args, root)
         if old:
-            packages |= {"grub2-efi", "grub2-tools", "grub2-efi-x64-modules", "shim-x64", "efibootmgr", "efivar-libs"}
+            add_packages(
+                args,
+                packages,
+                "grub2-efi",
+                "grub2-tools",
+                "grub2-efi-x64-modules",
+                "shim-x64",
+                "efibootmgr",
+                "efivar-libs",
+            )
         else:
             # this does not exist on CentOS 7
-            packages.add("systemd-udev")
+            add_packages(args, packages, "systemd-udev", conditional="systemd")
 
     if do_run_build_script:
         packages.update(args.build_packages)
@@ -2515,13 +2550,13 @@ def install_centos(args: CommandLineArguments, root: str, do_run_build_script: b
 
     if args.distribution == Distribution.centos_epel:
         repos += ["epel"]
-        packages.add("epel-release")
+        add_packages(args, packages, "epel-release")
 
     if do_run_build_script:
         packages.update(args.build_packages)
 
     if not do_run_build_script and args.distribution == Distribution.centos_epel and args.network_veth:
-        packages.add("systemd-networkd")
+        add_packages(args, packages, "systemd-networkd", conditional="systemd")
 
     invoke_dnf_or_yum(args, root, repos, packages, do_run_build_script)
 
@@ -2560,31 +2595,30 @@ def install_debian_or_ubuntu(args: CommandLineArguments, root: str, *, do_run_bu
     # Install extra packages via the secondary APT run, because it is smarter and can deal better with any
     # conflicts. dbus and libpam-systemd are optional dependencies for systemd in debian so we include them
     # explicitly.
-    extra_packages = {"systemd", "systemd-sysv", "dbus", "libpam-systemd"}
+    extra_packages: Set[str] = set()
+    add_packages(args, extra_packages, "systemd", "systemd-sysv", "dbus", "libpam-systemd")
     extra_packages.update(args.packages)
 
     if do_run_build_script:
         extra_packages.update(args.build_packages)
 
     if not do_run_build_script and args.bootable:
-        extra_packages.add("dracut")
-        extra_packages.add("binutils")
-
+        add_packages(args, extra_packages, "dracut", "binutils")
         configure_dracut(args, root)
 
         if args.distribution == Distribution.ubuntu:
-            extra_packages.add("linux-generic")
+            add_packages(args, extra_packages, "linux-generic")
         else:
-            extra_packages.add("linux-image-amd64")
+            add_packages(args, extra_packages, "linux-image-amd64")
 
         if args.bios_partno:
-            extra_packages.add("grub-pc")
+            add_packages(args, extra_packages, "grub-pc")
 
         if args.output_format == OutputFormat.gpt_btrfs:
-            extra_packages.add("btrfs-progs")
+            add_packages(args, extra_packages, "btrfs-progs")
 
     if not do_run_build_script and args.ssh:
-        extra_packages.add("openssh-server")
+        add_packages(args, extra_packages, "openssh-server")
 
     # Debian policy is to start daemons by default. The policy-rc.d script can be used choose which ones to
     # start. Let's install one that denies all daemon startups.
@@ -2918,22 +2952,20 @@ def install_arch(args: CommandLineArguments, root: str, do_run_build_script: boo
     if platform.machine() == "aarch64":
         keyring += "arm"
 
-    packages = {"base"}
+    packages: Set[str] = set()
+    add_packages(args, packages, "base")
 
     if not do_run_build_script and args.bootable:
         if args.output_format == OutputFormat.gpt_btrfs:
-            packages.add("btrfs-progs")
+            add_packages(args, packages, "btrfs-progs")
         elif args.output_format == OutputFormat.gpt_xfs:
-            packages.add("xfsprogs")
+            add_packages(args, packages, "xfsprogs")
         if args.encrypt:
-            packages.add("cryptsetup")
-            packages.add("device-mapper")
+            add_packages(args, packages, "cryptsetup", "device-mapper")
         if args.bios_partno:
-            packages.add("grub")
+            add_packages(args, packages, "grub")
 
-        packages.add("dracut")
-        packages.add("binutils")
-
+        add_packages(args, packages, "dracut", "binutils")
         configure_dracut(args, root)
 
     packages.update(args.packages)
@@ -2948,13 +2980,13 @@ def install_arch(args: CommandLineArguments, root: str, do_run_build_script: boo
     has_kernel_package = official_kernel_packages.intersection(args.packages)
     if not do_run_build_script and args.bootable and not has_kernel_package:
         # No user-specified kernel
-        packages.add("linux")
+        add_packages(args, packages, "linux")
 
     if do_run_build_script:
         packages.update(args.build_packages)
 
     if not do_run_build_script and args.ssh:
-        packages.add("openssh")
+        add_packages(args, packages, "openssh")
 
     def run_pacman(packages: Set[str]) -> None:
         conf = ["--config", pacman_conf]
@@ -3026,34 +3058,32 @@ def install_opensuse(args: CommandLineArguments, root: str, do_run_build_script:
         with open(os.path.join(root, "etc/zypp/zypp.conf"), "w") as f:
             f.write("rpm.install.excludedocs = yes\n")
 
-    packages = {"systemd", *args.packages}
+    packages = {*args.packages}
+    add_packages(args, packages, "systemd")
 
     if release.startswith("42."):
-        packages.add("patterns-openSUSE-minimal_base")
+        add_packages(args, packages, "patterns-openSUSE-minimal_base")
     else:
-        packages.add("patterns-base-minimal_base")
+        add_packages(args, packages, "patterns-base-minimal_base")
 
     if not do_run_build_script and args.bootable:
-        packages.add("kernel-default")
-        packages.add("dracut")
-        packages.add("binutils")
-
+        add_packages(args, packages, "kernel-default", "dracut", "binutils")
         configure_dracut(args, root)
 
         if args.bios_partno is not None:
-            packages.add("grub2")
+            add_packages(args, packages, "grub2")
 
     if not do_run_build_script and args.encrypt:
-        packages.add("device-mapper")
+        add_packages(args, packages, "device-mapper")
 
     if args.output_format in (OutputFormat.subvolume, OutputFormat.gpt_btrfs):
-        packages.add("btrfsprogs")
+        add_packages(args, packages, "btrfsprogs")
 
     if do_run_build_script:
         packages.update(args.build_packages)
 
     if not do_run_build_script and args.ssh:
-        packages.add("openssh-server")
+        add_packages(args, packages, "openssh-server")
 
     cmdline = [
         "zypper",
@@ -3070,7 +3100,7 @@ def install_opensuse(args: CommandLineArguments, root: str, do_run_build_script:
     with mount_api_vfs(args, root):
         run(cmdline)
 
-    # Disable packages caching in the image that was enabled previously to populate the package cache.
+    # Disable package caching in the image that was enabled previously to populate the package cache.
     run(["zypper", "--root", root, "modifyrepo", "-K", "repo-oss"])
     run(["zypper", "--root", root, "modifyrepo", "-K", "repo-update"])
 
@@ -4772,6 +4802,12 @@ def parse_source_file_transfer(value: str) -> Optional[SourceFileTransfer]:
         raise argparse.ArgumentTypeError(str(exp))
 
 
+def parse_base_packages(value: str) -> Union[str, bool]:
+    if value == "conditional":
+        return value
+    return parse_boolean(value)
+
+
 def create_parser() -> ArgumentParserMkosi:
     parser = ArgumentParserMkosi(prog="mkosi", description="Build Bespoke OS Images", add_help=False)
 
@@ -4928,6 +4964,13 @@ def create_parser() -> ArgumentParserMkosi:
     )
 
     group = parser.add_argument_group("Packages")
+    group.add_argument(
+        "--base-packages",
+        type=parse_base_packages,
+        default=True,
+        help="Automatically inject basic packages in the system (systemd, kernel, …)",
+        metavar="OPTION",
+    )
     group.add_argument(
         "-p",
         "--package",

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -80,6 +80,7 @@ class MkosiConfig(object):
             "output": None,
             "output_dir": None,
             "output_format": None,
+            "base_packages": True,
             "packages": [],
             "password": None,
             "password_is_hashed": False,


### PR DESCRIPTION
systemd, systemd-udev and some other packages were always automatically
inserted since the first version of mkosi. But I think this is the
wrong approach: packages to install should mostly be specified in the
configuration file, and not in mkosi sources.

Looking at some concrete examples:
- dracut: dracut is only necessary if using an initrd (and of
  course only if the initrd image is generated using dracut, and only
  if it is generated locally). But even for bootable images, a kernel
  with no initramfs might be enough. Or when using kvm, a direct
  kernel boot with an externally-provided kernel+initrd, etc.
  So pulling in dracut and dependencies is often not necessary.
- kernel-modules: despite the name, actually basic modules are in
  kernel-core. And kernel-modules is non-core modules. (And yes,
  kernel-modules-extra is extra-non-core-modules, and
  kernel-modules-internal is something else yet again).
- kernel-core: as with dracut, having a kernel image is not necessary
  in many scenarios.
- systemd: one big example where it's not useful is systemd itself.
  When using mkosi to build a systemd test image from sources, installing
  the big system image forces all deps to be installed, which might
  not be desired. Dropping systemd from the installation list makes
  mkosi useful for non-systemd stuff (either containers or non-systemd
  inits).
- grub* / systemd-boot: people might want to use grub even if sd-boot
  is available, etc.

To make this change more palatable, I kept various packages in
conditional mode: e.g. systemd-udev is probably necessary *if* installing
systemd and making a bootable image. This way we make more things
work automatically out box (the user only needs to specify 'systemd',
not the subpackages), but allow the unnecessary deps to be cut down.

It's possible that even those conditional deps are too much and should
be removed from here.

Also, I don't know non-rpm packaing with enough detail, so I didn't
touch the non-rpm parts, though they probably should get similar treatment.