### PR TITLE
Don't pass environment when running kernel-install

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -7111,8 +7111,7 @@ def run_kernel_install(config: MkosiConfig, state: MkosiState, for_cache: bool, 
 
     with complete_step("Generating initramfs images…"):
         for kver, kimg in gen_kernel_images(config, state.root):
-            run_workspace_command(config, state.root, ["kernel-install", "add", kver, Path("/") / kimg],
-                                  env=config.environment)
+            run_workspace_command(config, state.root, ["kernel-install", "add", kver, Path("/") / kimg])
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Initially introduced in 32d09033e94f36993bede7016948e0702a4cb185,
but the reason wasn't recorded. Generally, we don't want to pass
just any environment variables to kernel-install, so let's not pass
the entire environment when running it.