### PR TITLE
mkosi: record package list and changelogs in files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## v11 (unreleased)
 
-- The `--build-environemnt` option was renamed to `--environment` and
+- The `--build-environment=` option was renamed to `--environment=` and
   extended to cover *all* invoked scripts, not just the `mkosi.build`.
   The old name is still understood.
 

--- a/man/mkosi.1
+++ b/man/mkosi.1
@@ -341,6 +341,13 @@ system), \f[C]gpt_btrfs\f[R] (similar, but with an btrfs file system),
 \f[C]plain_squashfs\f[R] (a plain squashfs file system without a
 partition table).
 .TP
+\f[B]\f[CB]--manifest-format=\f[B]\f[R]
+The manifest format type or types to generate.
+A comma-delimited list consisting of \f[C]json\f[R] (the standard JSON
+output format that describes the packages installed),
+\f[C]changelog\f[R] (a human-readable text format designed for diffing).
+Defaults to \f[C]json\f[R].
+.TP
 \f[B]\f[CB]--output=\f[B]\f[R], \f[B]\f[CB]-o\f[B]\f[R]
 Path for the output image file to generate.
 Takes a relative or absolute path where the generated image will be
@@ -753,8 +760,8 @@ the local directory it is automatically used for this purpose (also see
 below).
 .TP
 \f[B]\f[CB]--environment=\f[B]\f[R]
-Adds environment variables to the environment that the build script is
-executed with.
+Adds variables to the environment that the
+build/prepare/postinstall/finalize scripts are executed with.
 Takes a space-separated list of variable assignments or just variable
 names.
 In the latter case, the values of those variables will be passed through
@@ -1151,6 +1158,13 @@ T}@T{
 \f[C][Output]\f[R]
 T}@T{
 \f[C]Format=\f[R]
+T}
+T{
+\f[C]--manifest-format=\f[R]
+T}@T{
+\f[C][Output]\f[R]
+T}@T{
+\f[C]ManifestFormat=\f[R]
 T}
 T{
 \f[C]--output=\f[R], \f[C]-o\f[R]

--- a/mkosi.md
+++ b/mkosi.md
@@ -342,6 +342,13 @@ details see the table below.
   squashfs file system), `plain_squashfs` (a plain squashfs file
   system without a partition table).
 
+`--manifest-format=`
+
+: The manifest format type or types to generate. A comma-delimited
+  list consisting of `json` (the standard JSON output format that
+  describes the packages installed), `changelog` (a human-readable
+  text format designed for diffing). Defaults to `json`.
+
 `--output=`, `-o`
 
 : Path for the output image file to generate. Takes a relative or
@@ -1087,6 +1094,7 @@ which settings file options.
 | `--mirror=`, `-m`                 | `[Distribution]`        | `Mirror=`                     |
 | `--architecture=`                 | `[Distribution]`        | `Architecture=`               |
 | `--format=`, `-t`                 | `[Output]`              | `Format=`                     |
+| `--manifest-format=`              | `[Output]`              | `ManifestFormat=`             |
 | `--output=`, `-o`                 | `[Output]`              | `Output=`                     |
 | `--output-split-root=`            | `[Output]`              | `OutputSplitRoot=`            |
 | `--output-split-verity=`          | `[Output]`              | `OutputSplitVerity=`          |

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4309,6 +4309,20 @@ def save_manifest(args: CommandLineArguments, manifest: Manifest) -> None:
                 manifest.write_json(f)
                 _link_output(args, f.name, f"{args.output}.manifest")
 
+        with complete_step(f"Saving report {args.output}.packages"):
+            g: TextIO = cast(
+                TextIO,
+                tempfile.NamedTemporaryFile(
+                    mode="w+",
+                    encoding="utf-8",
+                    prefix=".mkosi-",
+                    dir=os.path.dirname(args.output),
+                ),
+            )
+            with g:
+                manifest.write_package_report(g)
+                _link_output(args, g.name, f"{args.output}.packages")
+
 
 def print_output_size(args: CommandLineArguments) -> None:
     if args.output_format in (OutputFormat.directory, OutputFormat.subvolume):
