### PR TITLE
Guard cryptography imports

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -559,6 +559,18 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   provisions described in the [Discoverable Partitions
   Specification](https://systemd.io/DISCOVERABLE_PARTITIONS).
 
+  This option requires the [`cryptography`](https://cryptography.io/)
+  module.
+
+`Measure=`, `--measure`
+
+: Measure the components of the unified kernel image (UKI) using
+  `systemd-measure` and embed the PCR signature into the unified kernel
+  image.
+
+  This option requires the [`cryptography`](https://cryptography.io/)
+  module.
+
 `CompressFs=`, `--compress-fs=`
 
 : Enable or disable internal compression in the file system. Only

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3757,10 +3757,13 @@ def make_verity_sig(
 
     assert root_hash is not None
 
-    from cryptography import x509
-    from cryptography.hazmat.primitives import hashes, serialization
-    from cryptography.hazmat.primitives.asymmetric import ec, rsa
-    from cryptography.hazmat.primitives.serialization import pkcs7
+    try:
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import ec, rsa
+        from cryptography.hazmat.primitives.serialization import pkcs7
+    except ImportError:
+        die("Verity support needs the cryptography module. Please install it.")
 
     with complete_step("Signing verity root hash…"):
 
@@ -3987,38 +3990,42 @@ def install_unified_kernel(
             # systemd-measure binary around, then also include a
             # signature of expected PCR 11 values in the kernel image
             if state.config.secure_boot:
-                if shutil.which('systemd-measure'):
-                    with complete_step("Generating PCR 11 signature…"):
-                        from cryptography import x509
-                        from cryptography.hazmat.primitives import serialization
+                try:
+                    from cryptography import x509
+                    from cryptography.hazmat.primitives import serialization
 
-                        # Extract the public key from the SecureBoot certificate
-                        cert = x509.load_pem_x509_certificate(state.config.secure_boot_certificate.read_bytes())
-                        pcrpkey = state.workspace / "pcrpkey.pem"
-                        pcrpkey.write_bytes(cert.public_key().public_bytes(
-                            encoding=serialization.Encoding.PEM,
-                            format=serialization.PublicFormat.SubjectPublicKeyInfo))
+                    if shutil.which('systemd-measure'):
+                        with complete_step("Generating PCR 11 signature…"):
 
-                        cmd_measure: Sequence[PathString] = [
-                            "systemd-measure",
-                            "sign",
-                            f"--linux={state.root / kimg}",
-                            f"--osrel={osrelease}",
-                            f"--cmdline={cmdline}",
-                            f"--initrd={initrd}",
-                            f"--pcrpkey={pcrpkey}",
-                            f"--private-key={state.config.secure_boot_key}",
-                            f"--public-key={pcrpkey}",
-                            "--bank=sha1",
-                            "--bank=sha256",
-                        ]
+                            # Extract the public key from the SecureBoot certificate
+                            cert = x509.load_pem_x509_certificate(state.config.secure_boot_certificate.read_bytes())
+                            pcrpkey = state.workspace / "pcrpkey.pem"
+                            pcrpkey.write_bytes(cert.public_key().public_bytes(
+                                encoding=serialization.Encoding.PEM,
+                                format=serialization.PublicFormat.SubjectPublicKeyInfo))
 
-                        c = run(cmd_measure, stdout=subprocess.PIPE)
+                            cmd_measure = [
+                                "systemd-measure",
+                                "sign",
+                                f"--linux={state.root / kimg}",
+                                f"--osrel={osrelease}",
+                                f"--cmdline={cmdline}",
+                                f"--initrd={initrd}",
+                                f"--pcrpkey={pcrpkey}",
+                                f"--private-key={state.config.secure_boot_key}",
+                                f"--public-key={pcrpkey}",
+                                "--bank=sha1",
+                                "--bank=sha256",
+                            ]
 
-                        pcrsig = state.workspace / "pcrsig.json"
-                        pcrsig.write_bytes(c.stdout)
-                else:
-                    MkosiPrinter.info("Couldn't find systemd-measure binary, not embedding PCR signature in unified kernel image.")
+                            c = run(cmd_measure, stdout=subprocess.PIPE)
+
+                            pcrsig = state.workspace / "pcrsig.json"
+                            pcrsig.write_bytes(c.stdout)
+                    else:
+                        MkosiPrinter.info("Couldn't find systemd-measure binary, not embedding PCR signature in unified kernel image.")
+                except ImportError:
+                    MkosiPrinter.info("Couldn't import the cryptography Python module, not embedding PCR signature in unified kernel image.")
 
             cmd: List[PathString] = [
                 "objcopy",

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -485,6 +485,7 @@ class MkosiConfig:
     read_only: bool
     encrypt: Optional[str]
     verity: Union[bool, str]
+    measure: bool
     compress: Union[None, str, bool]
     compress_fs: Union[None, str, bool]
     compress_output: Union[None, str, bool]

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -128,6 +128,7 @@ class MkosiConfig:
             "bios_size": None,
             "verb": Verb.build,
             "verity": False,
+            "measure": False,
             "with_docs": False,
             "with_network": False,
             "with_tests": True,


### PR DESCRIPTION
This guards the cryptography imports - and adds a nicer error in the verity case - so that we are still nominally dependency-free beyond the stdlib.