### PR TITLE
nspawn: use --link-journal=no

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -7307,6 +7307,7 @@ def run_build_script(args: MkosiArgs, root: Path, raw: Optional[BinaryIO]) -> No
             f"--uuid={args.machine_id}",
             f"--machine=mkosi-{uuid.uuid4().hex}",
             "--as-pid2",
+            "--link-journal=no",
             "--register=no",
             f"--bind={install_dir(args, root)}:/root/dest",
             f"--bind={var_tmp(root)}:/var/tmp",

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -686,6 +686,7 @@ def run_workspace_command(
         "--uuid=" + args.machine_id,
         "--machine=mkosi-" + uuid.uuid4().hex,
         "--as-pid2",
+        "--link-journal=no",
         "--register=no",
         f"--bind={var_tmp(root)}:/var/tmp",
         "--setenv=SYSTEMD_OFFLINE=1",


### PR DESCRIPTION
The host might not have a journal.

On a minimal qemu build image on OBS, building SUSE Tumbleweed,
linking the journal fails with:

  Failed to retrieve machine ID: No medium found