### PR TITLE
Add --cache-initrd option

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -645,6 +645,13 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   supported distributions except Clear Linux and this option
   translates to enabling dracut's hostonly option.
 
+`CacheInitrd=`, `--cache-initrd`
+
+: If specified, and incremental mode is used, mkosi will build the initrd
+  in the cache image and reuse it in the final image. Note that this means
+  that any changes that are only applied to the final image and not the
+  cached image won't be included in the initrd.
+
 `UsrOnly=`, `--usr-only`
 
 : If specified, `mkosi` will only add the `/usr/` directory tree

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -448,6 +448,7 @@ class MkosiArgs:
     with_unified_kernel_images: bool
     gpt_first_lba: Optional[int]
     hostonly_initrd: bool
+    cache_initrd: bool
     base_packages: Union[str, bool]
     packages: List[str]
     remove_packages: List[str]

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -140,6 +140,7 @@ class MkosiConfig:
             "ephemeral": False,
             "with_unified_kernel_images": True,
             "hostonly_initrd": False,
+            "cache_initrd": False,
             "ssh": False,
             "ssh_key": None,
             "ssh_timeout": 0,
@@ -288,6 +289,8 @@ class MkosiConfig:
                 ]
             if "HostonlyInitrd" in mk_config_output:
                 self.reference_config[job_name]["hostonly_initrd"] = mk_config_output["HostonlyInitrd"]
+            if "CacheInitrd" in mk_config_output:
+                self.reference_config[job_name]["cache_initrd"] = mk_config_output["CacheInitrd"]
             if "MachineID" in mk_config_output:
                 self.reference_config[job_name]["MachineID"] = mk_config_output["MachineID"]
         if "Packages" in mk_config:


### PR DESCRIPTION
Building initrds is slow, let's add an option that allows building
the initrd as part of a cached image so that's it's only built once
and reused in any final images.