### PR TITLE
RFC: Split v2

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -6103,10 +6103,6 @@ def load_args(args: argparse.Namespace) -> MkosiArgs:
             args.release = "8"
         elif args.distribution == Distribution.mageia:
             args.release = "7"
-        elif args.distribution == Distribution.debian:
-            args.release = "testing"
-        elif args.distribution == Distribution.ubuntu:
-            args.release = "jammy"
         elif args.distribution == Distribution.opensuse:
             args.release = "tumbleweed"
         elif args.distribution == Distribution.photon:
@@ -6115,6 +6111,8 @@ def load_args(args: argparse.Namespace) -> MkosiArgs:
             args.release = "cooker"
         elif args.distribution == Distribution.gentoo:
             args.release = "17.1"
+        elif args.distribution in {Distribution.debian, Distribution.ubuntu}:
+            pass
         else:
             args.release = "rolling"
 
@@ -6168,12 +6166,6 @@ def load_args(args: argparse.Namespace) -> MkosiArgs:
     if args.mirror is None:
         if args.distribution in (Distribution.fedora, Distribution.centos):
             args.mirror = None
-        elif args.distribution == Distribution.debian:
-            args.mirror = "http://deb.debian.org/debian"
-        elif args.distribution == Distribution.ubuntu:
-            args.mirror = "http://archive.ubuntu.com/ubuntu"
-            if platform.machine() == "aarch64":
-                args.mirror = "http://ports.ubuntu.com/"
         elif args.distribution == Distribution.arch and platform.machine() == "aarch64":
             args.mirror = "http://mirror.archlinuxarm.org"
         elif args.distribution == Distribution.opensuse:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -111,6 +111,7 @@ from .backend import (
     workspace,
     write_grub_config,
 )
+from .distributions import DistributionInstaller, configure_dracut
 from .manifest import Manifest
 
 __version__ = "13"
@@ -132,21 +133,6 @@ PathString = Union[Path, str]
 MKOSI_COMMANDS_NEED_BUILD = (Verb.shell, Verb.boot, Verb.qemu, Verb.serve)
 MKOSI_COMMANDS_SUDO = (Verb.build, Verb.clean, Verb.shell, Verb.boot, Verb.qemu, Verb.serve)
 MKOSI_COMMANDS_CMDLINE = (Verb.build, Verb.shell, Verb.boot, Verb.qemu, Verb.ssh)
