### PR TITLE
Fedora 36: Add pam to the list of packages.

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2304,6 +2304,10 @@ def install_fedora(args: MkosiArgs, root: Path, do_run_build_script: bool) -> No
     if fedora_release_cmp(args.release, "34") < 0:
         add_packages(args, packages, "glibc-minimal-langpack", conditional="glibc")
 
+    # Fedora 36 doesn't include pam by default in his very base installation not allowing logins to the container
+    if fedora_release_cmp(args.release, "36") == 0:
+        add_packages(args, packages, "pam")
+
     if not do_run_build_script and args.bootable:
         add_packages(args, packages, "kernel-core", "kernel-modules", "dracut", "binutils")
         add_packages(args, packages, "systemd-udev", conditional="systemd")

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2304,7 +2304,7 @@ def install_fedora(args: MkosiArgs, root: Path, do_run_build_script: bool) -> No
     if fedora_release_cmp(args.release, "34") < 0:
         add_packages(args, packages, "glibc-minimal-langpack", conditional="glibc")
 
-    # Fedora 36 doesn't include pam by default in his very base installation not allowing logins to the container
+    # Fedora 36 doesn't include pam by default in its base installation, thus not allowing logins to the container
     if fedora_release_cmp(args.release, "36") == 0:
         add_packages(args, packages, "pam")
 


### PR DESCRIPTION
- machinectl shell/login are failing because pam is not present.

Signed-off-by: Eduard Tolosa <edu4rdshl@protonmail.com>