### PR TITLE
Use unittest instead of pytest for new tests

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,24 +1,25 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 import os
+import unittest
 
 from mkosi.backend import PackageType, Distribution, set_umask
 
+class BackendTests(unittest.TestCase):
+    def test_distribution(self):
+        self.assertEqual(Distribution.fedora.package_type, PackageType.rpm)
+        self.assertIs(Distribution.fedora, Distribution.fedora)
+        self.assertIsNot(Distribution.fedora,  Distribution.debian)
+        self.assertEqual(str(Distribution.photon), "photon")
 
-def test_distribution():
-    assert Distribution.fedora.package_type == PackageType.rpm
-    assert Distribution.fedora is Distribution.fedora
-    assert Distribution.fedora is not Distribution.debian
-    assert str(Distribution.photon) == "photon"
 
+    def test_set_umask(self):
+        with set_umask(0o767):
+            tmp1 = os.umask(0o777)
+            with set_umask(0o757):
+                tmp2 = os.umask(0o727)
+            tmp3 = os.umask(0o727)
 
-def test_set_umask():
-    with set_umask(0o767):
-        tmp1 = os.umask(0o777)
-        with set_umask(0o757):
-            tmp2 = os.umask(0o727)
-        tmp3 = os.umask(0o727)
-
-    assert tmp1 == 0o767
-    assert tmp2 == 0o757
-    assert tmp3 == 0o777
+        self.assertEqual(tmp1, 0o767)
+        self.assertEqual(tmp2, 0o757)
+        self.assertEqual(tmp3, 0o777)


### PR DESCRIPTION
Hacking on mkosi on older distributions becomes a lot easier when you
don't have any external library dependencies. You can simply get an
updated version of Python without the need to maintain external libraries
for that Python version.

This benefit seems substantial enough to me to justify using unittest
over pytest as it's part of the standard library. Arguably the biggest
loss is that we can't use "assert" anymore but have to use the assert
methods of unittest but this shouldn't be a huge deal.

I didn't touch the config tests since the plan is to remove them once
we add some simpler argparsing tests in the near future.

We can still use pytest to run all the tests as it supports running
unittest based tests as well.