### PR TITLE
Add option to make `systemd-nspawn` keep unit scope

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -1087,6 +1087,13 @@ a machine ID.
 : When used with the `qemu` verb, this options sets `qemu`'s `-m`
   argument which controls the amount of guest's RAM. Defaults to `1G`.
 
+`NspawnKeepUnit=`, `--nspawn-keep-unit`
+
+: When used, this option instructs underlying calls of systemd-nspawn to
+  use the current unit scope, instead of creating a dedicated transcient
+  scope unit for the containers. This option should be used when mkosi is
+  run by a service unit.
+
 `Netdev=`, `--netdev`
 
 : When used with the boot or qemu verbs, this option creates a virtual

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5590,6 +5590,11 @@ def create_parser() -> ArgumentParserMkosi:
     group.add_argument("--qemu-smp", help="Configure guest's SMP settings", metavar="SMP", default="2")
     group.add_argument("--qemu-mem", help="Configure guest's RAM size", metavar="MEM", default="1G")
     group.add_argument(
+        "--nspawn-keep-unit",
+        action=BooleanAction,
+        help="If specified, underlying systemd-nspawn containers use the ressources of the current unit."
+    )
+    group.add_argument(
         "--network-veth",
         dest="netdev",
         action=BooleanAction,
@@ -7213,6 +7218,9 @@ def run_build_script(args: MkosiArgs, root: Path, raw: Optional[BinaryIO]) -> No
         if args.usr_only:
             cmdline += [f"--bind={root_home(args, root)}:/root"]
 
+        if args.nspawn_keep_unit:
+            cmdline += ["--keep-unit"]
+
         cmdline += [f"/root/{args.build_script.name}"]
         cmdline += args.cmdline
 
@@ -7473,6 +7481,9 @@ def run_shell_cmdline(args: MkosiArgs, pipe: bool = False, commands: Optional[Se
         cmdline += ["--ephemeral"]
 
     cmdline += ["--machine", virt_name(args)]
+
+    if args.nspawn_keep_unit:
+        cmdline += ["--keep-unit"]
 
     if commands or args.cmdline:
         # If the verb is 'shell', args.cmdline contains the command to run.

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -502,6 +502,9 @@ class MkosiArgs:
     qemu_smp: str
     qemu_mem: str
 
+    # systemd-nspawn specific options
+    nspawn_keep_unit: bool
+
     # Some extra stuff that's stored in MkosiArgs for convenience but isn't populated by arguments
     machine_id_is_fixed: bool
     original_umask: int
@@ -645,6 +648,9 @@ def run_workspace_command(
     if capture_stdout:
         stdout = subprocess.PIPE
         nspawn += ["--console=pipe"]
+
+    if args.nspawn_keep_unit:
+        nspawn += ["--keep-unit"]
 
     result = run([*nspawn, "--", *cmd], check=False, stdout=stdout, text=capture_stdout)
     if result.returncode != 0:

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -131,6 +131,7 @@ class MkosiConfig:
             "qemu_headless": False,
             "qemu_smp": "2",
             "qemu_mem": "1G",
+            "nspawn_keep_unit": False,
             "netdev": False,
             "ephemeral": False,
             "with_unified_kernel_images": True,


### PR DESCRIPTION
Hello mkosi maintainers,

I propose this PR so mkosi could run inside a systemd-nspawn container with nested systemd-nspawn in the build steps.

I realized that `--register=no` is already hard-coded but I wasn't able to figure out why. In this situation, I though you could consider `--keep-unit` to be hard-coded as well. What do you thing about this?

Note this partially fixes #248 for systemd-nspawn containers, as far as I tested.