### PR TITLE
Closing etc/os-release

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -178,18 +178,19 @@ def read_os_release() -> Iterator[Tuple[str, str]]:
         filename = "/usr/lib/os-release"
         f = open(filename)
 
-    for line_number, line in enumerate(f, start=1):
-        line = line.rstrip()
-        if not line or line.startswith("#"):
-            continue
-        m = re.match(r"([A-Z][A-Z_0-9]+)=(.*)", line)
-        if m:
-            name, val = m.groups()
-            if val and val[0] in "\"'":
-                val = ast.literal_eval(val)
-            yield name, val
-        else:
-            print(f"{filename}:{line_number}: bad line {line!r}", file=sys.stderr)
+    with f:
+        for line_number, line in enumerate(f, start=1):
+            line = line.rstrip()
+            if not line or line.startswith("#"):
+                continue
+            m = re.match(r"([A-Z][A-Z_0-9]+)=(.*)", line)
+            if m:
+                name, val = m.groups()
+                if val and val[0] in "\"'":
+                    val = ast.literal_eval(val)
+                yield name, val
+            else:
+                print(f"{filename}:{line_number}: bad line {line!r}", file=sys.stderr)
 
 
 def print_running_cmd(cmdline: Iterable[str]) -> None:


### PR DESCRIPTION
The os-release files raises a warning message when conducting unit tests with the __init__.py file, even though the file is in read mode. Below, the error message:

> home/gabrielsegatti/mkosi/mkosi/__init__.py:167: ResourceWarning: unclosed file <_io.TextIOWrapper name='/etc/os-release' mode='r' encoding='UTF-8'>
>    return dict(f(*args, **kwargs))
> ResourceWarning: Enable tracemalloc to get the object allocation traceback

In order to suppress this message, I've added a context manager to the code.