### PR TITLE
name squashfs images as .raw too

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ time.
 - The preferred names for mkosi configuration files and directories are now mkosi.conf
 and mkosi.conf.d/ respectively. The old names (mkosi.default and mkosi.default.d) have
 been removed from the docs but are still supported for backwards compatibility.
+- `plain_squashfs` type images will now also be named with a `.raw` suffix.
 
 ## v13
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -6485,6 +6485,8 @@ def load_args(args: argparse.Namespace) -> MkosiArgs:
             output = f"{prefix}.tar.xz"
         elif args.output_format == OutputFormat.cpio:
             output = f"{prefix}.cpio" + (f".{args.compress}" if args.compress else "")
+        elif args.output_format.is_squashfs():
+            output = f"{prefix}.raw"
         else:
             output = prefix
         args.output = Path(output)


### PR DESCRIPTION
This is expected by systemd when used with RootImage= and friends