### PR TITLE
Use the right python when mkosi is a symlink

### DIFF
--- a/bin/mkosi
+++ b/bin/mkosi
@@ -13,6 +13,7 @@
 #   python3 -m pip install --user <mkosi>
 #   python3 -m pip install --user --editable <mkosi>
 #   /path/to/venv/bin/python3 -m pip install <mkosi>
+#   pipx install <mkosi>
 # and running directly from the source checkout.
 #
 # In the first and the next-to-last cases this script is a noop because we leave
@@ -22,7 +23,7 @@
 # cloned to, for "--editable" installations, when this script is run via sudo.
 # When running from a source checkout, we prepend that directory to the path.
 
-PYROOT=$(dirname "$0")
+PYROOT="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 if [[ -x "${PYROOT}/python3" ]]
 then


### PR DESCRIPTION
As mkosi would fail to run when installed with [pipx](https://pypa.github.io/pipx/), I noticed that it would use the main python3 to run mkosi (in my case `/usr/bin/python3 -m mkosi`) instead of the one from the virtualenv created by pipx and containing mkosi.

More generally, when the `mkosi` on the `PATH` is a symlink to the script installed inside a virtualenv, the script fails to find the python executable inside the virtualenv and falls back to the main python3. This is notably the case when installing mkosi with pipx.

By first following the symlink inside the virtualenv, the script can find the corresponding python executable.