### PR TITLE
Rename --network-veth to --netdev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
 
         [Host]
         Ssh=yes
-        NetworkVeth=yes
+        Netdev=yes
         EOF
 
         mkdir -p mkosi.skeleton/etc/portage

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,11 +2,11 @@
 
 ## v13
 
-- The networkd config file installed by mkosi when the --network-veth option is
-  used (/etc/systemd/network/80-mkosi-network-veth.network in the image) now only matches against network interfaces using the virtio_net driver.
+- The networkd config file installed by mkosi when the --netdev option is
+  used (/etc/systemd/network/80-mkosi-netdev.network in the image) now only matches against network interfaces using the virtio_net driver.
   Please make sure you weren't relying on this file to configure any network
   interfaces other than the tun/tap virtio-net interface created by mkosi when
-  booting the image in QEMU with the --network-veth option. If you were relying
+  booting the image in QEMU with the --netdev option. If you were relying
   on this config file to configure other interfaces, you'll have to re-create it
   with the correct match and a lower initial number in the filename to make sure networkd will keep configuring your
   interface, e.g. via the `mkosi.skeleton` or `mkosi.extra` trees or a `mkosi.postinst` script.

--- a/action/mkosi.default
+++ b/action/mkosi.default
@@ -53,4 +53,4 @@ Packages=bzip2
 QemuHeadless=yes
 
 [Host]
-NetworkVeth=yes
+Netdev=yes

--- a/mkosi.md
+++ b/mkosi.md
@@ -1087,7 +1087,7 @@ a machine ID.
 : When used with the `qemu` verb, this options sets `qemu`'s `-m`
   argument which controls the amount of guest's RAM. Defaults to `1G`.
 
-`NetworkVeth=`, `--network-veth`
+`Netdev=`, `--netdev`
 
 : When used with the boot or qemu verbs, this option creates a virtual
   ethernet link between the host and the container/VM. The host
@@ -1138,7 +1138,7 @@ a machine ID.
 : When used with the `ssh` verb, `mkosi` will attempt to retry the SSH connection
   up to given timeout (in seconds) in case it fails. This option is useful mainly
   in scripted environments where the `qemu` and `ssh` verbs are used in a quick
-  succession and the veth device might not get enough time to configure itself.
+  succession and the virtual device might not get enough time to configure itself.
 
 ### Commandline-only Options
 

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -453,7 +453,7 @@ class MkosiArgs:
     password_is_hashed: bool
     autologin: bool
     extra_search_paths: List[Path]
-    network_veth: bool
+    netdev: bool
     ephemeral: bool
     ssh: bool
     ssh_key: Optional[Path]

--- a/mkosi/machine.py
+++ b/mkosi/machine.py
@@ -47,7 +47,7 @@ class Machine:
             tmp.bootable = True
             tmp.qemu_headless = True
             tmp.hostonly_initrd = True
-            tmp.network_veth = True
+            tmp.netdev = True
             tmp.ssh = True
         elif tmp.verb == "boot":
             pass

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -128,7 +128,7 @@ class MkosiConfig:
             "qemu_headless": False,
             "qemu_smp": "2",
             "qemu_mem": "1G",
-            "network_veth": False,
+            "netdev": False,
             "ephemeral": False,
             "with_unified_kernel_images": True,
             "hostonly_initrd": False,
@@ -366,8 +366,8 @@ class MkosiConfig:
                 self._append_list("extra_search_paths", mk_config_host["ExtraSearchPaths"], job_name, ":")
             if "QemuHeadless" in mk_config_host:
                 self.reference_config[job_name]["qemu_headless"] = mk_config_host["QemuHeadless"]
-            if "NetworkVeth" in mk_config_host:
-                self.reference_config[job_name]["network_veth"] = mk_config_host["NetworkVeth"]
+            if "Netdev" in mk_config_host:
+                self.reference_config[job_name]["netdev"] = mk_config_host["Netdev"]
             if "Ephemeral" in mk_config_host:
                 self.reference_config[job_name]["ephemeral"] = mk_config_host["Ephemeral"]
             if "Ssh" in mk_config_host:
@@ -586,7 +586,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
             "Host": {
                 "ExtraSearchPaths": "search/here:search/there",
                 "QemuHeadless": True,
-                "NetworkVeth": True,
+                "Netdev": True,
             },
         }
         self._prepare_mkosi_default(directory, mk_config)
@@ -652,7 +652,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
             "Host": {
                 "ExtraSearchPaths": "search/ubu",
                 "QemuHeadless": True,
-                "NetworkVeth": True,
+                "Netdev": True,
             },
         }
         self._prepare_mkosi_default_d(directory, mk_config, 1)
@@ -718,7 +718,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
             "Host": {
                 "ExtraSearchPaths": "search/debi",
                 "QemuHeadless": True,
-                "NetworkVeth": True,
+                "Netdev": True,
             },
         }
         self._prepare_mkosi_default_d(directory, mk_config, 2)


### PR DESCRIPTION
--network-veth implies usage of veth virtual ethernet links which we
use for containers but not for VMs. Let's rename the option to --netdev
instead which encapsulates both veth links and tun/tap links which we
use for QEMU VMs.