### PR TITLE
action: Add stanzas to copy sources to action mkosi config

### DIFF
--- a/action/mkosi.default
+++ b/action/mkosi.default
@@ -20,6 +20,8 @@ Packages=debootstrap
          e2fsprogs
          xfsprogs
          btrfs-progs
+SourceFileTransferFinal=copy-git-others
+BuildSources=..
 
 [Validation]
 QemuHeadless=yes


### PR DESCRIPTION
To be able to run the development version of mkosi in a ubuntu VM,
let's copy the sources into the mkosi config we use to test the
action setup logic.