### PR TITLE
Allow running qemu as an unprivileged user

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -85,9 +85,6 @@ The following command line verbs are known:
   only supported on images that contain a boot loader, i.e. those
   built with `Bootable=yes` (see below). This command must be executed
   as `root` unless the image already exists and `-f` is not specified.
-  Some qemu arguments (such as those set by `Netdev=yes`) may also
-  prevent qemu from starting when this command is executed by a
-  non-root user.
 
 `ssh`
 

--- a/mkosi.md
+++ b/mkosi.md
@@ -85,6 +85,9 @@ The following command line verbs are known:
   only supported on images that contain a boot loader, i.e. those
   built with `Bootable=yes` (see below). This command must be executed
   as `root` unless the image already exists and `-f` is not specified.
+  Some qemu arguments (such as those set by `Netdev=yes`) may also
+  prevent qemu from starting when this command is executed by a
+  non-root user.
 
 `ssh`
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5005,7 +5005,7 @@ class ArgumentParserMkosi(argparse.ArgumentParser):
                             if cli_arg in action.option_strings:
                                 if isinstance(action, ListAction):
                                     value = value.replace(os.linesep, action.delimiter)
-                        new_arg_strings.extend([cli_arg, value])
+                        new_arg_strings.append(f"{cli_arg}={value}")
             except OSError as e:
                 self.error(str(e))
         # return the modified argument list

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -7806,8 +7806,9 @@ def run_qemu_cmdline(args: MkosiArgs) -> Iterator[List[str]]:
         cmdline += ["-vga", "virtio"]
 
     if args.netdev:
-        if not ensure_networkd(args):
-            # Fall back to usermode networking if the host doesn't have networkd (eg: Debian)
+        if not ensure_networkd(args) or os.getuid() != 0:
+            # Fall back to usermode networking if the host doesn't have networkd (eg: Debian).
+            # Also fall back if running as an unprivileged user, which likely can't set up the tap interface.
             fwd = f",hostfwd=tcp::{args.ssh_port}-:{args.ssh_port}" if args.ssh_port != 22 else ""
             cmdline += ["-nic", f"user,model=virtio-net-pci{fwd}"]
         else:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4719,6 +4719,7 @@ def remove_duplicates(items: List[T]) -> List[T]:
 
 class ListAction(argparse.Action):
     delimiter: str
+    deduplicate: bool = True
 
     def __init__(self, *args: Any, choices: Optional[Iterable[Any]] = None, **kwargs: Any) -> None:
         self.list_choices = choices
@@ -4762,7 +4763,8 @@ class ListAction(argparse.Action):
         else:
             ary.append(values)
 
-        ary = remove_duplicates(ary)
+        if self.deduplicate:
+            ary = remove_duplicates(ary)
         setattr(namespace, self.dest, ary)
 
 
@@ -4776,6 +4778,10 @@ class ColonDelimitedListAction(ListAction):
 
 class SpaceDelimitedListAction(ListAction):
     delimiter = " "
+
+
+class RepeatableSpaceDelimitedListAction(SpaceDelimitedListAction):
+    deduplicate = False
 
 
 class BooleanAction(argparse.Action):
@@ -5688,7 +5694,7 @@ def create_parser() -> ArgumentParserMkosi:
     )
     group.add_argument(
         "--qemu-args",
-        action=SpaceDelimitedListAction,
+        action=RepeatableSpaceDelimitedListAction,
         default=[],
         # Suppress the command line option because it's already possible to pass qemu args as normal
         # arguments.

--- a/mkosi/machine.py
+++ b/mkosi/machine.py
@@ -15,7 +15,7 @@ from typing import Any, Iterator, Optional, Sequence, TextIO, Union
 import pexpect  # type: ignore
 
 from . import (
-    MKOSI_COMMANDS_SUDO,
+    MKOSI_COMMANDS_NEED_BUILD,
     CompletedProcess,
     build_stuff,
     check_native,
@@ -106,7 +106,7 @@ class Machine:
         assert self._serial is not None or self.args.verb == Verb.shell
 
     def build(self) -> None:
-        if self.args.verb in MKOSI_COMMANDS_SUDO:
+        if self.args.verb in MKOSI_COMMANDS_NEED_BUILD + (Verb.build, Verb.clean):
             check_root()
             unlink_output(self.args)
 

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -600,7 +600,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
             "Host": {
                 "ExtraSearchPaths": "search/here:search/there",
                 "QemuHeadless": True,
-                "QemuArgs": "-vga none -device virtio-vga-gl",
+                "QemuArgs": "-device virtio-vga-gl -vga none",
                 "Netdev": True,
             },
         }
@@ -734,7 +734,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
             "Host": {
                 "ExtraSearchPaths": "search/debi",
                 "QemuHeadless": True,
-                "QemuArgs": "-nic user,model=virtio-net-pci",
+                "QemuArgs": "-device virtio-vga-gl,xres=1920,yres=1080 -display sdl,gl=on",
                 "Netdev": True,
             },
         }

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -174,7 +174,7 @@ class MkosiConfig:
                 is_eq = False
         return is_eq
 
