### PR TITLE
Add support for CentOS Stream releases

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -6200,7 +6200,7 @@ def load_args(args: argparse.Namespace) -> MkosiArgs:
         if args.distribution == Distribution.fedora:
             args.release = "35"
         elif args.distribution in (Distribution.centos, Distribution.centos_epel):
-            args.release = "8"
+            args.release = "8-stream"
         elif args.distribution in (Distribution.rocky, Distribution.rocky_epel):
             args.release = "8"
         elif args.distribution in (Distribution.alma, Distribution.alma_epel):


### PR DESCRIPTION
Extend the existing `centos` and `centos_epel` distribution to support CentOS Stream releases (`8-stream` and `9-stream` currently).