### PR TITLE
Ignore EBUSY on partition removal

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -984,7 +984,13 @@ def ioctl_partition_add(fd: int, nr: int, start: int, size: int) -> None:
 def ioctl_partition_remove(fd: int, nr: int) -> None:
     bp = blkpg_partition(pno=nr)
     ba = blkpg_ioctl_arg(op=BLKPG_DEL_PARTITION, data=ctypes.addressof(bp), datalen=ctypes.sizeof(bp))
-    fcntl.ioctl(fd, BLKPG, ba)
+    try:
+        fcntl.ioctl(fd, BLKPG, ba)
+    except OSError as e:
+        if e.errno != errno.EBUSY:
+            raise
+        else:
+            warn("Got EBUSY from the kernel while trying to remove partition, ignoring")
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
This can happen just after inserting a partition, probably because
udev starts operating on a device which makes us unable to remove
the partition, let's ignore EBUSY as a workaround until we get a
proper fix