### PR TITLE
mkosi: don't install skeleton trees into cached images again

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3091,8 +3091,11 @@ def install_extra_trees(args: CommandLineArguments, root: Path, for_cache: bool)
                 shutil.unpack_archive(cast(str, tree), root)
 
 
-def install_skeleton_trees(args: CommandLineArguments, root: Path) -> None:
+def install_skeleton_trees(args: CommandLineArguments, root: Path, cached: bool) -> None:
     if not args.skeleton_trees:
+        return
+
+    if cached:
         return
 
     with complete_step("Copying in skeleton file trees…"):
@@ -6316,7 +6319,7 @@ def build_image(
                     mount_bind(args.include_dir, root / "usr/include")
 
                 cached_tree = reuse_cache_tree(args, root, do_run_build_script, for_cache, cached)
-                install_skeleton_trees(args, root)
+                install_skeleton_trees(args, root, cached_tree)
                 install_distribution(args, root, do_run_build_script, cached_tree)
                 install_etc_hostname(args, root, cached_tree)
                 install_boot_loader(args, root, loopdev, do_run_build_script, cached_tree)


### PR DESCRIPTION
They already contain the skeleton trees, no need to copy them a second
time.

Fixes: #759