### PR TITLE
Start nspawn containers with read/write permissions

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -7535,9 +7535,6 @@ def run_shell_cmdline(config: MkosiConfig, pipe: bool = False, commands: Optiona
 
     cmdline = [nspawn_executable(), "--quiet", target]
 
-    if config.read_only:
-        cmdline += ["--read-only"]
-
     # If we copied in a .nspawn file, make sure it's actually honoured
     if config.nspawn_settings is not None:
         cmdline += ["--settings=trusted"]
@@ -7551,9 +7548,6 @@ def run_shell_cmdline(config: MkosiConfig, pipe: bool = False, commands: Optiona
         console_arg = f"--console={'interactive' if not pipe else 'pipe'}"
         if nspawn_knows_arg(console_arg):
             cmdline += [console_arg]
-
-    if is_generated_root(config) or config.verity:
-        cmdline += ["--volatile=overlay"]
 
     if config.netdev:
         if ensure_networkd(config):


### PR DESCRIPTION
Don't set the --read-only flag for nspawn containers if just the root partition is read-only. Don't set the --volatile=overlay flag for images created with usr-only or a generated root. If the --volatile=overlay flag is set the container won't find the shell or init program.

Error for example with --volatile=overlay and `mkosi boot`: `execv(/usr/lib/systemd/systemd, /lib/systemd/systemd, /sbin/init) failed: No such file or directory`
The --read-only argument was originally added by @keszybz in https://github.com/systemd/mkosi/commit/0ba62767748ca8ef2ea6b300168887a60f3a07c6
The --volatile=overlay argument was originally added by @DaanDeMeyer in https://github.com/systemd/mkosi/commit/721700be9971f61512474534726c5a03f93cc718 and https://github.com/systemd/mkosi/commit/76fbd875a7411977cd9db6b1cd0e5665686327c9
Can the checks be completely removed or are they still need for some configurations?

Minimal testcase: `mkosi --format gpt_squashfs --verity --usr-only`. (Doesn't boot with main, boots with patch.)