### PR TITLE
Drop CentOS 7 and BIOS/grub support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,9 +196,6 @@ jobs:
     - name: Build/Boot ${{ matrix.distro }}/${{ matrix.format }} UEFI UKI
       run: |
         tee mkosi.conf <<- EOF
-        [Output]
-        BootProtocols=uefi
-
         [Host]
         QemuBoot=uefi
         EOF
@@ -209,7 +206,6 @@ jobs:
       run: |
         tee mkosi.conf <<- EOF
         [Output]
-        BootProtocols=uefi
         WithUnifiedKernelImages=no
 
         [Host]
@@ -218,24 +214,10 @@ jobs:
 
         sudo MKOSI_TEST_DEFAULT_VERB=qemu python3 -m pytest --exitfirst -m integration -sv tests
 
-    - name: Build/Boot ${{ matrix.distro }}/${{ matrix.format }} BIOS
-      run: |
-        tee mkosi.conf <<- EOF
-        [Output]
-        BootProtocols=bios
-        WithUnifiedKernelImages=no
-
-        [Host]
-        QemuBoot=bios
-        EOF
-
-        sudo MKOSI_TEST_DEFAULT_VERB=qemu python3 -m pytest --exitfirst -m integration -sv tests
-
     - name: Build/Boot ${{ matrix.distro }}/${{ matrix.format}} QEMU Linux Boot
       run: |
         tee mkosi.conf <<- EOF
         [Output]
