### PR TITLE
Reuse machine ID when re-using a cached image

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1683,6 +1683,8 @@ def root_home(args: MkosiArgs, root: Path) -> Path:
 
 def prepare_tree(args: MkosiArgs, root: Path, do_run_build_script: bool, cached: bool) -> None:
     if cached:
+        # Reuse machine-id from cached image.
+        args.machine_id = uuid.UUID(root.joinpath("etc/machine-id").read_text().strip()).hex
         return
 
     with complete_step("Setting up basic OS tree…"):


### PR DESCRIPTION
4fb53aea9e04b931cccedf1545831e426d6ec2f7 broke incremental builds
for bootable Fedora images because when building the cached image,
the initrd is installed to "/efi/<machine-id>/...", and when doing
a cached build, a new machine ID is generated inside mkosi (but not
written to /etc/machine-id), making gen_kernel_images() unable to
find the initrd.

Let's fix the issue by re-using the machine ID from /etc/machine-id
when doing a cached build.

In the future, we can use the new entry-token feature of bootctl to
have kernel-install write to directory in /efi that's not tied to
the machine ID but until that's widely available this will have to
do.