### PR TITLE
Include any files ending in '.install' in package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     license="LGPLv2+",
     python_requires=">=3.7",
     packages = find_packages(".", exclude=["tests"]),
-    package_data = {"": ["*.sh", "*.hook", "*.conf"]},
+    package_data = {"": ["*.sh", "*.hook", "*.conf", "*.install"]},
     include_package_data = True,
     scripts = ["bin/mkosi"],
     cmdclass = { "man": BuildManpage },


### PR DESCRIPTION
This makes sure the new `dpkg-reconfigure-dracut.install` file under resources gets included as package data.

#1060 requires this change and has caused a regression without it.