### PR TITLE
Fix exception when removing partition after it has been written

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3947,6 +3947,15 @@ def insert_partition(
     with complete_step(f"Inserting partition of {format_bytes(part_size)}{ss}..."):
         args.partition_table.run_sfdisk(loopdev)
 
+        # Required otherwise the partition removal will fail
+        with open(loopdev, 'rb+') as f:
+            ioctl_partition_add(
+                f.fileno(),
+                part.number,
+                args.partition_table.partition_offset(part),
+                args.partition_table.partition_size(part)
+            )
+
     with complete_step("Writing partition..."):
         if ident == PartitionIdentifier.root:
             luks_format_root(args, loopdev, False, False, True)


### PR DESCRIPTION
There is unfortunately some form of delay where the kernel believes that a partition on a loopback device that has just been written to is still in use. Delaying the removal seems to resolve this issue even though it is not pretty.

I've tried without success:

  * Re-working the write and explicitly calling flush() on the loopback device
  * Explicitly calling sync on the loopback device

I'm more than open to suggestions but this seems to work successfully. What is an extra second during a build anyway?

This resolves #1045.