### PR TITLE
Use distro~release subdirectories under mkosi.output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,10 @@ for more information.
 wants to use them, they can be found [here](https://github.com/systemd/mkosi/tree/v13/mkosi/resources/arch).
 When building a bios image, /boot/vmlinuz-kver and /boot/initramfs-kver.img are
 now symlinks to the actual files as installed by kernel-install.
+- When mkosi.output/ or mkosi.builddir/ are used, mkosi now creates distro~release
+subdirectories inside these directories for each distro~release combination that
+is built. This allows building for multiple distros without throwing away the results
+of a previous distro build every time.
 
 ## v13
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -6381,16 +6381,30 @@ def args_find_path(args: argparse.Namespace, name: str, path: str, *, as_list: b
         setattr(args, name, [abspath] if as_list else abspath)
 
 
+def find_output(args: argparse.Namespace) -> None:
+    if args.output_dir is not None:
+        return
+
+    if os.path.exists("mkosi.output/"):
+        args.output_dir = Path("mkosi.output", f"{args.distribution}~{args.release}")
+        args.output_dir.mkdir(exist_ok=True)
+
+
+def find_builddir(args: argparse.Namespace) -> None:
+    if args.build_dir is not None:
+        return
+
+    if os.path.exists("mkosi.builddir/"):
+        args.build_dir = Path("mkosi.builddir", f"{args.distribution}~{args.release}")
+        args.build_dir.mkdir(exist_ok=True)
+
+
 def find_cache(args: argparse.Namespace) -> None:
     if args.cache_path is not None:
         return
 
     if os.path.exists("mkosi.cache/"):
-        dirname = args.distribution.name
-        if args.release is not None:
-            dirname += "~" + args.release
-
-        args.cache_path = Path("mkosi.cache", dirname)
+        args.cache_path = Path("mkosi.cache", f"{args.distribution}~{args.release}")
 
 
 def require_private_file(name: str, description: str) -> None:
@@ -6528,13 +6542,11 @@ def load_args(args: argparse.Namespace) -> MkosiArgs:
     args_find_path(args, "nspawn_settings", "mkosi.nspawn")
     args_find_path(args, "build_script", "mkosi.build")
     args_find_path(args, "build_sources", ".")
-    args_find_path(args, "build_dir", "mkosi.builddir/")
     args_find_path(args, "include_dir", "mkosi.includedir/")
     args_find_path(args, "install_dir", "mkosi.installdir/")
     args_find_path(args, "postinst_script", "mkosi.postinst")
     args_find_path(args, "prepare_script", "mkosi.prepare")
     args_find_path(args, "finalize_script", "mkosi.finalize")
-    args_find_path(args, "output_dir", "mkosi.output/")
     args_find_path(args, "workspace_dir", "mkosi.workspace/")
     args_find_path(args, "mksquashfs_tool", "mkosi.mksquashfs-tool", as_list=True)
     args_find_path(args, "repos_dir", "mkosi.reposdir/")
@@ -6628,6 +6640,8 @@ def load_args(args: argparse.Namespace) -> MkosiArgs:
         die("Sorry, bsdtar on OpenMandriva is incompatible with --tar-strip-selinux-context", MkosiNotSupportedException)
 
     find_cache(args)
+    find_output(args)
+    find_builddir(args)
 
     if args.mirror is None:
         if args.distribution in (Distribution.fedora, Distribution.centos):


### PR DESCRIPTION
Currently, when using incremental mode, building for a different
release or distribution means throwing away the cached images for
the previous distribution or release used unless each distro/release
combo is configured with an explicit output directory. Let's try to
be smarter here, by using the same logic as used for the cache path.
We create distro~release subdirectory under mkosi.output/ and use that
as the output directory. This makes sure cached images stay intact
even if we build for a different distribution.

This will end up using slightly more disk space when building for many
different distros when using mkosi.output/, but this should be a good
tradeoff to make regardless. If looking to regain disk space, a user
simply has to remove the output subdirectory for the distros he's not
interested in keeping.