### PR TITLE
Drop choices param from --debug option spec

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5973,7 +5973,6 @@ def create_parser() -> ArgumentParserMkosi:
     group.add_argument(
         "--debug",
         action=CommaDelimitedListAction,
-        choices=("run", "build-script", "workspace-command", "disk"),
         default=[],
         help="Turn on debugging output",
     )


### PR DESCRIPTION
Using choices prevents us from passing multiple options so let's drop
it for now.

Fixes #1006