### PR TITLE
arch: Modify SigLevel to pacman default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,9 @@ and mkosi.conf.d/ respectively. The old names (mkosi.default and mkosi.default.d
 been removed from the docs but are still supported for backwards compatibility.
 - `plain_squashfs` type images will now also be named with a `.raw` suffix.
 - `tar` type images will now respect the `--compress` option.
+- Pacman's `SigLevel` option was changed to use the same default value as used on Arch
+which is `SigLevel = Required DatabaseOptional`. If this results in keyring errors,
+you need to update the keyring by running `pacman-key --populate archlinux`.
 
 ## v13
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2728,7 +2728,7 @@ def install_arch(args: MkosiArgs, root: Path, do_run_build_script: bool) -> None
                 Architecture = auto
                 Color
                 CheckSpace
-                SigLevel = Required DatabaseOptional TrustAll
+                SigLevel = Required DatabaseOptional
                 ParallelDownloads = 5
 
                 [core]


### PR DESCRIPTION
Let's use the same default as pacman uses in Arch