### PR TITLE
action: Pin systemd-container version

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -27,7 +27,12 @@ runs:
         debootstrap \
         zypper \
         dnf \
-        systemd-container \
+        systemd=249.11-0ubuntu3.3 \
+        systemd-sysv=249.11-0ubuntu3.3 \
+        systemd-container=249.11-0ubuntu3.3 \
+        udev=249.11-0ubuntu3.3 \
+        libsystemd0=249.11-0ubuntu3.3 \
+        libudev1=249.11-0ubuntu3.3 \
         qemu-system-x86 \
         ovmf \
         e2fsprogs \


### PR DESCRIPTION
A faulty metadata update in Github Actions azure mirror for Ubuntu
is causing issues with unmet systemd-container versions. Let's pin
the systemd-container version as a workaround until the issue is
fixed.