### PR TITLE
mkosi: do not repeat option lists in help output

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4696,6 +4696,15 @@ class WithNetworkAction(BooleanAction):
         super().__call__(parser, namespace, values, option_string)
 
 
+class CustomHelpFormatter(argparse.HelpFormatter):
+    def _format_action_invocation(self, action):
+        if not action.option_strings or action.nargs == 0:
+            return super()._format_action_invocation(action)
+        default = self._get_default_metavar_for_optional(action)
+        args_string = self._format_args(action, default)
+        return ", ".join(action.option_strings) + " " + args_string
+
+
 class ArgumentParserMkosi(argparse.ArgumentParser):
     """ArgumentParser with support for mkosi.defaults file(s)
 
@@ -4735,8 +4744,12 @@ class ArgumentParserMkosi(argparse.ArgumentParser):
         self._ini_file_list_mode = False
 
         # Add config files to be parsed
-        kwargs["fromfile_prefix_chars"] = ArgumentParserMkosi.fromfile_prefix_chars
-        super().__init__(*kargs, **kwargs)
+        super().__init__(
+            *kargs,
+            **kwargs,
+            fromfile_prefix_chars=ArgumentParserMkosi.fromfile_prefix_chars,
+            formatter_class=CustomHelpFormatter,
+        )
 
     @staticmethod
     def _camel_to_arg(camel: str) -> str:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4697,7 +4697,7 @@ class WithNetworkAction(BooleanAction):
 
 
 class CustomHelpFormatter(argparse.HelpFormatter):
-    def _format_action_invocation(self, action):
+    def _format_action_invocation(self, action: argparse.Action) -> str:
         if not action.option_strings or action.nargs == 0:
             return super()._format_action_invocation(action)
         default = self._get_default_metavar_for_optional(action)
@@ -4744,12 +4744,10 @@ class ArgumentParserMkosi(argparse.ArgumentParser):
         self._ini_file_list_mode = False
 
         # Add config files to be parsed
-        super().__init__(
-            *kargs,
-            **kwargs,
-            fromfile_prefix_chars=ArgumentParserMkosi.fromfile_prefix_chars,
-            formatter_class=CustomHelpFormatter,
-        )
+        kwargs["fromfile_prefix_chars"] = ArgumentParserMkosi.fromfile_prefix_chars
+        kwargs["formatter_class"] = CustomHelpFormatter
+
+        super().__init__(*kargs, **kwargs)
 
     @staticmethod
     def _camel_to_arg(camel: str) -> str:


### PR DESCRIPTION
```diff
--- /tmp/out1	2021-06-05 17:01:24.327828067 +0200
+++ /tmp/out2	2021-06-05 17:01:32.367897483 +0200
@@ -59,21 +59,19 @@
   --version             show program's version number and exit

 Distribution:
-  -d {fedora,debian,ubuntu,arch,opensuse,mageia,centos,centos_epel,clear,photon,openmandriva}, --distribution {fedora,debian,ubuntu,arch,opensuse,mageia,centos,centos_epel,clear,photon,openmandriva}
+  -d, --distribution {fedora,debian,ubuntu,arch,opensuse,mageia,centos,centos_epel,clear,photon,openmandriva}
                         Distribution to install
-  -r RELEASE, --release RELEASE
+  -r, --release RELEASE
                         Distribution release to install
-  -m MIRROR, --mirror MIRROR
-                        Distribution mirror to use
+  -m, --mirror MIRROR   Distribution mirror to use
   --repositories REPOS  Repositories to use
   --architecture ARCHITECTURE
                         Override the architecture of installation

 Output:
-  -t {directory,subvolume,tar,cpio,gpt_ext4,gpt_xfs,gpt_btrfs,gpt_squashfs,plain_squashfs}, --format {directory,subvolume,tar,cpio,gpt_ext4,gpt_xfs,gpt_btrfs,gpt_squashfs,plain_squashfs}
+  -t, --format {directory,subvolume,tar,cpio,gpt_ext4,gpt_xfs,gpt_btrfs,gpt_squashfs,plain_squashfs}
                         Output Format
-  -o PATH, --output PATH
-                        Output image path
+  -o, --output PATH     Output image path
   --output-split-root PATH
                         Output root or /usr/ partition image path (if --split-
                         artifacts is used)
```
… and so on.