### PR TITLE
Add support for mkosi.conf and mkosi.conf.d configuration files/dirs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,9 +165,9 @@ jobs:
 
     - name: Build/Boot ${{ matrix.distro }}/${{ matrix.format }}
       run: |
-        mkdir -p mkosi.default.d
+        mkdir -p mkosi.conf.d
 
-        tee mkosi.default.d/mkosi.default <<- EOF
+        tee mkosi.conf.d/mkosi.conf <<- EOF
         [Distribution]
         Distribution=${{ matrix.distro }}
 
@@ -186,7 +186,7 @@ jobs:
 
     - name: Build ${{ matrix.distro }}/${{ matrix.format }} UsrOnly
       run: |
-        tee mkosi.default <<- EOF
+        tee mkosi.conf <<- EOF
         [Output]
         UsrOnly=True
         EOF
@@ -195,7 +195,7 @@ jobs:
 
     - name: Build/Boot ${{ matrix.distro }}/${{ matrix.format }} UEFI UKI
       run: |
-        tee mkosi.default <<- EOF
+        tee mkosi.conf <<- EOF
         [Output]
         BootProtocols=uefi
 
@@ -207,7 +207,7 @@ jobs:
 
     - name: Build/Boot ${{ matrix.distro }}/${{ matrix.format }} UEFI
       run: |
-        tee mkosi.default <<- EOF
+        tee mkosi.conf <<- EOF
         [Output]
         BootProtocols=uefi
         WithUnifiedKernelImages=no
@@ -220,7 +220,7 @@ jobs:
 
     - name: Build/Boot ${{ matrix.distro }}/${{ matrix.format }} BIOS
       run: |
-        tee mkosi.default <<- EOF
+        tee mkosi.conf <<- EOF
         [Output]
         BootProtocols=bios
         WithUnifiedKernelImages=no
@@ -233,7 +233,7 @@ jobs:
 
     - name: Build/Boot ${{ matrix.distro }}/${{ matrix.format}} QEMU Linux Boot
       run: |
-        tee mkosi.default <<- EOF
+        tee mkosi.conf <<- EOF
         [Output]
         BootProtocols=linux
         WithUnifiedKernelImages=no

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 /mkosi.extra
 /mkosi.nspawn
 /mkosi.rootpw
-/mkosi.default
+/mkosi.conf
 /mkosi.secure-boot.key
 /mkosi.secure-boot.crt
 __pycache__

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,9 @@ now symlinks to the actual files as installed by kernel-install.
 subdirectories inside these directories for each distro~release combination that
 is built. This allows building for multiple distros without throwing away the results
 of a previous distro build every time.
+- The preferred names for mkosi configuration files and directories are now mkosi.conf
+and mkosi.conf.d/ respectively. The old names (mkosi.default and mkosi.default.d) have
+been removed from the docs but are still supported for backwards compatibility.
 
 ## v13
 

--- a/mkosi.md
+++ b/mkosi.md
@@ -44,7 +44,7 @@ The following command line verbs are known:
 `build`
 
 : This builds the image, based on the settings passed in on the
-  command line or read from a `mkosi.default` file. This
+  command line or read from a `mkosi.conf` file. This
   verb is the default if no verb is explicitly specified. This command
   must be executed as `root`. Any arguments passed after `build` are
   passed as arguments to the build script (if there is one).
@@ -58,7 +58,7 @@ The following command line verbs are known:
 `summary`
 
 : Outputs a human-readable summary of all options used for building an
