### PR TITLE
cpio and zstd

### DIFF
--- a/.github/workflows/ci-unit-test.yml
+++ b/.github/workflows/ci-unit-test.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install
-      run: python3 -m pip install pytest mypy black isort
+      run: python3 -m pip install pytest mypy types-dataclasses black isort
 
     - name: Check formatting
       run: python3 -m black --check mkosi/ tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         format:
           - directory
           - tar
+          - cpio
           - gpt_ext4
           - gpt_xfs
           - gpt_btrfs
@@ -84,13 +85,15 @@ jobs:
         sudo python3 -m mkosi build
 
     - name: Boot ${{ matrix.distro }}/${{ matrix.format }}
-      if: matrix.format != 'tar'
+      if: matrix.format != 'tar' &&
+          matrix.format != 'cpio'
       run: sudo ./tests/pexpect/boot.py python3 -m mkosi boot
 
     - name: Build ${{ matrix.distro }}/${{ matrix.format }} UEFI UKI
       if: matrix.format != 'directory' &&
           matrix.format != 'plain_squashfs' &&
-          matrix.format != 'tar'
+          matrix.format != 'tar' &&
+          matrix.format != 'cpio'
       run: |
         tee mkosi.default <<- EOF
         [Output]
@@ -108,13 +111,15 @@ jobs:
           matrix.format != 'plain_squashfs' &&
           matrix.format != 'gpt_squashfs' &&
           matrix.format != 'tar' &&
+          matrix.format != 'cpio' &&
           !(matrix.distro == 'ubuntu' && matrix.format == 'gpt_squashfs')
       run: sudo ./tests/pexpect/boot.py python3 -m mkosi qemu
 
     - name: Build ${{ matrix.distro }}/${{ matrix.format }} UEFI
       if: matrix.format != 'directory' &&
           matrix.format != 'plain_squashfs' &&
