### PR TITLE
Set new TTYRows and TTYColumns properties when overriding getty units

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3119,6 +3119,8 @@ def set_serial_terminal(args: CommandLineArguments, root: Path, do_run_build_scr
                           Environment=TERM={os.getenv('TERM', 'vt220')}
                           Environment=COLUMNS={columns}
                           Environment=LINES={lines}
+                          TTYColumns={columns}
+                          TTYRows={lines}
                           """)
 
 

--- a/mkosi/resources/getty_autologin.conf
+++ b/mkosi/resources/getty_autologin.conf
@@ -1,3 +1,4 @@
 [Service]
 ExecStart=
-ExecStart=-/sbin/agetty -o '-p -- \\u' --autologin root --noclear %I $TERM
+ExecStart=-/sbin/agetty -o '-p -- \\u' --autologin root --noclear - $TERM
+StandardInput=tty

--- a/mkosi/resources/serial_getty_autologin.conf
+++ b/mkosi/resources/serial_getty_autologin.conf
@@ -1,3 +1,4 @@
 [Service]
 ExecStart=
-ExecStart=-/sbin/agetty -o '-p -- \\u' --autologin root --keep-baud 115200,57600,38400,9600 %I $TERM
+ExecStart=-/sbin/agetty -o '-p -- \\u' --autologin root --keep-baud 115200,57600,38400,9600 - $TERM
+StandardInput=tty


### PR DESCRIPTION
Sometimes, it's not sufficient to set the LINES and COLUMNS environment
variables to configure the serial terminal size. To properly configure
the serial terminal size when the env variables are not sufficient, we
need to configure the tty size in the kernel as well. To accomplish this,
two new properties TTYRows and TTYCols were added to systemd. Let's set
these properties when we override the getty units so systemd properly
configures the kernel tty size for us when systemd's version is recent
enough.

Additionally, this commit updates the getty unit resources to include
the recent systemd change to how the TTY is passed to agetty. Without
this change, the tty size configured with TTYRows and TTYCols is reset
when systemd invokes agetty. See systemd/systemd#21171
for more information.