### PR TITLE
Implement --repository-key-check=no for dnf-based distros

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2001,6 +2001,9 @@ def invoke_dnf(state: MkosiState, command: str, packages: Iterable[str]) -> None
         "--noplugins",
     ]
 
+    if not state.config.repository_key_check:
+        cmdline += ["--nogpgcheck"]
+
     if state.config.repositories:
         cmdline += ["--disablerepo=*"] + [f"--enablerepo={repo}" for repo in state.config.repositories]
 


### PR DESCRIPTION
This command-line option is currently implemented for Debian/Ubuntu, Arch, and openSUSE. This updates `invoke_dnf` to honor it as well.