### PR TITLE
Remove uneeded "name=" from EPEL repo definition

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2403,7 +2403,7 @@ def install_centos_repos_old(args: MkosiArgs, root: Path, epel_release: int) -> 
              Repo("centosplus", f"CentOS-{args.release} - Plus", centosplus_url, gpgpath, gpgurl)]
 
     if 'epel' in args.distribution.name:
-        repos += [Repo("epel", f"name=Extra Packages for Enterprise Linux {epel_release} - $basearch",
+        repos += [Repo("epel", f"Extra Packages for Enterprise Linux {epel_release} - $basearch",
                        epel_url, epel_gpgpath, epel_gpgurl)]
 
     setup_dnf(args, root, repos)
@@ -2439,7 +2439,7 @@ def install_centos_repos_new(args: MkosiArgs, root: Path, epel_release: int) -> 
              Repo("PowerTools", f"CentOS-{args.release} - PowerTools", powertools_url, gpgpath, gpgurl)]
 
     if 'epel' in args.distribution.name:
-        repos += [Repo("epel", f"name=Extra Packages for Enterprise Linux {epel_release} - $basearch",
+        repos += [Repo("epel", f"Extra Packages for Enterprise Linux {epel_release} - $basearch",
                        epel_url, epel_gpgpath, epel_gpgurl)]
 
     setup_dnf(args, root, repos)
@@ -2471,7 +2471,7 @@ def install_centos_stream_repos(args: MkosiArgs, root: Path, epel_release: int) 
              Repo("CRB", f"CentOS Stream {release} - CRB", crb_url, gpgpath, gpgurl)]
 
     if 'epel' in args.distribution.name:
-        repos += [Repo("epel", f"name=Extra Packages for Enterprise Linux {epel_release} - $basearch",
+        repos += [Repo("epel", f"Extra Packages for Enterprise Linux {epel_release} - $basearch",
                        epel_url, epel_gpgpath, epel_gpgurl)]
 
     setup_dnf(args, root, repos)
@@ -2504,7 +2504,7 @@ def install_rocky_repos(args: MkosiArgs, root: Path, epel_release: int) -> None:
              Repo("extras", f"Rocky-{args.release} - Extras", extras_url, gpgpath, gpgurl),
              Repo("plus", f"Rocky-{args.release} - Plus", plus_url, gpgpath, gpgurl)]
     if 'epel' in args.distribution.name:
-        repos += [Repo("epel", f"name=Extra Packages for Enterprise Linux {epel_release} - $basearch",
+        repos += [Repo("epel", f"Extra Packages for Enterprise Linux {epel_release} - $basearch",
                        epel_url, epel_gpgpath, epel_gpgurl)]
 
     setup_dnf(args, root, repos)
@@ -2539,7 +2539,7 @@ def install_alma_repos(args: MkosiArgs, root: Path, epel_release: int) -> None:
              Repo("HighAvailability", f"AlmaLinux-{args.release} - HighAvailability", ha_url, gpgpath, gpgurl)]
 
     if 'epel' in args.distribution.name:
-        repos += [Repo("epel", f"name=Extra Packages for Enterprise Linux {epel_release} - $basearch",
+        repos += [Repo("epel", f"Extra Packages for Enterprise Linux {epel_release} - $basearch",
                        epel_url, epel_gpgpath, epel_gpgurl)]
 
     setup_dnf(args, root, repos)


### PR DESCRIPTION
setup_dnf provides name= already

Before:

CentOS-8-stream - Plus                                                                    10 kB/s | 3.0 kB     00:00
CentOS-8-stream - PowerTools                                                              19 kB/s | 4.4 kB     00:00
name=Extra Packages for Enterprise Linux 8 - x86_64                                       10 kB/s | 4.7 kB     00:00

After:

CentOS-8-stream - Plus                                                                   5.3 kB/s | 3.0 kB     00:00
CentOS-8-stream - PowerTools                                                             8.1 kB/s | 4.4 kB     00:00
Extra Packages for Enterprise Linux 8 - x86_64                                           9.4 kB/s | 4.7 kB     00:00
