### PR TITLE
Use the detected distribution version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -44,6 +44,8 @@
 - Split dm-verity artifacts default names have been changed to match what
   `systemd` and other tools expect: `image.root.raw`, `image.root.verity`,
   `image.root.roothash`, `image.root.roothash.p7s` (same for `usr` variants).
+- `mkosi` will again default to the same OS release as the host system when the
+  host system uses the same distribution as the image that's being built.
 
 ## v13
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5864,6 +5864,9 @@ def load_distribution(args: argparse.Namespace) -> argparse.Namespace:
         if args.distribution is None:
             args.distribution = d
 
+        if args.distribution == d and args.release is None:
+            args.release = r
+
     if args.distribution is None:
         die("Couldn't detect distribution.")
 


### PR DESCRIPTION
I used mkosi without any explicit distro/version parameters and was a bit surprised that it built for Fedora 36 by default after successfully detecting that it's running on Fedora 37. I don't think this makes much sense. Let's use the same distro+version combination as what is detected. This is more likely to be what users expect, and also avoids the awkward issue that when we hardcode some default version, this version is likely to be "wrong" (not the latest) until both the distro and we make a release.