### PR TITLE
No longer mention black and fix indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,8 @@ This will install mkosi in editable mode to `~/.local/bin/mkosi`, allowing you
 to use your own changes right away.
 
 For development you also need [mypy](https://github.com/python/mypy), for type
-checking, [pytest](https://github.com/pytest-dev/pytest), to run tests, and
-[black](https://github.com/psf/black), for code formatting. We check tests,
-typing and code formatting in CI (see `.github/workflows`), but you can run the
+checking, and [pytest](https://github.com/pytest-dev/pytest), to run tests.
+We check tests and typing in CI (see `.github/workflows`), but you can run the
 tests locally as well.
 
 ## zipapp

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -680,10 +680,10 @@ def nspawn_knows_arg(arg: str) -> bool:
 
 
 def format_rlimit(rlimit: int) -> str:
-        limits = resource.getrlimit(rlimit)
-        soft = "infinity" if limits[0] == resource.RLIM_INFINITY else str(limits[0])
-        hard = "infinity" if limits[1] == resource.RLIM_INFINITY else str(limits[1])
-        return f"{soft}:{hard}"
+    limits = resource.getrlimit(rlimit)
+    soft = "infinity" if limits[0] == resource.RLIM_INFINITY else str(limits[0])
+    hard = "infinity" if limits[1] == resource.RLIM_INFINITY else str(limits[1])
+    return f"{soft}:{hard}"
 
 
 def nspawn_rlimit_params() -> Sequence[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[tool.black]
-line-length = 119
-target-version = ['py37']
-
 [tool.isort]
 profile = "black"
 multi_line_output = 3

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -32,29 +32,29 @@ def test_strip_suffixes() -> None:
 
 
 def test_copy_file(tmpdir: Path) -> None:
-        dir_path = Path(tmpdir)
-        file_1 = Path(dir_path) / "file_1.txt"
-        file_2 = Path(dir_path) / "file_2.txt"
-        file_1.touch()
-        file_2.touch()
+    dir_path = Path(tmpdir)
+    file_1 = Path(dir_path) / "file_1.txt"
+    file_2 = Path(dir_path) / "file_2.txt"
+    file_1.touch()
+    file_2.touch()
 
-        # Copying two empty files.
-        mkosi.copy_file(file_1, file_2)
-        assert filecmp.cmp(file_1, file_2)
+    # Copying two empty files.
+    mkosi.copy_file(file_1, file_2)
+    assert filecmp.cmp(file_1, file_2)
 
-        # Copying content from one file.
-        file_1.write_text("Testing copying content from this file to file_2.")
-        mkosi.copy_file(file_1, file_2)
-        assert filecmp.cmp(file_1, file_2)
+    # Copying content from one file.
+    file_1.write_text("Testing copying content from this file to file_2.")
+    mkosi.copy_file(file_1, file_2)
+    assert filecmp.cmp(file_1, file_2)
 
-        # Giving a non existing path/file.
-        with pytest.raises(OSError):
-            mkosi.copy_file("nullFilePath", file_1)
+    # Giving a non existing path/file.
+    with pytest.raises(OSError):
+        mkosi.copy_file("nullFilePath", file_1)
 
-        # Copying when there's already content in both files.
-        file_2.write_text("Testing copying content from file_1 to file_2, with previous data.")
-        mkosi.copy_file(file_1, file_2)
-        assert filecmp.cmp(file_1, file_2)
+    # Copying when there's already content in both files.
+    file_2.write_text("Testing copying content from file_1 to file_2, with previous data.")
+    mkosi.copy_file(file_1, file_2)
+    assert filecmp.cmp(file_1, file_2)
 
 
 def test_parse_bytes() -> None:

--- a/tests/test_parse_load_args.py
+++ b/tests/test_parse_load_args.py
@@ -104,7 +104,7 @@ def test_centos_brtfs() -> None:
     with cd_temp_dir():
         config = Path("mkosi.conf")
         for dist in (Distribution.centos, Distribution.centos_epel):
-            for release in range (2, 9):
+            for release in range(2, 9):
                 config.write_text(
                     textwrap.dedent(
                         f"""


### PR DESCRIPTION
Mkosi uses 4 spaces for indentation, fix 2 functions with 8 spaces. Since #779 formatting with black wasn't enforced but still mentioned as required in README.