### PR TITLE
mkosi: if image version logic is enabled, make sure to generate root=…

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -164,6 +164,8 @@ case "$COMMAND" in
             BOOT_OPTIONS="${BOOT_OPTIONS} roothash=${ROOTHASH}"
         elif [[ -n "$USRHASH" ]]; then
             BOOT_OPTIONS="${BOOT_OPTIONS} usrhash=${USRHASH}"
+        elif [[ -n "$IMAGE_VERSION" ]]; then
+            BOOT_OPTIONS="${BOOT_OPTIONS} root=PARTLABEL=${IMAGE_ID}_${IMAGE_VERSION}"
         fi
 
         if [[ -n "$KERNEL_IMAGE" ]]; then


### PR DESCRIPTION
… entry in kernel command line

When the --image-version= logic is enabled this indicates that multiple
versions of an OS might be used in parallel within the same partition
table eventually. That makes it essential to boot the right root file
system from each unified kernel, so that kernel and root fs always match
up correctly.

If Verity is on this already worked, since we encode roothash= on the
kernel cmdline in that case, and that implies the root fs to use. Now,
ensure for verity-less cases that this works too.

We use PARTLABEL= match, using the image-id/image-version combination,
i.e. matching how we pick the label for the partition.

If the image version logic is not used, let's continue to not use the
a root= for simplicity reasons. In that case automatically finding the
root fs via fully automatic discovery should be simple and robust.