### PR TITLE
Add missing docs

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -115,6 +115,12 @@ The following command line verbs are known:
   `--auto-bump`/`-B` may be used to automatically bump the version
   after each successful build.
 
+`genkey`
+
+: Generate a pair of SecureBoot keys for usage with the
+  `SecureBootKey=`/`--secure-boot-key=` and
+  `SecureBootCertificate=`/`--secure-boot-certificate=` options.
+
 `help`
 
 : This verb is equivalent to the `--help` switch documented below: it

--- a/mkosi.md
+++ b/mkosi.md
@@ -20,6 +20,16 @@ mkosi — Build Bespoke OS Images
 
 `mkosi [options…] qemu`
 
+`mkosi [options…] ssh`
+
+`mkosi [options…] serve`
+
+`mkosi [options…] bump`
+
+`mkosi [options…] genkey`
+
+`mkosi [options…] help`
+
 # DESCRIPTION
 
 `mkosi` is a tool for easily building customized OS images. It's a


### PR DESCRIPTION
Just noticed that I forgot to add a command summary for `genkey` back in the day and while looking at it, I noticed the synopsis was awfully short, tool.