### PR TITLE
Add `--update` and `--deep` to invoke_emerge call for pkgs_boot

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3122,7 +3122,11 @@ def install_gentoo(
         # Please don't move, needs to be called before installing dracut
         # dracut is part of gentoo_pkgs_boot
         configure_dracut(args, packages={"dracut"}, root=root)
-        gentoo.invoke_emerge(args, root, pkgs=gentoo.pkgs_boot)
+        # Installing sys-kernel/installkernel-systemd-boot fails spectacularly
+        # due to beeing soft blocked by sys-kernel/installkernel-gentoo (which
+        # is pulled in by debianutils) unless --update and --deep is also
+        # specified
+        gentoo.invoke_emerge(args, root, pkgs=gentoo.pkgs_boot, opts=["--update", "--deep"])
 
     if args.packages:
         gentoo.invoke_emerge(args, root, pkgs=args.packages)


### PR DESCRIPTION
When generating bootable images for gentoo, the emerge call to install
pkgs_boot fails for `sys-kernel/installkernel-systemd-boot`:

```
[…]
‣   Invoking emerge(1) inside stage3
!!! /etc/portage/binrepos.conf is missing (or PORTAGE_BINHOST is unset), but use is requested.

 * IMPORTANT: 9 news items need reading for repository 'gentoo'.
 * Use eselect news read to view new items.

!!! /etc/portage/binrepos.conf is missing (or PORTAGE_BINHOST is unset), but use is requested.
[binary  N    ] app-arch/cpio-2.12-r1-1
[binary  N    ] sys-firmware/edk2-ovmf-202105-r2-1
[binary  N    ] dev-libs/elfutils-0.186-1
[binary  N    ] sys-kernel/installkernel-systemd-boot-1-1
[binary  N    ] sys-kernel/dracut-055-r4-2
[binary  N    ] virtual/libelf-3-1
[binary  N    ] sys-kernel/gentoo-kernel-bin-5.15.19-1
[binary  N    ] virtual/dist-kernel-5.15.19-1
[blocks B     ] sys-kernel/installkernel-gentoo ("sys-kernel/installkernel-gentoo" is soft blocking sys-kernel/installkernel-systemd-boot-1)
[blocks B     ] sys-kernel/installkernel-systemd-boot ("sys-kernel/installkernel-systemd-boot" is soft blocking sys-kernel/installkernel-gentoo-3)

 * Error: The above package list contains packages which cannot be
 * installed at the same time on the same system.

  (sys-kernel/installkernel-gentoo-3-1:0/0::gentoo, installed) pulled in by
    sys-kernel/installkernel-gentoo required by (sys-kernel/gentoo-kernel-bin-5.15.19-1:5.15.19/5.15.19::gentoo, binary scheduled for merge) USE="initramfs -test"

  (sys-kernel/installkernel-systemd-boot-1-1:0/0::gentoo, binary scheduled for merge) pulled inby
    sys-kernel/installkernel-systemd-boot

‣ Error: Workspace command /usr/bin/emerge sys-kernel/installkernel-systemd-boot sys-kernel/gentoo-kernel-bin sys-firmware/edk2-ovmf --buildpkg=y --usepkg=y --keep-going=y --jobs=16 --load-average=15 --nospinner --quiet-build --quiet returned non-zero exit code 1.
‣  (Unmounting Package Cache)
‣  (Unmounting image)
‣  (Detaching /dev/loop0)
```

Adding `--update` and `--deep` allows to unmerge
`sys-kernel/installkernel-gentoo` and use `sys-kernel/installkernel-systemd-boot` instead.