### PR TITLE
Fixed regression when using UsrOnly during initial install

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1841,7 +1841,7 @@ def prepare_tree(args: MkosiArgs, root: Path, do_run_build_script: bool, cached:
             root.joinpath("etc/kernel/entry-token").write_text(f"{args.machine_id}\n")
             root.joinpath("etc/kernel/install.conf").write_text("layout=bls\n")
 
-        if do_run_build_script or args.ssh:
+        if do_run_build_script or args.ssh or args.usr_only:
             root_home(args, root).mkdir(mode=0o750)
 
         if args.ssh and not do_run_build_script:


### PR DESCRIPTION
Several distributions call `run_workspace_command()` during installation and this now requires the root directory that gets bind mounted in to exist. The created directory will be removed anyway since it exists under a temporary workspace.

As an example, the documentation removal when installing a Debian derivative will fail without this change.