### PR TITLE
Allow --compress=no with squashfs images

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -6580,8 +6580,6 @@ def load_args(args: argparse.Namespace) -> MkosiConfig:
         if args.root_size is None:
             # Size will be automatic
             args.minimize = True
-        if args.compress is False:
-            die("Cannot disable compression with squashfs", MkosiNotSupportedException)
         if args.compress is None:
             args.compress = True
 

--- a/tests/test_parse_load_args.py
+++ b/tests/test_parse_load_args.py
@@ -135,6 +135,5 @@ def test_shell_boot() -> None:
 def test_compression() -> None:
     assert parse(["--format", "gpt_squashfs"]).compress
 
-    with pytest.raises(MkosiException, match=".*compression.*squashfs"):
-        parse(["--format", "gpt_squashfs", "--compress", "False"])
+    assert not parse(["--format", "gpt_squashfs", "--compress", "False"]).compress
 


### PR DESCRIPTION
Running `mkosi --format=plain_squashfs --compress=no` yields this error:

```
‣ Error: Cannot disable compression with squashfs
```

The argument parsing logic blocks this case even though `generate_squashfs` handles the case correctly and `--compress-fs=no` would have worked too. Testing with this change, the above command produces an uncompressed squashfs image:

```
Found a valid SQUASHFS 4:0 superblock on uncompressed.img.
Creation or last append time Thu Oct 27 17:08:06 2022
Filesystem size 128206861 bytes (125202.01 Kbytes / 122.27 Mbytes)
Compression gzip
Block size 131072
Filesystem is exportable via NFS
Inodes are uncompressed
Data is uncompressed
Uids/Gids (Id table) are uncompressed
Fragments are uncompressed
Always-use-fragments option is not specified
Xattrs are uncompressed
Duplicates are removed
Number of fragments 308
Number of inodes 4018
Number of ids 9
Number of xattr ids 0
```