### PR TITLE
Qemu linux boot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,9 @@ jobs:
         tee mkosi.default <<- EOF
         [Output]
         BootProtocols=uefi
+
+        [Host]
+        QemuBoot=uefi
         EOF
 
         sudo MKOSI_TEST_DEFAULT_VERB=qemu python3 -m pytest -m integration -sv tests
@@ -198,6 +201,9 @@ jobs:
         [Output]
         BootProtocols=uefi
         WithUnifiedKernelImages=no
+
+        [Host]
+        QemuBoot=uefi
         EOF
 
         sudo MKOSI_TEST_DEFAULT_VERB=qemu python3 -m pytest -m integration -sv tests
@@ -208,6 +214,22 @@ jobs:
         [Output]
         BootProtocols=bios
         WithUnifiedKernelImages=no
+
+        [Host]
+        QemuBoot=bios
+        EOF
+
+        sudo MKOSI_TEST_DEFAULT_VERB=qemu python3 -m pytest -m integration -sv tests
+
+    - name: Build/Boot ${{ matrix.distro }}/${{ matrix.format}} QEMU Linux Boot
+      run: |
+        tee mkosi.default <<- EOF
+        [Output]
+        BootProtocols=linux
+        WithUnifiedKernelImages=no
+
+        [Host]
+        QemuBoot=linux
         EOF
 
         sudo MKOSI_TEST_DEFAULT_VERB=qemu python3 -m pytest -m integration -sv tests

--- a/mkosi.md
+++ b/mkosi.md
@@ -456,10 +456,14 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 
 : Pick one or more boot protocols to support when generating a
   bootable image, as enabled with `Bootable=`. Takes a comma-separated
-  list of `uefi` or `bios`. May be specified more than once in which
+  list of `uefi`, `bios`, or `linux`. May be specified more than once in which
   case the specified lists are merged. If `uefi` is specified the
   `sd-boot` UEFI boot loader is used, if `bios` is specified the GNU
-  Grub boot loader is used. Use "!\*" to remove all previously added
+  Grub boot loader is used. If `linux` is specified, the kernel image, initrd
+  and kernel cmdline are extracted from the image and stored in the output
+  directory. When running the `qemu` verb and setting the `--qemu-boot` option
+  to `linux`, qemu will be instructed to do a direct Linux kernel boot using
+  the previously extracted files. Use "!\*" to remove all previously added
   protocols or "!protocol" to remove one protocol.
 
 `KernelCommandLine=`, `--kernel-command-line=`
@@ -1128,6 +1132,13 @@ a machine ID.
   use the current unit scope, instead of creating a dedicated transcient
   scope unit for the containers. This option should be used when mkosi is
   run by a service unit.
+
+`QemuBoot=`, `--qemu-boot=`
+
+: When used with the `qemu` verb, this option sets the boot protocol to be used
+  by qemu. Can be set to either `uefi`, `bios`, or `linux`. Note that a boot
+  procotol needs to be included in `BootProtocols=` when building the image for
+  it to be usable with this option.
 
 `Netdev=`, `--netdev`
 

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -516,6 +516,7 @@ class MkosiArgs:
     qemu_mem: str
     qemu_kvm: bool
     qemu_args: Sequence[str]
+    qemu_boot: str
 
     # systemd-nspawn specific options
     nspawn_keep_unit: bool

--- a/mkosi/gentoo.py
+++ b/mkosi/gentoo.py
@@ -240,6 +240,8 @@ class Gentoo:
             elif args.get_partition(PartitionIdentifier.bios):
                 self.pkgs_boot = ["sys-boot/grub"]
                 self.grub_platforms = ["coreboot", "qemu", "pc"]
+            else:
+                self.pkgs_boot = []
 
             self.pkgs_boot += ["sys-kernel/gentoo-kernel-bin",
                                "sys-firmware/edk2-ovmf"]

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -135,6 +135,7 @@ class MkosiConfig:
             "qemu_kvm": mkosi.qemu_check_kvm_support(),
             "qemu_args": [],
             "nspawn_keep_unit": False,
+            "qemu_boot": None,
             "netdev": False,
             "ephemeral": False,
             "with_unified_kernel_images": True,


### PR DESCRIPTION
This allows using qemu's direct linux boot to boot images directly without involving a bootloader. This boots faster compared to going through UEFI but more importantly, it allows booting images of architectures that don't support UEFI  in qemu.

I wonder if we'd want to add "linux" as an option for "--boot-protocols" instead of gating all the build time changes behind the --qemu-linux-boot option. If we'd do that, we could also forgo adding boot loader partitions and all the related stuff if only "linux" is enabled in "--boot-protocols".