### PR TITLE
Always define args.architecture and add args.host_architecture

### DIFF
--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -8,6 +8,7 @@ import dataclasses
 import enum
 import math
 import os
+import platform
 import resource
 import shlex
 import shutil
@@ -415,7 +416,7 @@ class MkosiArgs:
     repositories: List[str]
     use_host_repositories: bool
     repos_dir: Optional[str]
-    architecture: Optional[str]
+    architecture: str
     output_format: OutputFormat
     manifest_format: List[ManifestFormat]
     output: Path
@@ -546,6 +547,9 @@ class MkosiArgs:
         if self.partition_table is None:
             return None
         return self.partition_table.partitions.get(ident)
+
+    def architecture_is_native(self) -> bool:
+        return self.architecture == platform.machine()
 
 
 def should_compress_fs(args: Union[argparse.Namespace, MkosiArgs]) -> Union[bool, str]:

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -45,7 +45,7 @@ class MkosiConfig:
         self.reference_config[job_name] = {
             "all": False,
             "all_directory": None,
-            "architecture": None,
+            "architecture": "x86_64",
             "bmap": False,
             "boot_protocols": [],
             "bootable": False,


### PR DESCRIPTION
I've now stumbled over `args.architecture` being `None` multiple times and since we have `args.architecture or platform.machine()` in a few places, I think it makes sense to always define `args.architecture` and default it to `platform.machine()`

There's a few places where we check whether `args.architecture` is different from the host's architecture I added `args.host_architecture` that's not plumbed through to the CLI and which always has the value of `platform.machine()`