### PR TITLE
mkosi: create bmap before compression

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -7448,6 +7448,7 @@ def build_stuff(args: MkosiArgs) -> Manifest:
             MkosiPrinter.print_step("Skipping (second) final image build phase.")
 
         raw = qcow2_output(args, image.raw)
+        bmap = calculate_bmap(args, raw)
         raw = compress_output(args, raw)
         split_root = compress_output(args, image.split_root, ".usr" if args.usr_only else ".root")
         split_verity = compress_output(args, image.split_verity, ".verity")
@@ -7469,7 +7470,6 @@ def build_stuff(args: MkosiArgs) -> Manifest:
             settings,
         )
         signature = calculate_signature(args, checksum)
-        bmap = calculate_bmap(args, raw)
 
         link_output(args, root, raw or image.archive)
         link_output_root_hash_file(args, root_hash_file)


### PR DESCRIPTION
Creation of bmap files needs to take place before any compression
happens, since bmaptool has to know where the "holes" of the image lie.
Compression removes the holes, preventing bmap from recreating the
original raw image. Move the bmap calculation step before the
compression.

Use case: compressed bmap images are very convenient for deploying OS images to remote repositories. These can be flashed directly to e.g. embedded devices or USB installers using `bmaptool copy https://remote/file /dev/sdX`, which streamlines download, decompression and flashing of the image in one go.