### PR TITLE
opensuse: do not attempt to overwrite pam.d/common-auth

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3222,7 +3222,8 @@ def install_opensuse(args: MkosiArgs, root: Path, do_run_build_script: bool) -> 
     run(["zypper", "--root", root, "modifyrepo", "-K", "repo-update"])
 
     if args.password == "":
-        shutil.copy2(root / "usr/etc/pam.d/common-auth", root / "etc/pam.d/common-auth")
+        if not os.path.exists(root / "etc/pam.d/common-auth"):
+            shutil.copy2(root / "usr/etc/pam.d/common-auth", root / "etc/pam.d/common-auth")
 
         def jj(line: str) -> str:
             if "pam_unix.so" in line:


### PR DESCRIPTION
Tumbleweed builds started to fail:

  File /usr/local/lib/python3.10/dist-packages/mkosi/__init__.py, line 3225, in install_opensuse
    shutil.copy2(root / usr/etc/pam.d/common-auth, root / etc/pam.d/common-auth)
  File /usr/lib/python3.10/shutil.py, line 434, in copy2
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File /usr/lib/python3.10/shutil.py, line 254, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '/var/tmp/mkosi-vb08b_gb/root/usr/etc/pam.d/common-auth'

/etc/pam.d/common-auth is already installed now. Do not attempt to
overwrite it if it already exists.