### PR TITLE
Adding --machine-id option.

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -653,6 +653,12 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   in building or further container import stages.  This option strips
   SELinux context attributes from the resulting tar archive.
 
+`MachineID=`, `--machine-id`
+
+: Set the machine's ID to the specified value. If unused, a random ID will
+be used while building the image and the final image will be shipped without
+a machine ID.
+
 ### [Content] Section
 
 `BasePackages=`, `--base-packages`

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -467,6 +467,7 @@ class MkosiArgs:
     debug: List[str]
     auto_bump: bool
     workspace_dir: Optional[Path]
+    machine_id: str
 
     # QEMU-specific options
     qemu_headless: bool
@@ -474,7 +475,7 @@ class MkosiArgs:
     qemu_mem: str
 
     # Some extra stuff that's stored in MkosiArgs for convenience but isn't populated by arguments
-    machine_id: str
+    machine_id_is_fixed: bool
     original_umask: int
     passphrase: Optional[Dict[str, str]]
 

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -88,6 +88,7 @@ class MkosiConfig:
             "output_format": None,
             "base_packages": True,
             "packages": [],
+            "machine_id": None,
             "password": None,
             "password_is_hashed": False,
             "autologin": False,
@@ -278,6 +279,8 @@ class MkosiConfig:
                 ]
             if "HostonlyInitrd" in mk_config_output:
                 self.reference_config[job_name]["hostonly_initrd"] = mk_config_output["HostonlyInitrd"]
+            if "MachineID" in mk_config_output:
+                self.reference_config[job_name]["MachineID"] = mk_config_output["MachineID"]
         if "Packages" in mk_config:
             mk_config_packages = mk_config["Packages"]
             if "Packages" in mk_config_packages:


### PR DESCRIPTION
Allows users to provide their own Machine ID via CLI or configuration file.