### PR TITLE
Fix losetup race condition with initializing partition devices

### DIFF
--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -339,6 +339,20 @@ class PartitionTable:
         else:
             return self.first_partition_offset(max_partitions)
 
+    def partition_offset(self, partition: Partition) -> int:
+        offset = self.first_partition_offset()
+
+        for p in self.partitions.values():
+            if p == partition:
+                break
+
+            offset += p.n_sectors * self.sector_size
+
+        return offset
+
+    def partition_size(self, partition: Partition) -> int:
+        return partition.n_sectors * self.sector_size
+
     def footer_size(self, max_partitions: int = 128) -> int:
         # The footer must have enough space for the GPT header (one sector),
         # and the GPT parition entry area. PEA size of 16384 (128 partitions)


### PR DESCRIPTION
This fixes the same issue we've seen in the systemd repo where
using PARTSCAN introduces a race condition with trying to use
the partition device since the kernel initializes the partition
devices asynchronously. To avoid the issue, we initialize partition
devices manually using the BLKPG ioctl(). We also avoid the same
problem on detaching loop devices by removing partition devices
explicitly using the BLKPG ioctl().

See https://github.com/systemd/systemd/pull/22992,
https://github.com/systemd/systemd/pull/23427,
https://github.com/systemd/systemd/issues/23174 and
https://github.com/systemd/systemd/issues/17469 for more context.