### PR TITLE
ssh: fix copy_file for authorized_keys

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -7099,6 +7099,7 @@ def configure_ssh(state: MkosiState, cached: bool) -> Optional[TextIO]:
                 stdout=subprocess.DEVNULL,
             )
 
+        authorized_keys.parent.mkdir(parents=True, exist_ok=True)
         copy_file(f"{f.name}.pub", authorized_keys)
         os.remove(f"{f.name}.pub")
 


### PR DESCRIPTION
When attempting to copy the public key to the remote images authorized_keys file, the parent path does not exist and the following exception is thrown[1]:
‣  Generating SSH key pair…
‣  (Unmounting image)
‣  (Detaching /dev/loop17)
Traceback (most recent call last):
  File "/home/wcrobert/workspace/mkosi/mkosi/__init__.py", line 7357, in setup_ssh
    copy_file(f"{f.name}.pub", authorized_keys)
  File "/home/wcrobert/workspace/mkosi/mkosi/__init__.py", line 614, in copy_file
    with open_close(newpath, os.O_WRONLY | os.O_CREAT | os.O_EXCL, st.st_mode) as newfd:
  File "/usr/lib/python3.8/contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "/home/wcrobert/workspace/mkosi/mkosi/__init__.py", line 571, in open_close
    fd = os.open(path, flags | os.O_CLOEXEC, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/var/tmp/mkosi-_0v_4emp/root/root/.ssh/authorized_keys'

The path only existed up to "/var/tmp/mkosi-_0v_4emp/root", thus a mkdir with -p semantics is required to create the full path, add that in.

[1] Note line numbers are off due to having some print's scattered through the code for debugging.

Fixes: #1238

Signed-off-by: William Roberts <william.c.roberts@intel.com>