### PR TITLE
Flush writes to temporary files after calling copy_file_object

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -616,6 +616,7 @@ def copy_file_object(oldobject: BinaryIO, newobject: BinaryIO) -> None:
         if e.errno not in {errno.EXDEV, errno.EOPNOTSUPP, errno.ENOTTY}:
             raise
         shutil.copyfileobj(oldobject, newobject)
+        newobject.flush()
 
 
 def copy_file(oldpath: PathString, newpath: PathString) -> None:


### PR DESCRIPTION
This resolves an issue where qemu sees an incomplete image when --ephemeral is used. I've seen failures as a result of the missing flush in `copy_image_temporary`, and upon seeing similar logic in `copy_file_temporary` have defensively added a flush call there as well.

Alternate options for the solution might include flushing in `copy_file_object` after invoking `shutil.copyfileobj`, or instead letting the caller to `copy_file_object` decide if it's appropriate for it to explicitly flush before closing the destination object. I'd be interested in input as to whether one of these alternative options may be preferable.

Fixes #1258 