@@ -5305,6 +5319,7 @@ def unlink_output(args: CommandLineArguments) -> None:
         with complete_step("Removing output files…"):
             unlink_try_hard(args.output)
             unlink_try_hard(f"{args.output}.manifest")
+            unlink_try_hard(f"{args.output}.packages")
 
             if args.checksum:
                 unlink_try_hard(args.output_checksum)

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4654,7 +4654,6 @@ def create_parser() -> ArgumentParserMkosi:
     group.add_argument(
         "--repositories",
         action=CommaDelimitedListAction,
-        dest="repositories",
         default=[],
         help="Repositories to use",
         metavar="REPOS",

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4359,6 +4359,12 @@ def setup_package_cache(args: CommandLineArguments) -> Optional[TempDir]:
     return d
 
 
+def remove_duplicates(items: List[T]) -> List[T]:
+    "Return list with any repetitions removed"
+    # We use a dictionary to simulate an ordered set
+    return list({x: None for x in items})
+
+
 class ListAction(argparse.Action):
     delimiter: str
 
@@ -4395,11 +4401,13 @@ class ListAction(argparse.Action):
             # Remove ! prefixed list entries from list. !* removes all entries. This works for strings only now.
             if x == "!*":
                 ary = []
-            elif x.startswith("!"):
+            elif isinstance(x, str) and x.startswith("!"):
                 if x[1:] in ary:
                     ary.remove(x[1:])
             else:
                 ary.append(x)
+
+        ary = remove_duplicates(ary)
         setattr(namespace, self.dest, ary)
 
 

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -72,6 +72,10 @@ class Parseable:
         except KeyError:
             raise argparse.ArgumentTypeError(f"unknown Format: {name!r}")
 
+    @classmethod
+    def parse_list(cls: Any, string: str) -> List[Any]:
+        return [cls.from_string(p) for p in string.split(",") if p]
+
 
 class PackageType(enum.Enum):
     rpm = 1
@@ -180,6 +184,11 @@ class OutputFormat(Parseable, enum.Enum):
         return self.is_squashfs() or self.is_btrfs()
 
 
+class ManifestFormat(Parseable, enum.Enum):
+    json = "json"  # the standard manifest in json format
+    changelog = "changelog"  # human-readable text file with package changelogs
+
+
 @dataclasses.dataclass
 class CommandLineArguments:
     """Type-hinted storage for command line arguments."""
@@ -193,6 +202,7 @@ class CommandLineArguments:
     repositories: List[str]
     architecture: Optional[str]
     output_format: OutputFormat
+    manifest_format: List[ManifestFormat]
     output: str
     output_dir: Optional[str]
     force_count: int

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -54,6 +54,25 @@ class MkosiException(Exception):
 ARG_DEBUG = ()
 
 
+class Parseable:
+    "A mix-in to provide conversions for argparse"
+
+    def __repr__(self) -> str:
+        """Return the member name without the class name"""
+        return cast(str, getattr(self, "name"))
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    @classmethod
+    def from_string(cls: Any, name: str) -> Any:
+        """A convenience method to be used with argparse"""
+        try:
+            return cls[name]
+        except KeyError:
+            raise argparse.ArgumentTypeError(f"unknown Format: {name!r}")
+
+
 class PackageType(enum.Enum):
     rpm = 1
     deb = 2
@@ -108,7 +127,7 @@ class SourceFileTransfer(enum.Enum):
         }
 
 
-class OutputFormat(enum.Enum):
+class OutputFormat(Parseable, enum.Enum):
     directory = enum.auto()
     subvolume = enum.auto()
     tar = enum.auto()
@@ -126,22 +145,6 @@ class OutputFormat(enum.Enum):
     raw_xfs = gpt_xfs
     raw_btrfs = gpt_btrfs
     raw_squashfs = gpt_squashfs
