### PR TITLE
Drop Clear Linux support

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -297,10 +297,10 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 `Distribution=`, `--distribution=`, `-d`
 
 : The distribution to install in the image. Takes one of the following
-  arguments: `fedora`, `debian`, `ubuntu`, `arch`, `opensuse`,
-  `mageia`, `centos`, `centos_epel`, `clear`, `photon`, `openmandriva`, `rocky`,
-  `rocky_epel`, `alma`, `alma_epel`. If not specified, defaults to the distribution
-   of the host.
+  arguments: `fedora`, `debian`, `ubuntu`, `arch`, `opensuse`, `mageia`,
+  `centos`, `centos_epel`, `photon`, `openmandriva`, `rocky`, `rocky_epel`,
+  `alma`, `alma_epel`. If not specified, defaults to the distribution of
+  the host.
 
 `Release=`, `--release=`, `-r`
 
@@ -642,8 +642,8 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 : If specified, mkosi will run the tool to create the initrd such that
   a non-generic initrd is created that will only be able to run on the
   system mkosi is run on. Currently mkosi uses dracut for all
-  supported distributions except Clear Linux and this option
-  translates to enabling dracut's hostonly option.
+  supported distributions and this option translates to enabling dracut's
+  hostonly option.
 
 `CacheInitrd=`, `--cache-initrd`
 
@@ -1302,8 +1302,6 @@ following operating systems:
 * *Mageia*
 
 * *CentOS*
-
-* *Clear Linux*
 
 * *Photon*
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2276,58 +2276,6 @@ def install_photon(args: MkosiArgs, root: Path, do_run_build_script: bool) -> No
     install_packages_tdnf(args, root, packages, gpgpath.exists(), do_run_build_script)
 
 
-@complete_step("Installing Clear Linux…")
-def install_clear(args: MkosiArgs, root: Path, do_run_build_script: bool) -> None:
-    if args.release == "latest":
-        release = "clear"
-    else:
-        release = "clear/" + args.release
-
-    packages = {*args.packages}
-    add_packages(args, packages, "os-core-plus")
-    if do_run_build_script:
-        packages.update(args.build_packages)
-    if not do_run_build_script and args.bootable:
-        add_packages(args, packages, "kernel-native")
-    if not do_run_build_script and args.ssh:
-        add_packages(args, packages, "openssh-server")
-
-    swupd_extract = shutil.which("swupd-extract")
-
-    if swupd_extract is None:
-        die(
-            dedent(
-                """
-                Couldn't find swupd-extract program, download (or update it) it using:
-
-                  go get -u github.com/clearlinux/mixer-tools/swupd-extract
-
-                and it will be installed by default in ~/go/bin/swupd-extract. Also
-                ensure that you have openssl program in your system.
-                """
-            )
-        )
-
-    cmdline: List[PathString] = [swupd_extract, "-output", root]
-    if args.cache_path:
-        cmdline += ["-state", args.cache_path]
-    cmdline += [release, *sort_packages(packages)]
-
-    run(cmdline)
-
-    root.joinpath("etc/resolv.conf").symlink_to("../run/systemd/resolve/resolv.conf")
-
-    # Clear Linux doesn't have a /etc/shadow at install time, it gets created
-    # when the root first logs in. To set the password via mkosi, create one.
-    if not do_run_build_script and args.password is not None:
-        shadow_file = root / "etc/shadow"
-        shadow_file.write_text("root::::::::\n")
-        shadow_file.chmod(0o400)
-        # Password is already empty for root, so no need to reset it later.
-        if args.password == "":
-            args.password = None
-
-
 @complete_step("Installing Fedora Linux…")
 def install_fedora(args: MkosiArgs, root: Path, do_run_build_script: bool) -> None:
     if args.release == "rawhide":
