### PR TITLE
Silence sfdisk when refreshing partition tables

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -648,7 +648,7 @@ def refresh_partition_table(args: CommandLineArguments, f: BinaryIO) -> None:
 
     with complete_step("Refreshing partition table…", "Refreshed partition table."):
         if args.partition_table.partitions:
-            args.partition_table.run_sfdisk(f.name)
+            args.partition_table.run_sfdisk(f.name, quiet=True)
 
 
 def refresh_file_system(args: CommandLineArguments, dev: Optional[Path], cached: bool) -> None:

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -324,15 +324,18 @@ class PartitionTable:
                  *(p.sfdisk_spec() for p in self.partitions.values())]
         return '\n'.join(table)
 
-    def run_sfdisk(self, device: PathString) -> None:
+    def run_sfdisk(self, device: PathString, *, quiet: bool = False) -> None:
         spec = self.sfdisk_spec()
         device = Path(device)
 
         if 'disk' in ARG_DEBUG:
             print_between_lines(spec)
 
-        run(["sfdisk", "--color=never", "--no-reread", "--no-tell-kernel", device],
-            input=spec.encode("utf-8"))
+        cmd: List[PathString] = ["sfdisk", "--color=never", "--no-reread", "--no-tell-kernel", device]
+        if quiet:
+            cmd += ["--quiet"]
+
+        run(cmd, input=spec.encode("utf-8"))
 
         if device.is_block_device():
             run(["sync"])


### PR DESCRIPTION
Let's try to keep the output minimal when building from cached images.
Currently sfdisk is the only program producing non-trivial amounts of
output when building from cached images so let's pass the --quiet flag
when refreshing partition tables.