### PR TITLE
centos: Write stream dnf variable file when a stream release is used

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2113,6 +2113,9 @@ def setup_dnf(args: MkosiArgs, root: Path, repos: Sequence[Repo] = ()) -> None:
         option = "repodir" if args.distribution == Distribution.photon else "reposdir"
         default_repos  = f"{option}={workspace(root)} {args.repos_dir if args.repos_dir else ''}"
 
+    vars_dir = workspace(root) / "vars"
+    vars_dir.mkdir(exist_ok=True)
+
     config_file = workspace(root) / "dnf.conf"
     config_file.write_text(
         dedent(
@@ -2120,6 +2123,7 @@ def setup_dnf(args: MkosiArgs, root: Path, repos: Sequence[Repo] = ()) -> None:
             [main]
             gpgcheck={'1' if gpgcheck else '0'}
             {default_repos }
+            varsdir={vars_dir}
             """
         )
     )
@@ -2549,6 +2553,9 @@ def install_centos(args: MkosiArgs, root: Path, do_run_build_script: bool) -> No
         install_centos_repos_new(args, root, epel_release)
     else:
         install_centos_stream_repos(args, root, epel_release)
+
+    if "-stream" in args.release:
+        workspace(root).joinpath("vars/stream").write_text(args.release)
 
     packages = {*args.packages}
     add_packages(args, packages, "centos-release", "systemd")


### PR DESCRIPTION
CentOS Stream SIGs use the $stream variable in their repo files to
identify the current CentOS Stream version. Let's make sure we write
this file so that SIG repo files can be copied into mkosi.reposdir
as is without requiring modifications to make them work.

Example SIG repo file using $stream:
https://git.centos.org/rpms/centos-release-hyperscale/blob/c8s-sig-hyperscale/f/SOURCES/CentOS-Stream-Hyperscale.repo