### PR TITLE
ci: Show output by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       run: pyright .
 
     - name: Unit Tests
-      run: python3 -m pytest -v tests
+      run: python3 -m pytest -sv tests
 
     - name: Test execution from current working directory
       run: python3 -m mkosi -h
@@ -181,7 +181,7 @@ jobs:
         sync-uri = https://raw.githubusercontent.com/257/binpkgs/main
         EOF
 
-        sudo MKOSI_TEST_DEFAULT_VERB=boot python3 -m pytest -m integration -v tests
+        sudo MKOSI_TEST_DEFAULT_VERB=boot python3 -m pytest -m integration -sv tests
 
     - name: Build/Boot ${{ matrix.distro }}/${{ matrix.format }} UEFI UKI
       run: |
@@ -190,7 +190,7 @@ jobs:
         BootProtocols=uefi
         EOF
 
-        sudo MKOSI_TEST_DEFAULT_VERB=qemu python3 -m pytest -m integration -v tests
+        sudo MKOSI_TEST_DEFAULT_VERB=qemu python3 -m pytest -m integration -sv tests
 
     - name: Build/Boot ${{ matrix.distro }}/${{ matrix.format }} UEFI
       run: |
@@ -200,7 +200,7 @@ jobs:
         WithUnifiedKernelImages=no
         EOF
 
-        sudo MKOSI_TEST_DEFAULT_VERB=qemu python3 -m pytest -m integration -v tests
+        sudo MKOSI_TEST_DEFAULT_VERB=qemu python3 -m pytest -m integration -sv tests
 
     - name: Build/Boot ${{ matrix.distro }}/${{ matrix.format }} BIOS
       run: |
@@ -210,4 +210,4 @@ jobs:
         WithUnifiedKernelImages=no
         EOF
 
-        sudo MKOSI_TEST_DEFAULT_VERB=qemu python3 -m pytest -m integration -v tests
+        sudo MKOSI_TEST_DEFAULT_VERB=qemu python3 -m pytest -m integration -sv tests


### PR DESCRIPTION
Let's have pytest show output even for successful tests. This helps
with debugging issues that aren't related to a failing test (e.g.
why is gentoo slow to build).