### PR TITLE
ci: reenable gentoo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,8 +113,7 @@ jobs:
           - fedora
           - rocky_epel
           - alma_epel
-          # Disabled until https://github.com/gentoo/baselayout/pull/2 is merged.
-          # - gentoo
+          - gentoo
         format:
           - directory
           - tar


### PR DESCRIPTION
The referenced baselayout [PR](https://github.com/gentoo/baselayout/pull/2) appears to be merged and released.