-    def _append_list(self, ref_entry: str, new_args: Any, job_name: str = DEFAULT_JOB_NAME, separator: str = ",") -> None:
+    def _append_list(self, ref_entry: str, new_args: Any, job_name: str = DEFAULT_JOB_NAME, separator: str = ",", with_duplicates: bool = False) -> None:
         """Helper function handling comma separated list as supported by mkosi"""
         args_list = []
         if isinstance(new_args, str):
@@ -189,7 +189,7 @@ class MkosiConfig:
             if isinstance(arg, str) and arg.startswith("!"):
                 if arg[1:] in self.reference_config[job_name][ref_entry]:
                     self.reference_config[job_name][ref_entry].remove(arg[1:])
-            elif arg not in self.reference_config[job_name][ref_entry]:
+            elif with_duplicates or arg not in self.reference_config[job_name][ref_entry]:
                 self.reference_config[job_name][ref_entry].append(arg)
 
     @staticmethod
@@ -378,6 +378,8 @@ class MkosiConfig:
                 self._append_list("extra_search_paths", mk_config_host["ExtraSearchPaths"], job_name, ":")
             if "QemuHeadless" in mk_config_host:
                 self.reference_config[job_name]["qemu_headless"] = mk_config_host["QemuHeadless"]
+            if "QemuArgs" in mk_config_host:
+                self._append_list("qemu_args", mk_config_host["QemuArgs"], job_name, " ", with_duplicates=True)
             if "Netdev" in mk_config_host:
                 self.reference_config[job_name]["netdev"] = mk_config_host["Netdev"]
             if "Ephemeral" in mk_config_host:
@@ -598,6 +600,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
             "Host": {
                 "ExtraSearchPaths": "search/here:search/there",
                 "QemuHeadless": True,
+                "QemuArgs": "-vga none -device virtio-vga-gl",
                 "Netdev": True,
             },
         }
@@ -664,6 +667,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
             "Host": {
                 "ExtraSearchPaths": "search/ubu",
                 "QemuHeadless": True,
+                "QemuArgs": "-vga virtio -device usb-kbd -device usb-mouse",
                 "Netdev": True,
             },
         }
@@ -730,6 +734,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
             "Host": {
                 "ExtraSearchPaths": "search/debi",
                 "QemuHeadless": True,
+                "QemuArgs": "-nic user,model=virtio-net-pci",
                 "Netdev": True,
             },
         }


### PR DESCRIPTION
When testing on my system (Wayland/Sway on Arch Linux), I was able to successfully boot an image as an unprivileged user when running `mkosi qemu` with default arguments.

I'd appreciate a sanity check on my changes to the `unlink_output()` handling.  On reading through the code, it seemed to me like the conditionals before and after entering the function were trying to express "do we need a rebuild?" and thus a better fit for `needs_build()` than for `MKOSI_COMMANDS_SUDO`.  I think the new check is equivalent to old checks except that, if the output files don't exist when we start a build, we attempt to unlink them anyway (which seems to be harmless).

Running `mkosi qemu` with `Netdev=true` as an unprivileged user results in qemu being unable to set up the network tunnel and erroring out, and I'm a bit ambivalent about how to deal with that.  Possible approaches:

1. Fall back to usermode networking (I'm not currently sure whether this works, since I haven't set up a SPICE client yet).
2. Let qemu error out and trust the user to figure out what's going on (somewhat unfriendly, especially to less experienced sysadmins).
3. Trigger `check_root()` when `args.netdev` is set.

I also haven't exhaustively checked the other qemu flags mkosi can set to see if any require root privileges, but none of them seem especially likely to.  Obviously users could get into trouble with custom `QemuArgs`, but I think that at that point it's reasonable to expect them to do their own debugging legwork.

This resolves #1076.