### PR TITLE
archlinux: Check both native machine arch and command line arch

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2708,7 +2708,7 @@ def install_arch(state: MkosiState) -> None:
                 GPGDir = /etc/pacman.d/gnupg/
                 HookDir = {state.root}/etc/pacman.d/hooks/
                 HoldPkg = pacman glibc
-                Architecture = auto
+                Architecture = {state.config.architecture}
                 Color
                 CheckSpace
                 SigLevel = {sig_level}
@@ -6414,10 +6414,11 @@ def load_args(args: argparse.Namespace) -> MkosiConfig:
             args.mirror = "http://archive.ubuntu.com/ubuntu"
             if platform.machine() == "aarch64":
                 args.mirror = "http://ports.ubuntu.com/"
-        elif args.distribution == Distribution.arch and platform.machine() == "aarch64":
-            args.mirror = "http://mirror.archlinuxarm.org"
-        elif args.distribution == Distribution.arch and platform.machine() == "x86_64":
-            args.mirror = "https://geo.mirror.pkgbuild.com"
+        elif args.distribution == Distribution.arch:
+            if args.architecture == "aarch64":
+                args.mirror = "http://mirror.archlinuxarm.org"
+            else:
+                args.mirror = "https://geo.mirror.pkgbuild.com"
         elif args.distribution == Distribution.opensuse:
             args.mirror = "http://download.opensuse.org"
         elif args.distribution in (Distribution.rocky, Distribution.rocky_epel):


### PR DESCRIPTION
Test both native machine architecture and command line --architecture switch when selecting the mirror.archlinuxarm.org. The former only works in case mkosi runs on aarch64 already, the later is necessary in case the mkosi is generated foreign architecture container (e.g. mkosi on amd64 generates arm64 container).

Fix Architecture parameter passed into pacman.conf to permit generation of foreign architecture containers.

The test on debian/sid amd64 used to generate archlinuxarm aarch64 container looks something like this:
1) Setup pacman
```
$ pacman-key --init
```
- Download http://mirror.archlinuxarm.org/aarch64/core/archlinuxarm-keyring-20140119-2-any.pkg.tar.xz
- Verify the download
- Extract keys into /usr/share/keyrings
```
$ pacman-key --populate
$ pacman-key --populate archlinuxarm
$ pacman-key --refresh-keys
```
2) Run `mkosi --architecture aarch64 ...`