### PR TITLE
dracut: make sure images with IMAGE_VERSION but without IMAGE_ID can …

### DIFF
--- a/mkosi/resources/dracut_unified_kernel_install.sh
+++ b/mkosi/resources/dracut_unified_kernel_install.sh
@@ -15,7 +15,13 @@ fi
 PREFIX=$(dirname $(dirname "$BOOT_DIR_ABS"))
 
 # Pick a default prefix name for the unified kernel binary
-if [[ -z "$IMAGE_ID" ]] ; then
+if [[ -n "$IMAGE_ID" ]] ; then
+    if [[ -n "$IMAGE_VERSION" ]]; then
+        PARTLABEL="${IMAGE_ID}_${IMAGE_VERSION}"
+    else
+        PARTLABEL="${IMAGE_ID}"
+    fi
+else
     IMAGE_ID=linux
 fi
 
@@ -43,8 +49,8 @@ case "$COMMAND" in
             BOOT_OPTIONS="${BOOT_OPTIONS} roothash=${ROOTHASH}"
         elif [[ -n "$USRHASH" ]]; then
             BOOT_OPTIONS="${BOOT_OPTIONS} usrhash=${USRHASH}"
-        elif [[ -n "$IMAGE_VERSION" ]]; then
-            BOOT_OPTIONS="${BOOT_OPTIONS} root=PARTLABEL=${IMAGE_ID}_${IMAGE_VERSION}"
+        elif [[ -n "$PARTLABEL" ]]; then
+            BOOT_OPTIONS="${BOOT_OPTIONS} root=PARTLABEL=${PARTLABEL}"
         fi
 
         if [[ -n "$KERNEL_IMAGE" ]]; then


### PR DESCRIPTION
…boot

If an image version is set but no image ID mkosi's table currently
places generic labels in the partition labels, instead of the image ids
(because we have none...). This means we cannot refrence the root
partition via root=PARTLABEL=… on the kernel cmdline. Hence do not do
that.

This change ensures we don't try to use IMAGE_ID-based root=PARTLABEL=
kernel cmdline swtches without IMAGE_ID being set.

(Note that the main reason IMAGE_ID/IMAGE_VERSION exists is to allow
versioned setups, i.e. where multiple versions of the same thing exist.
In such a case it's important to reference the right rootfs version that
matches the whole setup we are building here. But if IMAGE_ID isn't set
then this multi-version logic is not desired and we can assume that only
a single version of the OS is in the partition table, and thus rely on
gpt-auto-generators automatic root file system discovery)