### PR TITLE
Fixes for kernel/efi multi-architecture build/boot

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -425,6 +425,15 @@ DEBIAN_KERNEL_ARCHITECTURES = {
     "s390x": "s390x",
 }
 
+# EFI has its own conventions too
+EFI_ARCHITECTURES = {
+    "x86_64": "x64",
+    "x86": "ia32",
+    "aarch64": "aa64",
+    "armhfp": "arm",
+    "riscv64:": "riscv64",
+}
+
 
 class GPTRootTypeTriplet(NamedTuple):
     root: uuid.UUID
@@ -4065,7 +4074,7 @@ def install_unified_kernel(
                 "--add-section", f".cmdline={cmdline}",   "--change-section-vma", ".cmdline=0x30000",
                 "--add-section", f".linux={root / kimg}", "--change-section-vma", ".linux=0x2000000",
                 "--add-section", f".initrd={initrd}",     "--change-section-vma", ".initrd=0x3000000",
-                root / "lib/systemd/boot/efi/linuxx64.efi.stub",
+                root / f"lib/systemd/boot/efi/linux{EFI_ARCHITECTURES[args.architecture]}.efi.stub",
                 boot_binary,
             ]
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -411,6 +411,20 @@ DEBIAN_ARCHITECTURES = {
     "armhfp": "armhf",
 }
 
+# And the kernel package names have yet another format, so adjust accordingly
+DEBIAN_KERNEL_ARCHITECTURES = {
+    "x86_64": "amd64",
+    "x86": "i386",
+    "aarch64": "arm64",
+    "armhfp": "armmp",
+    "alpha": "alpha-generic",
+    "ia64": "itanium",
+    "ppc": "powerpc",
+    "ppc64": "powerpc64",
+    "ppc64le": "powerpc64le",
+    "s390x": "s390x",
+}
+
 
 class GPTRootTypeTriplet(NamedTuple):
     root: uuid.UUID
@@ -2519,10 +2533,24 @@ def install_debian_or_ubuntu(args: MkosiArgs, root: Path, *, do_run_build_script
     if not do_run_build_script and args.bootable:
         add_packages(args, extra_packages, "dracut")
 
+        # Don't pull in a kernel if users specify one, but otherwise try to pick a default
+        # one - linux-generic is a global metapackage in Ubuntu, but Debian doesn't have one,
+        # so try to infer from the architecture.
         if args.distribution == Distribution.ubuntu:
-            add_packages(args, extra_packages, "linux-generic")
-        else:
-            add_packages(args, extra_packages, "linux-image-amd64")
+            found = "linux-generic" in extra_packages
+            if not found:
+                for package in extra_packages:
+                    if package.startswith("linux-image"):
+                        found = True
+            if not found:
+                add_packages(args, extra_packages, "linux-generic")
+        elif args.distribution == Distribution.debian:
+            found = False
+            for package in extra_packages:
+                if package.startswith("linux-image"):
+                    found = True
+            if not found:
+                add_packages(args, extra_packages, f"linux-image-{DEBIAN_KERNEL_ARCHITECTURES[args.architecture]}")
 
         if args.get_partition(PartitionIdentifier.bios):
             add_packages(args, extra_packages, "grub-pc")


### PR DESCRIPTION
qemu aarch64 on uefi still doesn't boot, but at least tries to load the right file now:

```
‣ Warning: Couldn't find OVMF firmware blob with secure boot support, falling back to OVMF firmware blobs without secure boot support.
‣ Running command:
‣ qemu-system-aarch64 -machine virt -smp 1 -m 1G -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0,id=rng-device0 -cpu max -nographic -nodefaults -serial mon:stdio -drive if=pflash,format=raw,readonly=on,file=/usr/share/AAVMF/AAVMF_CODE.fd -drive 'if=virtio,id=hd,file=/home/luca/git/mkosi/mkosi.output/debian~testing/image.raw,format=raw'

BdsDxe: failed to load Boot0001 "UEFI Misc Device" from VenHw(93E34C7E-B50E-11DF-9223-2443DFD72085,00): Not Found
BdsDxe: loading Boot0002 "UEFI Misc Device 2" from PciRoot(0x0)/Pci(0x2,0x0)
BdsDxe: starting Boot0002 "UEFI Misc Device 2" from PciRoot(0x0)/Pci(0x2,0x0)


Synchronous Exception at 0x0000000077BABAFC


Synchronous Exception at 0x0000000077BABAFC
```