### PR TITLE
Error when trying to build an image without --bootable and run it with qemu

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -6488,6 +6488,9 @@ def load_args(args: argparse.Namespace) -> MkosiArgs:
         if not args.output_format.is_disk():
             die("Sorry, can't boot non-disk images with qemu.")
 
+    if needs_build(args) and args.verb == "qemu" and not args.bootable:
+        die("Images built without the --bootable option cannot be booted using qemu")
+
     if needs_build(args) and args.qemu_headless and not args.bootable:
         die("--qemu-headless requires --bootable")
 
@@ -7839,7 +7842,7 @@ def expand_specifier(s: str) -> str:
 
 
 def needs_build(args: Union[argparse.Namespace, MkosiArgs]) -> bool:
-    return args.verb == "build" or (not args.output.exists() and args.verb in MKOSI_COMMANDS_NEED_BUILD)
+    return args.verb == "build" or (not args.output.exists() and args.verb in MKOSI_COMMANDS_NEED_BUILD) or args.force > 0
 
 
 def run_verb(raw: argparse.Namespace) -> None:

--- a/tests/test_parse_load_args.py
+++ b/tests/test_parse_load_args.py
@@ -39,7 +39,7 @@ def test_parse_load_verb():
     assert parse(["build"]).verb == "build"
     assert parse(["shell"]).verb == "shell"
     assert parse(["boot"]).verb == "boot"
-    assert parse(["qemu"]).verb == "qemu"
+    assert parse(["--bootable", "qemu"]).verb == "qemu"
     with pytest.raises(SystemExit):
         parse(["invalid"])
 


### PR DESCRIPTION
We can only check this when we're building the image, since when we're not
building the image it's not required to pass the --bootable option in order
to be able to use the qemu verb to run it in qemu.

This also fixes needs_build() to take the args.force option into account.
This fixes usage of needs_build() before unlink_output() is called.