### PR TITLE
Fix short-form 'readonly' deprecation

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -7014,7 +7014,7 @@ def run_qemu(args: CommandLineArguments) -> None:
         cmdline += ["-nic", f"tap,script=no,downscript=no,ifname={ifname},model=virtio-net-pci"]
 
     if "uefi" in args.boot_protocols:
-        cmdline += ["-drive", f"if=pflash,format=raw,readonly,file={firmware}"]
+        cmdline += ["-drive", f"if=pflash,format=raw,readonly=on,file={firmware}"]
 
     with contextlib.ExitStack() as stack:
         if fw_supports_sb:


### PR DESCRIPTION
Running `mkosi` on my machine

```sh
➤ sudo mkosi qemu
‣ Running command:
‣ qemu-system-x86_64 -machine accel=kvm -smp 2 -m 1024 -cpu host -drive if=pflash,format=raw,readonly,file=/usr/share/ovmf/x64/OVMF_CODE.fd -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0,id=rng-device0 -vga virtio -drive format=raw,file=/storage/edwin/Docs/Programming/repos/dots-bootstrap/tests/data/mkosi/image.raw,if=virtio

qemu-system-x86_64: -drive if=pflash,format=raw,readonly,file=/usr/share/ovmf/x64/OVMF_CODE.fd: warning: short-form boolean option 'readonly' deprecated
Please use readonly=on instead
```

This appends `=on` to remove the deprecation warning