### PR TITLE
Correct pacman hook name

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2577,7 +2577,7 @@ def install_arch(args: CommandLineArguments, root: str, do_run_build_script: boo
         make_executable(kernel_remove_script)
 
         if args.esp_partno is not None:
-            bootctl_update_hook = os.path.join(hooks_dir, "91-mkosi-bootctl-update-hook")
+            bootctl_update_hook = os.path.join(hooks_dir, "91-mkosi-bootctl-update.hook")
             with open(bootctl_update_hook, "w") as f:
                 f.write(
                     dedent(


### PR DESCRIPTION
Fixes systemd/mkosi#750

Pacman hooks must end with `.hook` as per [Arch wiki](https://wiki.archlinux.org/title/pacman#Hooks)

However mkosi's hook to update bootctl when the kernel updates ends in `-hook` instead of `.hook` (likely a typo)
This means the hook doesn't get fired and kernel upgrades fail - see [this line](https://github.com/systemd/mkosi/blob/main/mkosi/__init__.py#L2580)