### PR TITLE
Allow for UID mapping to be disabled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Rename `--no-chown` to `--chown` and set it to default to `True`, preserving
   current behaviour.
+- Add `--idmap` option to run `--systemd-nspawn` with ID mapping support. Defaults
+  to `True`. `--idmap=no` can be used to prevent usage of ID mapping.
 
 ## v14
 

--- a/man/mkosi.1
+++ b/man/mkosi.1
@@ -711,6 +711,12 @@ archive.
 Set the machine\[cq]s ID to the specified value.
 If unused, a random ID will be used while building the image and the
 final image will be shipped without a machine ID.
+.TP
+\f[B]\f[CB]Idmap=\f[B]\f[R], \f[B]\f[CB]--idmap\f[B]\f[R]
+By default, \f[C]mkosi\f[R] will run \f[C]systemd-nspawn\f[R] with
+ID mapping enabled. This ensures newly-created directories and files are
+owned by the user calling \f[C]sudo\f[R] or \f[C]pkexec\f[R] instead of
+\f[C]root\f[R]. This behaviour can be disabled with \f[C]--idmap=no\f[R].
 .SS [Content] Section
 .TP
 \f[B]\f[CB]BasePackages=\f[B]\f[R], \f[B]\f[CB]--base-packages\f[B]\f[R]

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1780,7 +1780,7 @@ def nspawn_params_for_build_sources(config: MkosiConfig, sft: SourceFileTransfer
         params += ["--setenv=SRCDIR=/root/src",
                    "--chdir=/root/src"]
         if sft == SourceFileTransfer.mount:
-            idmap_opt = ":rootidmap" if nspawn_id_map_supported() else ""
+            idmap_opt = ":rootidmap" if nspawn_id_map_supported() and config.idmap else ""
             params += [f"--bind={config.build_sources}:/root/src{idmap_opt}"]
 
         if config.read_only:
@@ -3946,6 +3946,13 @@ def create_parser() -> ArgumentParserMkosi:
         help="When running with sudo, reassign ownership of the generated files to the original user",
     )  # NOQA: E501
     group.add_argument(
+        "--idmap",
+        metavar="BOOL",
+        action=BooleanAction,
+        default=True,
+        help="Use systemd-nspawn's rootidmap option for bind-mounted directories.",
+    )
+    group.add_argument(
         "--tar-strip-selinux-context",
         metavar="BOOL",
         action=BooleanAction,
@@ -5989,7 +5996,7 @@ def run_build_script(state: MkosiState, raw: Optional[BinaryIO]) -> None:
     if state.config.build_script is None:
         return
 
-    idmap_opt = ":rootidmap" if nspawn_id_map_supported() else ""
+    idmap_opt = ":rootidmap" if nspawn_id_map_supported() and state.config.idmap else ""
 
     with complete_step("Running build script…"):
         os.makedirs(install_dir(state), mode=0o755, exist_ok=True)

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -573,6 +573,7 @@ class MkosiConfig:
     image_id: Optional[str]
     hostname: Optional[str]
     chown: bool
+    idmap: bool
     tar_strip_selinux_context: bool
     incremental: bool
     minimize: bool

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -98,6 +98,7 @@ class MkosiConfig:
             "repository_key_check": True,
             "mksquashfs_tool": [],
             "chown": True,
+            "idmap": True,
             "nspawn_settings": None,
             "output": None,
             "output_dir": None,


### PR DESCRIPTION
By default, mkosi would bind mount directories with nspawn's rootidmap option to provide consistent files ownership. If the system doesn't support ID mapping, mkosi would fail.

Add --idmap option, default to True, to allow users to disabled UID mapping (--idmap=no).

Workaround for #1265.