### PR TITLE
manifest: include metadata about the image itself

### DIFF
--- a/mkosi/manifest.py
+++ b/mkosi/manifest.py
@@ -234,7 +234,22 @@ class Manifest:
         return len(self.packages) > 0
 
     def as_dict(self) -> Dict[str, Any]:
+        config = {
+            "name": self.args.image_id or "image",
+            "distribution": self.args.distribution.name,
+            "architecture": self.args.architecture,
+        }
+        if self.args.image_version is not None:
+            config["version"] = self.args.image_version
+        if self.args.release is not None:
+            config["release"] = self.args.release
+
         return {
+            # Bump this when incompatible changes are made to the manifest format.
+            "manifest_version": 1,
+            # Describe the image itself.
+            "config": config,
+            # Describe the image content in terms of packages.
             "packages": [package.as_dict() for package in self.packages],
         }
 


### PR DESCRIPTION
It would be useful to record more metadata than just the list of packages. eg:

```
{
  "image": {
    "distribution": "opensuse",
    "release": "tumbleweed",
    "architecture": "x86_64",
    "format": "plain_squashfs",
    "version": "1"
  },
  "packages": [
    {
      "type": "rpm",
      "name": "aaa_base",
      "version": "84.87+g",
      "architecture": "x86_64"
    },
<...>
```