### PR TITLE
Pass kernel args to systemd when booting in nspawn

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -7865,6 +7865,11 @@ def run_shell_cmdline(args: MkosiArgs, pipe: bool = False, commands: Optional[Se
     if args.source_file_transfer_final == SourceFileTransfer.mount:
         cmdline += [f"--bind={args.build_sources}:/root/src", "--chdir=/root/src"]
 
+    if args.verb == Verb.boot:
+        # kernel cmdline args of the form systemd.xxx= get interpreted by systemd when running in nspawn as
+        # well.
+        cmdline += args.kernel_command_line
+
     if commands or args.cmdline:
         # If the verb is 'shell', args.cmdline contains the command to run.
         # Otherwise, the verb is 'boot', and we assume args.cmdline contains nspawn arguments.


### PR DESCRIPTION
When booting systemd in systemd-nspawn, additional arguments can
be passed to systemd via nspawn's command line. The arguments get
interpreted by systemd in the container as if they were kernel
command line args.

To take advantage of this, let's pass any configured kernel command
line arguments to systemd running in nspawn as well. For example,
this allows using systemd.setenv to set environment variables as
early as possible for both qemu VMs and nspawn containers.