### PR TITLE
Pass KERNEL_INSTALL_BYPASS through to the places where it is used

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2017,7 +2017,7 @@ def invoke_dnf(state: MkosiState, command: str, packages: Iterable[str]) -> None
     cmdline += [command, *sort_packages(packages)]
 
     with mount_api_vfs(state.root):
-        run(cmdline, env=dict(KERNEL_INSTALL_BYPASS="1"))
+        run(cmdline, env={"KERNEL_INSTALL_BYPASS": state.environment.get("KERNEL_INSTALL_BYPASS", "1")})
 
     distribution, _ = detect_distribution()
     if distribution not in (Distribution.debian, Distribution.ubuntu):
@@ -2695,10 +2695,6 @@ def install_ubuntu(state: MkosiState) -> None:
     install_debian_or_ubuntu(state)
 
 
-def invoke_pacman(root: Path, pacman_conf: Path, packages: Set[str]) -> None:
-    run(["pacman", "--config", pacman_conf, "--noconfirm", "-Sy", *sort_packages(packages)], env=dict(KERNEL_INSTALL_BYPASS="1"))
-
-
 @complete_step("Installing Arch Linux…")
 def install_arch(state: MkosiState) -> None:
     if state.config.release is not None:
@@ -2846,7 +2842,8 @@ def install_arch(state: MkosiState) -> None:
         add_packages(state.config, packages, "openssh")
 
     with mount_api_vfs(state.root):
-        invoke_pacman(state.root, pacman_conf, packages)
+        run(["pacman", "--config", pacman_conf, "--noconfirm", "-Sy", *sort_packages(packages)],
+            env={"KERNEL_INSTALL_BYPASS": state.environment.get("KERNEL_INSTALL_BYPASS", "1")})
 
     state.root.joinpath("etc/pacman.d/mirrorlist").write_text(f"Server = {state.config.mirror}/$repo/os/$arch\n")
 


### PR DESCRIPTION
The idea of using KERNEL_INSTALL_BYPASS is to not run kernel-install twice unnecessarily, since we run it later anyway, but a user reported a regression of kernel-install not being run at all, although it apparently was in earlier. Passing the environment variable through will at most run kernel-install twice, this might be a workaround.

`invoke_pacman` is inlined into `install_arch` because that's the only place where it is used and it has a different signature than `invoke_dnf` and `invoke_apt` which breaks symmetry and makes it an unnecessary unicorn.

@leifliddy Does this solve your problem (when you add `KERNEL_INSTALL_BYPASS=0` to the environment in mkosi.default?)

Fixes: #1263