### PR TITLE
Centralize usage of suppress_stacktrace() and propagate returncode

### DIFF
--- a/mkosi/__main__.py
+++ b/mkosi/__main__.py
@@ -2,6 +2,7 @@
 # PYTHON_ARGCOMPLETE_OK
 import os
 import sys
+from subprocess import CalledProcessError
 
 from . import complete_step, parse_args, run_verb
 from .backend import MkosiException, die
@@ -24,7 +25,10 @@ def main() -> None:
                     run_verb(a)
             else:
                 run_verb(a)
-    except MkosiException:
+    except MkosiException as e:
+        cause = e.__cause__
+        if cause and isinstance(cause, CalledProcessError):
+            sys.exit(cause.returncode)
         sys.exit(1)
 
 

--- a/tests/test_machine.py
+++ b/tests/test_machine.py
@@ -1,11 +1,10 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 import os
-from subprocess import TimeoutExpired
+from subprocess import CalledProcessError, TimeoutExpired
 
 import pytest
 
-from mkosi.backend import MkosiException
 from mkosi.machine import Machine, MkosiMachineTest
 
 pytestmark = [
@@ -20,9 +19,9 @@ class MkosiMachineTestCase(MkosiMachineTest):
 
     def test_wrong_command(self) -> None:
         # Check = True from mkosi.backend.run(), therefore we see if an exception is raised
-        with pytest.raises(MkosiException):
+        with pytest.raises(CalledProcessError):
             self.machine.run(["NonExisting", "Command"])
-        with pytest.raises(MkosiException):
+        with pytest.raises(CalledProcessError):
             self.machine.run(["ls", "NullDirectory"])
 
         # Check = False to see if stderr and returncode have the expected values


### PR DESCRIPTION
Let's centralize the usage of suppress_stacktrace() to run_verb()
and make sure we properly propagate the returncode of the command
that failed.