-
-    def __repr__(self) -> str:
-        """Return the member name without the class name"""
-        return self.name
-
-    def __str__(self) -> str:
-        """Return the member name without the class name"""
-        return self.name
-
-    @classmethod
-    def from_string(cls, name: str) -> "OutputFormat":
-        """A convenience method to be used with argparse"""
-        try:
-            return cls[name]
-        except KeyError:
-            raise argparse.ArgumentTypeError(f"unknown Format: {name!r}")
 
     def is_disk_rw(self) -> bool:
         "Output format is a disk image with a parition table and a writable filesystem"

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -5,6 +5,7 @@ import contextlib
 import dataclasses
 import enum
 import os
+import pathlib
 import shlex
 import shutil
 import signal
@@ -526,6 +527,16 @@ def patch_file(filepath: str, line_rewriter: Callable[[str], str]) -> None:
     shutil.copystat(filepath, temp_new_filepath)
     os.remove(filepath)
     shutil.move(temp_new_filepath, filepath)
+
+
+def path_relative_to_cwd(path: str) -> pathlib.Path:
+    "Return path as relative to $PWD if underneath, absolute path otherwise"
+
+    path = pathlib.Path(path)
+    try:
+        return path.relative_to(os.getcwd())
+    except ValueError:
+        return path
 
 
 def write_grub_config(args: CommandLineArguments, root: str) -> None:

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -23,6 +23,7 @@ from typing import (
     NoReturn,
     Optional,
     Union,
+    cast,
 )
 
 if sys.version_info >= (3, 8):
@@ -52,18 +53,34 @@ class MkosiException(Exception):
 ARG_DEBUG = ()
 
 
+class PackageType(enum.Enum):
+    rpm = 1
+    deb = 2
+    pkg = 3
+    bundle = 4
+
+
 class Distribution(enum.Enum):
-    fedora = 1
-    debian = 2
-    ubuntu = 3
-    arch = 4
-    opensuse = 5
-    mageia = 6
-    centos = 7
-    centos_epel = 8
-    clear = 9
-    photon = 10
-    openmandriva = 11
+    fedora = 0, PackageType.rpm
+    debian = 1, PackageType.deb
+    ubuntu = 2, PackageType.deb
+    arch = 3, PackageType.pkg
+    opensuse = 4, PackageType.rpm
+    mageia = 5, PackageType.rpm
+    centos = 6, PackageType.rpm
+    centos_epel = 7, PackageType.rpm
+    clear = 8, PackageType.bundle
+    photon = 9, PackageType.rpm
+    openmandriva = 10, PackageType.rpm
+
+    def __new__(cls, number: int, package_type: PackageType) -> "Distribution":
+        # This turns the list above into enum entries with .package_type attributes.
+        # See https://docs.python.org/3.9/library/enum.html#when-to-use-new-vs-init
+        # for an explanation.
+        entry = object.__new__(cls)
+        entry._value_ = number
+        entry.package_type = package_type
+        return cast("Distribution", entry)
 
     def __str__(self) -> str:
         return self.name

