### PR TITLE
Fix failure of sfdisk grain detection on Ubuntu

### DIFF
--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -302,7 +302,7 @@ class Partition:
 
 @functools.lru_cache(maxsize=None)
 def sfdisk_grain_is_supported() -> bool:
-    cmd: List[PathString] = ["sfdisk", "--no-reread", "--no-act", "--quiet", "/dev/full"]
+    cmd: List[PathString] = ["sfdisk", "--no-reread", "--quiet", "/dev/full"]
 
     try:
         run(cmd, text=True, input='\n'.join(["label: gpt", "grain: 4096", "quit"]), stderr=subprocess.DEVNULL)


### PR DESCRIPTION
Removing the '--no-act' flag from the call to sfdisk on /dev/full
allows the command to return correctly. Without removing it, Ubuntu
sfdisk 2.37.2 (Jammy 'util-linux') tries to fsync and fails, there-
fore mkosi incorrectly decides that grain is not available, resulting in
failures with later (esp. incremental) disk image manipulations.