### PR TITLE
py3.11: fix Enum formatting to work with python3.11-a7

### DIFF
--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -256,11 +256,19 @@ class OutputFormat(Parseable, enum.Enum):
     def has_fs_compression(self) -> bool:
         return self.is_squashfs() or self.is_btrfs()
 
+    def __repr__(self) -> str:
+        return Parseable.__repr__(self)
+    def __str__(self) -> str:
+        return Parseable.__str__(self)
 
 class ManifestFormat(Parseable, enum.Enum):
     json      = "json"       # the standard manifest in json format
     changelog = "changelog"  # human-readable text file with package changelogs
 
+    def __repr__(self) -> str:
+        return Parseable.__repr__(self)
+    def __str__(self) -> str:
+        return Parseable.__str__(self)
 
 class PartitionIdentifier(enum.Enum):
     esp        = "esp"

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -90,12 +90,9 @@ ARG_DEBUG: Set[str] = set()
 class Parseable:
     "A mix-in to provide conversions for argparse"
 
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         """Return the member name without the class name"""
         return cast(str, getattr(self, "name"))
-
-    def __str__(self) -> str:
-        return self.__repr__()
 
     @classmethod
     def from_string(cls: Any, name: str) -> Any:
@@ -256,8 +253,6 @@ class OutputFormat(Parseable, enum.Enum):
     def has_fs_compression(self) -> bool:
         return self.is_squashfs() or self.is_btrfs()
 
-    def __repr__(self) -> str:
-        return Parseable.__repr__(self)
     def __str__(self) -> str:
         return Parseable.__str__(self)
 
@@ -265,8 +260,6 @@ class ManifestFormat(Parseable, enum.Enum):
     json      = "json"       # the standard manifest in json format
     changelog = "changelog"  # human-readable text file with package changelogs
 
-    def __repr__(self) -> str:
-        return Parseable.__repr__(self)
     def __str__(self) -> str:
         return Parseable.__str__(self)
 


### PR DESCRIPTION
Something strange is happening with .__repr__() access in python3.11:

```pycon
>>> mkosi.backend.ManifestFormat.mro()
[<enum 'ManifestFormat'>, <class 'mkosi.backend.Parseable'>, <enum 'Enum'>, <class 'object'>]
>>> mkosi.backend.ManifestFormat.changelog.__repr__()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python3.11/enum.py", line 1194, in __repr__
    return "<%s.%s: %s>" % (self.__class__.__name__, self._name_, v_repr(self._value_))
                                                                  ^^^^^^^^^^^^^^^^^^^^
  File "/home/zbyszek/src/mkosi/mkosi/backend.py", line 95, in __repr__
    return cast(str, getattr(self, "name"))
                     ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'name'
```

Enum somehow subverts normal lookup and makes its own __repr__ function be
used, even though Parseable is listed first in MRO. This seems to be related to
PEP 663, which was rejected, and the changes reverted for -a4 [1], but then the revert
was reverted [2].

Let's just sidestep MRO with a method redefinition:

```pycon
>>> mkosi.backend.ManifestFormat.changelog.__repr__
<bound method ManifestFormat.__repr__ of changelog>
>>> mkosi.backend.ManifestFormat.changelog.__repr__()
'changelog'
```

This should work on all python versions. If python3.11 returns to previous
semantics before the final release, we can remove the workaround.

```
[1] commit acf7403f9baea3ae1119fc6b4a3298522188bf96
Author: Ethan Furman <ethan@stoneleaf.us>
Date:   Sat Jan 15 22:41:43 2022 -0800

    bpo-40066:  [Enum] update str() and format() output (GH-30582)

    Undo rejected PEP-663 changes:

    - restore `repr()` to its 3.10 status
    - restore `str()` to its 3.10 status

[2] commit 42a64c03ec5c443f2a5c2ee4284622f5d1f5326c
Author: Victor Stinner <vstinner@python.org>
Date:   Mon Jan 17 13:58:40 2022 +0100

    Revert "bpo-40066:  [Enum] update str() and format() output (GH-30582)" (GH-30632)

    This reverts commit acf7403f9baea3ae1119fc6b4a3298522188bf96.
```