### PR TITLE
Add --noplugins when calling dnf

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1959,6 +1959,7 @@ def invoke_dnf(state: MkosiState, command: str, packages: Iterable[str]) -> None
         f"--installroot={state.root}",
         "--setopt=keepcache=1",
         "--setopt=install_weak_deps=0",
+        "--noplugins",
     ]
 
     if state.config.repositories:


### PR DESCRIPTION
Let's isolate image builds using dnf from the host a bit more by disabling all plugins. For example, plugins such as versionlock can interfere with the version of packages installed in the image which we want to avoid.