### PR TITLE
debian/ubuntu: Ignore apt config from the host system

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2447,7 +2447,9 @@ def invoke_apt(
         INITRD="No",
     )
 
-    with mount_api_vfs(args, root):
+    # Overmount /etc/apt on the host with an empty directory, so that apt doesn't parse any configuration
+    # from it.
+    with mount_bind(workspace(root) / "apt", Path("/") / "etc/apt"), mount_api_vfs(args, root):
         return run(cmdline, env=env, text=True, **kwargs)
 
 


### PR DESCRIPTION
We only want to consider the apt config from the target system.
Because apt is rather inflexible and only parses the Dir option we
pass via the CLI after parsing all the config files from the host,
we have to resort to bind mounting an empty directory over /etc/apt
on the host to prevent it from reading configuration from there.