### PR TITLE
action: Update systemd-container workaround point release

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -27,12 +27,12 @@ runs:
         debootstrap \
         zypper \
         dnf \
-        systemd=249.11-0ubuntu3.3 \
-        systemd-sysv=249.11-0ubuntu3.3 \
-        systemd-container=249.11-0ubuntu3.3 \
-        udev=249.11-0ubuntu3.3 \
-        libsystemd0=249.11-0ubuntu3.3 \
-        libudev1=249.11-0ubuntu3.3 \
+        systemd=249.11-0ubuntu3.4 \
+        systemd-sysv=249.11-0ubuntu3.4 \
+        systemd-container=249.11-0ubuntu3.4 \
+        udev=249.11-0ubuntu3.4 \
+        libsystemd0=249.11-0ubuntu3.4 \
+        libudev1=249.11-0ubuntu3.4 \
         qemu-system-x86 \
         ovmf \
         e2fsprogs \


### PR DESCRIPTION
The previous one isn't available anymore but the issue isn't fixed
yet so let's update the pinned version to fix the issue for now.