### PR TITLE
Add option to resolve symlinks when copying build sources

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,9 @@
   keys for usage with mkosi's `--secure-boot` options. The number of days the
   keys should remain valid can be specified via `--secure-boot-valid-days=` and
   their CN via `--secure-boot-common-name=`
+- Add `--source-resolve-symlinks` and `--source-resolve-symlinks-final` options
+  to control how symlinks in the build sources are handled when
+  `--source-file-transfer[-final]=copy-all`.
 
 ## v9
 

--- a/man/mkosi.1
+++ b/man/mkosi.1
@@ -769,6 +769,18 @@ Takes the same values as \f[C]--source-file-transfer\f[R] except
 \f[C]mount\f[R].
 By default, sources are not copied into the final image.
 .TP
+\f[B]\f[CB]--source-resolve-symlinks\f[B]\f[R]
+If given, any symbolic links in the source file tree are resolved and
+the file contents are copied to the build image.
+If not given, they are left as symbolic links.
+This only applies if \f[C]--source-file-transfer\f[R] is
+\f[C]copy-all\f[R].
+Defaults to leaving them as symbolic links.
+.TP
+\f[B]\f[CB]--source-resolve-symlinks-final\f[B]\f[R]
+Same as \f[C]--source-resolve-symlinks\f[R] but for the final image
+instead of the build image.
+.TP
 \f[B]\f[CB]--with-network\f[B]\f[R]
 Enables network connectivity while the build script
 \f[C]mkosi.build\f[R] is invoked.
@@ -1340,6 +1352,20 @@ T}@T{
 \f[C][Packages]\f[R]
 T}@T{
 \f[C]SourceFileTransferFinal=\f[R]
+T}
+T{
+\f[C]--source-resolve-symlinks\f[R]
+T}@T{
+\f[C][Packages]\f[R]
+T}@T{
+\f[C]SourceResolveSymlinks=\f[R]
+T}
+T{
+\f[C]--source-resolve-symlinks-final\f[R]
+T}@T{
+\f[C][Packages]\f[R]
+T}@T{
+\f[C]SourceResolveSymlinksFinal=\f[R]
 T}
 T{
 \f[C]--build-directory=\f[R]

--- a/mkosi.md
+++ b/mkosi.md
@@ -756,6 +756,18 @@ details see the table below.
   except `mount`. By default, sources are not copied into the final
   image.
 
+`--source-resolve-symlinks`
+
+: If given, any symbolic links in the source file tree are resolved and the
+  file contents are copied to the build image. If not given, they are left as
+  symbolic links. This only applies if `--source-file-transfer` is `copy-all`.
+  Defaults to leaving them as symbolic links.
+
+`--source-resolve-symlinks-final`
+
+: Same as `--source-resolve-symlinks` but for the final image instead of
+  the build image.
+
 `--with-network`
 
 : Enables network connectivity while the build script `mkosi.build` is
@@ -1011,6 +1023,8 @@ which settings file options.
 | `--build-sources=`                | `[Packages]`            | `BuildSources=`               |
 | `--source-file-transfer=`         | `[Packages]`            | `SourceFileTransfer=`         |
 | `--source-file-transfer-final=`   | `[Packages]`            | `SourceFileTransferFinal=`    |
+| `--source-resolve-symlinks`       | `[Packages]`            | `SourceResolveSymlinks=`      |
+| `--source-resolve-symlinks-final` | `[Packages]`            | `SourceResolveSymlinksFinal=` |
 | `--build-directory=`              | `[Packages]`            | `BuildDirectory=`             |
 | `--include-directory=`            | `[Packages]`            | `IncludeDirectory=`           |
 | `--install-directory=`            | `[Packages]`            | `InstallDirectory=`           |

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3259,10 +3259,13 @@ def install_build_src(args: CommandLineArguments, root: str, do_run_build_script
             copy_file(args.build_script, os.path.join(root_home(args, root), os.path.basename(args.build_script)))
 
     sft: Optional[SourceFileTransfer] = None
+    resolve_symlinks: bool = False
     if do_run_build_script:
         sft = args.source_file_transfer
+        resolve_symlinks = args.source_resolve_symlinks
     else:
         sft = args.source_file_transfer_final
+        resolve_symlinks = args.source_resolve_symlinks_final
 
     if args.build_sources is None or sft is None:
         return
@@ -3289,7 +3292,7 @@ def install_build_src(args: CommandLineArguments, root: str, do_run_build_script
                 os.path.basename(args.include_dir) + "/" if args.include_dir else "mkosi.includedir/",
                 os.path.basename(args.install_dir) + "/" if args.install_dir else "mkosi.installdir/",
             )
-            shutil.copytree(args.build_sources, target, symlinks=True, ignore=ignore)
+            shutil.copytree(args.build_sources, target, symlinks=not resolve_symlinks, ignore=ignore)
 
 
 def install_build_dest(args: CommandLineArguments, root: str, do_run_build_script: bool, for_cache: bool) -> None:
@@ -4798,6 +4801,20 @@ def create_parser() -> ArgumentParserMkosi:
         help="Method used to copy build sources to the final image."
         + "; ".join([f"'{k}': {v}" for k, v in SourceFileTransfer.doc().items() if k != SourceFileTransfer.mount])
         + " (default: None)",
+    )
+    group.add_argument(
+        "--source-resolve-symlinks",
+        action=BooleanAction,
+        help="If given, any symbolic links in the build sources are resolved and the file contents copied to the"
+        + " build image. If not given, they are left as symbolic links in the build image."
+        + " Only applies if --source-file-transfer is set to 'copy-all'. (default: keep as symbolic links)",
+    )
+    group.add_argument(
+        "--source-resolve-symlinks-final",
+        action=BooleanAction,
+        help="If given, any symbolic links in the build sources are resolved and the file contents copied to the"
+        + " final image. If not given, they are left as symbolic links in the final image."
+        + " Only applies if --source-file-transfer-final is set to 'copy-all'. (default: keep as symbolic links)",
     )
     group.add_argument(
         "--with-network",

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -214,6 +214,8 @@ class CommandLineArguments:
     finalize_script: Optional[str]
     source_file_transfer: SourceFileTransfer
     source_file_transfer_final: Optional[SourceFileTransfer]
+    source_resolve_symlinks: bool
+    source_resolve_symlinks_final: bool
     with_network: bool
     nspawn_settings: Optional[str]
     root_size: int

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -104,6 +104,8 @@ class MkosiConfig(object):
             "secure_boot_valid_days": "730",
             "sign": False,
             "skeleton_trees": [],
+            "source_resolve_symlinks": False,
+            "source_resolve_symlinks_final": False,
             "source_file_transfer": None,
             "source_file_transfer_final": None,
             "srv_size": None,


### PR DESCRIPTION
Currently, the `copy-all` method of copying build sources copies any symlinks into the image. This pull request adds a `--source-file-resolve-symlinks` option (and a corresponding `-final` option for copying into the final image) which corresponds to setting `symlinks=False` when calling `shutil.copytree`. If sets, this means the symlink is resolved and the contents of the file are copied to the image rather than the symlink itself. The option defaults to off so the behaviour is backwards-compatible.

For my use case, I have some utility scripts I want to reuse when generating different images; this change allows me to have them in one location and symlink them when needed, and then call them from the main build script.