### PR TITLE
debian/ubuntu: Increase apt recursive limit

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2458,6 +2458,7 @@ def invoke_apt(
         "-o", f"Dir={root}",
         "-o", f"DPkg::Chroot-Directory={root}",
         "-o", f"APT::Architecture={debarch}",
+        "-o", "dpkg::install::recursive::minimum=1000",
         operation,
         *extra,
     ]


### PR DESCRIPTION
With debian 11.4 amd64 host, mkosi fails with the following:
"
Chrooting into /var/tmp/mkosi-_elvunh3/root/
dpkg: error: cannot stat pathname '/tmp/apt-dpkg-install-LyrJgL': No such file or directory
"
By increasing the recursive limit, the parameter --recursive
is not passed to dpkg and the list of packages is passed to
dpkg on a command line instead of in the /tmp/apt-dpkg-install
temp file, which also avoids the aforementioned failure. There
seem to be no way to explicitly disable passing the --recursive
parameter to dpkg via apt options.

However, this is still a workaround. It is not clear why the
temp files are not found. Furthermore, add Debug::pkgDPkgPM=1
apt option makes this problem go away as well, which might
indicate some sort of race condition.

NOTE: Depends on https://github.com/systemd/mkosi/pull/1171 .