### PR TITLE
Make MkosiArgs.environment a dictionary

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3404,9 +3404,12 @@ def run_postinst_script(
                 raise ValueError("Parameter 'loopdev' required for bootable images.")
             nspawn_params += nspawn_params_for_blockdev_access(args, loopdev)
 
-        run_workspace_command(
-            args, root, ["/root/postinst", verb], network=(args.with_network is True), nspawn_params=nspawn_params
-        )
+        env = dict(cast(Tuple[str, str], v.split("=", maxsplit=1)) for v in args.environment)
+
+        run_workspace_command(args, root, ["/root/postinst", verb],
+                              network=(args.with_network is True),
+                              nspawn_params=nspawn_params,
+                              env=env)
         root_home(args, root).joinpath("postinst").unlink()
 
 

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -440,7 +440,7 @@ class MkosiArgs:
     skeleton_trees: List[Path]
     clean_package_metadata: Union[bool, str]
     remove_files: List[Path]
-    environment: List[str]
+    environment: Dict[str, str]
     build_sources: Optional[Path]
     build_dir: Optional[Path]
     include_dir: Optional[Path]
@@ -584,7 +584,7 @@ def nspawn_params_for_blockdev_access(args: MkosiArgs, loopdev: Path) -> List[st
         if path and path.exists():
             params += [f"--bind-ro={path}", f"--property=DeviceAllow={path}"]
 
-    params += [f"--setenv={env}" for env in args.environment]
+    params += [f"--setenv={env}={value}" for env, value in args.environment.items()]
 
     return params
 

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -27,6 +27,7 @@ from typing import (
     Dict,
     Iterator,
     List,
+    Mapping,
     NoReturn,
     Optional,
     Sequence,
@@ -606,7 +607,7 @@ def run_workspace_command(
     root: Path,
     cmd: Sequence[PathString],
     network: bool = False,
-    env: Optional[Dict[str, str]] = None,
+    env: Optional[Mapping[str, str]] = None,
     nspawn_params: Optional[List[str]] = None,
     capture_stdout: bool = False,
 ) -> Optional[str]:


### PR DESCRIPTION
This is a possible followup to #938 (and contains its commit) to make `MkosiArgs.environment` a dictionary of environment variable names and their values instead of the list of strings it currently is.

I guess it would be nicer to do the handling as an argparse action, but having it, like it is now, in `load_args` is shorter.