### PR TITLE
Only check whether a format can be booted if verb == qemu

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -6486,7 +6486,7 @@ def load_args(args: argparse.Namespace) -> MkosiArgs:
             args.release = "rolling"
 
     if args.bootable:
-        if args.output_format in (
+        if args.verb == Verb.qemu and args.output_format in (
             OutputFormat.directory,
             OutputFormat.subvolume,
             OutputFormat.tar,


### PR DESCRIPTION
We can still build these images without any problems, we just can't
boot them, so let's still allow building the images, just not booting
them.