### PR TITLE
mkosi: Always use the embedded default version when no release is specified

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,9 @@
   behavior, you can install the kernel-install script manually via a skeleton tree. The original script can be found
   [here](https://github.com/systemd/mkosi/blob/3798eb0c2ebcdf7dac207a559a3cb5a65cdb77b0/mkosi/resources/dracut_unified_kernel_install.sh).
 - Added QemuKvm option to configure whether to use KVM or not when running `mkosi qemu`.
+- mkosi won't default to the same OS release as the host system anymore when the host system uses the same
+  distribution as the image that's being built. Instead, when no release is specified, mkosi will now always
+  default to the default version embedded in mkosi itself.
 
 ## v12
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5801,9 +5801,6 @@ def load_distribution(args: argparse.Namespace) -> argparse.Namespace:
         if args.distribution is None:
             args.distribution = d
 
-        if args.distribution == d and d != Distribution.clear and args.release is None:
-            args.release = r
-
     if args.distribution is None:
         die("Couldn't detect distribution.")
 


### PR DESCRIPTION
Let's not have the host system determine the image distribution release.
Instead, let's always default to the default release embedded within mkosi.
This gives more consistent results when building images for a single distro
regardless of the host distribution.