### PR TITLE
qemu: revert back to virtio from virtio-scsi-pci on Debian

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -6874,14 +6874,21 @@ def run_qemu(args: CommandLineArguments) -> None:
         else:
             fname = args.output
 
-        cmdline += [
-            "-drive",
-            f"if=none,id=hd,file={fname},format={'qcow2' if args.qcow2 else 'raw'}",
-            "-device",
-            "virtio-scsi-pci,id=scsi",
-            "-device",
-            "scsi-hd,drive=hd,bootindex=1",
-        ]
+        # Debian images fail to boot with virtio-scsi, see: https://github.com/systemd/mkosi/issues/725
+        if args.distribution == Distribution.debian:
+            cmdline += [
+                "-drive",
+                f"if=virtio,id=hd,file={fname},format={'qcow2' if args.qcow2 else 'raw'}",
+            ]
+        else:
+            cmdline += [
+                "-drive",
+                f"if=none,id=hd,file={fname},format={'qcow2' if args.qcow2 else 'raw'}",
+                "-device",
+                "virtio-scsi-pci,id=scsi",
+                "-device",
+                "scsi-hd,drive=hd,bootindex=1",
+            ]
 
         cmdline += args.cmdline
 


### PR DESCRIPTION
qemu fails to boot with virtio-scsi-pci. Reverting back to virtio
does not show issues with the EFI shell, everything boots correctly.

Fixes: https://github.com/systemd/mkosi/issues/725

@DaanDeMeyer could you please double check if you still see the EFI shell problem with the boot order? It works fine for me on Debian 11. But booting with virtio-scsi fails as described in the issue.