### PR TITLE
fedora: use F34 by default

### DIFF
--- a/mkosi.files/mkosi.fedora
+++ b/mkosi.files/mkosi.fedora
@@ -3,7 +3,7 @@
 
 [Distribution]
 Distribution=fedora
-Release=32
+Release=34
 
 [Output]
 Format=gpt_ext4


### PR DESCRIPTION
F32 is no more… Also switch to btrfs, to match
https://fedoraproject.org/wiki/Changes/BtrfsByDefault.

It would be nice to enable compression too to match
https://fedoraproject.org/wiki/Changes/BtrfsTransparentCompression,
but that's more involved because mount options have to be set.