-  image. This will parse the command line and `mkosi.default` file as it
+  image. This will parse the command line and `mkosi.conf` file as it
   would do on `build`, but only output what it is configured for and not
   actually build anything.`
 
@@ -469,7 +469,7 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   images. By default command line arguments get appended. To remove all
   arguments from the current list pass "!\*". To remove specific arguments
   add a space separated list of "!" prefixed arguments.
-  For example adding "!\* console=ttyS0 rw" to a `mkosi.default` file or the
+  For example adding "!\* console=ttyS0 rw" to a `mkosi.conf` file or the
   command line arguments passes "console=ttyS0 rw" to the kernel in any
   case. Just adding "console=ttyS0 rw" would append these two arguments
   to the kernel command line created by lower priority configuration
@@ -731,7 +731,7 @@ a machine ID.
   version and/or architecture, package name globs, paths to packages in the
   file system, package groups, and virtual provides, including file paths.
 
-: To remove a package e.g. added by a `mkosi.default` configuration
+: To remove a package e.g. added by a `mkosi.conf` configuration
   file prepend the package name with `!`. For example -p "!apache2"
   would remove the apache2 package. To replace the apache2 package by
   the httpd package just add -p "!apache2,httpd" to the command line
@@ -1209,13 +1209,13 @@ Those settings cannot be configured in the configuration files.
   option is an effective way to build a project located in a specific
   directory.
 
-`--default=`
+`--config=`
 
 : Loads additional settings from the specified settings file. Most
   command line options may also be configured in a settings file. See
   the table below to see which command line options match which
   settings file option. If this option is not used, but a file
-  `mkosi.default` is found in the local directory it is automatically
+  `mkosi.conf` is found in the local directory it is automatically
   used for this purpose. If a setting is configured both on the
   command line and in the settings file, the command line generally
   wins, except for options taking lists in which case both lists are
@@ -1224,7 +1224,7 @@ Those settings cannot be configured in the configuration files.
 `--all`, `-a`
 
 : Iterate through all files `mkosi.*` in the `mkosi.files/`
-  subdirectory, and build each as if `--default=mkosi.files/mkosi.…`
+  subdirectory, and build each as if `--config=mkosi.files/mkosi.…`
   was invoked. This is a quick way to build a large number of images
   in one go. Any additional specified command line arguments override
   the relevant options in all files processed this way.
@@ -1362,7 +1362,7 @@ under the assumption that it is invoked from a *source*
 tree. Specifically, the following files are used if they exist in the
 local directory:
 
-* The **`mkosi.default`** file provides the default configuration for
+* The **`mkosi.conf`** file provides the default configuration for
   the image building process. For example, it may specify the
   distribution to use (`fedora`, `ubuntu`, `debian`, `arch`,
   `opensuse`, `mageia`, `openmandriva`, `gentoo`) for the image, or additional
@@ -1372,9 +1372,9 @@ local directory:
   `mkosi` without further parameters in your *source* tree is enough
   to get the right image of your choice set up.
 
-  Additionally, if a *`mkosi.default.d/`* directory exists, each file
+  Additionally, if a *`mkosi.conf.d/`* directory exists, each file
   in it is loaded in the same manner adding/overriding the values
-  specified in `mkosi.default`. If `mkosi.default.d/` contains a
+  specified in `mkosi.conf`. If `mkosi.conf.d/` contains a
   directory named after the distribution being built, each file in
   that directory is also processed.
 
@@ -1437,8 +1437,8 @@ local directory:
   via `.gitignore` entries is to use the `mkosi.output/` directory,
   which is an easy way to exclude all build artifacts.
 
-  The `$MKOSI_DEFAULT` environment variable will be set inside of this
-  script so that you know which `mkosi.default` (if any) was passed
+  The `$MKOSI_CONFIG` environment variable will be set inside of this
+  script so that you know which `mkosi.conf` (if any) was passed
   in.
 
 * The **`mkosi.prepare`** script is invoked directly after the
@@ -1576,7 +1576,7 @@ All these files are optional.
 
 Note that the location of all these files may also be configured
 during invocation via command line switches, and as settings in
-`mkosi.default`, in case the default settings are not acceptable for a
+`mkosi.conf`, in case the default settings are not acceptable for a
 project.
 
 # BUILD PHASES
@@ -1712,7 +1712,7 @@ an OS image containing a built version of the project in its current
 state:
 
 ```bash
-# cat >mkosi.default <<EOF
+# cat >mkosi.conf <<EOF
 [Distribution]
 Distribution=fedora
 Release=24
