### PR TITLE
ci: install cryptography so that pyright stops complaining

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Install
       run: |
-        python3 -m pip install pytest mypy types-cryptography isort pyflakes
+        python3 -m pip install pytest mypy cryptography types-cryptography isort pyflakes
         npm install -g pyright
 
     - name: Check that imports are sorted


### PR DESCRIPTION
Pyright threw a new error in #994 
```
  /home/runner/work/mkosi/mkosi/mkosi/__init__.py:4088:62 - warning: Import "cryptography.hazmat.primitives.serialization.pkcs7" could not be resolved from source (reportMissingModuleSource)
```

Let's see whether this fixes that.