### PR TITLE
action: Drop vm-vt workaround

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -44,24 +44,6 @@ runs:
       sudo pacman-key --init
       sudo pacman-key --populate archlinux
 
-      sudo tee /etc/systemd/network/80-vm-vt.network > /dev/null <<- EOF
-      [Match]
-      Name=vt-*
-      Driver=tun
-
-      [Network]
-      # Default to using a /28 prefix, giving up to 13 addresses per VM.
-      Address=0.0.0.0/28
-      LinkLocalAddressing=yes
-      DHCPServer=yes
-      IPMasquerade=yes
-      LLDP=yes
-      EmitLLDP=customer-bridge
-      IPv6PrefixDelegation=yes
-      EOF
-
-      sudo systemctl restart systemd-networkd
-
     env:
       BUILDDIR: build
 


### PR DESCRIPTION
Jammy's systemd version is recent enough that the file is there
already and we don't need to add it ourselves anymore.