### PR TITLE
tar/cpio: fix compression options handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ time.
 and mkosi.conf.d/ respectively. The old names (mkosi.default and mkosi.default.d) have
 been removed from the docs but are still supported for backwards compatibility.
 - `plain_squashfs` type images will now also be named with a `.raw` suffix.
+- `tar` type images will now respect the `--compress` option.
 
 ## v13
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -6500,14 +6500,14 @@ def load_args(args: argparse.Namespace) -> MkosiArgs:
     if args.output is None:
         iid = args.image_id if args.image_id is not None else "image"
         prefix = f"{iid}_{args.image_version}" if args.image_version is not None else iid
+        compress = should_compress_output(args)
 
         if args.output_format.is_disk():
-            compress = should_compress_output(args)
             output = prefix + (".qcow2" if args.qcow2 else ".raw") + (f".{compress}" if compress else "")
         elif args.output_format == OutputFormat.tar:
-            output = f"{prefix}.tar.xz"
+            output = f"{prefix}.tar" + (f".{compress}" if compress else "")
         elif args.output_format == OutputFormat.cpio:
-            output = f"{prefix}.cpio" + (f".{args.compress}" if args.compress else "")
+            output = f"{prefix}.cpio" + (f".{compress}" if compress else "")
         elif args.output_format.is_squashfs():
             output = f"{prefix}.raw"
         else:
@@ -6545,8 +6545,6 @@ def load_args(args: argparse.Namespace) -> MkosiArgs:
 
     args.output = args.output.absolute()
 
-    if args.output_format == OutputFormat.tar:
-        args.compress_output = "xz"
     if not args.output_format.is_disk():
         args.split_artifacts = False
 

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -611,6 +611,8 @@ def should_compress_output(args: Union[argparse.Namespace, MkosiArgs]) -> Union[
     c = args.compress_output
     if c is None and not args.output_format.has_fs_compression():
         c = args.compress
+    if c is None and args.output_format == OutputFormat.tar:
+        c = True
     if c is True:
         return "xz"  # default compression
     return False if c is None else c


### PR DESCRIPTION
Let users build uncompressed tarballs. Also take into account the
usual algorithm to determine the compression type for cpio.
Defaults are unchanged.