### PR TITLE
mkosi: only print the summary when explicitly requested

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -7113,7 +7113,7 @@ def run_verb(raw: argparse.Namespace) -> None:
     if args.verb == "build":
         check_output(args)
 
-    if args.verb == "summary" or (needs_build(args) and need_cache_images(args)):
+    if args.verb == "summary":
         print_summary(args)
 
     if needs_build(args):


### PR DESCRIPTION
Originally, the summary was printed whenever a build was done.
With 1f9a758fad3debbdddd2947a19978de3909aabf7, it is only printed
for cached builds. But that is surprising: when I turn on caching,
I suddently get extra output. Let's just print the summary when
requested.