@@ -3279,7 +3227,6 @@ def install_distribution(args: MkosiArgs, root: Path, do_run_build_script: bool,
         Distribution.ubuntu: install_ubuntu,
         Distribution.arch: install_arch,
         Distribution.opensuse: install_opensuse,
-        Distribution.clear: install_clear,
         Distribution.photon: install_photon,
         Distribution.openmandriva: install_openmandriva,
         Distribution.rocky: install_rocky,
@@ -3561,15 +3508,6 @@ def run_finalize_script(args: MkosiArgs, root: Path, do_run_build_script: bool, 
         run([args.finalize_script, verb], env=env)
 
 
-def install_boot_loader_clear(args: MkosiArgs, root: Path, loopdev: Path) -> None:
-    # clr-boot-manager uses blkid in the device backing "/" to
-    # figure out uuid and related parameters.
-    nspawn_params = nspawn_params_for_blockdev_access(args, loopdev)
-
-    cmdline = ["/usr/bin/clr-boot-manager", "update", "-i"]
-    run_workspace_command(args, root, cmdline, nspawn_params=nspawn_params)
-
-
 def install_boot_loader_centos_old_efi(args: MkosiArgs, root: Path, loopdev: Path) -> None:
     nspawn_params = nspawn_params_for_blockdev_access(args, loopdev)
 
@@ -3606,15 +3544,13 @@ def install_boot_loader(
 
     with complete_step("Installing boot loader…"):
         if args.get_partition(PartitionIdentifier.esp):
-            if args.distribution == Distribution.clear:
-                pass
-            elif (args.distribution in (Distribution.centos, Distribution.centos_epel) and
+            if (args.distribution in (Distribution.centos, Distribution.centos_epel) and
                   is_older_than_centos8(args.release)):
                 install_boot_loader_centos_old_efi(args, root, loopdev)
             else:
                 run_workspace_command(args, root, ["bootctl", "install"])
 
-        if args.get_partition(PartitionIdentifier.bios) and args.distribution != Distribution.clear:
+        if args.get_partition(PartitionIdentifier.bios):
             grub = (
                 "grub"
                 if args.distribution in (Distribution.ubuntu,
@@ -3628,9 +3564,6 @@ def install_boot_loader(
                 grub = f"/usr/sbin/{grub}"
 
             install_grub(args, root, loopdev, grub)
-
-        if args.distribution == Distribution.clear:
-            install_boot_loader_clear(args, root, loopdev)
 
 
 def install_extra_trees(args: MkosiArgs, root: Path, for_cache: bool) -> None:
@@ -6281,9 +6214,6 @@ def detect_distribution() -> Tuple[Optional[Distribution], Optional[str]]:
         if m:
             extracted_codename = m.group(1)
 
-    if dist_id == "clear-linux-os":
-        dist_id = "clear"
-
     d: Optional[Distribution] = None
     for the_id in [dist_id, *dist_id_like]:
         d = Distribution.__members__.get(the_id, None)
@@ -6470,10 +6400,7 @@ def find_cache(args: argparse.Namespace) -> None:
 
     if os.path.exists("mkosi.cache/"):
         dirname = args.distribution.name
-
-        # Clear has a release number that can be used, however the
-        # cache is valid (and more efficient) across releases.
-        if args.distribution != Distribution.clear and args.release is not None:
+        if args.release is not None:
             dirname += "~" + args.release
 
         args.cache_path = Path("mkosi.cache", dirname)
@@ -6659,8 +6586,6 @@ def load_args(args: argparse.Namespace) -> MkosiArgs:
             args.release = "jammy"
         elif args.distribution == Distribution.opensuse:
             args.release = "tumbleweed"
-        elif args.distribution == Distribution.clear:
-            args.release = "latest"
         elif args.distribution == Distribution.photon:
             args.release = "3.0"
         elif args.distribution == Distribution.openmandriva:
@@ -6711,13 +6636,6 @@ def load_args(args: argparse.Namespace) -> MkosiArgs:
         epel_release = int(args.release.split(".")[0])
         if epel_release == 8 and args.output_format == OutputFormat.gpt_btrfs:
             die(f"Sorry, Alma {epel_release} does not support btrfs", MkosiNotSupportedException)
-
-    # Remove once https://github.com/clearlinux/clr-boot-manager/pull/238 is merged and available.
-    if args.distribution == Distribution.clear and args.output_format == OutputFormat.gpt_btrfs:
-        die("Sorry, Clear Linux does not support btrfs", MkosiNotSupportedException)
-
-    if args.distribution == Distribution.clear and {"uefi", "bios"}.issubset(args.boot_protocols):
-        die("Sorry, Clear Linux does not support hybrid BIOS/UEFI images", MkosiNotSupportedException)
 
     if shutil.which("bsdtar") and args.distribution == Distribution.openmandriva and args.tar_strip_selinux_context:
         die("Sorry, bsdtar on OpenMandriva is incompatible with --tar-strip-selinux-context", MkosiNotSupportedException)
@@ -6967,7 +6885,7 @@ def load_args(args: argparse.Namespace) -> MkosiArgs:
     if is_generated_root(args) and "bios" in args.boot_protocols:
         die("Sorry, BIOS cannot be combined with --minimize or squashfs filesystems", MkosiNotSupportedException)
 
-    if args.bootable and args.distribution in (Distribution.clear, Distribution.photon):
+    if args.bootable and args.distribution == Distribution.photon:
         die("Sorry, --bootable is not supported on this distro", MkosiNotSupportedException)
 
     if args.verity and not args.with_unified_kernel_images:

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -143,7 +143,6 @@ class Distribution(enum.Enum):
     mageia = 5, PackageType.rpm
     centos = 6, PackageType.rpm
     centos_epel = 7, PackageType.rpm
-    clear = 8, PackageType.bundle
     photon = 9, PackageType.rpm
     openmandriva = 10, PackageType.rpm
     rocky = 11, PackageType.rpm


### PR DESCRIPTION
Due to lack of a maintainer, and deviating from established practices
almost universally (custom bootloader, custom package manager, ...),
it's not productive to keep support for Clear Linux in mkosi. We have
no idea if it works at all, no idea if something we do is going to
break it, and haven't received any feedback from Clear Linux users
for multiple years. Hence let's drop support for Clear Linux from
mkosi to reduce maintenance costs.