### PR TITLE
Added in check for modules.dep prior to running dracut install

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4093,7 +4093,7 @@ def install_unified_kernel(
         # Apparently openmandriva hasn't yet completed its usrmerge so we use lib here instead of usr/lib.
         with os.scandir(os.path.join(root, "lib/modules")) as d:
             for kver in d:
-                if not kver.is_dir():
+                if not (kver.is_dir() and os.path.isfile(os.path.join(kver, "modules.dep"))):
                     continue
 
                 prefix = "/boot" if args.xbootldr_partno is not None else "/efi"


### PR DESCRIPTION
Revert change that happened from v5 to v6 that removes the check for `modules.dep` and decreases the reliability of the tool.

Resolves https://github.com/systemd/mkosi/issues/733
