### PR TITLE
typing: use generics in @dictify type annotations

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -57,6 +57,7 @@ from typing import (
     Set,
     TextIO,
     Tuple,
+    TypeVar,
     Union,
     cast,
 )
@@ -170,8 +171,12 @@ class MkosiException(Exception):
     """Leads to sys.exit"""
 
 
-def dictify(f: Callable[..., Generator[Tuple[str, str], None, None]]) -> Callable[..., Dict[str, str]]:
-    def wrapper(*args: Any, **kwargs: Any) -> Dict[str, str]:
+T = TypeVar("T")
+V = TypeVar("V")
+
+
+def dictify(f: Callable[..., Generator[Tuple[T, V], None, None]]) -> Callable[..., Dict[T, V]]:
+    def wrapper(*args: Any, **kwargs: Any) -> Dict[T, V]:
         return dict(f(*args, **kwargs))
 
     return functools.update_wrapper(wrapper, f)


### PR DESCRIPTION
Instead of saying that it only works for [str, str], say it can create
a mapping of any two types. I verified that if I add a generator of a
different type, everything works as expected and mypy can detect type
mismatches.

I still don't know how to say that the wrapper takes the same
arguments as the decorated function. It would require a type
metavariable that would mean "some set of args and kwargs", and I
don't think there is syntax for anything like this.