### PR TITLE
Communicate the associated dir in the ESP via /etc/kernel/entry-token

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1835,6 +1835,7 @@ def prepare_tree(args: MkosiArgs, root: Path, do_run_build_script: bool, cached:
             root.joinpath("etc/kernel").mkdir(mode=0o755)
 
             root.joinpath("etc/kernel/cmdline").write_text(" ".join(args.kernel_command_line) + "\n")
+            root.joinpath("etc/kernel/entry-token").write_text(f"{args.machine_id}\n")
 
         if do_run_build_script or args.ssh:
             root_home(args, root).mkdir(mode=0o750)


### PR DESCRIPTION
/etc/kernel/entry-token is the new way introduced in systemd v251 to
identify the directory that kernel-install and bootctl should install
their stuff to. If it exists, bootctl and kernel-install will read it
and use the directory inside to install things to.

Currently, in mkosi, we generate a random machine ID during the build
and use that as the directory under the ESP to install things to. Until
all distros we support get support for /etc/kernel/entry-token, we're
limited to using the machine ID as the directory to install stuff under
in the ESP.

Since the machine ID used during the build is scrubbed from the image,
users don't a way to figure out the directory in the ESP associated
with the rootfs after the build is finished. To fix this, let's write
the machine ID to /etc/kernel/entry-token before it is scrubbed so
that users can read the file to figure out which directory in the ESP
that they should look under to find stuff associated with the
corresponding rootfs.

Fixes #686