### PR TITLE
Expose IMAGE_ID and IMAGE_VERSION to all scripts

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -614,7 +614,7 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   in the default output file name, i.e. instead of `image.raw` the
   default will be `image_0.1.raw` for version `0.1` of the image, and
   similar. The version is also passed via the `$IMAGE_VERSION` to any
-  build scripts invoked (which may be useful to patch it into
+  scripts invoked (which may be useful to patch it into
   `/etc/os-release` or similar, in particular the `IMAGE_VERSION=`
   field of it).
 
@@ -626,7 +626,7 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   this option is used the root, `/usr/` and Verity partitions in the
   image will have their labels set to this (possibly suffixed by the
   image version). The identifier is also passed via the `$IMAGE_ID` to
-  any build scripts invoked (which may be useful to patch it into
+  any scripts invoked (which may be useful to patch it into
   `/etc/os-release` or similar, in particular the `IMAGE_ID=` field of
   it).
 

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -713,6 +713,10 @@ def run_workspace_command(
         nspawn += [f"--setenv={k}={v}" for k, v in env.items()]
     if "workspace-command" in ARG_DEBUG:
         nspawn += ["--setenv=SYSTEMD_LOG_LEVEL=debug"]
+    if config.image_version is not None:
+        nspawn += [f"--setenv=IMAGE_VERSION={config.image_version}"]
+    if config.image_id is not None:
+        nspawn += [f"--setenv=IMAGE_ID={config.image_id}"]
 
     if nspawn_params:
         nspawn += nspawn_params


### PR DESCRIPTION
If the variables are available in mkosi.prepare or mkosi.postinst many images don't need a build phase.