### PR TITLE
debian: Switch default release from unstable to testing

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -6224,7 +6224,7 @@ def load_args(args: argparse.Namespace) -> MkosiArgs:
         elif args.distribution == Distribution.mageia:
             args.release = "7"
         elif args.distribution == Distribution.debian:
-            args.release = "unstable"
+            args.release = "testing"
         elif args.distribution == Distribution.ubuntu:
             args.release = "focal"
         elif args.distribution == Distribution.opensuse:


### PR DESCRIPTION
Unstable is a bit too bleeding edge. Let's switch to testing which
is roughly 5 days behind unstable so we don't get affected by
temporary issues that make it to unstable.