### PR TITLE
mkosi: optimize/fix patching of root part-type uuid

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4177,11 +4177,11 @@ def patch_root_uuid(
     # Use the first 128bit of the root hash as partition UUID of the root partition
     u = uuid.UUID(root_hash[:32])
 
-    with complete_step("Patching root partition UUID…"):
-        part = args.get_partition(PartitionIdentifier.root)
-        assert part is not None
+    part = args.get_partition(PartitionIdentifier.root)
+    assert part is not None
+    part.part_uuid = u
 
-        run(["sfdisk", "--part-uuid", loopdev, str(part.number), str(u)])
+    print('Root partition-type UUID:', u)
 
 
 def extract_partition(


### PR DESCRIPTION
The bug was that the part-type write we did would get overwritten when the
partition table was subsequently rewritten when we were adding the verity and
verity-sig paritions. We don't need to write out the part-type manually, it's
enough to store the right value in our partition list. This makes things a bit
faster too.

We know that if we calculated the verity info, we'll insert a partition soon
after and then it'll get written correctly.

‣  Generating verity hashes…
Root partition-type UUID: 25e87685-6aa9-86be-a9e3-71d020f407fe
‣  Inserting verity partition…

Fixes #997.