### PR TITLE
CI: Stop on first test failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
         sync-uri = https://raw.githubusercontent.com/257/binpkgs/main
         EOF
 
-        sudo MKOSI_TEST_DEFAULT_VERB=boot python3 -m pytest -m integration -sv tests
+        sudo MKOSI_TEST_DEFAULT_VERB=boot python3 -m pytest --exitfirst -m integration -sv tests
 
     - name: Build ${{ matrix.distro }}/${{ matrix.format }} UsrOnly
       run: |
@@ -203,7 +203,7 @@ jobs:
         QemuBoot=uefi
         EOF
 
-        sudo MKOSI_TEST_DEFAULT_VERB=qemu python3 -m pytest -m integration -sv tests
+        sudo MKOSI_TEST_DEFAULT_VERB=qemu python3 -m pytest --exitfirst -m integration -sv tests
 
     - name: Build/Boot ${{ matrix.distro }}/${{ matrix.format }} UEFI
       run: |
@@ -216,7 +216,7 @@ jobs:
         QemuBoot=uefi
         EOF
 
-        sudo MKOSI_TEST_DEFAULT_VERB=qemu python3 -m pytest -m integration -sv tests
+        sudo MKOSI_TEST_DEFAULT_VERB=qemu python3 -m pytest --exitfirst -m integration -sv tests
 
     - name: Build/Boot ${{ matrix.distro }}/${{ matrix.format }} BIOS
       run: |
@@ -229,7 +229,7 @@ jobs:
         QemuBoot=bios
         EOF
 
-        sudo MKOSI_TEST_DEFAULT_VERB=qemu python3 -m pytest -m integration -sv tests
+        sudo MKOSI_TEST_DEFAULT_VERB=qemu python3 -m pytest --exitfirst -m integration -sv tests
 
     - name: Build/Boot ${{ matrix.distro }}/${{ matrix.format}} QEMU Linux Boot
       run: |
@@ -242,4 +242,4 @@ jobs:
         QemuBoot=linux
         EOF
 
-        sudo MKOSI_TEST_DEFAULT_VERB=qemu python3 -m pytest -m integration -sv tests
+        sudo MKOSI_TEST_DEFAULT_VERB=qemu python3 -m pytest --exitfirst -m integration -sv tests


### PR DESCRIPTION
When one test fails, usually all of them fail, which makes the
output hard to digest, so let's configure pytest to stop on the
first test failure.