### PR TITLE
debian/ubuntu: Pass Architecture option to apt

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2451,10 +2451,13 @@ def invoke_apt(
     **kwargs: Any,
 ) -> CompletedProcess:
 
+    debarch = DEBIAN_ARCHITECTURES[config.architecture]
+
     cmdline = [
         f"/usr/bin/apt-{subcommand}",
         "-o", f"Dir={root}",
         "-o", f"DPkg::Chroot-Directory={root}",
+        "-o", f"APT::Architecture={debarch}",
         operation,
         *extra,
     ]


### PR DESCRIPTION
Pass the target architecture to apt, otherwise mkosi ... --architecture
pulls in packages for the host architecture. This fixes generation of
container images for non-host architectures, e.g. generation of images
on amd64 host for arm64 target.