### PR TITLE
Removal of Gentoo check at parse_args().

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5711,10 +5711,6 @@ def parse_args(argv: Optional[List[str]] = None) -> Dict[str, argparse.Namespace
             # Parse again with any extra distribution files included.
             args = parse_args_file_group(argv, os.fspath(default_path), args.distribution)
 
-            if args.distribution == "gentoo":
-                from .gentoo import Gentoo
-                Gentoo.try_import_portage()
-
         args_all["default"] = args
 
     return args_all


### PR DESCRIPTION
The Gentoo check at parse_args(), while allowing the system to fail early, makes it harder to unit test such function since it will fail unless Gentoo modules are installed. By removing this, testings for argument parsing are executable on any distro regardless of the installation of Gentoo's modules.

Since this check is also done at __init__ in _gentoo.py_, we're able to remove this without compromising Mkosi's capacity of functioning properly.