### PR TITLE
Drop bundle package type

### DIFF
--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -110,7 +110,6 @@ class PackageType(enum.Enum):
     rpm = 1
     deb = 2
     pkg = 3
-    bundle = 4
     ebuild = 5
 
 


### PR DESCRIPTION
Unused now that Clear Linux isn't supported anymore