### PR TITLE
Adding an Enum class for verb comparison.

### DIFF
--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -112,6 +112,24 @@ class PackageType(enum.Enum):
     ebuild = 5
 
 
+class Verb(enum.Enum):
+    build   = "build"
+    clean   = "clean"
+    summary = "summary"
+    shell   = "shell"
+    boot    = "boot"
+    qemu    = "qemu"
+    ssh     = "ssh"
+    serve   = "serve"
+    bump    = "bump"
+    help    = "help"
+    genkey  = "genkey"
+
+    # Defining __str__ is required to get "print_help()" output to include the human readable (values) of Verb.
+    def __str__(self) -> str:
+        return self.value
+
+
 class Distribution(enum.Enum):
     package_type: PackageType
 
@@ -225,17 +243,17 @@ class ManifestFormat(Parseable, enum.Enum):
 
 
 class PartitionIdentifier(enum.Enum):
-    esp        = 'esp'
-    bios       = 'bios'
-    xbootldr   = 'xbootldr'
-    root       = 'root'
-    swap       = 'swap'
-    home       = 'home'
-    srv        = 'srv'
-    var        = 'var'
-    tmp        = 'tmp'
-    verity     = 'verity'
-    verity_sig = 'verity-sig'
+    esp        = "esp"
+    bios       = "bios"
+    xbootldr   = "xbootldr"
+    root       = "root"
+    swap       = "swap"
+    home       = "home"
+    srv        = "srv"
+    var        = "var"
+    tmp        = "tmp"
+    verity     = "verity"
+    verity_sig = "verity-sig"
 
 
 @dataclasses.dataclass
@@ -367,7 +385,7 @@ class PartitionTable:
 class MkosiArgs:
     """Type-hinted storage for command line arguments."""
 
-    verb: str
+    verb: Verb
     cmdline: List[str]
     force: int
 

--- a/mkosi/machine.py
+++ b/mkosi/machine.py
@@ -27,7 +27,7 @@ from . import (
     run_shell_cmdline,
     unlink_output,
 )
-from .backend import MkosiArgs, die
+from .backend import MkosiArgs, Verb, die
 
 
 class Machine:
@@ -43,13 +43,13 @@ class Machine:
         tmp = parse_args(args)["default"]
         tmp.force = 1
         tmp.autologin = True
-        if tmp.verb == "qemu":
+        if tmp.verb == Verb.qemu:
             tmp.bootable = True
             tmp.qemu_headless = True
             tmp.hostonly_initrd = True
             tmp.network_veth = True
             tmp.ssh = True
-        elif tmp.verb == "boot":
+        elif tmp.verb == Verb.boot:
             pass
         else:
             die("No valid verb was entered.")
@@ -79,7 +79,7 @@ class Machine:
             check_root()
             unlink_output(self.args)
 
-        if self.args.verb == "build":
+        if self.args.verb == Verb.build:
             check_output(self.args)
 
         if needs_build(self.args):
@@ -91,9 +91,9 @@ class Machine:
         with contextlib.ExitStack() as stack:
             prepend_to_environ_path(self.args.extra_search_paths)
 
-            if self.args.verb in ("shell", "boot"):
+            if self.args.verb in (Verb.shell, Verb.boot):
                 cmdline = run_shell_cmdline(self.args)
-            elif self.args.verb == "qemu":
+            elif self.args.verb == Verb.qemu:
                 # We must keep the temporary file opened at run_qemu_cmdline accessible, hence the context stack.
                 cmdline = stack.enter_context(run_qemu_cmdline(self.args))
             else:
@@ -105,7 +105,7 @@ class Machine:
             # We use pexpect to boot an image that we will be able to interact with in the future
             # Then we tell the process to look for the # sign, which indicates the CLI for that image is active
             # Once we've build/boot an image the CLI will prompt "root@image ~]# "
-            # Then, when pexpects finds the "#" it means we're ready to interact with the process
+            # Then, when pexpects finds the '#' it means we're ready to interact with the process
             self._serial = pexpect.spawnu(cmd, logfile=None, timeout=240)
             self._serial.expect("#")
             self.stack = stack.pop_all()

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -10,6 +10,7 @@ from typing import Any, Generator, Mapping
 import pytest
 
 import mkosi
+from mkosi.backend import Verb
 
 
 @contextlib.contextmanager
@@ -119,7 +120,7 @@ class MkosiConfig:
             "tmp_size": None,
             "usr_only": False,
             "var_size": None,
-            "verb": "build",
+            "verb": Verb.build,
             "verity": False,
             "with_docs": False,
             "with_network": False,
@@ -453,7 +454,7 @@ class MkosiConfigSummary(MkosiConfigOne):
     def __init__(self):
         super().__init__()
         for ref_c in self.reference_config.values():
-            ref_c["verb"] = "summary"
+            ref_c["verb"] = Verb.summary
         self.cli_arguments = ["summary"]
 
 
@@ -518,7 +519,7 @@ class MkosiConfigDistroDir(MkosiConfigDistro):
     def __init__(self):
         super().__init__("a_sub_dir")
         for ref_c in self.reference_config.values():
-            ref_c["verb"] = "summary"
+            ref_c["verb"] = Verb.summary
 
 
 class MkosiConfigManyParams(MkosiConfigOne):
@@ -832,20 +833,20 @@ def tested_config(request):
 def test_verb_none(tmpdir):
     with change_cwd(tmpdir.strpath):
         args = mkosi.parse_args([])
