### PR TITLE
CI: Remove ext4, xfs and gpt_squashfs jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,7 @@ jobs:
           - directory
           - tar
           - cpio
-          - gpt_ext4
-          - gpt_xfs
           - gpt_btrfs
-          - gpt_squashfs
           - plain_squashfs
         exclude:
           # CentOS 8/Rocky/Alma Linux does not support btrfs.


### PR DESCRIPTION
We're running too many CI jobs, let's disable some that are similar
to others to reduce the strain on the CI.