### PR TITLE
Implement support for generated files ownership management.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,12 @@
   `image.root.roothash`, `image.root.roothash.p7s` (same for `usr` variants).
 - `mkosi` will again default to the same OS release as the host system when the
   host system uses the same distribution as the image that's being built.
+- By default, `mkosi` will now change the owner of newly created directories to
+  `SUDO_UID` or `PKEXEC_UID` if defined, unless `--no-chown` is used.
+- If `systemd-nspawn` v252 or newer is used, bind-mounted directories with
+  `systemd-nspawn` will use the new `rootidmap` option so files and directories
+  created from within the container will be owned by the actual directory owner
+  on the host.
 
 ## v13
 


### PR DESCRIPTION
Implement support for generated files ownership management: files and folders created by `mkosi` will be owned by the calling user (`SUDO_UID` or `PKEXEC_UID`, if defined) instead of `root`.

This PR is composed of 2 commits.

### `chown` mkosi-generated directories

Use `chown` to change the owner of directories created by `mkosi`, unless `--no-chown` is used. Directories owner will be set to `SUDO_UID` or `PKEXEC_UID` if defined, current UID otherwise.

### Use nspawn's rootidmap option for bind mount

Directories bind mounted with `systemd-nspawn` will now use `rootidmap` option if `systemd-nspawn` v252 or later is used. This will ensure the owner of the files within the mounted directory inside the container will be the same as the owner of the directory on the backing filesystem.