### PR TITLE
action: Install dependencies in action repo checkout

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -21,6 +21,7 @@ runs:
 
   - name: Dependencies
     shell: bash
+    working-directory: ${{ github.action_path }}
     run: |
       sudo apt-get update
       sudo apt-get install --assume-yes --no-install-recommends \
@@ -42,7 +43,7 @@ runs:
 
       mkdir -p $BUILDDIR
 
-      sudo -E ${{ github.action_path }}/action/setup-pacman.sh
+      sudo -E action/setup-pacman.sh
       sudo chown -R $USER: $BUILDDIR
 
       sudo pacman-key --init
@@ -73,6 +74,7 @@ runs:
   # systemd-nspawn from v251 from source.
   - name: Update systemd-nspawn
     shell: bash
+    working-directory: ${{ github.action_path }}
     run: |
       echo "deb-src http://archive.ubuntu.com/ubuntu/ $(lsb_release -cs) main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
       sudo apt-get update


### PR DESCRIPTION
Since we symlink systemd-nspawn from the build directory to /usr/bin,
if the directory that nspawn was built in is cleaned up (e.g. via
git clean), systemd-nspawn is gone as well. To make it harder to
accidentally delete systemd-nspawn, let's clone and build all the
dependencies we compile from source in the repo checkout of the
action instead of in the repo of the project that's using the mkosi
action.