### PR TITLE
Proof of concept for integration testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,9 @@ jobs:
       run: sudo apt-get update && sudo apt-get install --no-install-recommends python3-pexpect python3-pytest
 
     - name: Run integration tests
-      run: sudo python3 -m pytest -m integration tests
+      run: |
+        MKOSI_TEST_DEFAULT_VERB=qemu sudo python3 -m pytest -m integration tests
+        MKOSI_TEST_DEFAULT_VERB=boot sudo python3 -m pytest -m integration tests
 
   integration-test:
     runs-on: ubuntu-20.04

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5986,12 +5986,12 @@ def unlink_output(args: MkosiArgs) -> None:
 
 
 def parse_boolean(s: str) -> bool:
-    "Parse 1/true/yes as true and 0/false/no as false"
+    "Parse 1/true/yes/y/t/on as true and 0/false/no/n/f/off/None as false"
     s_l = s.lower()
-    if s_l in {"1", "true", "yes"}:
+    if s_l in {"1", "true", "yes", "y", "t", "on"}:
         return True
 
-    if s_l in {"0", "false", "no"}:
+    if s_l in {"0", "false", "no", "n", "f", "off"}:
         return False
 
     raise ValueError(f"Invalid literal for bool(): {s!r}")

--- a/tests/test_machine.py
+++ b/tests/test_machine.py
@@ -5,64 +5,50 @@ from subprocess import TimeoutExpired
 
 import pytest
 
-import mkosi.machine as machine
 from mkosi.backend import MkosiException
+from mkosi.machine import Machine, MkosiMachineTest
 
 pytestmark = [
     pytest.mark.integration,
-    pytest.mark.parametrize("verb", ["boot", "qemu"]),
     pytest.mark.skipif(os.getuid() != 0, reason="Must be invoked as root.")
 ]
 
+class MkosiMachineTestCase(MkosiMachineTest):
+    def test_simple_run(self) -> None:
+        process = self.machine.run(["echo", "This is a test."])
+        assert process.stdout.strip("\n") == "This is a test."
 
-def test_simple_run(verb: str) -> None:
-    with machine.Machine([verb]) as m:
-        p = m.run(["echo", "This is a test."])
-        assert "This is a test." == p.stdout.strip("\n")
-
-    assert m.exit_code == 0
-
-
-def test_wrong_command(verb: str) -> None:
-    # First tests with argument check = True from mkosi.backend.run(), therefore we see if an exception is raised
-    with machine.Machine([verb]) as m:
+    def test_wrong_command(self) -> None:
+        # Check = True from mkosi.backend.run(), therefore we see if an exception is raised
         with pytest.raises(MkosiException):
-            m.run(["NonExisting", "Command"])
+            self.machine.run(["NonExisting", "Command"])
         with pytest.raises(MkosiException):
-            m.run(["ls", "NullDirectory"])
+            self.machine.run(["ls", "NullDirectory"])
 
-    assert m.exit_code == 0
-
-    # Second group of tests with check = False to see if stderr and returncode have the expected values
-    with machine.Machine([verb]) as m:
-        result = m.run(["NonExisting", "Command"], check=False)
+        # Check = False to see if stderr and returncode have the expected values
+        result = self.machine.run(["NonExisting", "Command"], check=False)
         assert result.returncode in (203, 127)
 
-        result = m.run(["ls", "-"], check=False)
+        result = self.machine.run(["ls", "-"], check=False)
         assert result.returncode == 2
         assert "No such file or directory" in result.stderr
 
-    assert m.exit_code == 0
-
-
-def test_infinite_command(verb: str) -> None:
-    with machine.Machine([verb]) as m:
+    def test_infinite_command(self) -> None:
         with pytest.raises(TimeoutExpired):
-            m.run(["tail", "-f", "/dev/null"], 2)
-
-    assert m.exit_code == 0
+            self.machine.run(["tail", "-f", "/dev/null"], 2)
 
 
-def test_before_boot(verb: str) -> None:
-    m = machine.Machine([verb])
+def test_before_boot() -> None:
+    m = Machine()
     with pytest.raises(AssertionError):
         m.run(["ls"])
 
 
-def test_after_shutdown(verb: str) -> None:
-    with machine.Machine([verb]) as m:
+def test_after_shutdown() -> None:
+    with Machine() as m:
         pass
 
     with pytest.raises(AssertionError):
         m.run(["ls"])
+
     assert m.exit_code == 0


### PR DESCRIPTION
This PR has the goal of presenting a proof of concept implementation of what could be Mkosi's integration testing scheme.

Not so long ago [Machine](https://github.com/systemd/mkosi/pull/894) class was merged into main. That class provided us an abstraction to build/boot a Mkosi image and then run commands in that particular image from within a [python script ](https://github.com/systemd/mkosi/blob/main/tests/test_machine.py). This allowed setting testing functions that would build/boot run commands and exit the a Mkosi image within its scope.

Now, we've extended the usage of a single Mkosi build. That is, we are able to keep an image configuration running between multiple test cases. Therefore, the time once spent waiting during testing, while an image was built is dramatically decreased, since we don't need to rebuilt it at the beginning of every function anymore (we do reboot the image so that previous test runs don't interfere, but the time cost is marginal).

The way this is being leveraged into testing is through the Unittest library, the main reason being: we want to allow
as much possible scenarios of testing with Mkosi's structure, in the most manageable way (will get to why Pytest didn't provide that in a second).
Currently, we have a `MkosiMachineTest` class, which gives us a few things:

- `setUpClass()`, grants every subclass a running Mkosi machine with the specified configurations from "args".
- `setUp()` boots an Image at each testing function.
- `tearDown`, kill that image so the next test has a clean image.

Then, for each test class inheriting`MkosiMachineTest`, we'll initialise it with the arguments that its Mkosi image should have in order to run tests. Then, each class contains tests for which one specific configuration would be required.

Where Pytest was less than ideal in order to accomplish this (as far as I could find), is when we'd have the need to generate multiple Mkosi images with different configurations.
We want each fixture to return an instance of the Machine class, which will contain a running Mkosi image. [Pytest's fixtures are unable to receive parameters](https://github.com/pytest-dev/pytest/issues/8109), which means we would have to replicate fixtures multiple times with the hard coded parameters needed. This would also cause testing functions to become huge, if we desired to reuse one instance of the Machine class multiple times. 

So, if we wanted 2 Mkosi images, with different configurations, we'd have:

```
@pytest.fixture
def fixture_1():
    return machine[args]

def test_1(machine):
     machine.run([...])

@pytest.fixture
def fixture_2():
    return other_machine[args]

def test_2(other_machine):
     machine.run([...])
```

And, as we wanted to reutilize the configurations from `fixture_1`, the testing function would start to look like this:

```
@pytest.fixture
def fixture_1():
    return machine

def test_1(machine):
    machine.run([...])
    assert (...)
    machine.run([...])
    assert(...)
        .
        .
        .
```

With Unittest the scalability of tests becomes easier to manage, since, as long as there's a class with the configuration you need, you can simply add another testing method to it.
We also still use Pytest as the tests runner.

Please, let me know what you think about this, any suggestions or doubts and so on.