### PR TITLE
Change file owner of {build,output}-dir and parents to `SUDO_{U,G}ID`

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4452,7 +4452,7 @@ def chown_from_sudo(path: PathString) -> None:
 
 
 def mkdirp_chown(dirpath: PathString) -> None:
-    abspath = dirpath.absolute()
+    abspath = Path(dirpath).absolute()
     parents = []
     for d in abspath.parts:
         parents.append(d)

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4451,6 +4451,18 @@ def chown_from_sudo(path: PathString) -> None:
         os.chown(path, int(sudo_uid), int(sudo_gid))
 
 
+def mkdirp_chown(dirpath: PathString) -> None:
+    abspath = dirpath.absolute()
+    parents = []
+    for d in abspath.parts:
+        parents.append(d)
+        pd = Path(os.path.join(*parents))
+        if pd.exists():
+            continue
+        pd.mkdir()
+        chown_from_sudo(pd)
+
+
 def _link_output(
         config: MkosiConfig,
         oldpath: PathString,
@@ -6238,7 +6250,7 @@ def find_output(args: argparse.Namespace) -> None:
     else:
         return
 
-    args.output_dir.mkdir(parents=True, exist_ok=True)
+    mkdirp_chown(args.output_dir)
 
 
 def find_builddir(args: argparse.Namespace) -> None:
@@ -6251,7 +6263,7 @@ def find_builddir(args: argparse.Namespace) -> None:
     else:
         return
 
-    args.build_dir.mkdir(parents=True, exist_ok=True)
+    mkdirp_chown(args.build_dir)
 
 
 def find_cache(args: argparse.Namespace) -> None:
@@ -7033,7 +7045,7 @@ def make_output_dir(config: MkosiConfig) -> None:
     if config.output_dir is None:
         return
 
-    config.output_dir.mkdir(mode=0o755, exist_ok=True)
+    mkdirp_chown(config.output_dir)
 
 
 def make_build_dir(config: MkosiConfig) -> None:
@@ -7041,7 +7053,7 @@ def make_build_dir(config: MkosiConfig) -> None:
     if config.build_dir is None:
         return
 
-    config.build_dir.mkdir(mode=0o755, exist_ok=True)
+    mkdirp_chown(config.build_dir)
 
 
 def configure_ssh(state: MkosiState, cached: bool) -> Optional[TextIO]:


### PR DESCRIPTION
This PR ensures that the `--{build,output}-dir`s and any of their parents that mkosi creates are chowned to `SUDO_{U,G}ID`.

See issue #1232. With mkosi@main:

```bash
cd $(mktemp -d)
sudo mkosi --output-dir=a/b/c
tree -ug
# =>
# [nick     wheel   ]  .
# └── [root     root    ]  a
#     └── [root     root    ]  b
#         └── [root     root    ]  c
#             └── [root     root    ]  arch~rolling
#                 ├── [nick     wheel   ]  image.raw
#                 └── [nick     wheel   ]  image.raw.manifest
```

With this branch:

```bash
cd $(mktemp -d)
sudo mkosi --output-dir=a/b/c
tree -ug
# =>
# [nick     wheel   ]  .
# └── [nick     wheel   ]  a
#     └── [nick     wheel   ]  b
#         └── [nick     wheel   ]  c
#             └── [nick     wheel   ]  arch~rolling
#                 ├── [nick     wheel   ]  image.raw
#                 └── [nick     wheel   ]  image.raw.manifest
```

Note that this only changes directories that mkosi creates. Directories already present aren't modified:

```bash
cd $(mktemp -d)
sudo mkdir a
sudo mkosi --output-dir=a/b/c
tree -ug
# =>
# [nick     wheel   ]  .
# └── [root     root    ]  a
#     └── [nick     wheel   ]  b
#         └── [nick     wheel   ]  c
#             └── [nick     wheel   ]  arch~rolling
#                 ├── [nick     wheel   ]  image.raw
#                 └── [nick     wheel   ]  image.raw.manifest
```