### PR TITLE
Added support for generating an XFS UsrOnly root

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3654,6 +3654,39 @@ def generate_btrfs(args: MkosiArgs, root: Path, label: str, for_cache: bool) -> 
     return f
 
 
+def generate_xfs(args: MkosiArgs, root: Path, label: str, for_cache: bool) -> Optional[BinaryIO]:
+    if args.output_format != OutputFormat.gpt_xfs:
+        return None
+    if for_cache:
+        return None
+
+    @contextlib.contextmanager
+    def get_loopdev(f: BinaryIO) -> Iterator[Path]:
+        c = run(["losetup", "--find", "--show", f.name], stdout=PIPE, text=True)
+        l = Path(c.stdout.strip())
+        try:
+            yield l
+        finally:
+            run(["losetup", "--detach", l])
+
+    with complete_step("Creating xfs root file system…"):
+        f: BinaryIO = cast(
+            BinaryIO,
+            tempfile.NamedTemporaryFile(prefix=".mkosi-mkfs-xfs", dir=os.path.dirname(args.output))
+        )
+
+        f.truncate(args.root_size)
+        run(mkfs_xfs_cmd(label) + [f.name])
+
+        xfs_dir = workspace(root) / "xfs"
+        xfs_dir.mkdir()
+        with get_loopdev(f) as loopdev:
+            with mount_loop(args, loopdev, xfs_dir) as mp:
+                copy_path(root, mp)
+
+    return f
+
+
 def make_generated_root(args: MkosiArgs, root: Path, for_cache: bool) -> Optional[BinaryIO]:
 
     if not is_generated_root(args):
@@ -3662,6 +3695,8 @@ def make_generated_root(args: MkosiArgs, root: Path, for_cache: bool) -> Optiona
     label = "usr" if args.usr_only else "root"
     patched_root = root / "usr" if args.usr_only else root
 
+    if args.output_format == OutputFormat.gpt_xfs:
+        return generate_xfs(args, patched_root, label, for_cache)
     if args.output_format == OutputFormat.gpt_ext4:
         return generate_ext4(args, patched_root, label, for_cache)
     if args.output_format == OutputFormat.gpt_btrfs:


### PR DESCRIPTION
When the options `UsrOnly = yes` and `Format = gpt_xfs` are combined, `mkosi` throws an exception because the FS image is never created or populated. There is no error beforehand that this combination of options is invalid.

The only issue I can see with the code I've added is that XFS doesn't seem to support a minimize option similar to ext4 after the FS is populated.