--- a/mkosi/manifest.py
+++ b/mkosi/manifest.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
+import dataclasses
+import json
+from subprocess import DEVNULL, PIPE
+from textwrap import dedent
+from typing import IO, Any, Dict, List, Optional, cast
+
+from .backend import CommandLineArguments, PackageType, run
+
+
+@dataclasses.dataclass
+class PackageManifest:
+    """A description of a package
+
+    The fields used here must match
+    https://systemd.io/COREDUMP_PACKAGE_METADATA/#well-known-keys.
+    """
+
+    type: str
+    name: str
+    version: str
+    size: int
+
+    def as_dict(self) -> Dict[str, str]:
+        return {
+            "type": self.type,
+            "name": self.name,
+            "version": self.version,
+        }
+
+
+@dataclasses.dataclass
+class Manifest:
+    args: CommandLineArguments
+    packages: List[PackageManifest] = dataclasses.field(default_factory=list)
+
+    def record_packages(self, root: str) -> None:
+        if cast(Any, self.args.distribution).package_type == PackageType.rpm:
+            self.record_rpm_packages(root)
+        # TODO: add implementations for other package managers
+
+    def record_rpm_packages(self, root: str) -> None:
+        c = run(
+            ["rpm", f"--root={root}", "-qa", "--qf", r"%{NEVRA}\t%{SOURCERPM}\t%{NAME}\t%{SIZE}\n"],
+            stdout=PIPE,
+            stderr=DEVNULL,
+            universal_newlines=True,
+        )
+
+        packages = sorted(c.stdout.splitlines())
+
+        for package in packages:
+            nevra, srpm, name, size = package.split("\t")
+
+            assert nevra.startswith(f"{name}-")
+            evra = nevra[len(name) + 1 :]
+
+            size = int(size)
+
+            package = PackageManifest("rpm", name, evra, size)
+            self.packages.append(package)
+
+    def has_data(self) -> bool:
+        # We might add more data in the future
+        return len(self.packages) > 0
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "packages": [package.as_dict() for package in self.packages],
+        }
+
+    def write_json(self, out: IO[str]) -> None:
+        json.dump(self.as_dict(), out, indent=2)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
+from mkosi.backend import PackageType, Distribution
+
+
+def test_distribution():
+    assert Distribution.fedora.package_type == PackageType.rpm
+    assert Distribution.fedora is Distribution.fedora
+    assert Distribution.fedora is not Distribution.debian
+    assert str(Distribution.photon) == "photon"

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -168,7 +168,7 @@ class MkosiConfig(object):
             if isinstance(arg, str) and arg.startswith("!"):
                 if arg[1:] in self.reference_config[job_name][ref_entry]:
                     self.reference_config[job_name][ref_entry].remove(arg[1:])
-            else:
+            elif arg not in self.reference_config[job_name][ref_entry]:
                 self.reference_config[job_name][ref_entry].append(arg)
 
     @staticmethod
@@ -186,7 +186,7 @@ class MkosiConfig(object):
         for section, key_val in config_all_normalized.items():
             for key, val in key_val.items():
                 if isinstance(val, list):
-                    config_all_normalized[section][key] = os.linesep.join(val)
+                    config_all_normalized[section][key] = os.linesep.join(str(item) for item in val)
 
         config_parser.read_dict(config_all_normalized)
         with open(os.path.join(dname, fname), "w") as f_ini:

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -76,6 +76,7 @@ class MkosiConfig(object):
             "install_dir": None,
             "kernel_command_line": ["rhgb", "selinux=0", "audit=0"],
             "key": None,
+            "manifest_format": None,
             "mirror": None,
             "mksquashfs_tool": [],
             "no_chown": False,
@@ -215,6 +216,8 @@ class MkosiConfig(object):
                 self.reference_config[job_name]["output_format"] = mkosi.OutputFormat.from_string(
                     mk_config_output["Format"]
                 )
+            if "ManifestFormat" in mk_config_output:
+                self.reference_config[job_name]["manifest_format"] = mk_config_output["ManifestFormat"]
             if "Output" in mk_config_output:
                 self.reference_config[job_name]["output"] = mk_config_output["Output"]
             if "Force" in mk_config_output:
@@ -512,6 +515,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
             "Output": {
                 "Format": "gpt_ext4",
                 "Output": "test_image.raw",
+                "ManifestFormat": [mkosi.backend.ManifestFormat.json],
                 #                 # 'OutputDirectory': '',
                 "Bootable": False,
                 "BootProtocols": "uefi",


### PR DESCRIPTION
The output is something like this

```
{
  "packages": [
    {
      "name": "acl",
      "version": "2.3.1",
      "release": "2.fc35",
      "changelog": "* Wed Jul 21 2021 Fedora Release Engineering <releng@fedoraproject.org> - 2.3.1-2\n..."
    },
    {
      "name": "alternatives",
      "epoch": "3",
      "version": "1.19",
      "release": "1.fc35",
      "changelog": "* Fri Jul 23 2021 Jan Macku <jamacku@redhat.com> - 1.19-1\n..."
    },
    ...
 ]
}
```

Changelogs are identical for all packages built from a given srpm,
so the changelog field is only populated for the first of those.

Fixes #748.

Maybe it would make sense to also do a text format so it's nicer to diff?

Docs and some config options are missing… I'll add later when there's consensus on functionality.