### PR TITLE
Skip setting kernel root cmdline parameter for UsrOnly without verity

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4077,7 +4077,8 @@ def install_unified_kernel(
                 option = "usrhash" if args.usr_only else "roothash"
                 boot_options = f"{boot_options} {option}={root_hash}"
             elif partlabel:
-                boot_options = f"{boot_options} root=PARTLABEL={partlabel}"
+                option = "mount.usr" if args.usr_only else "root"
+                boot_options = f"{boot_options} {option}=PARTLABEL={partlabel}"
 
             osrelease = root / "usr/lib/os-release"
             cmdline = workspace(root) / "cmdline"


### PR DESCRIPTION
When an image is built as a /usr only image and does not use verity, the kernel command line should (and already does) contain the parameter `mount.usr`. It should not contain a root parameter since `systemd-repart` and `systemd-gpt-auto-generator` will take care of generating and mounting the root partition.

Without this change the root partition label used on the kernel command line will be invalid.