### PR TITLE
Rename --measure option and add a special value auto

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -566,10 +566,10 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 
 : Measure the components of the unified kernel image (UKI) using
   `systemd-measure` and embed the PCR signature into the unified kernel
-  image.
-
-  This option requires the [`cryptography`](https://cryptography.io/)
-  module.
+  image. This option takes a boolean value or the special value `auto`,
+  which is the default, which is equal to a true value if the
+  [`cryptography`](https://cryptography.io/) module is importable and
+  the `systemd-measure` binary is in `PATH`.
 
 `CompressFs=`, `--compress-fs=`
 

--- a/mkosi.md
+++ b/mkosi.md
@@ -562,7 +562,7 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   This option requires the [`cryptography`](https://cryptography.io/)
   module.
 
-`Measure=`, `--measure`
+`SignExpectedPCR=`, `--sign-expected-pcr`
 
 : Measure the components of the unified kernel image (UKI) using
   `systemd-measure` and embed the PCR signature into the unified kernel

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3991,15 +3991,15 @@ def install_unified_kernel(
             # If a SecureBoot key is configured, and we have the
             # systemd-measure binary around, then also include a
             # signature of expected PCR 11 values in the kernel image
-            if state.config.secure_boot and state.config.measure:
+            if state.config.secure_boot and state.config.sign_expected_pcr:
                 try:
                     from cryptography import x509
                     from cryptography.hazmat.primitives import serialization
                 except ImportError:
-                    die("Couldn't import the cryptography Python module. This is needed for the --measure option.")
+                    die("Couldn't import the cryptography Python module. This is needed for the --sign-expected-pcr option.")
 
                 if not shutil.which('systemd-measure'):
-                    die("Couldn't find systemd-measure binary. It is needed for the --measure option.")
+                    die("Couldn't find systemd-measure binary. It is needed for the --sign-expected-pcr option.")
 
                 with complete_step("Generating PCR 11 signature…"):
                     # Extract the public key from the SecureBoot certificate
@@ -4882,7 +4882,8 @@ class ArgumentParserMkosi(argparse.ArgumentParser):
         "PostInstallationScript": "--postinst-script",
         "GPTFirstLBA": "--gpt-first-lba",
         "TarStripSELinuxContext": "--tar-strip-selinux-context",
-        "MachineID": "--machine-id"
+        "MachineID": "--machine-id",
+        "SignExpectedPCR": "--sign-expected-pcr",
     }
 
     fromfile_prefix_chars: str = "@"
@@ -5210,7 +5211,7 @@ def create_parser() -> ArgumentParserMkosi:
         help="Add integrity partition, and optionally sign it (implies --read-only)",
     )
     group.add_argument(
-        "--measure",
+        "--sign-expected-pcr",
         action=BooleanAction,
         help="Measure the components of the unified kernel image (UKI) and embed the PCR signature into the UKI",
     )

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -485,7 +485,7 @@ class MkosiConfig:
     read_only: bool
     encrypt: Optional[str]
     verity: Union[bool, str]
-    measure: bool
+    sign_expected_pcr: bool
     compress: Union[None, str, bool]
     compress_fs: Union[None, str, bool]
     compress_output: Union[None, str, bool]

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -3,7 +3,9 @@
 import configparser
 import contextlib
 import copy
+import importlib
 import os
+import shutil
 from pathlib import Path
 from typing import Any, Dict, Generator, List, Mapping, Optional
 
@@ -35,6 +37,13 @@ class MkosiConfig:
     def __init__(self) -> None:
         self.cli_arguments = []
         self.reference_config = {}
+
+    def local_sign_expected_pcr_default(self) -> bool:
+        try:
+            importlib.import_module("cryptography")
+            return True if shutil.which('systemd-measure') else False
+        except ImportError:
+            return False
 
     def add_reference_config(self, job_name: str = DEFAULT_JOB_NAME) -> None:
         """create one initial reference configuration
@@ -128,7 +137,7 @@ class MkosiConfig:
             "bios_size": None,
             "verb": Verb.build,
             "verity": False,
-            "sign_expected_pcr": False,
+            "sign_expected_pcr": self.local_sign_expected_pcr_default(),
             "with_docs": False,
             "with_network": False,
             "with_tests": True,

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -128,7 +128,7 @@ class MkosiConfig:
             "bios_size": None,
             "verb": Verb.build,
             "verity": False,
-            "measure": False,
+            "sign_expected_pcr": False,
             "with_docs": False,
             "with_network": False,
             "with_tests": True,


### PR DESCRIPTION
As discussed in #1200 here another follow-up. 

It's a bit more unwieldy than I'd liked. Why that is, can be found in the message of the second commit. This would probably work just a fine without the additional argparse.action, but I didn't test this so far, because I didn't want to stray too much from what we had so far.