### PR TITLE
Add shellcheck for embedded shell scripts

### DIFF
--- a/.github/workflows/ci-unit-test.yml
+++ b/.github/workflows/ci-unit-test.yml
@@ -87,3 +87,8 @@ jobs:
       run: |
         ./tools/generate-zipapp.sh
         ./builddir/mkosi -h
+
+    - name: Test shell scripts
+      run: |
+        sudo apt-get update && sudo apt-get install --no-install-recommends shellcheck
+        bash -c 'set globstar; shellcheck mkosi/**/*.sh'

--- a/mkosi/resources/dracut_unified_kernel_install.sh
+++ b/mkosi/resources/dracut_unified_kernel_install.sh
@@ -12,7 +12,7 @@ if [[ -z "${KERNEL_INSTALL_MACHINE_ID-unset}" ]]; then
 fi
 
 # Strip machine ID and kernel version to get the boot directory.
-PREFIX=$(dirname $(dirname "$BOOT_DIR_ABS"))
+PREFIX=$(dirname "$(dirname "$BOOT_DIR_ABS")")
 
 # Pick a default prefix name for the unified kernel binary
 if [[ -n "$IMAGE_ID" ]] ; then
@@ -59,6 +59,7 @@ case "$COMMAND" in
             DRACUT_KERNEL_IMAGE_OPTION=""
         fi
 
+        # shellcheck disable=SC2086
         dracut \
             --uefi \
             --kver "$KERNEL_VERSION" \


### PR DESCRIPTION
Since @bluca just mentioned shellcheck in #818 I thought it might be a good time to add this. This is not yet all-encompassing, but it should get all the scripts that are factored out into the resource module.