### PR TITLE
dnf: Disable versionlock plugin

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1957,6 +1957,7 @@ def invoke_dnf(state: MkosiState, command: str, packages: Iterable[str]) -> None
         "--allowerasing",
         f"--releasever={release}",
         f"--installroot={state.root}",
+        "--disableplugin=versionlock",
         "--setopt=keepcache=1",
         "--setopt=install_weak_deps=0",
     ]


### PR DESCRIPTION
The host's versionlock plugin / setup will exclude stuff that one tries to get into the image… Most of the other tools (mock, kiwi) are doing it this way.