### PR TITLE
Override various autodetection features

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,8 +4,6 @@
 
 * work on device nodes
 
-* allow passing env vars
-
 * mkosi --all (for building everything in mkosi.files/)
 
 * --architecture= is chaos: we need to define a clear vocabulary of
@@ -19,3 +17,9 @@
   automatic updating schemes (i.e. take an old image that is currently
   in use, add a root partition with the new root image (+ verity), and
   drop the new kernel into the ESP, and an update is complete.
+
+* minimization with gpt_btrfs doesn't seem to take fs compression into
+  account. The resulting device is half-empty.
+
+* --format gpt_mksquashfs --minimize throws an error. It should just
+  silently ignore --minimize, since it's implied.

--- a/mkosi.md
+++ b/mkosi.md
@@ -754,16 +754,6 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 : Takes a comma-separated list of globs. Files in the image matching
   the globs will be purged at the end.
 
-`BuildScript=`, `--build-script=`
-
-: Takes a path to an executable that is used as build script for this
-  image. If this option is used the build process will be two-phased
-  instead of single-phased. The specified script is copied onto the
-  development image and executed inside an `systemd-nspawn` container
-  environment. If this option is not used, but the `mkosi.build` file
-  found in the local directory it is automatically used for this
-  purpose (also see the "Files" section below).
-
 `Environment=`, `--environment=`
 
 : Adds variables to the environment that the
@@ -859,6 +849,17 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   the artifacts that were created locally in `$BUILDDIR`, but
   ultimately plan to discard the final image.
 
+`BuildScript=`, `--build-script=`
+
+: Takes a path to an executable that is used as build script for this
+  image. If this option is used the build process will be two-phased
+  instead of single-phased. The specified script is copied onto the
+  development image and executed inside an `systemd-nspawn` container
+  environment. If this option is not used, but the `mkosi.build` file
+  found in the local directory it is automatically used for this
+  purpose (also see the "Files" section below). Specify an empty value
+  to disable automatic detection.
+
 `PrepareScript=`, `--prepare-script=`
 
 : Takes a path to an executable that is invoked inside the image right
@@ -867,7 +868,8 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   is invoked inside a `systemd-nspawn` container environment, and thus
   does not have access to host resources.  If this option is not used,
   but an executable script `mkosi.prepare` is found in the local
-  directory, it is automatically used for this purpose.
+  directory, it is automatically used for this purpose. Specify an
+  empty value to disable automatic detection.
 
 `PostInstallationScript=`, `--postinst-script=`
 
@@ -877,7 +879,8 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   container environment, and thus does not have access to host
   resources. If this option is not used, but an executable
   `mkosi.postinst` is found in the local directory, it is
-  automatically used for this purpose.
+  automatically used for this purpose. Specify an empty value to
+  disable automatic detection.
 
 `FinalizeScript=`, `--finalize-script=`
 
@@ -888,7 +891,8 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   is invoked directly in the host environment, and hence has full
   access to the host's resources. If this option is not used, but an
   executable `mkosi.finalize` is found in the local directory, it is
-  automatically used for this purpose.
+  automatically used for this purpose. Specify an empty value to
+  disable automatic detection.
 
 `SourceFileTransfer=`, `--source-file-transfer=`
 

--- a/mkosi.md
+++ b/mkosi.md
@@ -741,6 +741,14 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   file may be provided too. `mkosi.skeleton.tar` will be automatically
   used if found in the local directory.
 
+`CleanPackageMetadata=`, `--clean-package-metadata=`
+
+: Enable/disable removal of package manager databases, caches, and
+  logs at the end of installation. Can be specifed as true, false, or
+  "`auto`" (the default). With "`auto`", files will be removed if the
+  respective package manager executable is *not* present at the end of
+  the installation.
+
 `RemoveFiles=`, `--remove-files=`
 
 : Takes a comma-separated list of globs. Files in the image matching

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1687,7 +1687,7 @@ def clean_dnf_metadata(root: Path, always: bool) -> None:
     keeping the dnf metadata, since it's not usable from within the
     image anyway.
     """
-    dnf_metadata_paths = [
+    paths = [
         root / "var/lib/dnf",
         *root.glob("var/log/dnf.*"),
         *root.glob("var/log/hawkey.*"),
@@ -1696,16 +1696,17 @@ def clean_dnf_metadata(root: Path, always: bool) -> None:
 
     cond = always or os.access(root / "bin/dnf", os.F_OK, follow_symlinks=False)
 
-    if  not cond or not any(os.path.exists(path) for path in dnf_metadata_paths):
+    if not cond or not any(path.exists() for path in paths):
         return
 
     with complete_step("Cleaning dnf metadata…"):
-        remove_glob(*dnf_metadata_paths)
+        for path in paths:
+            unlink_try_hard(path)
 
 
 def clean_yum_metadata(root: Path, always: bool) -> None:
     """Remove yum metadata if /bin/yum is not present in the image"""
-    yum_metadata_paths = [
+    paths = [
         root / "var/lib/yum",
         *root.glob("var/log/yum.*"),
         root / "var/cache/yum",
@@ -1713,40 +1714,42 @@ def clean_yum_metadata(root: Path, always: bool) -> None:
 
     cond = always or os.access(root / "bin/yum", os.F_OK, follow_symlinks=False)
 
-    if not cond or not any(os.path.exists(path) for path in yum_metadata_paths):
+    if not cond or not any(path.exists() for path in paths):
         return
 
     with complete_step("Cleaning yum metadata…"):
-        remove_glob(*yum_metadata_paths)
+        for path in paths:
+            unlink_try_hard(path)
 
 
 def clean_rpm_metadata(root: Path, always: bool) -> None:
     """Remove rpm metadata if /bin/rpm is not present in the image"""
-    rpm_metadata_path = root / "var/lib/rpm"
+    path = root / "var/lib/rpm"
 
     cond = always or os.access(root / "bin/rpm", os.F_OK, follow_symlinks=False)
 
-    if not cond or not rpm_metadata_path.exists():
+    if not cond or not path.exists():
         return
 
     with complete_step("Cleaning rpm metadata…"):
-        remove_glob(rpm_metadata_path)
+        unlink_try_hard(path)
 
 
 def clean_tdnf_metadata(root: Path, always: bool) -> None:
     """Remove tdnf metadata if /bin/tdnf is not present in the image"""
-    tdnf_metadata_paths = [
+    paths = [
         *root.glob("var/log/tdnf.*"),
         root / "var/cache/tdnf",
     ]
 
     cond = always or os.access(root / "usr/bin/tdnf", os.F_OK, follow_symlinks=False)
 
-    if not cond or not any(os.path.exists(path) for path in tdnf_metadata_paths):
+    if not cond or not any(path.exists() for path in paths):
         return
 
     with complete_step("Cleaning tdnf metadata…"):
-        remove_glob(*tdnf_metadata_paths)
+        for path in paths:
+            unlink_try_hard(path)
 
 
 def clean_package_manager_metadata(args: CommandLineArguments, root: Path) -> None:

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -242,7 +242,6 @@ class CommandLineArguments:
     skeleton_trees: List[Path]
     clean_package_metadata: Union[bool, str]
     remove_files: List[Path]
-    build_script: Optional[Path]
     environment: List[str]
     build_sources: Optional[Path]
     build_dir: Optional[Path]
@@ -250,8 +249,9 @@ class CommandLineArguments:
     install_dir: Optional[Path]
     build_packages: List[str]
     skip_final_phase: bool
-    postinst_script: Optional[Path]
+    build_script: Optional[Path]
     prepare_script: Optional[Path]
+    postinst_script: Optional[Path]
     finalize_script: Optional[Path]
     source_file_transfer: SourceFileTransfer
     source_file_transfer_final: Optional[SourceFileTransfer]

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -240,6 +240,7 @@ class CommandLineArguments:
     cache_path: Optional[Path]
     extra_trees: List[Path]
     skeleton_trees: List[Path]
+    clean_package_metadata: Union[bool, str]
     remove_files: List[Path]
     build_script: Optional[Path]
     environment: List[str]


### PR DESCRIPTION
Again, this is a grab-bag of loosely related commits. But splitting this into multiple PRs would generate conflicts, so I don't think it's worth it. Apart from the refactorings, this implements two new "features": `--finalize-script=` makes mkosi skip the finalize script (and similarly for the build script and others), and `--clean-package-metadata=yes|no` disables autodetection and does the cleanup or not as specified.