### PR TITLE
ci: Add back shellcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,11 @@ jobs:
         ./tools/generate-zipapp.sh
         ./builddir/mkosi -h
 
+    - name: Test shell scripts
+      run: |
+        sudo apt-get update && sudo apt-get install --no-install-recommends shellcheck
+        bash -c 'shopt -s globstar; shellcheck **/*.sh'
+
   integration-test:
     runs-on: ubuntu-20.04
     needs: unit-test


### PR DESCRIPTION
Turns out the globbing wasn't done quite right. Fixed the globbing
so it applies to all shell scripts in the mkosi repository.