### PR TITLE
Verity: rename split files to match what systemd expects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,9 @@ on which grub can be installed.
 - mkosi now runs apt and dpkg on the host. As such, we now require apt and dpkg to be
 installed on the host along with debootstrap in order to be able to build debian/ubuntu
 images.
+- Split dm-verity artifacts default names have been changed to match what `systemd`
+  and other tools expect: `image.root.raw`, `image.root.verity`, `image.root.roothash`,
+  `image.root.roothash.p7s` (same for `usr` variants).
 
 ## v13
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -6531,7 +6531,7 @@ def load_args(args: argparse.Namespace) -> MkosiArgs:
         if args.verity:
             args.output_split_verity = build_auxiliary_output_path(args, ".verity", True)
             if args.verity == "signed":
-                args.output_split_verity_sig = build_auxiliary_output_path(args, ".verity-sig", True)
+                args.output_split_verity_sig = build_auxiliary_output_path(args, ".p7s", True)
         if args.bootable:
             args.output_split_kernel = build_auxiliary_output_path(args, ".efi", True)
 
@@ -7471,7 +7471,7 @@ def build_stuff(args: MkosiArgs) -> Manifest:
         raw = compress_output(args, raw)
         split_root = compress_output(args, image.split_root, ".usr" if args.usr_only else ".root")
         split_verity = compress_output(args, image.split_verity, ".verity")
-        split_verity_sig = compress_output(args, image.split_verity_sig, ".verity-sig")
+        split_verity_sig = compress_output(args, image.split_verity_sig, ".p7s")
         split_kernel = compress_output(args, image.split_kernel, ".efi")
         root_hash_file = write_root_hash_file(args, image.root_hash)
         root_hash_p7s_file = write_root_hash_p7s_file(args, image.root_hash_p7s)

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -6285,7 +6285,8 @@ def xescape(s: str) -> str:
 
 def build_auxiliary_output_path(args: Union[argparse.Namespace, MkosiArgs], suffix: str, can_compress: bool = False) -> Path:
     output = strip_suffixes(args.output)
-    compression = f".{should_compress_output(args)}" if can_compress else ''
+    should_compress = should_compress_output(args)
+    compression = f".{should_compress}" if can_compress and should_compress else ''
     return output.with_name(f"{output.name}{suffix}{compression}")
 
 


### PR DESCRIPTION
foo.raw means systemd searches automatically for foo.verity, foo.roothash/usrhash,
foo.roothash/usrhash.p7s so make the output match these existing
expectations

      Output Split Root FS: /home/luca/git/mkosi/mkosi.output/debian~unstable/image.usr.raw.zstd
       Output Split Verity: /home/luca/git/mkosi/mkosi.output/debian~unstable/image.usr.verity.zstd
  Output Split Verity Sig.: /home/luca/git/mkosi/mkosi.output/debian~unstable/image.usr.usrhash.p7s.zstd