-          matrix.format != 'tar' && (
+          matrix.format != 'tar' &&
+          matrix.format != 'cpio' && (
           matrix.distro == 'arch' ||
           matrix.distro == 'centos' ||
           matrix.distro == 'fedora')
@@ -136,6 +141,7 @@ jobs:
     - name: Boot ${{ matrix.distro }}/${{ matrix.format }} UEFI
       if: matrix.format != 'directory' &&
           matrix.format != 'plain_squashfs' &&
+          matrix.format != 'cpio' &&
           matrix.format != 'tar' && (
           matrix.distro == 'arch' ||
           matrix.distro == 'centos' ||
@@ -146,7 +152,8 @@ jobs:
       if: matrix.format != 'directory' &&
           matrix.format != 'gpt_squashfs' &&
           matrix.format != 'plain_squashfs' &&
-          matrix.format != 'tar'
+          matrix.format != 'tar' &&
+          matrix.format != 'cpio'
       run: |
         tee mkosi.default <<- EOF
         [Output]
@@ -164,5 +171,6 @@ jobs:
       if: matrix.format != 'directory' &&
           matrix.format != 'gpt_squashfs' &&
           matrix.format != 'plain_squashfs' &&
+          matrix.format != 'cpio' &&
           matrix.format != 'tar'
       run: sudo ./tests/pexpect/boot.py python3 -m mkosi qemu

--- a/man/mkosi.1
+++ b/man/mkosi.1
@@ -47,7 +47,10 @@ btrfs subvolume, with separate subvolumes for \f[C]/var\f[R],
 \f[C]/home\f[R], \f[C]/srv\f[R], \f[C]/var/tmp\f[R]
 (\f[I]subvolume\f[R])
 .IP \[bu] 2
-Tarball (\f[I]tar\f[R])
+Tar archive (\f[I]tar\f[R])
+.IP \[bu] 2
+CPIO archive (\f[I]cpio\f[R]) in the format appropriate for a kernel
+initrd
 .PP
 When a \f[I]GPT\f[R] disk image is created, the following additional
 options are available:
@@ -527,7 +530,8 @@ removed first, and then re-created.
 If true, automatically install packages to ensure basic functionality,
 as appropriate for the given image type.
 For example, \f[C]systemd\f[R] is always included,
-\f[C]systemd-udev\f[R] if the image is bootable, and so on.
+\f[C]systemd-udev\f[R] and \f[C]dracut\f[R] if the image is bootable,
+and so on.
 If false, only packages specified with
 \f[C]--package\f[R]/\f[C]Packages\f[R] will be installed.
 If \f[C]conditional\f[R], the list of packages to install will be

--- a/man/mkosi.1
+++ b/man/mkosi.1
@@ -238,7 +238,8 @@ placed.
 If neither this option nor \f[C]--output-dir=\f[R] is used (see below),
 the image is generated under the name \f[C]image\f[R], but its name
 suffixed with an appropriate file suffix (e.g.\ \f[C]image.raw.xz\f[R]
-in case \f[C]gpt_ext4\f[R] is used in combination with \f[C]--xz\f[R]).
+in case \f[C]gpt_ext4\f[R] is used in combination with \f[C]xz\f[R]
+compression).
 If the \f[C]--image-id=\f[R] option is configured it is used instead of
 \f[C]image\f[R] in the default output name.
 If an image version is specified (via
@@ -392,32 +393,38 @@ against off-line modification, the verification data is placed in an
 additional GPT partition.
 Implies \f[C]--read-only\f[R].
 .TP
-\f[B]\f[CB]--compress=\f[B]\f[R]
-Compress the generated file systems.
-Only applies to \f[C]gpt_btrfs\f[R], \f[C]subvolume\f[R],
-\f[C]gpt_squashfs\f[R], \f[C]plain_squashfs\f[R].
+\f[B]\f[CB]--compress-fs=\f[B]\f[R]
+Enable or disable internal compression in the file system.
+Only applies to output formats with squashfs or btrfs.
 Takes one of \f[C]zlib\f[R], \f[C]lzo\f[R], \f[C]zstd\f[R],
 \f[C]lz4\f[R], \f[C]xz\f[R] or a boolean value as argument.
 If the latter is used compression is enabled/disabled and the default
 algorithm is used.
 In case of the \f[C]squashfs\f[R] output formats compression is implied,
-however this option may be used to select the algorithm.
+but this option may be used to select the algorithm.
+.TP
+\f[B]\f[CB]--compress-output=\f[B]\f[R]
+Configure compression for the resulting image or archive.
+The argument can be either a boolean or a compression algorithm
+(\f[C]xz\f[R], \f[C]zstd\f[R]).
+\f[C]xz\f[R] compression is used by default.
+Note that when applied to block device image types this means the image
+cannot be started directly but needs to be decompressed first.
+This also means that the \f[C]shell\f[R], \f[C]boot\f[R], \f[C]qemu\f[R]
+verbs are not available when this option is used.
+Implied for \f[C]tar\f[R] and \f[C]cpio\f[R].
+.TP
+\f[B]\f[CB]--compress=\f[B]\f[R]
+Enable compression.
+Using this option is equivalent to either \f[C]--compress-fs=\f[R] or
+\f[C]--compress-output=\f[R]; the appropriate type of compression is
+selected automatically.
 .TP
 \f[B]\f[CB]--mksquashfs=\f[B]\f[R]
 Set the path to the \f[C]mksquashfs\f[R] executable to use.
 This is useful in case the parameters for the tool shall be augmented,
 as the tool may be replaced by a script invoking it with the right
 parameters, this way.
-.TP
-\f[B]\f[CB]--xz\f[B]\f[R]
-Compress the resulting image with \f[C]xz\f[R].
-This only applies to \f[C]gpt_ext4\f[R], \f[C]gpt_xfs\f[R],
-\f[C]gpt_btrfs\f[R], \f[C]gpt_squashfs\f[R] and is implied for
-\f[C]tar\f[R].
-Note that when applied to the block device image types this means the
-image cannot be started directly but needs to be decompressed first.
-This also means that the \f[C]shell\f[R], \f[C]boot\f[R], \f[C]qemu\f[R]
-verbs are not available when this option is used.
 .TP
 \f[B]\f[CB]--qcow2\f[B]\f[R]
 Encode the resulting image as QEMU QCOW2 image.
@@ -1149,18 +1156,25 @@ T}@T{
 \f[C]Compress=\f[R]
 T}
 T{
+\f[C]--compress-fs=\f[R]
+T}@T{
+\f[C][Output]\f[R]
+T}@T{
+\f[C]CompressFs=\f[R]
+T}
+T{
+\f[C]--compress-output=\f[R]
+T}@T{
+\f[C][Output]\f[R]
+T}@T{
+\f[C]CompressOutput=\f[R]
+T}
+T{
 \f[C]--mksquashfs=\f[R]
 T}@T{
 \f[C][Output]\f[R]
 T}@T{
 \f[C]Mksquashfs=\f[R]
-T}
-T{
-\f[C]--xz\f[R]
-T}@T{
-\f[C][Output]\f[R]
-T}@T{
-\f[C]XZ=\f[R]
 T}
 T{
 \f[C]--qcow2\f[R]
@@ -2010,7 +2024,7 @@ file, and install \f[I]SSH\f[R] into it:
 .IP
 .nf
 \f[C]
-# mkosi -d fedora -t gpt_squashfs --checksum --xz --package=openssh-clients
+# mkosi -d fedora -t gpt_squashfs --checksum --compress --package=openssh-clients
 \f[R]
 .fi
 .PP

--- a/mkosi.md
+++ b/mkosi.md
@@ -47,7 +47,9 @@ The following output formats are supported:
 * btrfs subvolume, with separate subvolumes for `/var`, `/home`,
   `/srv`, `/var/tmp` (*subvolume*)
 
-* Tarball (*tar*)
+* Tar archive (*tar*)
+
+* CPIO archive (*cpio*) in the format appropriate for a kernel initrd
 
 When a *GPT* disk image is created, the following additional
 options are available:

--- a/mkosi.md
+++ b/mkosi.md
@@ -242,9 +242,9 @@ details see the table below.
   this option nor `--output-dir=` is used (see below), the image is
   generated under the name `image`, but its name suffixed with an
   appropriate file suffix (e.g. `image.raw.xz` in case `gpt_ext4` is
-  used in combination with `--xz`). If the `--image-id=` option is
-  configured it is used instead of `image` in the default output
-  name. If an image version is specified (via
+  used in combination with `xz` compression). If the `--image-id=`
+  option is configured it is used instead of `image` in the default
+  output name. If an image version is specified (via
   `--image-version=`/`ImageVersion=`) it is included in the default
   name, e.g. a specified image version of `7.8` might result in an
   image file name of `image_7.8.raw.xz`.
@@ -392,15 +392,31 @@ details see the table below.
   modification, the verification data is placed in an additional GPT
   partition. Implies `--read-only`.
 
+`--compress-fs=`
+
+: Enable or disable internal compression in the file system. Only
+  applies to output formats with squashfs or btrfs. Takes one of
+  `zlib`, `lzo`, `zstd`, `lz4`, `xz` or a boolean value as argument.
+  If the latter is used compression is enabled/disabled and the
+  default algorithm is used. In case of the `squashfs` output formats
+  compression is implied, but this option may be used to select the
+  algorithm.
+
+`--compress-output=`
+
+: Configure compression for the resulting image or archive. The
+  argument can be either a boolean or a compression algorithm (`xz`,
+  `zstd`). `xz` compression is used by default. Note that when applied
+  to block device image types this means the image cannot be started
+  directly but needs to be decompressed first. This also means that
+  the `shell`, `boot`, `qemu` verbs are not available when this option
+  is used. Implied for `tar` and `cpio`.
+
 `--compress=`
 
-: Compress the generated file systems. Only applies to `gpt_btrfs`,
-  `subvolume`, `gpt_squashfs`, `plain_squashfs`. Takes one of `zlib`,
-  `lzo`, `zstd`, `lz4`, `xz` or a boolean value as argument. If the
-  latter is used compression is enabled/disabled and the default
-  algorithm is used. In case of the `squashfs` output formats
-  compression is implied, however this option may be used to select
-  the algorithm.
+: Enable compression. Using this option is equivalent to either
+  `--compress-fs=` or `--compress-output=`; the appropriate type
+  of compression is selected automatically.
 
 `--mksquashfs=`
 
@@ -408,15 +424,6 @@ details see the table below.
   in case the parameters for the tool shall be augmented, as the tool
   may be replaced by a script invoking it with the right parameters,
   this way.
-
-`--xz`
-
-: Compress the resulting image with `xz`. This only applies to
-  `gpt_ext4`, `gpt_xfs`, `gpt_btrfs`, `gpt_squashfs` and is implied
-  for `tar`. Note that when applied to the block device image types
-  this means the image cannot be started directly but needs to be
-  decompressed first. This also means that the `shell`, `boot`, `qemu`
-  verbs are not available when this option is used.
 
 `--qcow2`
 
@@ -973,8 +980,9 @@ which settings file options.
 | `--encrypt=`                      | `[Output]`              | `Encrypt=`                    |
 | `--verity=`                       | `[Output]`              | `Verity=`                     |
 | `--compress=`                     | `[Output]`              | `Compress=`                   |
+| `--compress-fs=`                  | `[Output]`              | `CompressFs=`                 |
+| `--compress-output=`              | `[Output]`              | `CompressOutput=`             |
 | `--mksquashfs=`                   | `[Output]`              | `Mksquashfs=`                 |
-| `--xz`                            | `[Output]`              | `XZ=`                         |
 | `--qcow2`                         | `[Output]`              | `QCow2=`                      |
 | `--no-chown`                      | `[Output]`              | `NoChown=`                    |
 | `--tar-strip-selinux-context`     | `[Output]`              | `TarStripSELinuxContext=`     |
@@ -1436,7 +1444,7 @@ Create a compressed image `image.raw.xz` and add a checksum file, and
 install *SSH* into it:
 
 ```bash
-# mkosi -d fedora -t gpt_squashfs --checksum --xz --package=openssh-clients
+# mkosi -d fedora -t gpt_squashfs --checksum --compress --package=openssh-clients
 ```
 
 Inside the source directory of an `automake`-based project,

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -78,6 +78,7 @@ from .backend import (
     patch_file,
     run,
     run_workspace_command,
+    spawn,
     tmp_dir,
     var_tmp,
     warn,
@@ -3308,6 +3309,10 @@ def make_read_only(args: CommandLineArguments, root: str, for_cache: bool, b: bo
         btrfs_subvol_make_ro(root, b)
 
 
+def xz_binary() -> str:
+    return "pxz" if shutil.which("pxz") else "xz"
+
+
 def make_tar(args: CommandLineArguments, root: str, do_run_build_script: bool, for_cache: bool) -> Optional[BinaryIO]:
     if do_run_build_script:
         return None
@@ -3316,20 +3321,61 @@ def make_tar(args: CommandLineArguments, root: str, do_run_build_script: bool, f
     if for_cache:
         return None
 
-    tar_root_dir = f"{root}/usr" if args.usr_only else root
+    root_dir = f"{root}/usr" if args.usr_only else root
 
     with complete_step("Creating archive"):
         f: BinaryIO = cast(BinaryIO, tempfile.NamedTemporaryFile(dir=os.path.dirname(args.output), prefix=".mkosi-"))
         # OpenMandriva defaults to bsdtar(libarchive) which uses POSIX argument list so let's keep a separate list
         if shutil.which("bsdtar") and args.distribution == Distribution.openmandriva:
-            _tar_cmd = ["bsdtar", "-C", tar_root_dir, "-c", "-J", "--xattrs", "-f", "-", "."]
+            cmd = ["bsdtar", "-C", root_dir, "-c", "-J", "--xattrs", "-f", "-", "."]
         else:
-            _tar_cmd = ["tar", "-C", tar_root_dir, "-c", "-J", "--xattrs", "--xattrs-include=*"]
+            cmd = ["tar", "-C", root_dir, "-c", "-J", "--xattrs", "--xattrs-include=*"]
             if args.tar_strip_selinux_context:
-                _tar_cmd.append("--xattrs-exclude=security.selinux")
-            _tar_cmd.append(".")
+                cmd.append("--xattrs-exclude=security.selinux")
+            cmd.append(".")
 
-        run(_tar_cmd, env={"XZ_OPT": "-T0"}, stdout=f)
+        run(cmd, env={"XZ_OPT": "-T0"}, stdout=f)
+
+    return f
+
+
+def find_files(root: str) -> Generator[str, None, None]:
+    """Generate a list of all filepaths relative to @root"""
+    root = root.rstrip("/") + "/"  # make sure the path ends in exactly one '/'
+    prefix_len = len(root)
+    queue = collections.deque([root])
+
+    while queue:
+        for entry in os.scandir(queue.pop()):
+            yield entry.path[prefix_len:]
+            if entry.is_dir(follow_symlinks=False):
+                queue.append(entry.path)
+
+
+def make_cpio(args: CommandLineArguments, root: str, do_run_build_script: bool, for_cache: bool) -> Optional[BinaryIO]:
+    if do_run_build_script:
+        return None
+    if args.output_format != OutputFormat.cpio:
+        return None
+    if for_cache:
+        return None
+
+    root_dir = f"{root}/usr" if args.usr_only else root
+
+    with complete_step("Creating archive"):
+        f: BinaryIO = cast(BinaryIO, tempfile.NamedTemporaryFile(dir=os.path.dirname(args.output), prefix=".mkosi-"))
+
+        compressor = [xz_binary(), "--check=crc32", "--lzma2=dict=1MiB", "-T0"]
+        files = find_files(root_dir)
+        cmd = ["cpio", "-o", "--reproducible", "--null", "-H", "newc", "--quiet", "-D", root_dir]
+
+        with spawn(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE) as cpio:
+            with spawn(compressor, stdin=cpio.stdout, stdout=f, delay_interrupt=False):
+                for file in files:
+                    cpio.stdin.write(file.encode("utf8") + b"\0")
+                cpio.stdin.close()
+        if cpio.wait() != 0:
+            die("Failed to create archive")
 
     return f
 
@@ -3808,13 +3854,11 @@ def xz_output(
     if not args.xz:
         return data
 
-    xz_binary = "pxz" if shutil.which("pxz") else "xz"
-
     with complete_step(f"Compressing output file {data.name}"):
         f: BinaryIO = cast(
             BinaryIO, tempfile.NamedTemporaryFile(prefix=".mkosi-", suffix=suffix, dir=os.path.dirname(args.output))
         )
-        run([xz_binary, "-c", data.name], stdout=f)
+        run([xz_binary(), "-c", data.name], stdout=f)
 
     return f
 
@@ -3887,7 +3931,7 @@ def hash_file(of: TextIO, sf: BinaryIO, fname: str) -> None:
 def calculate_sha256sum(
     args: CommandLineArguments,
     raw: Optional[BinaryIO],
-    tar: Optional[BinaryIO],
+    archive: Optional[BinaryIO],
     root_hash_file: Optional[BinaryIO],
     split_root: Optional[BinaryIO],
     split_verity: Optional[BinaryIO],
@@ -3912,8 +3956,8 @@ def calculate_sha256sum(
 
         if raw is not None:
             hash_file(f, raw, os.path.basename(args.output))
-        if tar is not None:
-            hash_file(f, tar, os.path.basename(args.output))
+        if archive is not None:
+            hash_file(f, archive, os.path.basename(args.output))
         if root_hash_file is not None:
             assert args.output_root_hash_file is not None
             hash_file(f, root_hash_file, os.path.basename(args.output_root_hash_file))
@@ -4025,7 +4069,11 @@ def link_output(args: CommandLineArguments, root: str, artifact: Optional[Binary
             os.rename(root, args.output)
             make_read_only(args, args.output, for_cache=False, b=True)
 
-        elif args.output_format.is_disk() or args.output_format in (OutputFormat.plain_squashfs, OutputFormat.tar):
+        elif args.output_format.is_disk() or args.output_format in (
+            OutputFormat.plain_squashfs,
+            OutputFormat.tar,
+            OutputFormat.cpio,
+        ):
             assert artifact is not None
             _link_output(args, artifact.name, args.output)
 
@@ -4723,7 +4771,7 @@ def create_parser() -> ArgumentParserMkosi:
         "--usr-only", action=BooleanAction, help="Generate a /usr/ partition instead of a root partition"
     )
 
-    group = parser.add_argument_group("Validation (only gpt_ext4, gpt_xfs, gpt_btrfs, gpt_squashfs, tar)")
+    group = parser.add_argument_group("Validation (only gpt_ext4, gpt_xfs, gpt_btrfs, gpt_squashfs, tar, cpio)")
     group.add_argument("--checksum", action=BooleanAction, help="Write SHA256SUMS file")
     group.add_argument("--sign", action=BooleanAction, help="Write and sign SHA256SUMS file")
     group.add_argument("--key", help="GPG key to use for signing")
@@ -5291,6 +5339,8 @@ def strip_suffixes(path: str) -> str:
             t = t[:-4]
         elif t.endswith(".tar"):
             t = t[:-4]
+        elif t.endswith(".cpio"):
+            t = t[:-5]
         elif t.endswith(".qcow2"):
             t = t[:-6]
         else:
@@ -5388,9 +5438,10 @@ def load_args(args: argparse.Namespace) -> CommandLineArguments:
             OutputFormat.directory,
             OutputFormat.subvolume,
             OutputFormat.tar,
+            OutputFormat.cpio,
             OutputFormat.plain_squashfs,
         ):
-            die("Directory, subvolume, tar and plain squashfs images cannot be booted.")
+            die("Directory, subvolume, tar, cpio, and plain squashfs images cannot be booted.")
 
         if not args.boot_protocols:
             args.boot_protocols = ["uefi"]
@@ -5467,6 +5518,8 @@ def load_args(args: argparse.Namespace) -> CommandLineArguments:
             args.output = prefix + (".qcow2" if args.qcow2 else ".raw") + (".xz" if args.xz else "")
         elif args.output_format == OutputFormat.tar:
             args.output = f"{prefix}.tar.xz"
+        elif args.output_format == OutputFormat.cpio:
+            args.output = f"{prefix}.cpio.xz"
         else:
             args.output = prefix
 
@@ -5605,8 +5658,8 @@ def load_args(args: argparse.Namespace) -> CommandLineArguments:
 
     if args.verb in ("shell", "boot"):
         opname = "acquire shell" if args.verb == "shell" else "boot"
-        if args.output_format == OutputFormat.tar:
-            die(f"Sorry, can't {opname} with a tar archive.")
+        if args.output_format in (OutputFormat.tar, OutputFormat.cpio):
+            die(f"Sorry, can't {opname} with a {args.output_format} archive.")
         if args.xz:
             die("Sorry, can't {opname} with a compressed image.")
         if args.qcow2:
@@ -6145,9 +6198,11 @@ def build_image(
                 else None
             )
 
-    tar = make_tar(args, root, do_run_build_script, for_cache)
+    archive = make_tar(args, root, do_run_build_script, for_cache) or make_cpio(
+        args, root, do_run_build_script, for_cache
+    )
 
-    return raw or generated_root, tar, root_hash, sshkey, split_root, split_verity, split_kernel
+    return raw or generated_root, archive, root_hash, sshkey, split_root, split_verity, split_kernel
 
 
 def one_zero(b: bool) -> str:
@@ -6251,7 +6306,7 @@ def remove_artifacts(
     args: CommandLineArguments,
     root: str,
     raw: Optional[BinaryIO],
-    tar: Optional[BinaryIO],
+    archive: Optional[BinaryIO],
     do_run_build_script: bool,
     for_cache: bool = False,
 ) -> None:
@@ -6266,9 +6321,9 @@ def remove_artifacts(
         with complete_step("Removing disk image from " + what):
             del raw
 
-    if tar is not None:
-        with complete_step("Removing tar image from " + what):
-            del tar
+    if archive is not None:
+        with complete_step("Removing archive image from " + what):
+            del archive
 
     with complete_step("Removing artifacts from " + what):
         unlink_try_hard(root)
@@ -6284,7 +6339,7 @@ def build_stuff(args: CommandLineArguments) -> None:
 
     root_hash = None
     raw = None
-    tar = None
+    archive = None
     sshkey = None
 
     # Make sure tmpfiles' aging doesn't interfere with our workspace
@@ -6303,37 +6358,38 @@ def build_stuff(args: CommandLineArguments) -> None:
             if args.build_script:
                 with complete_step("Running first (development) stage to generate cached copy"):
                     # Generate the cache version of the build image, and store it as "cache-pre-dev"
-                    raw, tar, root_hash, sshkey, split_root, split_verity, split_kernel = build_image(
+                    raw, archive, root_hash, sshkey, split_root, split_verity, split_kernel = build_image(
                         args, root, do_run_build_script=True, for_cache=True
                     )
+
                     save_cache(args, root, raw.name if raw is not None else None, args.cache_pre_dev)
 
-                    remove_artifacts(args, root, raw, tar, do_run_build_script=True)
+                    remove_artifacts(args, root, raw, archive, do_run_build_script=True)
 
             with complete_step("Running second (final) stage to generate cached copy"):
                 # Generate the cache version of the build image, and store it as "cache-pre-inst"
-                raw, tar, root_hash, sshkey, split_root, split_verity, split_kernel = build_image(
+                raw, archive, root_hash, sshkey, split_root, split_verity, split_kernel = build_image(
                     args, root, do_run_build_script=False, for_cache=True
                 )
 
                 if raw:
                     save_cache(args, root, raw.name, args.cache_pre_inst)
-                    remove_artifacts(args, root, raw, tar, do_run_build_script=False)
+                    remove_artifacts(args, root, raw, archive, do_run_build_script=False)
 
         if args.build_script:
             with complete_step("Running first (development) stage"):
                 # Run the image builder for the first (development) stage in preparation for the build script
-                raw, tar, root_hash, sshkey, split_root, split_verity, split_kernel = build_image(
+                raw, archive, root_hash, sshkey, split_root, split_verity, split_kernel = build_image(
                     args, root, do_run_build_script=True
                 )
 
                 run_build_script(args, root, raw)
-                remove_artifacts(args, root, raw, tar, do_run_build_script=True)
+                remove_artifacts(args, root, raw, archive, do_run_build_script=True)
 
         # Run the image builder for the second (final) stage
         if not args.skip_final_phase:
             with complete_step("Running second (final) stage"):
-                raw, tar, root_hash, sshkey, split_root, split_verity, split_kernel = build_image(
+                raw, archive, root_hash, sshkey, split_root, split_verity, split_kernel = build_image(
                     args, root, do_run_build_script=False, cleanup=True
                 )
         else:
@@ -6347,12 +6403,12 @@ def build_stuff(args: CommandLineArguments) -> None:
         root_hash_file = write_root_hash_file(args, root_hash)
         settings = copy_nspawn_settings(args)
         checksum = calculate_sha256sum(
-            args, raw, tar, root_hash_file, split_root, split_verity, split_kernel, settings
+            args, raw, archive, root_hash_file, split_root, split_verity, split_kernel, settings
         )
         signature = calculate_signature(args, checksum)
         bmap = calculate_bmap(args, raw)
 
-        link_output(args, root, raw or tar)
+        link_output(args, root, raw or archive)
         link_output_root_hash_file(args, root_hash_file.name if root_hash_file is not None else None)
         link_output_checksum(args, checksum.name if checksum is not None else None)
         link_output_signature(args, signature.name if signature is not None else None)

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5600,12 +5600,13 @@ def load_args(args: argparse.Namespace) -> CommandLineArguments:
             )  # NOQA: E501
 
     if args.verb in ("shell", "boot"):
+        opname = "acquire shell" if args.verb == "shell" else "boot"
         if args.output_format == OutputFormat.tar:
-            die("Sorry, can't acquire shell in or boot a tar archive.")
+            die(f"Sorry, can't {opname} with a tar archive.")
         if args.xz:
-            die("Sorry, can't acquire shell in or boot an XZ compressed image.")
+            die("Sorry, can't {opname} with a compressed image.")
         if args.qcow2:
-            die("Sorry, can't acquire shell in or boot a qcow2 image.")
+            die("Sorry, can't {opname} using a qcow2 image.")
 
     if args.verb == "qemu":
         if not args.output_format.is_disk():

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5735,12 +5735,10 @@ def none_to_none(o: Optional[object]) -> str:
     return "none" if o is None else str(o)
 
 
-def line_join_list(ary: List[str]) -> str:
-
-    if not ary:
+def line_join_list(array: List[str]) -> str:
+    if not array:
         return "none"
-
-    return "\n                        ".join(ary)
+    return "\n                            ".join(array)
 
 
 def print_summary(args: CommandLineArguments) -> None:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -78,6 +78,8 @@ from .backend import (
     patch_file,
     run,
     run_workspace_command,
+    should_compress_fs,
+    should_compress_output,
     spawn,
     tmp_dir,
     var_tmp,
@@ -1209,15 +1211,13 @@ def mount_loop(args: CommandLineArguments, dev: str, where: str, read_only: bool
     if not args.output_format.is_squashfs():
         options.append("discard")
 
+    compress = should_compress_fs(args)
     if (
-        args.compress
+        compress
         and args.output_format == OutputFormat.gpt_btrfs
         and not (where.endswith("/efi") or where.endswith("/boot"))
     ):
-        if isinstance(args.compress, bool):
-            options.append("compress")
-        else:
-            options.append(f"compress={args.compress}")
+        options.append("compress" if compress is True else f"compress={compress}")
 
     if read_only:
         options.append("ro")
@@ -3313,6 +3313,19 @@ def xz_binary() -> str:
     return "pxz" if shutil.which("pxz") else "xz"
 
 
+def compressor_command(option: Union[str, bool]) -> List[str]:
+    """Returns a command suitable for compressing archives."""
+
+    if option == "xz":
+        return [xz_binary(), "--check=crc32", "--lzma2=dict=1MiB", "-T0"]
+    elif option == "zstd":
+        return ["zstd", "-15", "-q", "-T0"]
+    elif option is False:
+        return ["cat"]
+    else:
+        die(f"Unknown compression {option}")
+
+
 def make_tar(args: CommandLineArguments, root: str, do_run_build_script: bool, for_cache: bool) -> Optional[BinaryIO]:
     if do_run_build_script:
         return None
@@ -3327,14 +3340,19 @@ def make_tar(args: CommandLineArguments, root: str, do_run_build_script: bool, f
         f: BinaryIO = cast(BinaryIO, tempfile.NamedTemporaryFile(dir=os.path.dirname(args.output), prefix=".mkosi-"))
         # OpenMandriva defaults to bsdtar(libarchive) which uses POSIX argument list so let's keep a separate list
         if shutil.which("bsdtar") and args.distribution == Distribution.openmandriva:
-            cmd = ["bsdtar", "-C", root_dir, "-c", "-J", "--xattrs", "-f", "-", "."]
+            cmd = ["bsdtar", "-C", root_dir, "-c", "--xattrs", "-f", "-"]
         else:
-            cmd = ["tar", "-C", root_dir, "-c", "-J", "--xattrs", "--xattrs-include=*"]
+            cmd = ["tar", "-C", root_dir, "-c", "--xattrs", "--xattrs-include=*"]
             if args.tar_strip_selinux_context:
-                cmd.append("--xattrs-exclude=security.selinux")
-            cmd.append(".")
+                cmd += ["--xattrs-exclude=security.selinux"]
 
-        run(cmd, env={"XZ_OPT": "-T0"}, stdout=f)
+        compress = should_compress_output(args)
+        if compress:
+            cmd += ["--use-compress-program=" + " ".join(compressor_command(compress))]
+
+        cmd += ["."]
+
+        run(cmd, stdout=f)
 
     return f
 
@@ -3365,7 +3383,7 @@ def make_cpio(args: CommandLineArguments, root: str, do_run_build_script: bool, 
     with complete_step("Creating archive"):
         f: BinaryIO = cast(BinaryIO, tempfile.NamedTemporaryFile(dir=os.path.dirname(args.output), prefix=".mkosi-"))
 
-        compressor = [xz_binary(), "--check=crc32", "--lzma2=dict=1MiB", "-T0"]
+        compressor = compressor_command(should_compress_output(args))
         files = find_files(root_dir)
         cmd = ["cpio", "-o", "--reproducible", "--null", "-H", "newc", "--quiet", "-D", root_dir]
 
@@ -3846,19 +3864,21 @@ def extract_unified_kernel(
     return f
 
 
-def xz_output(
+def compress_output(
     args: CommandLineArguments, data: Optional[BinaryIO], suffix: Optional[str] = None
 ) -> Optional[BinaryIO]:
     if data is None:
         return None
-    if not args.xz:
+    compress = should_compress_output(args)
+
+    if not compress:
         return data
 
     with complete_step(f"Compressing output file {data.name}"):
         f: BinaryIO = cast(
             BinaryIO, tempfile.NamedTemporaryFile(prefix=".mkosi-", suffix=suffix, dir=os.path.dirname(args.output))
         )
-        run([xz_binary(), "-c", data.name], stdout=f)
+        run([*compressor_command(compress), "--stdout", data.name], stdout=f)
 
     return f
 
@@ -4365,7 +4385,7 @@ class ArgumentParserMkosi(argparse.ArgumentParser):
         "QCow2": "--qcow2",
         "OutputDirectory": "--output-dir",
         "WorkspaceDirectory": "--workspace-dir",
-        "XZ": "--xz",
+        "XZ": "--compress-output=xz",
         "NSpawnSettings": "--settings",
         "ESPSize": "--esp-size",
         "CheckSum": "--checksum",
@@ -4583,16 +4603,34 @@ def create_parser() -> ArgumentParserMkosi:
     group.add_argument(
         "--compress",
         type=parse_compression,
-        help="Enable compression in file system (only gpt_btrfs, subvolume, gpt_squashfs, plain_squashfs)",
+        nargs="?",
+        metavar="ALG",
+        help="Enable compression (in-fs if supported, whole-output otherwise)",
+    )
+    group.add_argument(
+        "--compress-fs",
+        type=parse_compression,
+        nargs="?",
+        metavar="ALG",
+        help="Enable in-filesystem compression (gpt_btrfs, subvolume, gpt_squashfs, plain_squashfs)",
+    )
+    group.add_argument(
+        "--compress-output",
+        type=parse_compression,
+        nargs="?",
+        metavar="ALG",
+        help="Enable whole-output compression (with images or archives)",
     )
     group.add_argument(
         "--mksquashfs", dest="mksquashfs_tool", type=str.split, default=[], help="Script to call instead of mksquashfs"
     )
     group.add_argument(
         "--xz",
-        action=BooleanAction,
-        help="Compress resulting image with xz (only gpt_ext4, gpt_xfs, gpt_btrfs, gpt_squashfs, implied on tar)",
-    )  # NOQA: E501
+        action="store_const",
+        dest="compress_output",
+        const="xz",
+        help=argparse.SUPPRESS,
+    )
     group.add_argument(
         "--qcow2",
         action=BooleanAction,
@@ -5335,6 +5373,8 @@ def strip_suffixes(path: str) -> str:
     while True:
         if t.endswith(".xz"):
             t = t[:-3]
+        elif t.endswith(".zstd"):
+            t = t[:-5]
         elif t.endswith(".raw"):
             t = t[:-4]
         elif t.endswith(".tar"):
@@ -5362,8 +5402,10 @@ def xescape(s: str) -> str:
     return ret
 
 
-def build_auxiliary_output_path(path: str, suffix: str, xz: Optional[bool] = False) -> str:
-    return strip_suffixes(path) + suffix + (".xz" if xz else "")
+def build_auxiliary_output_path(args: argparse.Namespace, suffix: str, can_compress: bool = False) -> str:
+    output = strip_suffixes(args.output)
+    compress = should_compress_output(args) if can_compress else False
+    return output + suffix + (f".{compress}" if compress else "")
 
 
 def check_valid_script(path: str) -> None:
@@ -5515,11 +5557,12 @@ def load_args(args: argparse.Namespace) -> CommandLineArguments:
         prefix = f"{iid}_{args.image_version}" if args.image_version is not None else iid
 
         if args.output_format.is_disk():
-            args.output = prefix + (".qcow2" if args.qcow2 else ".raw") + (".xz" if args.xz else "")
+            compress = should_compress_output(args)
+            args.output = prefix + (".qcow2" if args.qcow2 else ".raw") + (f".{compress}" if compress else "")
         elif args.output_format == OutputFormat.tar:
             args.output = f"{prefix}.tar.xz"
         elif args.output_format == OutputFormat.cpio:
-            args.output = f"{prefix}.cpio.xz"
+            args.output = f"{prefix}.cpio" + (f".{args.compress}" if args.compress else "")
         else:
             args.output = prefix
 
@@ -5541,7 +5584,7 @@ def load_args(args: argparse.Namespace) -> CommandLineArguments:
     args.output = os.path.abspath(args.output)
 
     if args.output_format == OutputFormat.tar:
-        args.xz = True
+        args.compress_output = "xz"
     if not args.output_format.is_disk():
         args.split_artifacts = False
 
@@ -5555,7 +5598,7 @@ def load_args(args: argparse.Namespace) -> CommandLineArguments:
 
     if args.verity:
         args.read_only = True
-        args.output_root_hash_file = build_auxiliary_output_path(args.output, roothash_suffix(args.usr_only))
+        args.output_root_hash_file = build_auxiliary_output_path(args, roothash_suffix(args.usr_only))
 
     if args.checksum:
         args.output_checksum = os.path.join(os.path.dirname(args.output), "SHA256SUMS")
@@ -5564,24 +5607,22 @@ def load_args(args: argparse.Namespace) -> CommandLineArguments:
         args.output_signature = os.path.join(os.path.dirname(args.output), "SHA256SUMS.gpg")
 
     if args.bmap:
-        args.output_bmap = build_auxiliary_output_path(args.output, ".bmap")
+        args.output_bmap = build_auxiliary_output_path(args, ".bmap")
 
     if args.nspawn_settings is not None:
         args.nspawn_settings = os.path.abspath(args.nspawn_settings)
-        args.output_nspawn_settings = build_auxiliary_output_path(args.output, ".nspawn")
+        args.output_nspawn_settings = build_auxiliary_output_path(args, ".nspawn")
 
     # We want this set even if --ssh is not specified so we can find the SSH key when verb == "ssh".
     if args.ssh_key is None:
         args.output_sshkey = os.path.join(os.path.dirname(args.output), "id_rsa")
 
     if args.split_artifacts:
-        args.output_split_root = build_auxiliary_output_path(
-            args.output, ".usr" if args.usr_only else ".root", args.xz
-        )
+        args.output_split_root = build_auxiliary_output_path(args, ".usr" if args.usr_only else ".root", True)
         if args.verity:
-            args.output_split_verity = build_auxiliary_output_path(args.output, ".verity", args.xz)
+            args.output_split_verity = build_auxiliary_output_path(args, ".verity", True)
         if args.bootable:
-            args.output_split_kernel = build_auxiliary_output_path(args.output, ".efi", args.xz)
+            args.output_split_kernel = build_auxiliary_output_path(args, ".efi", True)
 
     if args.build_script is not None:
         check_valid_script(args.build_script)
@@ -5660,7 +5701,7 @@ def load_args(args: argparse.Namespace) -> CommandLineArguments:
         opname = "acquire shell" if args.verb == "shell" else "boot"
         if args.output_format in (OutputFormat.tar, OutputFormat.cpio):
             die(f"Sorry, can't {opname} with a {args.output_format} archive.")
-        if args.xz:
+        if should_compress_output(args):
             die("Sorry, can't {opname} with a compressed image.")
         if args.qcow2:
             die("Sorry, can't {opname} using a qcow2 image.")
@@ -5762,6 +5803,10 @@ def yes_no(b: Optional[bool]) -> str:
     return "yes" if b else "no"
 
 
+def yes_no_or(b: Union[bool, str]) -> str:
+    return b if isinstance(b, str) else yes_no(b)
+
+
 def format_bytes_or_disabled(sz: Optional[int]) -> str:
     if sz is None:
         return "(disabled)"
@@ -5850,10 +5895,10 @@ def print_summary(args: CommandLineArguments) -> None:
     MkosiPrinter.info("               Incremental: " + yes_no(args.incremental))
 
     MkosiPrinter.info("                 Read-only: " + yes_no(args.read_only))
-    detail = " ({})".format(args.compress) if args.compress and not isinstance(args.compress, bool) else ""
-    MkosiPrinter.info("            FS Compression: " + yes_no(cast(bool, args.compress)) + detail)
 
-    MkosiPrinter.info("            XZ Compression: " + yes_no(args.xz))
+    MkosiPrinter.info(" Internal (FS) Compression: " + yes_no_or(should_compress_fs(args)))
+    MkosiPrinter.info("Outer (output) Compression: " + yes_no_or(should_compress_output(args)))
+
     if args.mksquashfs_tool:
         MkosiPrinter.info("           Mksquashfs tool: " + " ".join(args.mksquashfs_tool))
 
@@ -6396,10 +6441,10 @@ def build_stuff(args: CommandLineArguments) -> None:
             MkosiPrinter.print_step("Skipping (second) final image build phase.")
 
         raw = qcow2_output(args, raw)
-        raw = xz_output(args, raw)
-        split_root = xz_output(args, split_root, ".usr" if args.usr_only else ".root")
-        split_verity = xz_output(args, split_verity, ".verity")
-        split_kernel = xz_output(args, split_kernel, ".efi")
+        raw = compress_output(args, raw)
+        split_root = compress_output(args, split_root, ".usr" if args.usr_only else ".root")
+        split_verity = compress_output(args, split_verity, ".verity")
+        split_kernel = compress_output(args, split_kernel, ".efi")
         root_hash_file = write_root_hash_file(args, root_hash)
         settings = copy_nspawn_settings(args)
         checksum = calculate_sha256sum(

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1952,6 +1952,10 @@ def install_fedora(args: CommandLineArguments, root: str, do_run_build_script: b
     with open(os.path.join(root, "etc/locale.conf"), "w") as f:
         f.write("LANG=C.UTF-8\n")
 
+    # FIXME: should this be conditionalized on args.with_docs like in install_debian_or_ubuntu()?
+    #        But we set LANG=C.UTF-8 anyway.
+    shutil.rmtree(os.path.join(root, "usr/share/locale"))
+
 
 @complete_step("Installing Mageia")
 def install_mageia(args: CommandLineArguments, root: str, do_run_build_script: bool) -> None:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3388,6 +3388,9 @@ def make_cpio(args: CommandLineArguments, root: str, do_run_build_script: bool, 
         cmd = ["cpio", "-o", "--reproducible", "--null", "-H", "newc", "--quiet", "-D", root_dir]
 
         with spawn(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE) as cpio:
+            #  https://github.com/python/mypy/issues/10583
+            assert cpio.stdin is not None
+
             with spawn(compressor, stdin=cpio.stdout, stdout=f, delay_interrupt=False):
                 for file in files:
                     cpio.stdin.write(file.encode("utf8") + b"\0")

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -86,6 +86,7 @@ class OutputFormat(enum.Enum):
     directory = enum.auto()
     subvolume = enum.auto()
     tar = enum.auto()
+    cpio = enum.auto()
 
     gpt_ext4 = enum.auto()
     gpt_xfs = enum.auto()

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -55,6 +55,8 @@ class MkosiConfig(object):
             "checksum": False,
             "cmdline": [],
             "compress": None,
+            "compress_fs": None,
+            "compress_output": None,
             "debug": [],
             "default_path": None,
             "directory": None,
@@ -114,7 +116,6 @@ class MkosiConfig(object):
             "with_network": False,
             "with_tests": True,
             "xbootldr_size": None,
-            "xz": False,
             "qemu_headless": False,
             "qemu_smp": "2",
             "qemu_mem": "1G",
@@ -239,10 +240,12 @@ class MkosiConfig(object):
                 self.reference_config[job_name]["verity"] = mk_config_output["Verity"]
             if "Compress" in mk_config_output:
                 self.reference_config[job_name]["compress"] = mk_config_output["Compress"]
+            if "CompressFs" in mk_config_output:
+                self.reference_config[job_name]["compress_fs"] = mk_config_output["CompressFs"]
+            if "CompressOutput" in mk_config_output:
+                self.reference_config[job_name]["compress_output"] = mk_config_output["CompressOutput"]
             if "Mksquashfs" in mk_config_output:
                 self.reference_config[job_name]["mksquashfs_tool"] = mk_config_output["Mksquashfs"].split()
-            if "XZ" in mk_config_output:
-                self.reference_config[job_name]["xz"] = mk_config_output["XZ"]
             if "QCow2" in mk_config_output:
                 self.reference_config[job_name]["qcow2"] = mk_config_output["QCow2"]
             if "TarStripSELinuxContext" in mk_config_output:
@@ -518,7 +521,6 @@ class MkosiConfigManyParams(MkosiConfigOne):
                 "Verity": False,
                 "Compress": "lz4",
                 "Mksquashfs": "my/fo/sq-tool",
-                "XZ": False,
                 "QCow2": False,
                 "Hostname": "myhost1",
                 "UsrOnly": False,
@@ -584,7 +586,6 @@ class MkosiConfigManyParams(MkosiConfigOne):
                 "Verity": True,
                 "Compress": "zstd",
                 "Mksquashfs": "my/fo/sq-tool-ubu",
-                "XZ": True,
                 "QCow2": True,
                 "Hostname": "myubuhost1",
                 "UsrOnly": False,
@@ -650,7 +651,6 @@ class MkosiConfigManyParams(MkosiConfigOne):
                 "Verity": True,
                 "Compress": "zstd",
                 "Mksquashfs": "my/fo/sq-tool-debi",
-                "XZ": True,
                 "QCow2": True,
                 "Hostname": "mydebihost1",
                 "UsrOnly": False,


### PR DESCRIPTION
This adds support for building cpio.zstd archives. See https://github.com/keszybz/mkosi-initrd for instructions how to create a functional pure-systemd initrd from Fedora packages.

I'm marking it as RFC. The cpio part is fine I think. The *implementation* of compression with zstd is also OK. But the user interface needs some design: right now we have `--xz` option, based on the assumption that `xz` is the only compression one would want to use. I think this isn't really true any more: `zstd` achieves very similar compression at a fraction of the compression/decompression times. For images that are widely distributed `xz` is still probably the best choice, but `zstd` is better for local work and anything where speed matters.

So I think we should deprecate the `--xz` option, and have `--inner-compression` (internally in the fs or archive where supported) and `--outer-compression` (for doing compression of the full output, like `--xz` right now), and `--compression` that would pick `--inner-compression` or `--outer-compression` as appropriate. Most of the time users would specify `--compression=yes` or `--compression=zstd|xz|gz|…` and `mkosi` would apply it in the appropriate place.

If you think that's the way to go, I will rework the pull request along those lines.