### PR TITLE
Allow single files to be used with --extra-search-paths

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -1275,13 +1275,6 @@ Those settings cannot be configured in the configuration files.
   each build in a series will have a version number one higher then
   the previous one.
 
-### Environment Variables
-
-`MKOSI_NSPAWN_EXECUTABLE`
-
-: Takes a path. If specified, mkosi will use this path as the systemd-nspawn
-  executable instead of the system installation of systemd-nspawn.
-
 ## Supported distributions
 
 Images may be created containing installations of the

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -86,7 +86,6 @@ from .backend import (
     is_centos_variant,
     is_epel_variant,
     is_rpm_distribution,
-    nspawn_executable,
     nspawn_knows_arg,
     nspawn_rlimit_params,
     nspawn_version,
@@ -7236,7 +7235,7 @@ def run_build_script(state: MkosiState, raw: Optional[BinaryIO]) -> None:
         with_network = 1 if state.config.with_network is True else 0
 
         cmdline = [
-            nspawn_executable(),
+            "systemd-nspawn",
             "--quiet",
             target,
             f"--machine=mkosi-{uuid.uuid4().hex}",
@@ -7535,7 +7534,7 @@ def run_shell_cmdline(config: MkosiConfig, pipe: bool = False, commands: Optiona
     else:
         target = f"--image={config.output}"
 
-    cmdline = [nspawn_executable(), "--quiet", target]
+    cmdline = ["systemd-nspawn", "--quiet", target]
 
     if config.read_only:
         cmdline += ["--read-only"]

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -673,7 +673,7 @@ def workspace(root: Path) -> Path:
 def nspawn_knows_arg(arg: str) -> bool:
     # Specify some extra incompatible options so nspawn doesn't try to boot a container in the current
     # directory if it has a compatible layout.
-    return "unrecognized option" not in run([nspawn_executable(), arg,
+    return "unrecognized option" not in run(["systemd-nspawn", arg,
                                             "--directory", "/dev/null", "--image", "/dev/null"],
                                             stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=False,
                                             text=True).stderr
@@ -692,12 +692,8 @@ def nspawn_rlimit_params() -> Sequence[str]:
     ] if nspawn_knows_arg("--rlimit") else []
 
 
-def nspawn_executable() -> str:
-    return os.getenv("MKOSI_NSPAWN_EXECUTABLE", "systemd-nspawn")
-
-
 def nspawn_version() -> int:
-    return int(run([nspawn_executable(), "--version"], stdout=subprocess.PIPE).stdout.strip().split()[1])
+    return int(run(["systemd-nspawn", "--version"], stdout=subprocess.PIPE).stdout.strip().split()[1])
 
 
 def run_workspace_command(
@@ -710,7 +706,7 @@ def run_workspace_command(
     check: bool = True,
 ) -> CompletedProcess:
     nspawn = [
-        nspawn_executable(),
+        "systemd-nspawn",
         "--quiet",
         f"--directory={state.root}",
         "--machine=mkosi-" + uuid.uuid4().hex,


### PR DESCRIPTION
Sometimes we just want to use one file from a directory of files
with --extra-search-paths. Let's make sure we support this by putting
a symlink to the file in a temporary directory and adding that directory
to PATH.