### PR TITLE
Added support for Rolling Rhino Remix (https://rollingrhino.org)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
           - centos_epel
           - debian
           - ubuntu
+          - rolling_rhino
           - fedora
           - rocky_epel
           - alma_epel

--- a/mkosi.md
+++ b/mkosi.md
@@ -297,7 +297,7 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 `Distribution=`, `--distribution=`, `-d`
 
 : The distribution to install in the image. Takes one of the following
-  arguments: `fedora`, `debian`, `ubuntu`, `arch`, `opensuse`,
+  arguments: `fedora`, `debian`, `ubuntu`, `rolling_rhino`, `arch`, `opensuse`,
   `mageia`, `centos`, `centos_epel`, `clear`, `photon`, `openmandriva`, `rocky`,
   `rocky_epel`, `alma`, `alma_epel`. If not specified, defaults to the distribution
    of the host.
@@ -311,7 +311,8 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   Ubuntu, …, e.g. `artful`). If neither this option, nor
   `Distribution=` is specified, defaults to the distribution version
   of the host. If the distribution is specified, defaults to a recent
-  version of it.
+  version of it. For `rolling_rhino` it is recommended to set the release to
+  the latest development version of Ubuntu.
 
 `Mirror=`, `--mirror=`, `-m`
 
@@ -1295,6 +1296,8 @@ following operating systems:
 
 * *Ubuntu*
 
+* *Rolling Rhino*
+
 * *Arch Linux*
 
 * *openSUSE*
@@ -1318,7 +1321,7 @@ following operating systems:
 In theory, any distribution may be used on the host for building
 images containing any other distribution, as long as the necessary
 tools are available. Specifically, any distribution that packages
-`debootstrap` may be used to build *Debian* or *Ubuntu* images. Any
+`debootstrap` may be used to build *Debian*, *Ubuntu* or *Rolling Rhino* images. Any
 distribution that packages `dnf` may be used to build *Fedora Linux*,
 *Mageia* or *OpenMandriva* images. Any distro that packages `pacman` may be used to
 build *Arch Linux* images. Any distribution that packages `zypper` may
@@ -1371,7 +1374,7 @@ local directory:
 
 * The **`mkosi.default`** file provides the default configuration for
   the image building process. For example, it may specify the
-  distribution to use (`fedora`, `ubuntu`, `debian`, `arch`,
+  distribution to use (`fedora`, `ubuntu`, `rolling_rhino`, `debian`, `arch`,
   `opensuse`, `mageia`, `openmandriva`, `gentoo`) for the image, or additional
   distribution packages to install. Note that all options encoded in
   this configuration file may also be set on the command line, and
@@ -1761,9 +1764,9 @@ Hostname=image
 
 # REQUIREMENTS
 
-mkosi is packaged for various distributions: Debian, Ubuntu, Arch
-Linux, Fedora Linux, OpenMandriva, Gentoo. It is usually easiest to use the
-distribution package.
+mkosi is packaged for various distributions: Debian, Ubuntu, Rolling Rhino,
+Arch Linux, Fedora Linux, OpenMandriva, Gentoo. It is usually easiest to use
+the distribution package.
 
 The current version requires systemd 233 (or actually, systemd-nspawn of it).
 

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -151,6 +151,7 @@ class Distribution(enum.Enum):
     alma = 13, PackageType.rpm
     alma_epel = 14, PackageType.rpm
     gentoo = 15, PackageType.ebuild
+    rolling_rhino = 16, PackageType.deb
 
     def __new__(cls, number: int, package_type: PackageType) -> Distribution:
         # This turns the list above into enum entries with .package_type attributes.

--- a/mkosi/resources/convert_to_rolling_rhino.sh
+++ b/mkosi/resources/convert_to_rolling_rhino.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e
+
+cd $(dirname $0)
+[ -d rhino-convert ] && rm -r rhino-convert
+[ -d convert ] && rm -r convert
+
+#TODO: Uncomment when the below PR is merged:
+#
+#   https://github.com/rollingrhinoremix/rhino-convert/pull/2
+#
+#git clone https://github.com/rollingrhinoremix/rhino-convert.git
+
+#TODO: Remove these lines when the above PR is merged
+git clone https://github.com/mcassaniti/rhino-convert.git
+cd rhino-convert
+git checkout origin/convert-vs-creation-directories-v1 > /dev/null 2>&1
+cd ..
+# END lines to remove
+
+# The update process will prompt for confirmation without this option
+echo 'APT::Get::Assume-Yes "yes";' > /etc/apt/apt.conf.d/00-apt-assume-yes
+
+# Silences sudo name resolution errors
+echo "127.0.0.2 $(hostname)" > /etc/hosts
+
+# Convert the OS from Ubuntu to Rhino
+chmod +x rhino-convert/convert.sh
+rhino-convert/convert.sh
+
+# Update the mirror used when it is not the default
+if [ "$MIRROR" != "http://archive.ubuntu.com/ubuntu" ] ; then
+    # Taken from:
+    # https://github.com/rollingrhinoremix/assets/blob/0c5983475a6bc29c51d62135021b4ac51fd2470c/.sources.sh
+
+    cat > /etc/apt/sources.list << EOF
+deb $MIRROR devel main restricted
+deb $MIRROR devel-updates main restricted
+deb $MIRROR devel universe
+deb $MIRROR devel-updates universe
+deb $MIRROR devel multiverse
+deb $MIRROR devel-updates multiverse
+deb $MIRROR devel-backports main restricted universe multiverse
+deb $MIRROR devel-security main restricted
+deb $MIRROR devel-security restricted
+deb $MIRROR devel-security multiverse
+
+EOF
+
+fi
+
+# Update the OS
+source .bash_aliases
+shopt -s expand_aliases
+rhino-init
+rhino-update
+
+rm /etc/hosts
+rm /etc/apt/apt.conf.d/00-apt-assume-yes
+rm -rf rhino-convert
+
+# Remove if rhino-update ever supports caching. See:
+#   https://github.com/rollingrhinoremix/rhino-update/issues/64
+rm -rf $HOME/.rhino


### PR DESCRIPTION
Initial support for Rolling Rhino.

Note:

  * I may have misunderstood when to check `do_run_build_script`
  * Once https://github.com/rollingrhinoremix/rhino-convert/pull/2 is merged then the update process should be just a little bit smoother
  * The basic process is to install the latest Ubuntu development release (kinetic at this time) and run the conversion script provided upstream
  * I'm not associated with the Rolling Rhino project
  * If it speeds things up, I'm happy for changes to be done on my branch directly