### PR TITLE
test: squelch asyncion io warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,6 @@ py_version = "37"
 
 [tool.pyright]
 pythonVersion = "3.7"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"


### PR DESCRIPTION
This silences the deprecation warning

> The 'asyncio_mode' default value will change to 'strict' in future, please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.

The difference is whether pytest considers async tests to be asyncio-driven even when they are not marked `@pytest.mark.asyncio` with 'auto' meaning yes, consider them even when not marked, and 'strict' requiring the marking.

This doesn't really make a difference for us, since we don't have any async tests, but it's nevertheless nice to silence the warning, since this warning has really been getting on my nerves. :)