### PR TITLE
mkosi: dont encrypt genkey private keys

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -7194,6 +7194,7 @@ def generate_secure_boot_key(args: CommandLineArguments) -> NoReturn:
         str(args.secure_boot_valid_days),
         "-subj",
         f"/CN={cn}/",
+        "-nodes",
     ]
 
     os.execvp(cmd[0], cmd)


### PR DESCRIPTION
Let's turn off "DES" encryption of X509 private keys we generate. It's
not really a useful feature, we aren't really an interactive tool (and
thus asking for a password is weird). And it's not secure at all.