-
-DRACUT_SYSTEMD_EXTRAS = [
-    "/usr/bin/systemd-repart",
-    "/usr/lib/systemd/system-generators/systemd-veritysetup-generator",
-    "/usr/lib/systemd/system/initrd-root-fs.target.wants/systemd-repart.service",
-    "/usr/lib/systemd/system/initrd-usr-fs.target",
-    "/usr/lib/systemd/system/sysinit.target.wants/veritysetup.target",
-    "/usr/lib/systemd/system/systemd-repart.service",
-    "/usr/lib/systemd/system/systemd-volatile-root.service",
-    "/usr/lib/systemd/system/veritysetup.target",
-    "/usr/lib/systemd/systemd-veritysetup",
-    "/usr/lib/systemd/systemd-volatile-root",
-    "/usr/bin/systemd-ask-password",
-    "/usr/bin/systemd-tty-ask-password-agent"
-]
 
 
 def write_resource(
@@ -1593,46 +1579,6 @@ def mount_cache(args: MkosiArgs, root: Path) -> Iterator[None]:
 
 def umount(where: Path) -> None:
     run(["umount", "--recursive", "-n", where])
-
-
-def configure_dracut(args: MkosiArgs, packages: Set[str], root: Path) -> None:
-    if "dracut" not in packages:
-        return
-
-    dracut_dir = root / "etc/dracut.conf.d"
-    dracut_dir.mkdir(mode=0o755)
-
-    dracut_dir.joinpath('30-mkosi-hostonly.conf').write_text(
-        f'hostonly={yes_no(args.hostonly_initrd)}\n'
-        'hostonly_default_device=no\n'
-    )
-
-    dracut_dir.joinpath("30-mkosi-qemu.conf").write_text('add_dracutmodules+=" qemu "\n')
-
-    with dracut_dir.joinpath("30-mkosi-systemd-extras.conf").open("w") as f:
-        for extra in DRACUT_SYSTEMD_EXTRAS:
-            f.write(f'install_optional_items+=" {extra} "\n')
-
-    if args.hostonly_initrd:
-        dracut_dir.joinpath("30-mkosi-filesystem.conf").write_text(
-            f'filesystems+=" {(args.output_format.needed_kernel_module())} "\n'
-        )
-
-    if args.get_partition(PartitionIdentifier.esp):
-        # These distros need uefi_stub configured explicitly for dracut to find the systemd-boot uefi stub.
-        if args.distribution in (Distribution.ubuntu,
-                                 Distribution.debian,
-                                 Distribution.mageia,
-                                 Distribution.openmandriva,
-                                 Distribution.gentoo):
-            dracut_dir.joinpath("30-mkosi-uefi-stub.conf").write_text(
-                "uefi_stub=/usr/lib/systemd/boot/efi/linuxx64.efi.stub\n"
-            )
-
-        # efivarfs must be present in order to GPT root discovery work
-        dracut_dir.joinpath("30-mkosi-efivarfs.conf").write_text(
-            '[[ $(modinfo -k "$kernel" -F filename efivarfs 2>/dev/null) == /* ]] && add_drivers+=" efivarfs "\n'
-        )
 
 
 def prepare_tree_root(args: MkosiArgs, root: Path) -> None:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -66,6 +66,7 @@ from typing import (
 )
 
 from .backend import (
+    _IO,
     ARG_DEBUG,
     Distribution,
     ManifestFormat,
@@ -80,13 +81,21 @@ from .backend import (
     PartitionTable,
     SourceFileTransfer,
     Verb,
+    add_packages,
+    complete_step,
+    copy_file,
+    copy_file_object,
+    copy_path,
     die,
+    disable_pam_securetty,
     install_grub,
+    install_skeleton_trees,
     is_rpm_distribution,
     nspawn_executable,
     nspawn_params_for_blockdev_access,
     nspawn_rlimit_params,
     nspawn_version,
+    open_close,
     patch_file,
     path_relative_to_cwd,
     run,
@@ -96,14 +105,13 @@ from .backend import (
     should_compress_output,
     spawn,
     tmp_dir,
+    unlink_try_hard,
     var_tmp,
     warn,
     workspace,
     write_grub_config,
 )
 from .manifest import Manifest
-
-complete_step = MkosiPrinter.complete_step
 
 __version__ = "13"
 
@@ -536,127 +544,6 @@ def format_bytes(num_bytes: int) -> str:
     return f"{num_bytes}B"
 
 
-_IOC_NRBITS   =  8  # NOQA: E221,E222
-_IOC_TYPEBITS =  8  # NOQA: E221,E222
-_IOC_SIZEBITS = 14  # NOQA: E221,E222
-_IOC_DIRBITS  =  2  # NOQA: E221,E222
-
-_IOC_NRSHIFT   = 0  # NOQA: E221
-_IOC_TYPESHIFT = _IOC_NRSHIFT + _IOC_NRBITS  # NOQA: E221
-_IOC_SIZESHIFT = _IOC_TYPESHIFT + _IOC_TYPEBITS  # NOQA: E221
-_IOC_DIRSHIFT  = _IOC_SIZESHIFT + _IOC_SIZEBITS  # NOQA: E221
-
-_IOC_NONE  = 0  # NOQA: E221
-_IOC_WRITE = 1  # NOQA: E221
-_IOC_READ  = 2  # NOQA: E221
-
-
-def _IOC(dir_rw: int, type_drv: int, nr: int, argtype: Optional[str] = None) -> int:
-    size = {"int": 4, "size_t": 8}[argtype] if argtype else 0
-    return dir_rw << _IOC_DIRSHIFT | type_drv << _IOC_TYPESHIFT | nr << _IOC_NRSHIFT | size << _IOC_SIZESHIFT
-
-
-def _IOW(type_drv: int, nr: int, size: str) -> int:
-    return _IOC(_IOC_WRITE, type_drv, nr, size)
-
-
-def _IO(type_drv: int, nr: int) -> int:
-    return _IOC(_IOC_NONE, type_drv, nr)
-
-
-FICLONE = _IOW(0x94, 9, "int")
-
-
-@contextlib.contextmanager
-def open_close(path: PathString, flags: int, mode: int = 0o664) -> Iterator[int]:
-    fd = os.open(path, flags | os.O_CLOEXEC, mode)
-    try:
-        yield fd
-    finally:
-        os.close(fd)
-
-
-def _reflink(oldfd: int, newfd: int) -> None:
-    fcntl.ioctl(newfd, FICLONE, oldfd)
-
-
-def copy_fd(oldfd: int, newfd: int) -> None:
-    try:
-        _reflink(oldfd, newfd)
-    except OSError as e:
-        if e.errno not in {errno.EXDEV, errno.EOPNOTSUPP, errno.ENOTTY}:
-            raise
-        # While mypy handles this correctly, Pyright doesn't yet.
-        shutil.copyfileobj(open(oldfd, "rb", closefd=False), cast(Any, open(newfd, "wb", closefd=False)))
-
-
-def copy_file_object(oldobject: BinaryIO, newobject: BinaryIO) -> None:
-    try:
-        _reflink(oldobject.fileno(), newobject.fileno())
-    except OSError as e:
-        if e.errno not in {errno.EXDEV, errno.EOPNOTSUPP, errno.ENOTTY}:
-            raise
-        shutil.copyfileobj(oldobject, newobject)
-
-
-def copy_file(oldpath: PathString, newpath: PathString) -> None:
-    oldpath = Path(oldpath)
-    newpath = Path(newpath)
-
-    if oldpath.is_symlink():
-        src = os.readlink(oldpath)  # TODO: use oldpath.readlink() with python3.9+
-        newpath.symlink_to(src)
-        return
-
-    with open_close(oldpath, os.O_RDONLY) as oldfd:
-        st = os.stat(oldfd)
-
-        try:
-            with open_close(newpath, os.O_WRONLY | os.O_CREAT | os.O_EXCL, st.st_mode) as newfd:
-                copy_fd(oldfd, newfd)
-        except FileExistsError:
-            newpath.unlink()
-            with open_close(newpath, os.O_WRONLY | os.O_CREAT, st.st_mode) as newfd:
-                copy_fd(oldfd, newfd)
-    shutil.copystat(oldpath, newpath, follow_symlinks=False)
-
-
-def symlink_f(target: str, path: Path) -> None:
-    try:
-        path.symlink_to(target)
-    except FileExistsError:
-        os.unlink(path)
-        path.symlink_to(target)
-
-
-def copy_path(oldpath: PathString, newpath: Path, *, copystat: bool = True) -> None:
-    try:
-        newpath.mkdir(exist_ok=True)
-    except FileExistsError:
-        # something that is not a directory already exists
-        newpath.unlink()
-        newpath.mkdir()
-
-    for entry in os.scandir(oldpath):
-        newentry = newpath / entry.name
-        if entry.is_dir(follow_symlinks=False):
-            copy_path(entry.path, newentry)
-        elif entry.is_symlink():
-            target = os.readlink(entry.path)
-            symlink_f(target, newentry)
-            shutil.copystat(entry.path, newentry, follow_symlinks=False)
-        else:
-            st = entry.stat(follow_symlinks=False)
-            if stat.S_ISREG(st.st_mode):
-                copy_file(entry.path, newentry)
-            else:
-                print("Ignoring", entry.path)
-                continue
-
-    if copystat:
-        shutil.copystat(oldpath, newpath, follow_symlinks=True)
-
-
 @complete_step("Detaching namespace")
 def init_namespace(args: MkosiArgs) -> None:
     unshare(CLONE_NEWNS)
@@ -679,24 +566,6 @@ def setup_workspace(args: MkosiArgs) -> TempDir:
 def btrfs_subvol_create(path: Path, mode: int = 0o755) -> None:
     with set_umask(~mode & 0o7777):
         run(["btrfs", "subvol", "create", path])
-
-
-def btrfs_subvol_delete(path: Path) -> None:
-    # Extract the path of the subvolume relative to the filesystem
-    c = run(["btrfs", "subvol", "show", path], stdout=PIPE, stderr=DEVNULL, text=True)
-    subvol_path = c.stdout.splitlines()[0]
-    # Make the subvolume RW again if it was set RO by btrfs_subvol_delete
-    run(["btrfs", "property", "set", path, "ro", "false"])
-    # Recursively delete the direct children of the subvolume
-    c = run(["btrfs", "subvol", "list", "-o", path], stdout=PIPE, stderr=DEVNULL, text=True)
-    for line in c.stdout.splitlines():
-        if not line:
-            continue
-        child_subvol_path = line.split(" ", 8)[-1]
-        child_path = path / cast(str, os.path.relpath(child_subvol_path, subvol_path))
-        btrfs_subvol_delete(child_path)
-    # Delete the subvolume now that all its descendants have been deleted
-    run(["btrfs", "subvol", "delete", path], stdout=DEVNULL, stderr=DEVNULL)
 
 
 def btrfs_subvol_make_ro(path: Path, b: bool = True) -> None:
@@ -1871,15 +1740,6 @@ def prepare_tree(args: MkosiArgs, root: Path, do_run_build_script: bool, cached:
             root.joinpath("etc/systemd/network").mkdir(mode=0o755)
 
 
-def disable_pam_securetty(root: Path) -> None:
-    def _rm_securetty(line: str) -> str:
-        if "pam_securetty.so" in line:
-            return ""
-        return line
-
-    patch_file(root / "etc/pam.d/login", _rm_securetty)
-
-
 def url_exists(url: str) -> bool:
     req = urllib.request.Request(url, method="HEAD")
     try:
@@ -1893,23 +1753,6 @@ def url_exists(url: str) -> bool:
 def make_executable(path: Path) -> None:
     st = path.stat()
     os.chmod(path, st.st_mode | stat.S_IEXEC)
-
-
-def add_packages(
-    args: MkosiArgs, packages: Set[str], *names: str, conditional: Optional[str] = None
-) -> None:
-
-    """Add packages in @names to @packages, if enabled by --base-packages.
-
-    If @conditional is specified, rpm-specific syntax for boolean
-    dependencies will be used to include @names if @conditional is
-    satisfied.
-    """
-    assert args.base_packages is True or args.base_packages is False or args.base_packages == "conditional"
-
-    if args.base_packages is True or (args.base_packages == "conditional" and conditional):
-        for name in names:
-            packages.add(f"({name} if {conditional})" if conditional else name)
 
 
 def sort_packages(packages: Iterable[str]) -> List[str]:
@@ -3561,26 +3404,6 @@ def install_extra_trees(args: MkosiArgs, root: Path, for_cache: bool) -> None:
 
     with complete_step("Copying in extra file trees…"):
         for tree in args.extra_trees:
-            if tree.is_dir():
-                copy_path(tree, root, copystat=False)
-            else:
-                # unpack_archive() groks Paths, but mypy doesn't know this.
-                # Pretend that tree is a str.
-                shutil.unpack_archive(cast(str, tree), root)
-
-
-def install_skeleton_trees(args: MkosiArgs, root: Path, cached: bool, *, late: bool=False) -> None:
-    if not args.skeleton_trees:
-        return
-
-    if cached:
-        return
-
-    if not late and args.distribution in (Distribution.debian, Distribution.ubuntu):
-        return
-
-    with complete_step("Copying in skeleton file trees…"):
-        for tree in args.skeleton_trees:
             if tree.is_dir():
                 copy_path(tree, root, copystat=False)
             else:
@@ -6209,28 +6032,6 @@ def detect_distribution() -> Tuple[Optional[Distribution], Optional[str]]:
         version_id = version_codename or extracted_codename
 
     return d, version_id
-
-
-def unlink_try_hard(path: Optional[PathString]) -> None:
-    if path is None:
-        return
-
-    path = Path(path)
-    try:
-        return path.unlink()
-    except FileNotFoundError:
-        return
-    except Exception:
-        pass
-
-    if shutil.which("btrfs"):
-        try:
-            btrfs_subvol_delete(path)
-            return
-        except Exception:
-            pass
-
-    shutil.rmtree(path)
 
 
 def remove_glob(*patterns: PathString) -> None:

--- a/mkosi/__main__.py
+++ b/mkosi/__main__.py
@@ -4,8 +4,8 @@ import os
 import sys
 from subprocess import CalledProcessError
 
-from . import complete_step, parse_args, run_verb
-from .backend import MkosiException, die
+from . import parse_args, run_verb
+from .backend import MkosiException, complete_step, die
 
 
 def main() -> None:

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -545,6 +545,10 @@ class MkosiArgs:
 
     partition_table: Optional[PartitionTable] = None
 
+    def __post_init__(self) -> None:
+        # this dummy is needed so that post init hooks of subclasses are run
+        pass
+
     def get_partition(self, ident: PartitionIdentifier) -> Optional[Partition]:
         "A shortcut to check that we have a partition table and extract the partition object"
         if self.partition_table is None:

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Set
+
+from ..backend import Distribution, MkosiArgs, PartitionIdentifier
+
+DRACUT_SYSTEMD_EXTRAS = [
+    "/usr/bin/systemd-repart",
+    "/usr/lib/systemd/system-generators/systemd-veritysetup-generator",
+    "/usr/lib/systemd/system/initrd-root-fs.target.wants/systemd-repart.service",
+    "/usr/lib/systemd/system/initrd-usr-fs.target",
+    "/usr/lib/systemd/system/sysinit.target.wants/veritysetup.target",
+    "/usr/lib/systemd/system/systemd-repart.service",
+    "/usr/lib/systemd/system/systemd-volatile-root.service",
+    "/usr/lib/systemd/system/veritysetup.target",
+    "/usr/lib/systemd/systemd-veritysetup",
+    "/usr/lib/systemd/systemd-volatile-root",
+    "/usr/bin/systemd-ask-password",
+    "/usr/bin/systemd-tty-ask-password-agent"
+]
+
+
+def configure_dracut(args: MkosiArgs, packages: Set[str], root: Path) -> None:
+    if "dracut" not in packages:
+        return
+
+    dracut_dir = root / "etc/dracut.conf.d"
+    dracut_dir.mkdir(mode=0o755)
+
+    dracut_dir.joinpath('30-mkosi-hostonly.conf').write_text(
+        f'hostonly={"yes" if args.hostonly_initrd else "no"}\n'
+        'hostonly_default_device=no\n'
+    )
+
+    dracut_dir.joinpath("30-mkosi-qemu.conf").write_text('add_dracutmodules+=" qemu "\n')
+
+    with dracut_dir.joinpath("30-mkosi-systemd-extras.conf").open("w") as f:
+        for extra in DRACUT_SYSTEMD_EXTRAS:
+            f.write(f'install_optional_items+=" {extra} "\n')
+
+    if args.hostonly_initrd:
+        dracut_dir.joinpath("30-mkosi-filesystem.conf").write_text(
+            f'filesystems+=" {(args.output_format.needed_kernel_module())} "\n'
+        )
+
+    if args.get_partition(PartitionIdentifier.esp):
+        # These distros need uefi_stub configured explicitly for dracut to find the systemd-boot uefi stub.
+        if args.distribution in (Distribution.ubuntu,
+                                 Distribution.debian,
+                                 Distribution.mageia,
+                                 Distribution.openmandriva,
+                                 Distribution.gentoo):
+            dracut_dir.joinpath("30-mkosi-uefi-stub.conf").write_text(
+                "uefi_stub=/usr/lib/systemd/boot/efi/linuxx64.efi.stub\n"
+            )
+
+        # efivarfs must be present in order to GPT root discovery work
+        dracut_dir.joinpath("30-mkosi-efivarfs.conf").write_text(
+            '[[ $(modinfo -k "$kernel" -F filename efivarfs 2>/dev/null) == /* ]] && add_drivers+=" efivarfs "\n'
+        )
+
+
+class DistributionInstaller(MkosiArgs):
+    def hook_install_etc_locale(self, root: Path, cached: bool) -> None:
+        pass
+
+    def which_cache_directory(self, root: Path) -> Path:
+        raise NotImplementedError
+
+    def hook_configure_dracut(self, packages: Set[str], root: Path) -> None:
+        pass
+
+    def hook_prepare_tree(self, root: Path, do_run_build_script: bool, cached: bool) -> None:
+        pass
+
+    def hook_rpmdb_fixup(self, root: Path) -> None:
+        pass
+
+    def hook_install(self, root: Path, *, do_run_build_script: bool) -> None:
+        pass
+
+    def which_grub(self) -> str:
+        return "grub"
+
+    def which_kernel_image(self, kernel_version: str) -> Path:
+        return Path("lib/modules") / kernel_version / "vmlinuz"
+
+    def hook_run_kernel_install(self, root: Path, do_run_build_script: bool, for_cache: bool, cached: bool) -> None:
+        pass
+
+    def hook_remove_packages(self, root: Path) -> None:
+        pass

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -48,14 +48,14 @@ def configure_dracut(args: MkosiArgs, packages: Set[str], root: Path) -> None:
 
     if args.get_partition(PartitionIdentifier.esp):
         # These distros need uefi_stub configured explicitly for dracut to find the systemd-boot uefi stub.
-        if args.distribution in (Distribution.ubuntu,
-                                 Distribution.debian,
-                                 Distribution.mageia,
+        if args.distribution in (Distribution.mageia,
                                  Distribution.openmandriva,
                                  Distribution.gentoo):
             dracut_dir.joinpath("30-mkosi-uefi-stub.conf").write_text(
                 "uefi_stub=/usr/lib/systemd/boot/efi/linuxx64.efi.stub\n"
             )
+        elif isinstance(args, DistributionInstaller):
+            args.hook_configure_dracut(packages, root)
 
         # efivarfs must be present in order to GPT root discovery work
         dracut_dir.joinpath("30-mkosi-efivarfs.conf").write_text(
@@ -83,7 +83,7 @@ class DistributionInstaller(MkosiArgs):
         pass
 
     def which_grub(self) -> str:
-        return "grub"
+        return "grub2"
 
     def which_kernel_image(self, kernel_version: str) -> Path:
         return Path("lib/modules") / kernel_version / "vmlinuz"

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -4,7 +4,7 @@ import os
 import shutil
 from pathlib import Path
 from subprocess import PIPE
-from typing import AbstractSet, Any, Iterable, List, Set, cast
+from typing import AbstractSet, Iterable, List, Set, cast
 
 from ..backend import (
     Distribution,
@@ -26,9 +26,6 @@ from ..distributions import DistributionInstaller, configure_dracut
 class DebianInstaller(DistributionInstaller):
     _repos_for_boot: Set[str] = set()
     _kernel_package = "linux-image-amd64"
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
 
     def hook_install_etc_locale(self, root: Path, cached: bool) -> None:
         # Debian/Ubuntu use a different path to store the locale so let's make sure that path is a symlink to

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
+import os
+import shutil
+from pathlib import Path
+from subprocess import PIPE
+from typing import Any, Iterable, List, Set, cast
+
+from ..backend import (
+    Distribution,
+    MkosiArgs,
+    OutputFormat,
+    PartitionIdentifier,
+    PathString,
+    add_packages,
+    complete_step,
+    disable_pam_securetty,
+    install_skeleton_trees,
+    run,
+    run_workspace_command,
+    unlink_try_hard,
+)
+from ..distributions import DistributionInstaller, configure_dracut
+
+
+class DebianInstaller(DistributionInstaller):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+    def hook_install_etc_locale(self, root: Path, cached: bool) -> None:
+        # Debian/Ubuntu use a different path to store the locale so let's make sure that path is a symlink to
+        # etc/locale.conf.
+        try:
+            root.joinpath("etc/default/locale").unlink()
+        except FileNotFoundError:
+            pass
+        root.joinpath("etc/default/locale").symlink_to("../locale.conf")
+
+    def which_cache_directory(self, root: Path) -> Path:
+        return root / "var/cache/apt/archives"
+
+    def hook_configure_dracut(self, packages: Set[str], root: Path) -> None:
+        dracut_dir = root / "etc/dracut.conf.d"
+        dracut_dir.joinpath("30-mkosi-uefi-stub.conf").write_text(
+            "uefi_stub=/usr/lib/systemd/boot/efi/linuxx64.efi.stub\n"
+        )
+
+    def hook_prepare_tree(self, root: Path, do_run_build_script: bool, cached: bool) -> None:
+        # Make sure kernel-install actually runs when needed by creating the machine-id subdirectory
+        # under /boot. For "bios" on Debian/Ubuntu, it's required for grub to pick up the generated
+        # initrd. For "linux", we need kernel-install to run so we can extract the generated initrd
+        # from /boot later.
+        if "bios" in self.boot_protocols:
+            root.joinpath("boot", self.machine_id).mkdir(mode=0o700, exist_ok=True)
+
+    def hook_rpmdb_fixup(self, root: Path) -> None:
+        # On Debian, rpm/dnf ship with a patch to store the rpmdb under ~/
+        # so it needs to be copied back in the right location, otherwise
+        # the rpmdb will be broken. See: https://bugs.debian.org/1004863
+        rpmdb_home = root / "root/.rpmdb"
+        if rpmdb_home.exists():
+            # Take into account the new location in F36
+            rpmdb = root / "usr/lib/sysimage/rpm"
+            if not rpmdb.exists():
+                rpmdb = root / "var/lib/rpm"
+            unlink_try_hard(rpmdb)
+            shutil.move(cast(str, rpmdb_home), rpmdb)
+
+    def hook_install(self, root: Path, *, do_run_build_script: bool) -> None:
+        install_debian_or_ubuntu(self, root, do_run_build_script=do_run_build_script)
+
+    def which_grub(self) -> str:
+        return "/usr/sbin/grub"
+
+    def which_kernel_image(self, kernel_version: str) -> Path:
+        return Path(f"boot/vmlinuz-{kernel_version}")
+
+    def hook_run_kernel_install(self, root: Path, do_run_build_script: bool, for_cache: bool, cached: bool) -> None:
+        run_workspace_command(self, root, ["dpkg-reconfigure", "dracut"])
+
+    def hook_remove_packages(self, root: Path) -> None:
+        if self.remove_packages:
+            with complete_step(f"Removing {len(self.packages)} packages…"):
+                invoke_apt(self, False, root, "purge", ["--auto-remove", *self.remove_packages])
+
+
+# Debian calls their architectures differently, so when calling debootstrap we
+# will have to map to their names
+DEBIAN_ARCHITECTURES = {
+    "x86_64": "amd64",
+    "x86": "i386",
+    "aarch64": "arm64",
+    "armhfp": "armhf",
+}
+
+
+def debootstrap_knows_arg(arg: str) -> bool:
+    return bytes("invalid option", "UTF-8") not in run(["debootstrap", arg], stdout=PIPE, check=False).stdout
+
+
+def invoke_apt(
+    args: MkosiArgs,
+    do_run_build_script: bool,
+    root: Path,
+    command: str,
+    extra: Iterable[str],
+) -> None:
+
+    cmdline = ["/usr/bin/apt-get", "--assume-yes", command, *extra]
+    env = dict(
+        DEBIAN_FRONTEND="noninteractive",
+        DEBCONF_NONINTERACTIVE_SEEN="true",
+        INITRD="No",
+    )
+
+    run_workspace_command(args, root, cmdline, network=True, env=env)
+
+
+def install_debian_or_ubuntu(args: MkosiArgs, root: Path, *, do_run_build_script: bool) -> None:
+    # Either the image builds or it fails and we restart, we don't need safety fsyncs when bootstrapping
+    # Add it before debootstrap, as the second stage already uses dpkg from the chroot
+    dpkg_io_conf = root / "etc/dpkg/dpkg.cfg.d/unsafe_io"
+    os.makedirs(dpkg_io_conf.parent, mode=0o755, exist_ok=True)
+    dpkg_io_conf.write_text("force-unsafe-io\n")
+
+    repos = set(args.repositories) or {"main"}
+    # Ubuntu needs the 'universe' repo to install 'dracut'
+    if args.distribution == Distribution.ubuntu and args.bootable:
+        repos.add("universe")
+
+    # debootstrap fails if a base image is used with an already populated root, so skip it.
+    if args.base_image is None:
+        cmdline: List[PathString] = [
+            "debootstrap",
+            "--variant=minbase",
+            "--include=ca-certificates",
+            "--merged-usr",
+            f"--components={','.join(repos)}",
+        ]
+
+        if args.architecture is not None:
+            debarch = DEBIAN_ARCHITECTURES.get(args.architecture)
+            cmdline += [f"--arch={debarch}"]
+
+        # Let's use --no-check-valid-until only if debootstrap knows it
+        if debootstrap_knows_arg("--no-check-valid-until"):
+            cmdline += ["--no-check-valid-until"]
+
+        assert args.mirror is not None
+        cmdline += [args.release, root, args.mirror]
+        run(cmdline)
+
+    # Install extra packages via the secondary APT run, because it is smarter and can deal better with any
+    # conflicts. dbus and libpam-systemd are optional dependencies for systemd in debian so we include them
+    # explicitly.
+    extra_packages: Set[str] = set()
+    add_packages(args, extra_packages, "systemd", "systemd-sysv", "dbus", "libpam-systemd")
+    extra_packages.update(args.packages)
+
+    if do_run_build_script:
+        extra_packages.update(args.build_packages)
+
+    if not do_run_build_script and args.bootable:
+        add_packages(args, extra_packages, "dracut")
+        configure_dracut(args, extra_packages, root)
+
+        if args.distribution == Distribution.ubuntu:
+            add_packages(args, extra_packages, "linux-generic")
+        else:
+            add_packages(args, extra_packages, "linux-image-amd64")
+
+        if args.get_partition(PartitionIdentifier.bios):
+            add_packages(args, extra_packages, "grub-pc")
+
+        if args.output_format == OutputFormat.gpt_btrfs:
+            add_packages(args, extra_packages, "btrfs-progs")
+
+    if not do_run_build_script and args.ssh:
+        add_packages(args, extra_packages, "openssh-server")
+
+    # Debian policy is to start daemons by default. The policy-rc.d script can be used choose which ones to
+    # start. Let's install one that denies all daemon startups.
+    # See https://people.debian.org/~hmh/invokerc.d-policyrc.d-specification.txt for more information.
+    # Note: despite writing in /usr/sbin, this file is not shipped by the OS and instead should be managed by
+    # the admin.
+    policyrcd = root / "usr/sbin/policy-rc.d"
+    policyrcd.write_text("#!/bin/sh\nexit 101\n")
+    policyrcd.chmod(0o755)
+
+    doc_paths = [
+        "/usr/share/locale",
+        "/usr/share/doc",
+        "/usr/share/man",
+        "/usr/share/groff",
+        "/usr/share/info",
+        "/usr/share/lintian",
+        "/usr/share/linda",
+    ]
+    if not args.with_docs:
+        # Remove documentation installed by debootstrap
+        cmdline = ["/bin/rm", "-rf", *doc_paths]
+        run_workspace_command(args, root, cmdline)
+        # Create dpkg.cfg to ignore documentation on new packages
+        dpkg_nodoc_conf = root / "etc/dpkg/dpkg.cfg.d/01_nodoc"
+        with dpkg_nodoc_conf.open("w") as f:
+            f.writelines(f"path-exclude {d}/*\n" for d in doc_paths)
+
+    if not do_run_build_script and args.bootable and args.with_unified_kernel_images and args.base_image is None:
+        # systemd-boot won't boot unified kernel images generated without a BUILD_ID or VERSION_ID in
+        # /etc/os-release. Build one with the mtime of os-release if we don't find them.
+        with root.joinpath("etc/os-release").open("r+") as f:
+            os_release = f.read()
+            if "VERSION_ID" not in os_release and "BUILD_ID" not in os_release:
+                f.write(f"BUILD_ID=mkosi-{args.release}\n")
+
+    if args.release not in ("testing", "unstable"):
+        if args.distribution == Distribution.ubuntu:
+            updates = f"deb http://archive.ubuntu.com/ubuntu {args.release}-updates {' '.join(repos)}"
+        else:
+            updates = f"deb http://deb.debian.org/debian {args.release}-updates {' '.join(repos)}"
+
+        root.joinpath(f"etc/apt/sources.list.d/{args.release}-updates.list").write_text(f"{updates}\n")
+
+        if args.distribution == Distribution.ubuntu:
+            security = f"deb http://archive.ubuntu.com/ubuntu {args.release}-security {' '.join(repos)}"
+        elif args.release in ("stretch", "buster"):
+            security = f"deb http://security.debian.org/debian-security/ {args.release}/updates main"
+        else:
+            security = f"deb https://security.debian.org/debian-security {args.release}-security main"
+
+        root.joinpath(f"etc/apt/sources.list.d/{args.release}-security.list").write_text(f"{security}\n")
+
+    install_skeleton_trees(args, root, False, late=True)
+
+    invoke_apt(args, do_run_build_script, root, "update", [])
+
+    if args.bootable and not do_run_build_script and args.get_partition(PartitionIdentifier.esp):
+        if run_workspace_command(args, root, ["apt-cache", "search", "--names-only", "^systemd-boot$"],
+                                 capture_stdout=True).stdout.strip() != "":
+            add_packages(args, extra_packages, "systemd-boot")
+
+    invoke_apt(args, do_run_build_script, root, "install", ["--no-install-recommends", *extra_packages])
+
+    policyrcd.unlink()
+    dpkg_io_conf.unlink()
+    if not args.with_docs and args.base_image is not None:
+        # Don't ship dpkg config files in extensions, they belong with dpkg in the base image.
+        dpkg_nodoc_conf.unlink() # type: ignore
+
+    if args.base_image is None:
+        # Debian still has pam_securetty module enabled, disable it in the base image.
+        disable_pam_securetty(root)
+
+    if args.distribution == Distribution.debian and "systemd" in extra_packages:
+        # The default resolv.conf points to 127.0.0.1, and resolved is disabled, fix it in
+        # the base image.
+        root.joinpath("etc/resolv.conf").unlink()
+        root.joinpath("etc/resolv.conf").symlink_to("../run/systemd/resolve/resolv.conf")
+        run(["systemctl", "--root", root, "enable", "systemd-resolved"])

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -4,7 +4,17 @@ import os
 import shutil
 from pathlib import Path
 from subprocess import PIPE
-from typing import AbstractSet, Iterable, List, Set, cast
+from typing import (
+    AbstractSet,
+    ClassVar,
+    Dict,
+    FrozenSet,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    cast,
+)
 
 from ..backend import (
     Distribution,
@@ -24,8 +34,13 @@ from ..distributions import DistributionInstaller, configure_dracut
 
 
 class DebianInstaller(DistributionInstaller):
-    _repos_for_boot: Set[str] = set()
-    _kernel_package = "linux-image-amd64"
+    _default_release: ClassVar[str] = "testing"
+    _default_mirror: ClassVar[Dict[Optional[str], str]] = {
+        "x86_64": "http://deb.debian.org/debian"
+    }
+
+    _repos_for_boot: ClassVar[FrozenSet[str]] = frozenset()
+    _kernel_package: ClassVar[str] = "linux-image-amd64"
 
     def hook_install_etc_locale(self, root: Path, cached: bool) -> None:
         # Debian/Ubuntu use a different path to store the locale so let's make sure that path is a symlink to

--- a/mkosi/distributions/ubuntu.py
+++ b/mkosi/distributions/ubuntu.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
-from typing import AbstractSet, Any
+from typing import AbstractSet
 
 from .debian import DebianInstaller
 
@@ -9,9 +9,6 @@ class UbuntuInstaller(DebianInstaller):
     # Ubuntu needs the 'universe' repo to install 'dracut'
     _repos_for_boot = {"universe"}
     _kernel_package = "linux-generic"
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
 
     def _updates_repo(self, repos: AbstractSet[str]) -> str:
         return f"deb http://archive.ubuntu.com/ubuntu {self.release}-updates {' '.join(repos)}"

--- a/mkosi/distributions/ubuntu.py
+++ b/mkosi/distributions/ubuntu.py
@@ -1,10 +1,20 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
-from typing import Any
+from typing import AbstractSet, Any
 
 from .debian import DebianInstaller
 
 
 class UbuntuInstaller(DebianInstaller):
+    # Ubuntu needs the 'universe' repo to install 'dracut'
+    _repos_for_boot = {"universe"}
+    _kernel_package = "linux-generic"
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+
+    def _updates_repo(self, repos: AbstractSet[str]) -> str:
+        return f"deb http://archive.ubuntu.com/ubuntu {self.release}-updates {' '.join(repos)}"
+
+    def _security_repo(self, repos: AbstractSet[str]) -> str:
+        return f"deb http://archive.ubuntu.com/ubuntu {self.release}-security {' '.join(repos)}"

--- a/mkosi/distributions/ubuntu.py
+++ b/mkosi/distributions/ubuntu.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
+from typing import Any
+
+from .debian import DebianInstaller
+
+
+class UbuntuInstaller(DebianInstaller):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)

--- a/mkosi/distributions/ubuntu.py
+++ b/mkosi/distributions/ubuntu.py
@@ -1,14 +1,21 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
-from typing import AbstractSet
+
+from typing import AbstractSet, ClassVar, Dict, FrozenSet, Optional
 
 from .debian import DebianInstaller
 
 
 class UbuntuInstaller(DebianInstaller):
+    _default_release: ClassVar[str] = "jammy"
+    _default_mirror: ClassVar[Dict[Optional[str], str]] = {
+        "x86_64": "http://archive.ubuntu.com/ubuntu",
+        "aarch64": "http://ports.ubuntu.com/",
+    }
+
     # Ubuntu needs the 'universe' repo to install 'dracut'
-    _repos_for_boot = {"universe"}
-    _kernel_package = "linux-generic"
+    _repos_for_boot: ClassVar[FrozenSet[str]] = frozenset({"universe"})
+    _kernel_package: ClassVar[str] = "linux-generic"
 
     def _updates_repo(self, repos: AbstractSet[str]) -> str:
         return f"deb http://archive.ubuntu.com/ubuntu {self.release}-updates {' '.join(repos)}"

--- a/mkosi/gentoo.py
+++ b/mkosi/gentoo.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Dict, Generator, List, Sequence
 
-from . import copy_path, open_close, unlink_try_hard
 from .backend import (
     ARG_DEBUG,
     MkosiArgs,
@@ -19,8 +18,11 @@ from .backend import (
     MkosiPrinter,
     OutputFormat,
     PartitionIdentifier,
+    copy_path,
     die,
+    open_close,
     run_workspace_command,
+    unlink_try_hard,
 )
 
 ARCHITECTURES = {

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 import mkosi
+import mkosi.backend
 
 
 def test_fedora_release_cmp() -> None:
@@ -30,6 +31,7 @@ def test_strip_suffixes() -> None:
     assert mkosi.strip_suffixes(Path("home.xz/test")) == Path("home.xz/test")
     assert mkosi.strip_suffixes(Path("home.xz/test.txt")) == Path("home.xz/test.txt")
 
+
 def test_copy_file(tmpdir: Path) -> None:
         dir_path = Path(tmpdir)
         file_1 = Path(dir_path) / "file_1.txt"
@@ -38,19 +40,19 @@ def test_copy_file(tmpdir: Path) -> None:
         file_2.touch()
 
         # Copying two empty files.
-        mkosi.copy_file(file_1, file_2)
+        mkosi.backend.copy_file(file_1, file_2)
         assert filecmp.cmp(file_1, file_2)
 
         # Copying content from one file.
         file_1.write_text("Testing copying content from this file to file_2.")
-        mkosi.copy_file(file_1, file_2)
+        mkosi.backend.copy_file(file_1, file_2)
         assert filecmp.cmp(file_1, file_2)
 
         # Giving a non existing path/file.
         with pytest.raises(OSError):
-            mkosi.copy_file("nullFilePath", file_1)
+            mkosi.backend.copy_file("nullFilePath", file_1)
 
         # Copying when there's already content in both files.
         file_2.write_text("Testing copying content from file_1 to file_2, with previous data.")
-        mkosi.copy_file(file_1, file_2)
+        mkosi.backend.copy_file(file_1, file_2)
         assert filecmp.cmp(file_1, file_2)


### PR DESCRIPTION
After the failed attempt in #715 here a new try.

In #715 I did a weird and somewhat futile dance of keeping the distribution specific and `MkosiArgs` classes separate from each other, but this attempt doubles down on `MkosiArgs` and subclasses it in `DistributionInstaller`. The relevant commits to look at this are the second and third commit. 

The second commit introduces `DistributionInstaller` as an empty shell and the third commit ports Debian and Ubuntu over to it, using it as a thin wrapper for the existing functions. Where previously functions would check for `Distribution.debian` they now make an instance check and use whatever hook method the `DistributionInstaller` has there. I'm not invested in the `hook_` and `which_` names, but the `MkosiArgs` attributes are already a pretty big namespace and without some prefix there would be a clash with `remove_packages`. 

Whether we have a regular `MkosiArgs` or `DistributionInstaller` is decided by some importlib magic in `load_args`. If some magic names exist (`FooInstaller` in `mkosi.distributions.foo`) we'll use that `DistributionInstaller` and if that fails we use `MkosiArgs` as a fallback. The idea is to allow for a piecemeal porting from the current way to split modules.

Even with the thin wrapper approach the diff is pretty big, but most is done by the first commit which moves around some code (again in a non-optimal way in terms of what is where, but I guess that's something to solve after getting a split going) so that the imports can still make a DAG (and even so there's the aforementioned importlib hackery).

Just an RFC so far to gather feedback whether this is the way to do this. So far I only build a Debian image with it and looked that it type checks, various other things might be broken.