### PR TITLE
Drop Photon support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Support for Clear Linux was dropped. See https://github.com/systemd/mkosi/pull/1037
 for more information.
+- Support for Photon was dropped. See https://github.com/systemd/mkosi/pull/1048
+for more information.
 - The Arch kernel/bootloader pacman hooks were removed. For anyone that still
 wants to use them, they can be found [here](https://github.com/systemd/mkosi/tree/v13/mkosi/resources/arch).
 When building a bios image, /boot/vmlinuz-kver and /boot/initramfs-kver.img are

--- a/mkosi.md
+++ b/mkosi.md
@@ -298,9 +298,8 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 
 : The distribution to install in the image. Takes one of the following
   arguments: `fedora`, `debian`, `ubuntu`, `arch`, `opensuse`, `mageia`,
-  `centos`, `centos_epel`, `photon`, `openmandriva`, `rocky`, `rocky_epel`,
-  `alma`, `alma_epel`. If not specified, defaults to the distribution of
-  the host.
+  `centos`, `centos_epel`, `openmandriva`, `rocky`, `rocky_epel`, `alma`,
+  `alma_epel`. If not specified, defaults to the distribution of the host.
 
 `Release=`, `--release=`, `-r`
 
@@ -329,7 +328,7 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 `UseHostRepositories=`, `--use-host-repositories`
 
 : This option is only applicable for RPM-based distributions:
-  *CentOS*, *Fedora Linux*, *Mageia*, *Photon*, *Rocky Linux*, *Alma Linux*
+  *CentOS*, *Fedora Linux*, *Mageia*, *Rocky Linux*, *Alma Linux*
   and *OpenMandriva*.
   Allows use of the host's existing RPM repositories.
   By default, a hardcoded set of default RPM repositories is generated and used.
@@ -1300,8 +1299,6 @@ following operating systems:
 * *Mageia*
 
 * *CentOS*
-
-* *Photon*
 
 * *OpenMandriva*
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1712,8 +1712,6 @@ def mount_cache(args: MkosiArgs, root: Path) -> Iterator[None]:
             caches = [mount_bind(args.cache_path, root / "var/cache/binpkgs")]
         elif args.distribution == Distribution.opensuse:
             caches = [mount_bind(args.cache_path, root / "var/cache/zypp/packages")]
-        elif args.distribution == Distribution.photon:
-            caches = [mount_bind(args.cache_path / "tdnf", root / "var/cache/tdnf")]
     try:
         yield
     finally:
@@ -2011,16 +2009,6 @@ def clean_rpm_metadata(root: Path, always: bool) -> None:
     clean_paths(root, paths, tool='/bin/rpm', always=always)
 
 
-def clean_tdnf_metadata(root: Path, always: bool) -> None:
-    """Remove tdnf metadata if /usr/bin/tdnf is not present in the image"""
-    paths = [
-        "/var/log/tdnf.*",
-        "/var/cache/tdnf",
-    ]
-
-    clean_paths(root, paths, tool='/usr/bin/tdnf', always=always)
-
-
 def clean_apt_metadata(root: Path, always: bool) -> None:
     """Remove apt metadata if /usr/bin/apt is not present in the image"""
     paths = [
@@ -2059,7 +2047,6 @@ def clean_package_manager_metadata(args: MkosiArgs, root: Path) -> None:
     clean_dnf_metadata(root, always=always)
     clean_yum_metadata(root, always=always)
     clean_rpm_metadata(root, always=always)
-    clean_tdnf_metadata(root, always=always)
     clean_apt_metadata(root, always=always)
     clean_dpkg_metadata(root, always=always)
     # FIXME: implement cleanup for other package managers: swupd, pacman
@@ -2161,50 +2148,6 @@ def install_packages_dnf(
     invoke_dnf(args, root, 'install', packages)
 
 
-def invoke_tdnf(
-    args: MkosiArgs,
-    root: Path,
-    command: str,
-    packages: Set[str],
-    gpgcheck: bool,
-    do_run_build_script: bool,
-) -> None:
-
-    config_file = workspace(root) / "dnf.conf"
-    packages = make_rpm_list(args, packages, do_run_build_script)
-
-    cmdline = [
-        "tdnf",
-        "-y",
-        f"--config={config_file}",
-        f"--releasever={args.release}",
-        f"--installroot={root}",
-    ]
-
-    if args.repositories:
-        cmdline += ["--disablerepo=*"] + [f"--enablerepo={repo}" for repo in args.repositories]
-
-    if not gpgcheck:
-        cmdline += ["--nogpgcheck"]
-
-    cmdline += [command, *sort_packages(packages)]
-
-    with mount_api_vfs(args, root):
-        run(cmdline)
-
-
-def install_packages_tdnf(
-    args: MkosiArgs,
-    root: Path,
-    packages: Set[str],
-    gpgcheck: bool,
-    do_run_build_script: bool,
-) -> None:
-
-    packages = make_rpm_list(args, packages, do_run_build_script)
-    invoke_tdnf(args, root, 'install', packages, gpgcheck, do_run_build_script)
-
-
 class Repo(NamedTuple):
     id: str
     name: str
@@ -2244,8 +2187,7 @@ def setup_dnf(args: MkosiArgs, root: Path, repos: Sequence[Repo] = ()) -> None:
     if args.use_host_repositories:
         default_repos  = ""
     else:
-        option = "repodir" if args.distribution == Distribution.photon else "reposdir"
-        default_repos  = f"{option}={workspace(root)} {args.repos_dir if args.repos_dir else ''}"
+        default_repos  = f"reposdir={workspace(root)} {args.repos_dir if args.repos_dir else ''}"
 
     vars_dir = workspace(root) / "vars"
     vars_dir.mkdir(exist_ok=True)
@@ -2261,25 +2203,6 @@ def setup_dnf(args: MkosiArgs, root: Path, repos: Sequence[Repo] = ()) -> None:
             """
         )
     )
-
-
-@complete_step("Installing Photon…")
-def install_photon(args: MkosiArgs, root: Path, do_run_build_script: bool) -> None:
-    release_url = "baseurl=https://packages.vmware.com/photon/$releasever/photon_release_$releasever_$basearch"
-    updates_url = "baseurl=https://packages.vmware.com/photon/$releasever/photon_updates_$releasever_$basearch"
-    gpgpath = Path("/etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY")
-
-    repos = [Repo("photon", f"VMware Photon OS {args.release} Release", release_url, gpgpath),
-             Repo("photon-updates", f"VMware Photon OS {args.release} Updates", updates_url, gpgpath)]
-
-    setup_dnf(args, root, repos)
-
-    packages = {*args.packages}
-    add_packages(args, packages, "minimal")
-    if not do_run_build_script and args.bootable:
-        add_packages(args, packages, "linux", "initramfs")
-
-    install_packages_tdnf(args, root, packages, gpgpath.exists(), do_run_build_script)
 
 
 def parse_fedora_release(release: str) -> Tuple[str, str]:
@@ -3213,7 +3136,6 @@ def install_distribution(args: MkosiArgs, root: Path, do_run_build_script: bool,
         Distribution.ubuntu: install_ubuntu,
         Distribution.arch: install_arch,
         Distribution.opensuse: install_opensuse,
-        Distribution.photon: install_photon,
         Distribution.openmandriva: install_openmandriva,
         Distribution.rocky: install_rocky,
         Distribution.rocky_epel: install_rocky,
@@ -3234,20 +3156,20 @@ def install_distribution(args: MkosiArgs, root: Path, do_run_build_script: bool,
 def remove_packages(args: MkosiArgs, root: Path) -> None:
     """Remove packages listed in args.remove_packages"""
 
+    if not args.remove_packages:
+        return
+
     remove: Callable[[List[str]], None]
 
-    if (args.distribution.package_type == PackageType.rpm and
-        args.distribution != Distribution.photon):
+    if (args.distribution.package_type == PackageType.rpm):
         remove = lambda p: invoke_dnf(args, root, 'remove', p)
     elif args.distribution.package_type == PackageType.deb:
         remove = lambda p: invoke_apt(args, False, root, "purge", ["--auto-remove", *p])
     else:
-        # FIXME: implement removal for other package managers: tdnf, swupd, pacman
-        return
+        die(f"Removing packages is not supported for {args.distribution}")
 
-    if args.remove_packages:
-        with complete_step(f"Removing {len(args.packages)} packages…"):
-            remove(args.remove_packages)
+    with complete_step(f"Removing {len(args.packages)} packages…"):
+        remove(args.remove_packages)
 
 
 def reset_machine_id(args: MkosiArgs, root: Path, do_run_build_script: bool, for_cache: bool) -> None:
@@ -6570,8 +6492,6 @@ def load_args(args: argparse.Namespace) -> MkosiArgs:
             args.release = "jammy"
         elif args.distribution == Distribution.opensuse:
             args.release = "tumbleweed"
-        elif args.distribution == Distribution.photon:
-            args.release = "3.0"
         elif args.distribution == Distribution.openmandriva:
             args.release = "cooker"
         elif args.distribution == Distribution.gentoo:
@@ -6592,14 +6512,8 @@ def load_args(args: argparse.Namespace) -> MkosiArgs:
         if not args.boot_protocols:
             args.boot_protocols = ["uefi"]
 
-            if args.distribution == Distribution.photon:
-                args.boot_protocols = ["bios"]
-
         if not {"uefi", "bios", "linux"}.issuperset(args.boot_protocols):
             die("Not a valid boot protocol")
-
-        if "uefi" in args.boot_protocols and args.distribution == Distribution.photon:
-            die(f"uefi boot not supported for {args.distribution}", MkosiNotSupportedException)
 
     if args.distribution in (Distribution.centos, Distribution.centos_epel):
         epel_release = parse_epel_release(args.release)
@@ -6868,9 +6782,6 @@ def load_args(args: argparse.Namespace) -> MkosiArgs:
 
     if is_generated_root(args) and "bios" in args.boot_protocols:
         die("Sorry, BIOS cannot be combined with --minimize or squashfs filesystems", MkosiNotSupportedException)
-
-    if args.bootable and args.distribution == Distribution.photon:
-        die("Sorry, --bootable is not supported on this distro", MkosiNotSupportedException)
 
     if args.verity and not args.with_unified_kernel_images:
         die("Sorry, --verity can only be used with unified kernel images", MkosiNotSupportedException)

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -142,7 +142,6 @@ class Distribution(enum.Enum):
     mageia = 5, PackageType.rpm
     centos = 6, PackageType.rpm
     centos_epel = 7, PackageType.rpm
-    photon = 9, PackageType.rpm
     openmandriva = 10, PackageType.rpm
     rocky = 11, PackageType.rpm
     rocky_epel = 12, PackageType.rpm
@@ -168,7 +167,6 @@ def is_rpm_distribution(d: Distribution) -> bool:
         Distribution.mageia,
         Distribution.centos,
         Distribution.centos_epel,
-        Distribution.photon,
         Distribution.openmandriva,
         Distribution.rocky,
         Distribution.rocky_epel,

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -11,7 +11,7 @@ def test_distribution() -> None:
     assert Distribution.fedora.package_type == PackageType.rpm
     assert Distribution.fedora is Distribution.fedora
     assert Distribution.fedora.package_type is not Distribution.debian.package_type
-    assert str(Distribution.photon) == "photon"
+    assert str(Distribution.fedora) == "fedora"
 
 
 def test_set_umask() -> None:


### PR DESCRIPTION
Booting a systemd-nspawn container with a Photon image produced by
mkosi without --netdev waits for 2 minutes until "wait for network
to come online" times out. After logging in there's 3 failed services
in systemctl status. This is without trying to use any of mkosi's
more advanced features.

Bootable images are not supported at all on Photon. Given this and
the broken container support, it's clear that Photon support isn't
really usable at the moment and probably hasn't been for quite a
while (see #664).

Given that Photon has been broken for multiple releases and that
aside form #664, no one has bothered to report concrete issues or
make an attempt to fix the issues aside from a mirror update, this
gives us a pretty clear indication that no one is using or trying
to use mkosi to build Photon images.

Given that none of the existing maintainers are familiar with Photon
(and are likely not interested in doing the effort needed to support
it), let's drop the Photon support from mkosi.