### PR TITLE
mkosi: add option for adding extra qemu args

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -1117,6 +1117,11 @@ a machine ID.
   should use KVM acceleration. Defaults to yes if the host machine
   supports KVM acceleration, no otherwise.
 
+`QemuArgs=`
+
+: Space-delimited list of additional arguments to pass when invoking
+  qemu.
+
 `NspawnKeepUnit=`, `--nspawn-keep-unit`
 
 : When used, this option instructs underlying calls of systemd-nspawn to

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5692,6 +5692,14 @@ def create_parser() -> ArgumentParserMkosi:
     group.add_argument("--qemu-kvm", action=BooleanAction, help="Configure whether to use KVM or not",
                        default=qemu_check_kvm_support())
     group.add_argument(
+        "--qemu-args",
+        action=SpaceDelimitedListAction,
+        default=[],
+        # Suppress the command line option because it's already possible to pass qemu args as normal
+        # arguments.
+        help=argparse.SUPPRESS,
+    )
+    group.add_argument(
         "--nspawn-keep-unit",
         action=BooleanAction,
         help="If specified, underlying systemd-nspawn containers use the ressources of the current unit."
@@ -6934,7 +6942,8 @@ def print_summary(args: MkosiArgs) -> None:
     MkosiPrinter.info("\nHOST CONFIGURATION:")
     MkosiPrinter.info("        Extra search paths: " + line_join_list(args.extra_search_paths))
     MkosiPrinter.info("             QEMU Headless: " + yes_no(args.qemu_headless))
-    MkosiPrinter.info("              Netdev:       " + yes_no(args.netdev))
+    MkosiPrinter.info("      QEMU Extra Arguments: " + line_join_list(args.qemu_args))
+    MkosiPrinter.info("                    Netdev: " + yes_no(args.netdev))
 
 
 def reuse_cache_tree(
@@ -7796,6 +7805,7 @@ def run_qemu_cmdline(args: MkosiArgs) -> Iterator[List[str]]:
                 "scsi-hd,drive=hd,bootindex=1",
             ]
 
+        cmdline += args.qemu_args
         cmdline += args.cmdline
 
         print_running_cmd(cmdline)

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -518,6 +518,7 @@ class MkosiArgs:
     qemu_smp: str
     qemu_mem: str
     qemu_kvm: bool
+    qemu_args: Sequence[str]
 
     # systemd-nspawn specific options
     nspawn_keep_unit: bool

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -133,6 +133,7 @@ class MkosiConfig:
             "qemu_smp": "2",
             "qemu_mem": "1G",
             "qemu_kvm": mkosi.qemu_check_kvm_support(),
+            "qemu_args": [],
             "nspawn_keep_unit": False,
             "netdev": False,
             "ephemeral": False,


### PR DESCRIPTION
Let's add an option for adding extra options to pass to all our qemu
invocations.

Example: mkosi qemu --qemu-extra="-fw_cfg name=opt/io.systemd.credentials/foo,string=bar"