### PR TITLE
Add --repository-directory option

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -314,13 +314,21 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 
 `UseHostRepositories=`, `--use-host-repositories`
 
-: This option is only applicable for dnf-based distributions:
+: This option is only applicable for RPM-based distributions:
   *CentOS*, *Fedora Linux*, *Mageia*, *Photon*, *Rocky Linux*, *Alma Linux*
   and *OpenMandriva*.
-  Allows use of the host's existing dnf repositories.
-  By default, a hardcoded set of default dnf repositories is generated and used.
+  Allows use of the host's existing RPM repositories.
+  By default, a hardcoded set of default RPM repositories is generated and used.
   Use `--repositories=` to identify a custom set of repositories to be enabled
   and used for the build.
+
+`RepositoryDirectory`, `--repository-directory`
+
+: This option can (for now) only be used with RPM-based istributions and Arch
+  Linux. It identifies a directory containing extra repository definitions that
+  will be used when installing packages. The files are passed directly to the
+  corresponding package manager and should be written in the format expected by
+  the package manager of the image's distro.
 
 `Architecture=`, `--architecture=`
 
@@ -1507,6 +1515,10 @@ local directory:
   shall be built from the same working directory, as otherwise the
   build result of a preceding run might be copied into a build image
   as part of the source tree (see above).
+
+* The **`mkosi.reposdir/`** directory, if it exists, is automatically
+  used as the repository directory for extra repository files. See
+  the `RepositoryDirectory` option for more information.
 
 All these files are optional.
 

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -168,6 +168,20 @@ class Distribution(enum.Enum):
     def __str__(self) -> str:
         return self.name
 
+def is_rpm_distribution(d: Distribution) -> bool:
+    return d in (
+        Distribution.fedora,
+        Distribution.mageia,
+        Distribution.centos,
+        Distribution.centos_epel,
+        Distribution.photon,
+        Distribution.openmandriva,
+        Distribution.rocky,
+        Distribution.rocky_epel,
+        Distribution.alma,
+        Distribution.alma_epel
+    )
+
 
 class SourceFileTransfer(enum.Enum):
     copy_all = "copy-all"
@@ -404,6 +418,7 @@ class MkosiArgs:
     mirror: Optional[str]
     repositories: List[str]
     use_host_repositories: bool
+    repos_dir: Optional[str]
     architecture: Optional[str]
     output_format: OutputFormat
     manifest_format: List[ManifestFormat]

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -104,6 +104,7 @@ class MkosiConfig:
             "release": None,
             "repositories": [],
             "use_host_repositories": False,
+            "repos_dir": None,
             "base_image": None,
             "root_size": None,
             "secure_boot": False,


### PR DESCRIPTION
The repository directory can contain extra repositories to be
used when installing packages. If mkosi.reposdir/ exists, it's
used as the repository directory unless it's explicitly
specified.

Only supported for rpm based distros and Arch for now. We don't
support Ubuntu/Debian atm because we can't point apt to the
extra repositories directory because apt runs inside the image
compared to dnf and pacman which run outside of the image.