### PR TITLE
Fix needs_build() logic

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -7845,7 +7845,7 @@ def expand_specifier(s: str) -> str:
 
 
 def needs_build(args: Union[argparse.Namespace, MkosiArgs]) -> bool:
-    return args.verb == "build" or (not args.output.exists() and args.verb in MKOSI_COMMANDS_NEED_BUILD) or args.force > 0
+    return args.verb == "build" or (args.verb in MKOSI_COMMANDS_NEED_BUILD and (not args.output.exists() or args.force > 0))
 
 
 def run_verb(raw: argparse.Namespace) -> None:


### PR DESCRIPTION
We should only check the -f option if the verb is one of the verbs
that needs a build. With the current check, we start rebuilding an
image even if the verb is "summary".