### PR TITLE
debian: include ca-certificates for bootstrap packages

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2742,6 +2742,7 @@ def install_debian_or_ubuntu(args: MkosiArgs, root: Path, *, do_run_build_script
         cmdline: List[PathString] = [
             "debootstrap",
             "--variant=minbase",
+            "--include=ca-certificates",
             "--merged-usr",
             f"--components={','.join(repos)}",
         ]


### PR DESCRIPTION
`apt` throws warnings because it cannot verify the certificates for the security repositories we included recently. We could add this to `extra_packages`, but then `ca-certificates` is missing when we call `apt update` for the first time, so add it to the debootsrap call.

@nickbroon Can you test whether this addresses your issue?

Fixes: #962