-        BootProtocols=linux
         WithUnifiedKernelImages=no
 
         [Host]

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,8 +8,6 @@ for more information.
 for more information.
 - The Arch kernel/bootloader pacman hooks were removed. For anyone that still
 wants to use them, they can be found [here](https://github.com/systemd/mkosi/tree/v13/mkosi/resources/arch).
-When building a bios image, /boot/vmlinuz-kver and /boot/initramfs-kver.img are
-now symlinks to the actual files as installed by kernel-install.
 - mkosi now creates distro~release subdirectories inside the build, cache and output
 directories for each distro~release combination that is built. This allows building
 for multiple distros without throwing away the results of a previous distro build every
@@ -23,6 +21,9 @@ been removed from the docs but are still supported for backwards compatibility.
 which is `SigLevel = Required DatabaseOptional`. If this results in keyring errors,
 you need to update the keyring by running `pacman-key --populate archlinux`.
 - Support for CentOS 7 was dropped.
+- Support for BIOS/grub was dropped. To allow users to configure grub themselves, the
+new `--bios-size` option can be used to add a BIOS boot partition of the specified size
+on which grub can be installed.
 
 ## v13
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@ been removed from the docs but are still supported for backwards compatibility.
 - Pacman's `SigLevel` option was changed to use the same default value as used on Arch
 which is `SigLevel = Required DatabaseOptional`. If this results in keyring errors,
 you need to update the keyring by running `pacman-key --populate archlinux`.
+- Support for CentOS 7 was dropped.
 
 ## v13
 

--- a/mkosi.md
+++ b/mkosi.md
@@ -268,7 +268,7 @@ options are available:
 
 * A swap partition may be added in
 
-* The image may be made bootable on *EFI* and *BIOS* systems
+* The image may be made bootable on *EFI* systems
 
 * Separate partitions for `/srv` and `/home` may be added in
 
@@ -454,23 +454,7 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 
 `Bootable=`, `--bootable`, `-b`
 
-: Generate a bootable image. By default this will generate an image
-  bootable on UEFI systems. Use `BootProtocols=` to select support
-  for a different boot protocol.
-
-`BootProtocols=`, `--boot-protocols=`
-
-: Pick one or more boot protocols to support when generating a
-  bootable image, as enabled with `Bootable=`. Takes a comma-separated
-  list of `uefi`, `bios`, or `linux`. May be specified more than once in which
-  case the specified lists are merged. If `uefi` is specified the
-  `sd-boot` UEFI boot loader is used, if `bios` is specified the GNU
-  Grub boot loader is used. If `linux` is specified, the kernel image, initrd
-  and kernel cmdline are extracted from the image and stored in the output
-  directory. When running the `qemu` verb and setting the `--qemu-boot` option
-  to `linux`, qemu will be instructed to do a direct Linux kernel boot using
-  the previously extracted files. Use "!\*" to remove all previously added
-  protocols or "!protocol" to remove one protocol.
+: Generate a bootable image for UEFI systems.
 
 `KernelCommandLine=`, `--kernel-command-line=`
 
@@ -1148,10 +1132,9 @@ a machine ID.
 
 `QemuBoot=`, `--qemu-boot=`
 
-: When used with the `qemu` verb, this option sets the boot protocol to be used
-  by qemu. Can be set to either `uefi`, `bios`, or `linux`. Note that a boot
-  procotol needs to be included in `BootProtocols=` when building the image for
-  it to be usable with this option.
+: When used with the `qemu` verb, this option specifies how qemu should
+  boot the image. Can be set to either `uefi` to do a UEFI boot or `linux`
+  to do a qemu direct linux boot.
 
 `Netdev=`, `--netdev`
 
@@ -1344,8 +1327,8 @@ systemd-nspawn -bi image.raw
 ```
 
 Additionally, bootable *GPT* disk images (as created with the
-`--bootable` flag) work when booted directly by *EFI* and *BIOS*
-systems, for example in *KVM* via:
+`--bootable` flag) work when booted directly by *EFI* systems,
+for example in *KVM* via:
 
 ```bash
 qemu-kvm -m 512 -smp 2 -bios /usr/share/edk2/ovmf/OVMF_CODE.fd -drive format=raw,file=image.raw

--- a/mkosi/gentoo.py
+++ b/mkosi/gentoo.py
@@ -53,7 +53,6 @@ class Gentoo:
     pkgs_sys: List[str]
     # filesystem packages (dosfstools, btrfs, squashfs, etc)
     pkgs_fs: List[str]
-    grub_platforms: List[str]
     UNINSTALL_IGNORE: List[str]
     root: Path
     portage_cfg_dir: Path
@@ -234,24 +233,18 @@ class Gentoo:
         if args.encrypt:
             self.pkgs_fs += ["cryptsetup", "device-mapper"]
 
-        self.grub_platforms = []
         if not do_run_build_script and args.bootable:
             if args.get_partition(PartitionIdentifier.esp):
                 self.pkgs_boot = ["sys-kernel/installkernel-systemd-boot"]
-            elif args.get_partition(PartitionIdentifier.bios):
-                self.pkgs_boot = ["sys-boot/grub"]
-                self.grub_platforms = ["coreboot", "qemu", "pc"]
             else:
                 self.pkgs_boot = []
 
             self.pkgs_boot += ["sys-kernel/gentoo-kernel-bin",
                                "sys-firmware/edk2-ovmf"]
 
-        # GENTOO_DONTMOVE: self.grub_platforms, for instance, must be set
         self.emerge_vars = {
             "BOOTSTRAP_USE": " ".join(self.portage_use_flags),
             "FEATURES": " ".join(self.portage_features),
-            "GRUB_PLATFORMS": " ".join(self.grub_platforms),
             "UNINSTALL_IGNORE": " ".join(self.UNINSTALL_IGNORE),
             "USE": " ".join(self.portage_use_flags),
         }
@@ -423,7 +416,6 @@ class Gentoo:
 
         self.baselayout_use = package_use.joinpath("baselayout")
         self.baselayout_use.write_text("sys-apps/baselayout build\n")
-        package_use.joinpath("grub").write_text("sys-boot/grub device-mapper truetype\n")
         package_use.joinpath("systemd").write_text(
             # repart for usronly
             dedent(

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -47,7 +47,7 @@ class MkosiConfig:
             "all_directory": None,
             "architecture": "x86_64",
             "bmap": False,
-            "boot_protocols": [],
+            "boot_protocols": None,
             "bootable": False,
             "build_dir": None,
             "build_packages": [],
@@ -124,6 +124,7 @@ class MkosiConfig:
             "tmp_size": None,
             "usr_only": False,
             "var_size": None,
+            "bios_size": None,
             "verb": Verb.build,
             "verity": False,
             "with_docs": False,
@@ -136,7 +137,7 @@ class MkosiConfig:
             "qemu_kvm": mkosi.qemu_check_kvm_support(),
             "qemu_args": [],
             "nspawn_keep_unit": False,
-            "qemu_boot": None,
+            "qemu_boot": "uefi",
             "netdev": False,
             "ephemeral": False,
             "with_unified_kernel_images": True,
@@ -248,8 +249,6 @@ class MkosiConfig:
                 self.reference_config[job_name]["force"] += 1
             if "Bootable" in mk_config_output:
                 self.reference_config[job_name]["bootable"] = mk_config_output["Bootable"]
-            if "BootProtocols" in mk_config_output:
-                self._append_list("boot_protocols", mk_config_output["BootProtocols"], job_name)
             if "KernelCommandLine" in mk_config_output:
                 self._append_list("kernel_command_line", mk_config_output["KernelCommandLine"], job_name, " ")
             if "SecureBoot" in mk_config_output:
@@ -555,7 +554,6 @@ class MkosiConfigManyParams(MkosiConfigOne):
                 "ManifestFormat": [mkosi.backend.ManifestFormat.json],
                 #                 # 'OutputDirectory': '',
                 "Bootable": False,
-                "BootProtocols": "uefi",
                 "KernelCommandLine": ["console=ttyS0"],
                 "SecureBoot": False,
                 "SecureBootKey": "/foo.pem",
@@ -624,7 +622,6 @@ class MkosiConfigManyParams(MkosiConfigOne):
                 "Output": "test_image.raw.xz",
                 #                 # 'OutputDirectory': '',
                 "Bootable": True,
-                "BootProtocols": "bios",
                 "KernelCommandLine": ["console=ttyS1"],
                 "SecureBoot": True,
                 "SecureBootKey": "/foo-ubu.pem",
@@ -691,7 +688,6 @@ class MkosiConfigManyParams(MkosiConfigOne):
                 "Output": "test_image.raw.xz",
                 #                 # 'OutputDirectory': '',
                 "Bootable": True,
-                "BootProtocols": "bios",
                 "KernelCommandLine": ["console=ttyS1"],
                 "SecureBoot": True,
                 "SecureBootKey": "/foo-debi.pem",

--- a/tests/test_parse_load_args.py
+++ b/tests/test_parse_load_args.py
@@ -140,5 +140,3 @@ def test_compression() -> None:
     with pytest.raises(MkosiException, match=".*compression.*squashfs"):
         parse(["--format", "gpt_squashfs", "--compress", "False"])
 
-    with pytest.raises(MkosiException, match=".*BIOS.*squashfs"):
-        parse(["--format", "gpt_squashfs", "--boot-protocols", "bios"])

--- a/tests/test_parse_load_args.py
+++ b/tests/test_parse_load_args.py
@@ -121,23 +121,6 @@ def test_centos_brtfs() -> None:
                 with pytest.raises(MkosiException, match=".CentOS.*btrfs"):
                     parse([])
 
-    with cd_temp_dir():
-        config = Path("mkosi.conf")
-        for dist in (Distribution.centos, Distribution.centos_epel):
-            for release in range (2, 8):
-                config.write_text(
-                    textwrap.dedent(
-                        f"""
-                        [Distribution]
-                        Distribution={Distribution.centos}
-                        Release={release}
-                        Bootable=yes
-                        """
-                    )
-                )
-                with pytest.raises(MkosiException, match=".CentOS.*unified.*kernel"):
-                    parse([])
-
 def test_shell_boot() -> None:
     with pytest.raises(MkosiException, match=".boot.*tar"):
         parse(["--format", "tar", "boot"])


### PR DESCRIPTION
See the individual commit messages. The goal is to align on EFI systems and systemd-boot as the only supported bootloaders for mkosi generated bootable images as discussed in the last biweekly.

cc @bluca @poettering @keszybz 