### PR TITLE
Include image ID and version in environment variables

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3165,7 +3165,7 @@ def run_prepare_script(state: MkosiState, cached: bool) -> None:
 
         nspawn_params = nspawn_params_for_build_sources(state.config, SourceFileTransfer.mount)
         run_workspace_command(state, ["/root/prepare", verb],
-                              network=True, nspawn_params=nspawn_params, env=state.config.environment)
+                              network=True, nspawn_params=nspawn_params, env=state.environment)
 
         srcdir = root_home(state) / "src"
         if srcdir.exists():
@@ -3192,7 +3192,7 @@ def run_postinst_script(state: MkosiState) -> None:
         shutil.copy2(state.config.postinst_script, root_home(state) / "postinst")
 
         run_workspace_command(state, ["/root/postinst", verb],
-                              network=(state.config.with_network is True), env=state.config.environment)
+                              network=(state.config.with_network is True), env=state.environment)
         root_home(state).joinpath("postinst").unlink()
 
 
@@ -3210,8 +3210,7 @@ def run_finalize_script(state: MkosiState) -> None:
 
     with complete_step("Running finalize script…"):
         run([state.config.finalize_script, verb],
-            env={**state.config.environment, "BUILDROOT": str(state.root), "OUTPUTDIR": str(output_dir(state.config))})
-
+            env={**state.environment, "BUILDROOT": str(state.root), "OUTPUTDIR": str(output_dir(state.config))})
 
 
 def install_boot_loader(
@@ -6495,6 +6494,11 @@ def load_args(args: argparse.Namespace) -> MkosiConfig:
     else:
         args.environment = {}
 
+    if args.image_id is not None:
+        args.environment['IMAGE_ID'] = args.image_id
+    if args.image_version is not None:
+        args.environment['IMAGE_VERSION'] = args.image_version
+
     if args.cache_path is not None:
         args.cache_path = args.cache_path.absolute()
 
@@ -7265,12 +7269,6 @@ def run_build_script(state: MkosiState, raw: Optional[BinaryIO]) -> None:
                 f"--setenv=MKOSI_DEFAULT={state.config.config_path}"
             ]
 
-        if state.config.image_version is not None:
-            cmdline += [f"--setenv=IMAGE_VERSION={state.config.image_version}"]
-
-        if state.config.image_id is not None:
-            cmdline += [f"--setenv=IMAGE_ID={state.config.image_id}"]
-
         cmdline += nspawn_params_for_build_sources(state.config, state.config.source_file_transfer)
 
         if state.config.build_dir is not None:
@@ -7292,7 +7290,7 @@ def run_build_script(state: MkosiState, raw: Optional[BinaryIO]) -> None:
         if state.config.nspawn_keep_unit:
             cmdline += ["--keep-unit"]
 
-        cmdline += [f"--setenv={env}={value}" for env, value in state.config.environment.items()]
+        cmdline += [f"--setenv={env}={value}" for env, value in state.environment.items()]
 
         cmdline += [f"/root/{state.config.build_script.name}"]
 
@@ -7373,6 +7371,7 @@ def build_stuff(config: MkosiConfig) -> Manifest:
             workspace=Path(workspace.name),
             cache=cache,
             do_run_build_script=False,
+            environment=config.environment,
             machine_id=config.machine_id or uuid.uuid4().hex,
             for_cache=False,
         )

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -506,6 +506,7 @@ class MkosiConfig:
     skeleton_trees: List[Path]
     clean_package_metadata: Union[bool, str]
     remove_files: List[Path]
+    # Environment should not be used directly. Use MkosiState environment instead.
     environment: Dict[str, str]
     build_sources: Optional[Path]
     build_dir: Optional[Path]
@@ -598,6 +599,7 @@ class MkosiState:
     do_run_build_script: bool
     machine_id: str
     for_cache: bool
+    environment: Dict[str, str]
 
     cache_pre_inst: Optional[Path] = None
     cache_pre_dev: Optional[Path] = None

--- a/mkosi/machine.py
+++ b/mkosi/machine.py
@@ -117,6 +117,10 @@ class Machine:
         if needs_build(self.config):
             check_root()
             check_native(self.config)
+
+            # Useful if testing within Docker
+            if parse_boolean(os.getenv("MKOSI_TEST_NO_NAMESPACE", "0")):
+                raise unittest.SkipTest("Build test skipped due to environment variable.")
             init_namespace()
             build_stuff(self.config)
 


### PR DESCRIPTION
This change will allow the image ID and image version arguments to be referenced in scripts (prepare, build, postinst, finalize). This is useful for substituting or adding into relevant files.

For example:

```shell
$ cat mkosi.postinst
#!/bin/sh

...

echo "IMAGE_ID=$IMAGE_ID"           >> /etc/os-release
echo "IMAGE_VERSION=$IMAGE_VERSION" >> /etc/os-release

# These files were added from mkosi.extra
for f in $(find /usr/lib/sysupdate.d/ -name '*.conf') ; do
    sed --in-place s/'IMAGE_ID'/"$IMAGE_ID"/ $f
done
```