### PR TITLE
Clover experiments

### DIFF
--- a/mkosi/gentoo.py
+++ b/mkosi/gentoo.py
@@ -52,7 +52,6 @@ class Gentoo:
     pkgs_sys: List[str]
     # filesystem packages (dosfstools, btrfs, squashfs, etc)
     pkgs_fs: List[str]
-    grub_platforms: List[str]
     UNINSTALL_IGNORE: List[str]
     root: Path
     portage_cfg_dir: Path
@@ -233,24 +232,18 @@ class Gentoo:
         if args.encrypt:
             self.pkgs_fs += ["cryptsetup", "device-mapper"]
 
-        self.grub_platforms = []
         if not do_run_build_script and args.bootable:
             if args.get_partition(PartitionIdentifier.esp):
                 self.pkgs_boot = ["sys-kernel/installkernel-systemd-boot"]
-            elif args.get_partition(PartitionIdentifier.bios):
-                self.pkgs_boot = ["sys-boot/grub"]
-                self.grub_platforms = ["coreboot", "qemu", "pc"]
             else:
                 self.pkgs_boot = []
 
             self.pkgs_boot += ["sys-kernel/gentoo-kernel-bin",
                                "sys-firmware/edk2-ovmf"]
 
-        # GENTOO_DONTMOVE: self.grub_platforms, for instance, must be set
         self.emerge_vars = {
             "BOOTSTRAP_USE": " ".join(self.portage_use_flags),
             "FEATURES": " ".join(self.portage_features),
-            "GRUB_PLATFORMS": " ".join(self.grub_platforms),
             "UNINSTALL_IGNORE": " ".join(self.UNINSTALL_IGNORE),
             "USE": " ".join(self.portage_use_flags),
         }
@@ -422,7 +415,6 @@ class Gentoo:
 
         self.baselayout_use = package_use.joinpath("baselayout")
         self.baselayout_use.write_text("sys-apps/baselayout build\n")
-        package_use.joinpath("grub").write_text("sys-boot/grub device-mapper truetype\n")
         package_use.joinpath("systemd").write_text(
             # repart for usronly
             dedent(

--- a/mkosi/resources/config.plist
+++ b/mkosi/resources/config.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Boot</key>
+	<dict>
+		<key>DefaultVolume</key>
+		<string>EFI</string>
+		<key>DefaultLoader</key>
+		<string>\EFI\systemd\systemd-bootx64.efi</string>
+		<key>Fast</key>
+		<true/>
+		<key>Debug</key>
+		<true/>
+	</dict>
+	<key>GUI</key>
+	<dict>
+		<key>Custom</key>
+		<dict>
+			<key>Entries</key>
+			<array>
+				<dict>
+					<key>Hidden</key>
+					<false/>
+					<key>Disabled</key>
+					<false/>
+					<key>Image</key>
+					<string>os_arch</string>
+					<key>Volume</key>
+					<string>EFI</string>
+					<key>Path</key>
+					<string>\EFI\systemd\systemd-bootx64.efi</string>
+					<key>Title</key>
+					<string>Arch Linux</string>
+					<key>Type</key>
+					<string>Linux</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
This uses Clover to emulate UEFI on BIOS and to chainload into systemd-boot. It works, but with a few caveats:

- Using qemu virtio disks does not work (qemu hangs on boot)
- Using the qemu serial console without graphical interface does not work (qemu hangs on boot)
- Using -cpu max causes a hardware exception

We can generally work around these but it makes me wonder how well this would work on actual BIOS hardware though.

This is just me experimenting, the code is in no state to be merged.