### PR TITLE
Always use a distro~release subdirectory for output, cache, builddir

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,10 +10,10 @@ for more information.
 wants to use them, they can be found [here](https://github.com/systemd/mkosi/tree/v13/mkosi/resources/arch).
 When building a bios image, /boot/vmlinuz-kver and /boot/initramfs-kver.img are
 now symlinks to the actual files as installed by kernel-install.
-- When mkosi.output/ or mkosi.builddir/ are used, mkosi now creates distro~release
-subdirectories inside these directories for each distro~release combination that
-is built. This allows building for multiple distros without throwing away the results
-of a previous distro build every time.
+- mkosi now creates distro~release subdirectories inside the build, cache and output
+directories for each distro~release combination that is built. This allows building
+for multiple distros without throwing away the results of a previous distro build every
+time.
 - The preferred names for mkosi configuration files and directories are now mkosi.conf
 and mkosi.conf.d/ respectively. The old names (mkosi.default and mkosi.default.d) have
 been removed from the docs but are still supported for backwards compatibility.

--- a/mkosi.md
+++ b/mkosi.md
@@ -398,7 +398,9 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   exists in the local directory, it is automatically used for this
   purpose. If the setting is not used and `mkosi.output/` does not
   exist, all output artifacts are placed adjacent to the output image
-  file.
+  file. If an output directory is configured, mkosi will create
+  `distro~release` subdirectories in it to store the artfifacts per
+  distro, release combination that's built.
 
 `WorkspaceDirectory=`, `--workspace-dir=`
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -6180,29 +6180,42 @@ def args_find_path(args: argparse.Namespace, name: str, path: str, *, as_list: b
 
 
 def find_output(args: argparse.Namespace) -> None:
+    subdir = f"{args.distribution}~{args.release}"
+
     if args.output_dir is not None:
+        args.output_dir = Path(args.output_dir, subdir)
+    elif os.path.exists("mkosi.output/"):
+        args.output_dir = Path("mkosi.output", subdir)
+    else:
         return
 
-    if os.path.exists("mkosi.output/"):
-        args.output_dir = Path("mkosi.output", f"{args.distribution}~{args.release}")
-        args.output_dir.mkdir(exist_ok=True)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
 
 
 def find_builddir(args: argparse.Namespace) -> None:
+    subdir = f"{args.distribution}~{args.release}"
+
     if args.build_dir is not None:
+        args.build_dir = Path(args.build_dir, subdir)
+    elif os.path.exists("mkosi.builddir/"):
+        args.build_dir = Path("mkosi.builddir", subdir)
+    else:
         return
 
-    if os.path.exists("mkosi.builddir/"):
-        args.build_dir = Path("mkosi.builddir", f"{args.distribution}~{args.release}")
-        args.build_dir.mkdir(exist_ok=True)
+    args.build_dir.mkdir(parents=True, exist_ok=True)
 
 
 def find_cache(args: argparse.Namespace) -> None:
+    subdir = f"{args.distribution}~{args.release}"
+
     if args.cache_path is not None:
+        args.cache_path = Path(args.cache_path, subdir)
+    elif os.path.exists("mkosi.cache/"):
+        args.cache_path = Path("mkosi.cache", subdir)
+    else:
         return
 
-    if os.path.exists("mkosi.cache/"):
-        args.cache_path = Path("mkosi.cache", f"{args.distribution}~{args.release}")
+    args.cache_path.mkdir(parents=True, exist_ok=True)
 
 
 def require_private_file(name: str, description: str) -> None:


### PR DESCRIPTION
Let's be consistent and always use a distro~release subdirectory for
these directories, instead of only using these when the correct directory
exists in the directory mkosi is invoked from.