### PR TITLE
Skip tests requiring namespaces when using env MKOSI_TEST_NO_NAMESPACE=1

### DIFF
--- a/mkosi/machine.py
+++ b/mkosi/machine.py
@@ -117,6 +117,10 @@ class Machine:
         if needs_build(self.config):
             check_root()
             check_native(self.config)
+
+            # Useful if testing within Docker which will not allow more namespaces
+            if parse_boolean(os.getenv("MKOSI_TEST_NO_NAMESPACE", "0")):
+                raise unittest.SkipTest("Build test skipped due to environment variable.")
             init_namespace()
             build_stuff(self.config)
 


### PR DESCRIPTION
This change will skip any unit tests that require Linux namespace support if the environment variable `MKOSI_TEST_NO_NAMESPACE=1`. This is primarily useful for wrapping unit testing inside a Docker container.