### PR TITLE
Replace references to pacstrap with pacman

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mkosi — Build Bespoke OS Images
 
-A fancy wrapper around `dnf --installroot`, `debootstrap`, `pacstrap`
+A fancy wrapper around `dnf --installroot`, `debootstrap`, `pacman`
 and `zypper` that generates customized disk images with a number of
 bells and whistles.
 

--- a/mkosi.md
+++ b/mkosi.md
@@ -33,7 +33,7 @@ mkosi — Build Bespoke OS Images
 # DESCRIPTION
 
 `mkosi` is a tool for easily building customized OS images. It's a
-fancy wrapper around `dnf --installroot`, `debootstrap`, `pacstrap`
+fancy wrapper around `dnf --installroot`, `debootstrap`, `pacman`
 and `zypper` that may generate disk images with a number of bells and
 whistles.
 
@@ -1297,7 +1297,7 @@ images containing any other distribution, as long as the necessary
 tools are available. Specifically, any distribution that packages
 `debootstrap` may be used to build *Debian* or *Ubuntu* images. Any
 distribution that packages `dnf` may be used to build *Fedora Linux*,
-*Mageia* or *OpenMandriva* images. Any distro that packages `pacstrap` may be used to
+*Mageia* or *OpenMandriva* images. Any distro that packages `pacman` may be used to
 build *Arch Linux* images. Any distribution that packages `zypper` may
 be used to build *openSUSE* images. Any distribution that packages
 `yum` (or the newer replacement `dnf`) may be used to build *CentOS*, *Rocky Linux*,

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2943,7 +2943,7 @@ def install_arch(args: MkosiArgs, root: Path, do_run_build_script: bool) -> None
 
     # Permissions on these directories are all 0o777 because of 'mount --bind'
     # limitations but pacman expects them to be 0o755 so we fix them before
-    # calling pacstrap (except /var/tmp which is 0o1777).
+    # calling pacman (except /var/tmp which is 0o1777).
     fix_permissions_dirs = {
         "boot": 0o755,
         "etc": 0o755,


### PR DESCRIPTION
We call pacman directly these days so let's remove all references
to pacstrap.