### PR TITLE
add a workaround for missing user= parameter in subprocess.run on python 3.8

### DIFF
--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -764,6 +764,14 @@ def run(
         # output.
         stdout = sys.stderr
 
+    # This is a workaround for copy_git_files, which uses the user= option to
+    # subprocess.run, which is only available starting with Python 3.9
+    # TODO: remove this branch once mkosi defaults to at least Python 3.9
+    if "user" in kwargs and sys.version_info < (3, 9):
+        user = kwargs.pop("user")
+        user = f"#{user}" if isinstance(user, int) else user
+        cmdline = ["sudo", "-u", user] + cmdline
+
     cm = do_delay_interrupt if delay_interrupt else do_noop
     try:
         with cm():


### PR DESCRIPTION
@vt-alt This is a first stab at the issue, can you check whether this resolves it for you?

That being said, this workaround is ugly and I guess once the GA on Ubuntu 22.04 goes out of beta, we should probably ratchet up the minimum Python version to 3.9, this will allow us to remove some other kludges as well.

Fixes: #967