### PR TITLE
arch: Drop locale-gen logic

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2896,22 +2896,6 @@ def run_pacman(root: Path, pacman_conf: Path, packages: Set[str]) -> None:
         run(["gpgconf", "--homedir", root / "etc/pacman.d/gnupg", "--kill", "all"])
 
 
-def patch_locale_gen(args: MkosiArgs, root: Path) -> None:
-    # If /etc/locale.gen exists, uncomment the desired locale and leave the rest of the file untouched.
-    # If it doesn’t exist, just write the desired locale in it.
-    try:
-
-        def _patch_line(line: str) -> str:
-            if line.startswith("#C.UTF-8"):
-                return line[1:]
-            return line
-
-        patch_file(root / "etc/locale.gen", _patch_line)
-
-    except FileNotFoundError:
-        root.joinpath("etc/locale.gen").write_text("C.UTF-8 UTF-8\n")
-
-
 @complete_step("Installing Arch Linux…")
 def install_arch(args: MkosiArgs, root: Path, do_run_build_script: bool) -> None:
     if args.release is not None:
@@ -3077,10 +3061,6 @@ def install_arch(args: MkosiArgs, root: Path, do_run_build_script: bool) -> None
 
     with mount_api_vfs(args, root):
         run_pacman(root, pacman_conf, packages)
-
-    # Make sure the C.UTF-8 locale is available.
-    patch_locale_gen(args, root)
-    run_workspace_command(args, root, ["/usr/bin/locale-gen"])
 
     # Arch still uses pam_securetty which prevents root login into
     # systemd-nspawn containers. See https://bugs.archlinux.org/task/45903.


### PR DESCRIPTION
C.UTF-8 is included by default in the latest glibc package update.