### PR TITLE
fedora: Automatically pick latest rawhide release

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2079,11 +2079,7 @@ def setup_dnf(args: MkosiArgs, root: Path, repos: Sequence[Repo] = ()) -> None:
 
 
 def parse_fedora_release(release: str) -> Tuple[str, str]:
-    if release == "rawhide":
-        last = list(FEDORA_KEYS_MAP)[-1]
-        warn(f"Assuming rawhide is version {last} — " + "You may specify otherwise with --release=rawhide-<version>")
-        return ("rawhide", last)
-    elif release.startswith("rawhide-"):
+    if release.startswith("rawhide-"):
         release, releasever = release.split("-")
         MkosiPrinter.info(f"Fedora rawhide — release version: {releasever}")
         return ("rawhide", releasever)


### PR DESCRIPTION
We can automatically get the key for the latest rawhide now as there's
a symlink we can use to get it. For remote GPG keys, the existing
mechanism can be used.