### PR TITLE
Use chunked reads when inserting partition

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3713,7 +3713,10 @@ def insert_partition(
             # Let's discard the partition block device first, to ensure the GPT partition table footer that
             # likely is stored in it is flushed out. After all we want to write with dd's sparse option.
             run(["blkdiscard", path])
-            path.write_bytes(blob.read())
+
+            # Without this the entire blob will be read into memory which could exceed system memory
+            with open(path, mode='wb') as path_fp:
+                os.sendfile(path_fp.fileno(), blob.fileno(), offset=0, count=blob_size)
 
     return part
 


### PR DESCRIPTION
When inserting a large partition that exceeds the available system memory, a `MemoryError` exception will occur during the partition insert. This is regardless of both the input and output files being opened in buffered I/O mode.

I did try setting a fixed size for the buffers during open without chunking the read but this made no difference.

If you want to test an alternate solution, read your entire disk out to `/dev/null` and if the memory usage of python doesn't keep going up then success. I know I've almost always had to re-write code changes, so I'm hoping this might help before someone makes a suggestion.