### PR TITLE
Move debian/ubuntu kernel-install workaround to a kernel-install script

### DIFF
--- a/mkosi/resources/dpkg-reconfigure-dracut.install
+++ b/mkosi/resources/dpkg-reconfigure-dracut.install
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+
+COMMAND="${1:?}"
+
+case "$COMMAND" in
+    add)
+        if [ "$#" -ge 5 ]; then
+            # An explicit initrd path was passed so no need to regenerate the default initrd.
+            exit 0
+        fi
+
+        # Running kernel-install on Debian/Ubuntu doesn't regenerate the initramfs. Instead, we can trigger
+        # regeneration of the initramfs via "dpkg-reconfigure dracut".
+        dpkg-reconfigure dracut
+        ;;
+    *)
+        exit 0
+        ;;
+esac


### PR DESCRIPTION
Instead of manually running dpkg-reconfigure dracut in mkosi. Let's
drop in a kernel install script that runs dpkg-reconfigure dracut. We
can install this script as part of the install function and get rid
of a distribution specific check.