### PR TITLE
Added option to skip use of hardcoded default distro repositories

### DIFF
--- a/man/mkosi.1
+++ b/man/mkosi.1
@@ -334,6 +334,14 @@ e.g.\ \[lq]!repo-url\[rq] to remove just one specific repository.
 For Arch Linux, additional repositories must be passed in the form
 \f[C]<name>::<url>\f[R] (e.g.\ \f[C]myrepo::https://myrepo.net\f[R]).
 .TP
+\f[B]\f[CB]UseSystemRepositories=\f[B]\f[R], \f[B]\f[CB]--use-system-repositories=\f[B]\f[R]
+This option is only applicable for dnf-based distributions:
+\f[I]CentOS\f[R], \f[I]Fedora Linux\f[R], \f[I]Mageia\f[R], \f[I]Photon\f[R], and \f[I]OpenMandriva\f[R].
+Allows use of the system's existing dnf repositories.
+By default, a hardcoded set of default dnf repositories is generated and used.
+Use \f[C]--repositories=\f[R] to identify a custom set of repositories to
+be enabled and used for the build.
+.TP
 \f[B]\f[CB]Architecture=\f[B]\f[R], \f[B]\f[CB]--architecture=\f[B]\f[R]
 The architecture to build the image for.
 Note that this currently only works for architectures compatible with

--- a/mkosi.md
+++ b/mkosi.md
@@ -335,6 +335,15 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   Linux, additional repositories must be passed in the form `<name>::<url>`
   (e.g. `myrepo::https://myrepo.net`).
 
+`UseSystemRepositories=`, `--use-system-repositories`
+
+: This option is only applicable for dnf-based distributions:
+  *CentOS*, *Fedora Linux*, *Mageia*, *Photon*, and *OpenMandriva*.
+  Allows use of the system's existing dnf repositories.
+  By default, a hardcoded set of default dnf repositories is generated and used.
+  Use `--repositories=` to identify a custom set of repositories to be enabled
+  and used for the build.
+
 `Architecture=`, `--architecture=`
 
 : The architecture to build the image for. Note that this currently

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1925,13 +1925,18 @@ def setup_dnf(args: CommandLineArguments, root: Path, repos: Sequence[Repo] = ()
                 )
             )
 
+    if args.use_system_repositories:
+        default_repos  = ""
+    else:
+        default_repos  = f"{'repodir' if args.distribution == Distribution.photon else 'reposdir'}={workspace(root)}"
+
     config_file = workspace(root) / "dnf.conf"
     config_file.write_text(
         dedent(
             f"""\
             [main]
             gpgcheck={'1' if gpgcheck else '0'}
-            {"repodir" if args.distribution == Distribution.photon else "reposdir"}={workspace(root)}
+            {default_repos }
             """
         )
     )
@@ -4732,6 +4737,9 @@ def create_parser() -> ArgumentParserMkosi:
     group.add_argument(
         "--repositories", action=CommaDelimitedListAction, default=[], help="Repositories to use", metavar="REPOS"
     )
+    group.add_argument(
+        "--use-system-repositories", action=BooleanAction, help="Use existing software package repositories"
+    )
     group.add_argument("--architecture", help="Override the architecture of installation")
 
     group = parser.add_argument_group("Output")
@@ -6197,6 +6205,7 @@ def print_summary(args: CommandLineArguments) -> None:
         MkosiPrinter.info("                    Mirror: " + args.mirror)
     if args.repositories is not None and len(args.repositories) > 0:
         MkosiPrinter.info("              Repositories: " + ",".join(args.repositories))
+    MkosiPrinter.info("   Use System Repositories: " + yes_no(args.use_system_repositories))
     MkosiPrinter.info("\nOUTPUT:")
     if args.hostname:
         MkosiPrinter.info("                  Hostname: " + args.hostname)

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -202,6 +202,7 @@ class CommandLineArguments:
     release: str
     mirror: Optional[str]
     repositories: List[str]
+    use_system_repositories: bool
     architecture: Optional[str]
     output_format: OutputFormat
     manifest_format: List[ManifestFormat]

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -98,6 +98,7 @@ class MkosiConfig(object):
             "read_only": False,
             "release": None,
             "repositories": [],
+            "use_system_repositories": False,
             "root_size": None,
             "secure_boot": False,
             "secure_boot_certificate": None,
@@ -210,6 +211,8 @@ class MkosiConfig(object):
                 self.reference_config[job_name]["release"] = mk_config_distro["Release"]
             if "Repositories" in mk_config_distro:
                 self._append_list("repositories", mk_config_distro["Repositories"], job_name)
+            if "UseSystemRepositories" in mk_config_distro:
+                self.reference_config[job_name]["use_system_repositories"] = mk_config_distro["UseSystemRepositories"]
             if "Mirror" in mk_config_distro:
                 self.reference_config[job_name]["mirror"] = mk_config_distro["Mirror"]
             if "Architecture" in mk_config_distro:
@@ -515,6 +518,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
                 "Distribution": "fedora",
                 "Release": "28",
                 "Repositories": "http://fedora/repos",
+                "UseSystemRepositories": False,
                 "Mirror": "http://fedora/mirror",
                 "Architecture": "i386",
             },
@@ -583,6 +587,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
                 "Distribution": "ubuntu",
                 "Release": "18.04",
                 "Repositories": "http://ubuntu/repos",
+                "UseSystemRepositories": False,
                 "Mirror": "http://ubuntu/mirror",
                 "Architecture": "x86_64",
             },
@@ -648,6 +653,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
                 "Distribution": "debian",
                 "Release": "unstable",
                 "Repositories": "http://debian/repos",
+                "UseSystemRepositories": False,
                 "Mirror": "http://ubuntu/mirror",
                 "Architecture": "x86_64",
             },


### PR DESCRIPTION
An alternative solution to https://github.com/systemd/mkosi/pull/662 that should also resolve https://github.com/systemd/mkosi/issues/536

Adding this option reverts mkosi functionality to how it was working for fedora/centos/rhel previously.

Allowing it to use the repo files that exist on the system, instead of locking the script into using the hardcoded repo file only containing the default repos for each distro.