### PR TITLE
Force initializing the partition table every time create_image is called

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,15 @@ jobs:
 
         sudo MKOSI_TEST_DEFAULT_VERB=boot python3 -m pytest -m integration -sv tests
 
+    - name: Build ${{ matrix.distro }}/${{ matrix.format }} UsrOnly
+      run: |
+        tee mkosi.default <<- EOF
+        [Output]
+        UsrOnly=True
+        EOF
+
+        sudo mkosi --force build
+
     - name: Build/Boot ${{ matrix.distro }}/${{ matrix.format }} UEFI UKI
       run: |
         tee mkosi.default <<- EOF

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -769,8 +769,8 @@ def root_partition_description(
     return prefix + ' ' + (suffix if suffix is not None else 'Partition')
 
 
-def initialize_partition_table(args: MkosiArgs) -> None:
-    if args.partition_table is not None:
+def initialize_partition_table(args: MkosiArgs, force: bool = False) -> None:
+    if args.partition_table is not None and not force:
         return
 
     if not args.output_format.is_disk():
@@ -809,7 +809,7 @@ def initialize_partition_table(args: MkosiArgs) -> None:
 
 
 def create_image(args: MkosiArgs, for_cache: bool) -> Optional[BinaryIO]:
-    initialize_partition_table(args)
+    initialize_partition_table(args, force=True)
     if args.partition_table is None:
         return None
 

--- a/mkosi/gentoo.py
+++ b/mkosi/gentoo.py
@@ -20,6 +20,7 @@ from .backend import (
     OutputFormat,
     PartitionIdentifier,
     die,
+    root_home,
     run_workspace_command,
 )
 
@@ -501,6 +502,8 @@ class Gentoo:
                                     f"actions={actions} outside stage3")
             emerge_main([*pkgs, *opts, *actions] + PREFIX_OPTS + self.emerge_default_opts)
         else:
+            if args.usr_only:
+                root_home(args, root).mkdir(mode=0o750, exist_ok=True)
 
             cmd = ["/usr/bin/emerge", *pkgs, *self.emerge_default_opts, *opts, *actions]
 


### PR DESCRIPTION
When creating the build and final images `args.partition_table` is not re-initialized which results in a mismatch between the on disk partition layout and the records in memory.

Also added is some testing for UsrOnly.

So what happens without this? I've seen cases where there are two partition table entries, but `args.partition_table.partitions` contains partitions numbered 1 and 3, but no partition 2.

An example table might be:
```
New situation:
Disklabel type: gpt
Disk identifier: C4C5DC42-244D-5241-9EF9-D7B11AC2B1CC

Device         Start      End  Sectors  Size Type
/dev/loop5p1      40  1024039  1024000  500M EFI System
/dev/loop5p2 1024040 26189863 25165824   12G Linux /usr (x86-64)
```

The start of the exception comes from `run(["blkdiscard", '/dev/loop5p3'])` under `insert_partition()`.