### PR TITLE
mkosi: call dracut/unified kernel image on the final image, not the c…

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3746,9 +3746,17 @@ def install_unified_kernel(
 
     if not args.bootable or args.esp_partno is None or not args.with_unified_kernel_images:
         return
-    if for_cache and args.verity:
-        return
-    if cached and not args.verity:
+
+    # Don't run dracut if this is for the cache. The unified kernel
+    # typically includes the image ID, roothash and other data that
+    # differs between cached version and final result. Moreover, we
+    # want that the initrd for the image actually takes the changes we
+    # make to the image into account (e.g. when we build a systemd
+    # test image with this we want that the systemd we just built is
+    # in the initrd, and not one from the cache. Hence even though
+    # dracut is slow we invoke it only during the last final build,
+    # never for the cached builds.
+    if for_cache:
         return
 
     # Don't bother running dracut if this is a development build. Strictly speaking it would probably be a


### PR DESCRIPTION
…ached image

We need to invoke dracut on the final image, not on the cached image.
Currently, it's done the other way round, in light of the fact that
dracut is the slowest part of the build. However that doesn't really
work, since the generated unified kernel image depends on the final
build.

The generated image after all will:

1. when verity is enabled receives the root hash which depends on the
   final fs image to be complete

2. when the image id/version logic is enabled the unified kernel image
   name will change with every build

3. we want to base the initrd on the resources installed in the OS
   during the build. Besides configuration this prominently includes a
   freshly build systemd. After all, one of the major usecases for mkosi
   was to be useful to build test images for systemd development. There
   we really want to ensure the systemd we just built is included in the
   initrd, and not an old version that happened to be around when the
   cache image was first created.

This reverts major parts of e4277c77618f47be6a5126a709f64ad48492807b