### PR TITLE
Fix debian releases w/o updates and security fixes

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2860,7 +2860,7 @@ def install_debian_or_ubuntu(args: MkosiArgs, root: Path, *, do_run_build_script
             if "VERSION_ID" not in os_release and "BUILD_ID" not in os_release:
                 f.write(f"BUILD_ID=mkosi-{args.release}\n")
 
-    if args.release not in ("testing", "unstable"):
+    if args.release not in ("unstable", "sid"):
         if args.distribution == Distribution.ubuntu:
             updates = f"deb http://archive.ubuntu.com/ubuntu {args.release}-updates {' '.join(repos)}"
         else:


### PR DESCRIPTION
Actually Debian testing release has security updates available, metadata are available at these URL:

http://ftp.debian.org/debian/dists/testing-updates/
http://security.debian.org/debian-security/dists/testing-security/

However, sid (the other name of unstable) does not have additional security updates repositories, as fixes land in sid main repository directly.

This PR fixes the set of Debian releases for which the security and updates repositories are not deployed.