@@ -1745,7 +1745,7 @@ To create a *Fedora Linux* image with hostname:
 
 Also you could set hostname in configuration file:
 ```bash
-# cat mkosi.default
+# cat mkosi.conf
 ...
 [Output]
 Hostname=image

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -519,7 +519,7 @@ class MkosiArgs:
     ssh_timeout: int
     ssh_port: int
     directory: Optional[Path]
-    default_path: Optional[Path]
+    config_path: Optional[Path]
     all: bool
     all_directory: Optional[Path]
     debug: List[str]

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -64,7 +64,7 @@ class MkosiConfig:
             "compress_fs": None,
             "compress_output": None,
             "debug": [],
-            "default_path": None,
+            "config_path": None,
             "directory": None,
             "distribution": None,
             "encrypt": None,
@@ -194,7 +194,7 @@ class MkosiConfig:
 
     @staticmethod
     def write_ini(dname: str, fname: str, config: Dict[str, Any], prio: int = 1000) -> None:
-        """Write mkosi.default(.d/*) files"""
+        """Write mkosi.conf(.d/*) files"""
         if not os.path.exists(dname):
             os.makedirs(dname)
         if prio < 1000:
@@ -395,9 +395,9 @@ class MkosiConfigOne(MkosiConfig):
     called by pytest for each class derived from this class. These test cases
     verify the parse_args function in single image (not --all) mode.
     This class implements four functions:
-    - prepare_mkosi_default
-    - prepare_mkosi_default_d_1
-    - prepare_mkosi_default_d_2
+    - prepare_mkosi_conf
+    - prepare_mkosi_conf_d_1
+    - prepare_mkosi_conf_d_2
     - prepare_args or prepare_args_short
 
     The purpose of these function is to generate configuration files and sets of command line
@@ -406,12 +406,12 @@ class MkosiConfigOne(MkosiConfig):
     function under test.
 
     This allows to write test cases with four steps. The first step generates a reference configuration
-    consisting of mkosi.default file only. Therefore prepare_mkosi_default function is is called to
+    consisting of mkosi.conf file only. Therefore prepare_mkosi_conf function is is called to
     generate the test configuration. Finally parse_args is called and the configuration returned by
     parse_args is compared against the reference_config. The second test step generates a test
-    configuration by calling prepare_mkosi_default and prepare_mkosi_default_d_1. This verifies the
-    behavior of parse_args is fine for mkosi.default plus one override file. The third test case verifies
-    that mkosi.default with two files in mkosi.default.d folder works as expected. The fourth test case
+    configuration by calling prepare_mkosi_conf and prepare_mkosi_conf_d_1. This verifies the
+    behavior of parse_args is fine for mkosi.conf plus one override file. The third test case verifies
+    that mkosi.conf with two files in mkosi.conf.d folder works as expected. The fourth test case
     additionally overrides some default values with command line arguments.
 
     Classes derived from this base class should override the mentioned functions to implement specific
@@ -419,29 +419,29 @@ class MkosiConfigOne(MkosiConfig):
     """
 
     def __init__(self) -> None:
-        """Add the default mkosi.default config"""
+        """Add the default mkosi.conf config"""
         super().__init__()
         self.add_reference_config()
 
-    def _prepare_mkosi_default(self, directory: str, config: Dict[str, Any]) -> None:
-        MkosiConfig.write_ini(directory, "mkosi.default", config)
+    def _prepare_mkosi_conf(self, directory: str, config: Dict[str, Any]) -> None:
+        MkosiConfig.write_ini(directory, "mkosi.conf", config)
 
-    def _prepare_mkosi_default_d(self, directory: str, config: Dict[str, Any], prio: int = 1000, fname: str = "mkosi.conf") -> None:
-        MkosiConfig.write_ini(os.path.join(directory, "mkosi.default.d"), fname, config, prio)
+    def _prepare_mkosi_conf_d(self, directory: str, config: Dict[str, Any], prio: int = 1000, fname: str = "mkosi.conf") -> None:
+        MkosiConfig.write_ini(os.path.join(directory, "mkosi.conf.d"), fname, config, prio)
 
-    def prepare_mkosi_default(self, directory: str) -> None:
-        """Generate a mkosi.default defaults file in the working directory"""
+    def prepare_mkosi_conf(self, directory: str) -> None:
+        """Generate a mkosi.conf config file in the working directory"""
         pass
 
-    def prepare_mkosi_default_d_1(self, directory: str) -> None:
-        """Generate a prio 1 config file in mkosi.default.d
+    def prepare_mkosi_conf_d_1(self, directory: str) -> None:
+        """Generate a prio 1 config file in mkosi.conf.d
 
         The file name should be prefixed with 001_.
         """
         pass
 
-    def prepare_mkosi_default_d_2(self, directory: str) -> None:
-        """Generate a prio 2 config file in mkosi.default.d
+    def prepare_mkosi_conf_d_2(self, directory: str) -> None:
+        """Generate a prio 2 config file in mkosi.conf.d
 
         The file name should be prefixed with 002_.
         """
@@ -475,9 +475,9 @@ class MkosiConfigDistro(MkosiConfigOne):
     """Minimal test configuration for the distribution parameter
 
     This tests defines the distribution parameter on several configuration priorities:
-    - mkosi.default
-    - mkosi.default.d/001_mkosi.conf
-    - mkosi.default.d/002_mkosi.conf
+    - mkosi.conf
+    - mkosi.conf.d/001_mkosi.conf
+    - mkosi.conf.d/002_mkosi.conf
     - --distribution
     """
 
@@ -489,9 +489,9 @@ class MkosiConfigDistro(MkosiConfigOne):
                 ref_c["directory"] = self.subdir_name
             self.cli_arguments = ["--directory", self.subdir_name, "summary"]
 
-    def prepare_mkosi_default(self, directory: str) -> None:
+    def prepare_mkosi_conf(self, directory: str) -> None:
         mk_config = {"Distribution": {"Distribution": "fedora"}}
-        self._prepare_mkosi_default(directory, mk_config)
+        self._prepare_mkosi_conf(directory, mk_config)
         for ref_c in self.reference_config.values():
             ref_c["distribution"] = "fedora"
             if self.subdir_name:
@@ -499,15 +499,15 @@ class MkosiConfigDistro(MkosiConfigOne):
         if self.subdir_name:
             self.cli_arguments = ["--directory", self.subdir_name, "summary"]
 
-    def prepare_mkosi_default_d_1(self, directory: str) -> None:
+    def prepare_mkosi_conf_d_1(self, directory: str) -> None:
         mk_config = {"Distribution": {"Distribution": "ubuntu"}}
-        self._prepare_mkosi_default_d(directory, mk_config, 1)
+        self._prepare_mkosi_conf_d(directory, mk_config, 1)
         for ref_c in self.reference_config.values():
             ref_c["distribution"] = "ubuntu"
 
-    def prepare_mkosi_default_d_2(self, directory: str) -> None:
+    def prepare_mkosi_conf_d_2(self, directory: str) -> None:
         mk_config = {"Distribution": {"Distribution": "debian"}}
-        self._prepare_mkosi_default_d(directory, mk_config, 2)
+        self._prepare_mkosi_conf_d(directory, mk_config, 2)
         for ref_c in self.reference_config.values():
             ref_c["distribution"] = "debian"
 
@@ -538,7 +538,7 @@ class MkosiConfigDistroDir(MkosiConfigDistro):
 class MkosiConfigManyParams(MkosiConfigOne):
     """Test configuration for most parameters"""
 
-    def prepare_mkosi_default(self, directory: str) -> None:
+    def prepare_mkosi_conf(self, directory: str) -> None:
         mk_config = {
             "Distribution": {
                 "Distribution": "fedora",
@@ -604,11 +604,11 @@ class MkosiConfigManyParams(MkosiConfigOne):
                 "Netdev": True,
             },
         }
-        self._prepare_mkosi_default(directory, mk_config)
+        self._prepare_mkosi_conf(directory, mk_config)
         for j in self.reference_config:
             self._update_ref_from_file(mk_config, j)
 
-    def prepare_mkosi_default_d_1(self, directory: str) -> None:
+    def prepare_mkosi_conf_d_1(self, directory: str) -> None:
         mk_config = {
             "Distribution": {
                 "Distribution": "ubuntu",
@@ -671,11 +671,11 @@ class MkosiConfigManyParams(MkosiConfigOne):
                 "Netdev": True,
             },
         }
-        self._prepare_mkosi_default_d(directory, mk_config, 1)
+        self._prepare_mkosi_conf_d(directory, mk_config, 1)
         for j in self.reference_config:
             self._update_ref_from_file(mk_config, j)
 
-    def prepare_mkosi_default_d_2(self, directory: str) -> None:
+    def prepare_mkosi_conf_d_2(self, directory: str) -> None:
         mk_config = {
             "Distribution": {
                 "Distribution": "debian",
@@ -738,7 +738,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
                 "Netdev": True,
             },
         }
-        self._prepare_mkosi_default_d(directory, mk_config, 2)
+        self._prepare_mkosi_conf_d(directory, mk_config, 2)
         for j in self.reference_config:
             self._update_ref_from_file(mk_config, j)
 
@@ -771,7 +771,7 @@ class MkosiConfigManyParams(MkosiConfigOne):
 class MkosiConfigIniLists1(MkosiConfigOne):
     """Manually written ini files with advanced list syntax."""
 
-    def prepare_mkosi_default(self, directory: str) -> None:
+    def prepare_mkosi_conf(self, directory: str) -> None:
         ini_lines = [
             "[Distribution]",
             "Distribution=fedora",
@@ -781,12 +781,12 @@ class MkosiConfigIniLists1(MkosiConfigOne):
             "  httpd",
             "  tar",
         ]
-        with open(os.path.join(directory, "mkosi.default"), "w") as f_ini:
+        with open(os.path.join(directory, "mkosi.conf"), "w") as f_ini:
             f_ini.write(os.linesep.join(ini_lines))
         self.reference_config[DEFAULT_JOB_NAME]["distribution"] = "fedora"
         self.reference_config[DEFAULT_JOB_NAME]["packages"] = ["openssh-clients", "httpd", "tar"]
 
-    def prepare_mkosi_default_d_1(self, directory: str) -> None:
+    def prepare_mkosi_conf_d_1(self, directory: str) -> None:
         ini_lines = [
             "[Distribution]",
             "Distribution=ubuntu",
@@ -799,7 +799,7 @@ class MkosiConfigIniLists1(MkosiConfigOne):
             "[Output]",
             "KernelCommandLine=console=ttyS0",
         ]
-        dname = os.path.join(directory, "mkosi.default.d")
+        dname = os.path.join(directory, "mkosi.conf.d")
         if not os.path.exists(dname):
             os.makedirs(dname)
         with open(os.path.join(dname, "1_ubuntu.conf"), "w") as f_ini:
@@ -810,7 +810,7 @@ class MkosiConfigIniLists1(MkosiConfigOne):
         self.reference_config[DEFAULT_JOB_NAME]["packages"].append("apache2")
         self.reference_config[DEFAULT_JOB_NAME]["kernel_command_line"].extend(["console=ttyS0"])
 
-    def prepare_mkosi_default_d_2(self, directory: str) -> None:
+    def prepare_mkosi_conf_d_2(self, directory: str) -> None:
         ini_lines = [
             "[Content]",
             "Packages=[ vim,!vi",
@@ -819,7 +819,7 @@ class MkosiConfigIniLists1(MkosiConfigOne):
             "KernelCommandLine=console=ttyS1",
             "  driver.feature=1",
         ]
-        dname = os.path.join(directory, "mkosi.default.d")
+        dname = os.path.join(directory, "mkosi.conf.d")
         if not os.path.exists(dname):
             os.makedirs(dname)
         with open(os.path.join(dname, "2_additional_stuff.conf"), "w") as f_ini:
@@ -833,9 +833,9 @@ class MkosiConfigIniLists1(MkosiConfigOne):
 class MkosiConfigIniLists2(MkosiConfigIniLists1):
     """Same as MkosiConfigIniLists2 but with clean KernelCommandLine"""
 
-    def prepare_mkosi_default(self, directory: str) -> None:
+    def prepare_mkosi_conf(self, directory: str) -> None:
         ini_lines = ["[Output]", "KernelCommandLine=!*"]
-        with open(os.path.join(directory, "mkosi.default"), "w") as f_ini:
+        with open(os.path.join(directory, "mkosi.conf"), "w") as f_ini:
             f_ini.write(os.linesep.join(ini_lines))
         self.reference_config[DEFAULT_JOB_NAME]["kernel_command_line"] = []
 
@@ -928,43 +928,43 @@ def test_builtin(tested_config: Any, tmpdir: Path) -> None:
 
 
 def test_def(tested_config: Any, tmpdir: Path) -> None:
-    """Generate the mkosi.default file only"""
+    """Generate the mkosi.conf file only"""
     with change_cwd(tmpdir):
-        tested_config.prepare_mkosi_default(tmpdir)
+        tested_config.prepare_mkosi_conf(tmpdir)
         args = mkosi.parse_args(tested_config.cli_arguments)
         assert tested_config == args
 
 
 def test_def_1(tested_config: Any, tmpdir: Path) -> None:
-    """Generate the mkosi.default file plus one config file"""
+    """Generate the mkosi.conf file plus one config file"""
     with change_cwd(tmpdir):
-        tested_config.prepare_mkosi_default(tmpdir)
-        tested_config.prepare_mkosi_default_d_1(tmpdir)
+        tested_config.prepare_mkosi_conf(tmpdir)
+        tested_config.prepare_mkosi_conf_d_1(tmpdir)
         args = mkosi.parse_args(tested_config.cli_arguments)
         assert tested_config == args
 
 
 def test_def_2(tested_config: Any, tmpdir: Path) -> None:
-    """Generate the mkosi.default file plus another config file"""
+    """Generate the mkosi.conf file plus another config file"""
     with change_cwd(tmpdir):
-        tested_config.prepare_mkosi_default(tmpdir)
-        tested_config.prepare_mkosi_default_d_2(tmpdir)
+        tested_config.prepare_mkosi_conf(tmpdir)
+        tested_config.prepare_mkosi_conf_d_2(tmpdir)
         args = mkosi.parse_args(tested_config.cli_arguments)
         assert tested_config == args
 
 
 def test_def_1_2(tested_config: Any, tmpdir: Path) -> None:
-    """Generate the mkosi.default file plus two config files"""
+    """Generate the mkosi.conf file plus two config files"""
     with change_cwd(tmpdir):
-        tested_config.prepare_mkosi_default(tmpdir)
-        tested_config.prepare_mkosi_default_d_1(tmpdir)
-        tested_config.prepare_mkosi_default_d_2(tmpdir)
+        tested_config.prepare_mkosi_conf(tmpdir)
+        tested_config.prepare_mkosi_conf_d_1(tmpdir)
+        tested_config.prepare_mkosi_conf_d_2(tmpdir)
         args = mkosi.parse_args(tested_config.cli_arguments)
         assert tested_config == args
 
 
 def test_def_args(tested_config: Any, tmpdir: Path) -> None:
-    """Generate the mkosi.default plus command line arguments"""
+    """Generate the mkosi.conf plus command line arguments"""
     with change_cwd(tmpdir):
         tested_config.prepare_args()
         args = mkosi.parse_args(tested_config.cli_arguments)
@@ -972,32 +972,32 @@ def test_def_args(tested_config: Any, tmpdir: Path) -> None:
 
 
 def test_def_1_args(tested_config: Any, tmpdir: Path) -> None:
-    """Generate the mkosi.default plus a config file plus command line arguments"""
+    """Generate the mkosi.conf plus a config file plus command line arguments"""
     with change_cwd(tmpdir):
-        tested_config.prepare_mkosi_default(tmpdir)
-        tested_config.prepare_mkosi_default_d_1(tmpdir)
+        tested_config.prepare_mkosi_conf(tmpdir)
+        tested_config.prepare_mkosi_conf_d_1(tmpdir)
         tested_config.prepare_args()
         args = mkosi.parse_args(tested_config.cli_arguments)
         assert tested_config == args
 
 
 def test_def_1_2_args(tested_config: Any, tmpdir: Path) -> None:
-    """Generate the mkosi.default plus two config files plus command line arguments"""
+    """Generate the mkosi.conf plus two config files plus command line arguments"""
     with change_cwd(tmpdir):
-        tested_config.prepare_mkosi_default(tmpdir)
-        tested_config.prepare_mkosi_default_d_1(tmpdir)
-        tested_config.prepare_mkosi_default_d_2(tmpdir)
+        tested_config.prepare_mkosi_conf(tmpdir)
+        tested_config.prepare_mkosi_conf_d_1(tmpdir)
+        tested_config.prepare_mkosi_conf_d_2(tmpdir)
         tested_config.prepare_args()
         args = mkosi.parse_args(tested_config.cli_arguments)
         assert tested_config == args
 
 
 def test_def_1_2_argssh(tested_config: Any, tmpdir: Path) -> None:
-    """Generate the mkosi.default plus two config files plus short command line arguments"""
+    """Generate the mkosi.conf plus two config files plus short command line arguments"""
     with change_cwd(tmpdir):
-        tested_config.prepare_mkosi_default(tmpdir)
-        tested_config.prepare_mkosi_default_d_1(tmpdir)
-        tested_config.prepare_mkosi_default_d_2(tmpdir)
+        tested_config.prepare_mkosi_conf(tmpdir)
+        tested_config.prepare_mkosi_conf_d_1(tmpdir)
+        tested_config.prepare_mkosi_conf_d_2(tmpdir)
         tested_config.prepare_args_short()
         args = mkosi.parse_args(tested_config.cli_arguments)
         assert tested_config == args
@@ -1015,7 +1015,7 @@ class MkosiConfigAllHost(MkosiConfigAll):
     """Test --all option with two simple configs"""
 
     def __init__(self) -> None:
-        """Add two default mkosi.default configs"""
+        """Add two default mkosi.conf configs"""
         super().__init__()
         for hostname in ["test1.example.org", "test2.example.org"]:
             job_name = "mkosi." + hostname
@@ -1045,7 +1045,7 @@ def tested_config_all(request: Any) -> Any:
 
 
 def test_all_1(tested_config_all: Any, tmpdir: Path) -> None:
-    """Generate the mkosi.default plus two config files plus short command line arguments"""
+    """Generate the mkosi.conf plus two config files plus short command line arguments"""
     with change_cwd(tmpdir):
         tested_config_all.prepare_mkosi_files(tmpdir)
         args = mkosi.parse_args(tested_config_all.cli_arguments)

--- a/tests/test_parse_load_args.py
+++ b/tests/test_parse_load_args.py
@@ -55,7 +55,7 @@ def test_os_distribution() -> None:
 
     for dist in Distribution:
         with cd_temp_dir():
-            config = Path("mkosi.default")
+            config = Path("mkosi.conf")
             config.write_text(f"[Distribution]\nDistribution={dist}")
             assert parse([]).distribution == dist
 
@@ -72,14 +72,14 @@ def test_machine_id() -> None:
         parse(["--machine-id"])
 
     with cd_temp_dir():
-        config = Path("mkosi.default")
+        config = Path("mkosi.conf")
         config.write_text(f"[Output]\nMachineID={id}")
         load_args = parse([])
         assert load_args.machine_id == id
         assert load_args.machine_id_is_fixed
 
     with cd_temp_dir():
-        config = Path("mkosi.default")
+        config = Path("mkosi.conf")
         config.write_text("[Output]\nMachineID=")
         with pytest.raises(MkosiException):
             parse([])
@@ -92,19 +92,19 @@ def test_hostname() -> None:
         parse(["--hostname"])
 
     with cd_temp_dir():
-        config = Path("mkosi.default")
+        config = Path("mkosi.conf")
         config.write_text("[Output]\nHostname=name")
         assert parse([]).hostname == "name"
 
     with cd_temp_dir():
-        config = Path("mkosi.default")
+        config = Path("mkosi.conf")
         config.write_text("[Output]\nHostname=")
         config = Path("hostname.txt")
         assert parse([]).hostname == ""
 
 def test_centos_brtfs() -> None:
     with cd_temp_dir():
-        config = Path("mkosi.default")
+        config = Path("mkosi.conf")
         for dist in (Distribution.centos, Distribution.centos_epel):
             for release in range (2, 9):
                 config.write_text(
@@ -122,7 +122,7 @@ def test_centos_brtfs() -> None:
                     parse([])
 
     with cd_temp_dir():
-        config = Path("mkosi.default")
+        config = Path("mkosi.conf")
         for dist in (Distribution.centos, Distribution.centos_epel):
             for release in range (2, 8):
                 config.write_text(


### PR DESCRIPTION
"default" is a rather unintuitive file extension for a config file.
Let's prefer the more widespread "conf" file extension instead. We'll
now look for mkosi.conf and mkosi.conf.d in addition to the already
supported mkosi.default and mkosi.default.d.

We also rename the --default option to --config.

All mentions of mkosi.default, mkosi.default.d and --default in the
docs have been replaced with their conf counterpart.