### PR TITLE
mkosi: Force /etc/default/locale to be a symlink to locale.conf

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2836,6 +2836,10 @@ def install_debian_or_ubuntu(args: MkosiArgs, root: Path, *, do_run_build_script
             run_workspace_command(args, root, ["kernel-install", "add", kver, Path("/") / kimg])
 
     root.joinpath("etc/locale.conf").write_text("LANG=C.UTF-8\n")
+    try:
+        root.joinpath("etc/default/locale").unlink()
+    except FileNotFoundError:
+        pass
     root.joinpath("etc/default/locale").symlink_to("/etc/locale.conf")
 
 


### PR DESCRIPTION
If the locales package is installed, /etc/default/locale will exist
in the filesystem already. Let's make sure we handle that properly.