### PR TITLE
Write uninitialized to /etc/machine-id when resetting

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3025,7 +3025,7 @@ def reset_machine_id(args: MkosiArgs, root: Path, do_run_build_script: bool, for
                 machine_id.unlink()
             except FileNotFoundError:
                 pass
-            machine_id.touch()
+            machine_id.write_text("uninitialized\n")
 
         dbus_machine_id = root / "var/lib/dbus/machine-id"
         try:


### PR DESCRIPTION
This makes sure the firstboot logic is triggered when the image is
booted for the first time.