### PR TITLE
debian/ubuntu: Run apt/dpkg on the host instead of in the root

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,9 @@ you need to update the keyring by running `pacman-key --populate archlinux`.
 - Support for BIOS/grub was dropped. To allow users to configure grub themselves, the
 new `--bios-size` option can be used to add a BIOS boot partition of the specified size
 on which grub can be installed.
+- mkosi now runs apt and dpkg on the host. As such, we now require apt and dpkg to be
+installed on the host along with debootstrap in order to be able to build debian/ubuntu
+images.
 
 ## v13
 


### PR DESCRIPTION
Similar to the other package managers, run apt/dpkg on the host
instead of in the container. This should allow us to implement
--repository-directory for apt as well and brings it more in line
with the other package managers.