### PR TITLE
Use `mount`'s new `X-mount.idmap` option

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -329,7 +329,7 @@ def mount_cache(state: MkosiState) -> Iterator[None]:
     # We can't do this in mount_image() yet, as /var itself might have to be created as a subvolume first
     with complete_step("Mounting Package Cache", "Unmounting Package Cache"), contextlib.ExitStack() as stack:
         for cache_path in cache_paths:
-            stack.enter_context(mount_bind(state.cache, state.root / cache_path))
+            stack.enter_context(mount_bind(state.cache, state.root / cache_path, with_idmapping=True))
         yield
 
 
@@ -3819,7 +3819,7 @@ def build_stuff(config: MkosiConfig) -> None:
                 shutil.move(str(state.staging / p.name), str(p))
                 if p in (state.config.output, state.config.output_split_kernel):
                     compress_output(state.config, p)
-            if state.config.chown and p.exists(): 
+            if state.config.chown and p.exists():
                 chown_to_running_user(p)
 
         for p in state.staging.iterdir():

--- a/mkosi/mounts.py
+++ b/mkosi/mounts.py
@@ -62,13 +62,19 @@ def mount(
         run(["umount", "--no-mtab", "--recursive", where])
 
 
-def mount_bind(what: Path, where: Optional[Path] = None) -> ContextManager[Path]:
+def mount_bind(what: Path, where: Optional[Path] = None, *, with_idmapping: bool = False) -> ContextManager[Path]:
     if where is None:
         where = what
 
     os.makedirs(what, 0o755, True)
     os.makedirs(where, 0o755, True)
-    return mount(what, where, operation="--bind")
+
+    options = []
+    if with_idmapping:
+        uid = what.stat().st_uid
+        options += [f"X-mount.idmap={uid}:0:1"]
+
+    return mount(what, where, operation="--bind", options=options)
 
 
 def mount_tmpfs(where: Path) -> ContextManager[Path]:


### PR DESCRIPTION
Directories bind mounted locally by `mkosi` use `mount`'s new `X-mount.idmap` option to prevent ownership discrepancies on backing directories. This has the same effect as `nspawn`'s `rootidmap` option.

This feature is not yet merged into `util-linux` repository (https://github.com/util-linux/util-linux/pull/1661). If `X-mount.idmap` is not supported, `mount` will silently ignore it and mount the directory without it. This doesn't prevent `mkosi` to function properly (tested).