### PR TITLE
Added support for including UUID in artifact names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
   mkosi.default.d) have been removed from the docs but are still supported for
   backwards compatibility.
 - `plain_squashfs` type images will now also be named with a `.raw` suffix.
+- Support for including the UUID of usr and verity partitions in the output file
+  name was added when using verity. See `VerityUUIDNames`.
 - `tar` type images will now respect the `--compress` option.
 - Pacman's `SigLevel` option was changed to use the same default value as used
   on Arch which is `SigLevel = Required DatabaseOptional`. If this results in

--- a/mkosi.md
+++ b/mkosi.md
@@ -398,13 +398,14 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   included in the default name, e.g. a specified image version of
   `7.8` might result in an image file name of `image_7.8.raw.xz`.
 
-`OutputSplitRoot=`, `--output-split-root=`, `OutputSplitVerify=`, `--output-split-verity=`, `OutputSplitKernel=`, `--output-split-kernel=`
+`OutputSplitRoot=`, `--output-split-root=`, `OutputSplitVerity=`, `--output-split-verity=`, `OutputSplitKernel=`, `--output-split-kernel=`
 
 : Paths for the split-out output image files, when
   `SplitArtifacts=yes` is used. If unspecified, the relevant split
   artifact files will be named like the main image, but with `.root`,
   `.verity`, and `.efi` suffixes inserted (and in turn possibly
-  suffixed by compression suffix, if compression is enabled).
+  suffixed by compression suffix, if compression is enabled). Also
+  see `VerityUUIDNames`.
 
 `OutputDirectory=`, `--output-dir=`, `-O`
 
@@ -558,6 +559,20 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   self-contained signed disk images, implementing the Verity
   provisions described in the [Discoverable Partitions
   Specification](https://systemd.io/DISCOVERABLE_PARTITIONS).
+
+`VerityUUIDNames=`, `--verity-uuid-names`
+
+: Add the UUID to the name of split artifacts if verity is enabled.
+  For example, if an artifact is named `artifact.verity` and the
+  UUID of the verity partition is
+  `93e00bec-0948-4119-8877-c10c0850617d`, the artifact name will
+  become
+  `artifact_93e00bec-0948-4119-8877-c10c0850617d.verity`.
+
+  This option **always** renames artifacts even if the artifact path
+  name is specified using `OutputSplitVerity` and the like. This option
+  affects the paths for root (or /usr), verity and verity signature
+  split artifacts.
 
 `CompressFs=`, `--compress-fs=`
 

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -480,6 +480,7 @@ class MkosiConfig:
     read_only: bool
     encrypt: Optional[str]
     verity: Union[bool, str]
+    verity_uuid_names: bool
     compress: Union[None, str, bool]
     compress_fs: Union[None, str, bool]
     compress_output: Union[None, str, bool]

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -128,6 +128,7 @@ class MkosiConfig:
             "bios_size": None,
             "verb": Verb.build,
             "verity": False,
+            "verity_uuid_names": False,
             "with_docs": False,
             "with_network": False,
             "with_tests": True,


### PR DESCRIPTION
When performing updates using `systemd-sysupdate`, it is ideal to provide the partition UUIDs so that `systemd-gpt-auto-generator` can find the partitions based on either `roothash=` or `usrhash=` from the kernel command line. See the examples [here](https://www.freedesktop.org/software/systemd/man/sysupdate.d.html#Examples) from the `sysupdate.d` documentation.

I'm sure there will be some disagreement over the naming of options, so if someone can come up with something better than `VerityUUIDNames` I'm all for it.

Currently I've got a script doing this work, but that also requires updating the file names in `SHA256SUMS` and re-signing.