-        assert args["default"].verb == "build"
+        assert args["default"].verb == Verb.build
 
 
 def test_verb_build(tmpdir):
     with change_cwd(tmpdir.strpath):
         args = mkosi.parse_args(["build"])
-        assert args["default"].verb == "build"
+        assert args["default"].verb == Verb.build
 
 
 def test_verb_boot_no_cli_args1(tmpdir):
     with change_cwd(tmpdir.strpath):
         cmdline_ref = ["boot", "--par-for-sub", "--pom", "--for_sub", "1234"]
         args = mkosi.parse_args(cmdline_ref)
-        assert args["default"].verb == "boot"
+        assert args["default"].verb == Verb.boot
         assert args["default"].cmdline == cmdline_ref[1:]
 
 
@@ -853,7 +854,7 @@ def test_verb_boot_no_cli_args2(tmpdir):
     with change_cwd(tmpdir.strpath):
         cmdline_ref = ["-pa-package", "boot", "--par-for-sub", "--popenssl", "--for_sub", "1234"]
         args = mkosi.parse_args(cmdline_ref)
-        assert args["default"].verb == "boot"
+        assert args["default"].verb == Verb.boot
         assert "a-package" in args["default"].packages
         assert args["default"].cmdline == cmdline_ref[2:]
 
@@ -862,7 +863,7 @@ def test_verb_boot_no_cli_args3(tmpdir):
     with change_cwd(tmpdir.strpath):
         cmdline_ref = ["-pa-package", "-p", "another-package", "build"]
         args = mkosi.parse_args(cmdline_ref)
-        assert args["default"].verb == "build"
+        assert args["default"].verb == Verb.build
         assert args["default"].packages == ["a-package", "another-package"]
 
 
@@ -870,7 +871,7 @@ def test_verb_summary_no_cli_args4(tmpdir):
     with change_cwd(tmpdir.strpath):
         cmdline_ref = ["-pa-package", "-p", "another-package", "summary"]
         args = mkosi.parse_args(cmdline_ref)
-        assert args["default"].verb == "summary"
+        assert args["default"].verb == Verb.summary
         assert args["default"].packages == ["a-package", "another-package"]
 
 
@@ -878,7 +879,7 @@ def test_verb_shell_cli_args5(tmpdir):
     with change_cwd(tmpdir.strpath):
         cmdline_ref = ["-pa-package", "-p", "another-package", "shell", "python3 -foo -bar;", "ls --inode"]
         args = mkosi.parse_args(cmdline_ref)
-        assert args["default"].verb == "shell"
+        assert args["default"].verb == Verb.shell
         assert args["default"].packages == ["a-package", "another-package"]
         assert args["default"].cmdline == cmdline_ref[4:]
 
@@ -887,7 +888,7 @@ def test_verb_shell_cli_args6(tmpdir):
     with change_cwd(tmpdir.strpath):
         cmdline_ref = ["-i", "yes", "summary"]
         args = mkosi.parse_args(cmdline_ref)
-        assert args["default"].verb == "summary"
+        assert args["default"].verb == Verb.summary
         assert args["default"].incremental == True
 
 
@@ -895,7 +896,7 @@ def test_verb_shell_cli_args7(tmpdir):
     with change_cwd(tmpdir.strpath):
         cmdline_ref = ["-i", "summary"]
         args = mkosi.parse_args(cmdline_ref)
-        assert args["default"].verb == "summary"
+        assert args["default"].verb == Verb.summary
         assert args["default"].incremental == True
 
 

--- a/tests/test_parse_load_args.py
+++ b/tests/test_parse_load_args.py
@@ -9,9 +9,10 @@ from os import chdir, getcwd
 from pathlib import Path
 from typing import List, Optional
 
-import mkosi
 import pytest
-from mkosi.backend import Distribution, MkosiArgs, MkosiException
+
+import mkosi
+from mkosi.backend import Distribution, MkosiArgs, MkosiException, Verb
 
 
 def parse(argv: Optional[List[str]] = None) -> MkosiArgs:
@@ -29,17 +30,17 @@ def cd_temp_dir():
             chdir(old_dir)
 
 def test_parse_load_verb():
-    assert parse(["build"]).verb == "build"
-    assert parse(["clean"]).verb == "clean"
+    assert parse(["build"]).verb == Verb.build
+    assert parse(["clean"]).verb == Verb.clean
     with pytest.raises(SystemExit):
         parse(["help"])
-    assert parse(["genkey"]).verb == "genkey"
-    assert parse(["bump"]).verb == "bump"
-    assert parse(["serve"]).verb == "serve"
-    assert parse(["build"]).verb == "build"
-    assert parse(["shell"]).verb == "shell"
-    assert parse(["boot"]).verb == "boot"
-    assert parse(["--bootable", "qemu"]).verb == "qemu"
+    assert parse(["genkey"]).verb == Verb.genkey
+    assert parse(["bump"]).verb == Verb.bump
+    assert parse(["serve"]).verb == Verb.serve
+    assert parse(["build"]).verb == Verb.build
+    assert parse(["shell"]).verb == Verb.shell
+    assert parse(["boot"]).verb == Verb.boot
+    assert parse(["--bootable", "qemu"]).verb == Verb.qemu
     with pytest.raises(SystemExit):
         parse(["invalid"])
 


### PR DESCRIPTION
As suggested here: [894](https://github.com/systemd/mkosi/pull/894#discussion_r803610296).
The idea is: we parse CLI-entered verbs into the Enum class to allow comparisons to happen more easily.