### PR TITLE
Rename --no-chown option to --chown

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # mkosi Changelog
 
+## v15
+
+- Rename `--no-chown` to `--chown` and set it to default to `True`, preserving
+  current behaviour.
+
 ## v14
 
 - Support for Clear Linux was dropped. See https://github.com/systemd/mkosi/pull/1037

--- a/man/mkosi.1
+++ b/man/mkosi.1
@@ -693,12 +693,11 @@ This is useful in A/B update scenarios where an existing disk image
 shall be augmented with a new version of a root or \f[C]/usr\f[R]
 partition along with its Verity partition and unified kernel.
 .TP
-\f[B]\f[CB]NoChown=\f[B]\f[R], \f[B]\f[CB]--no-chown\f[B]\f[R]
+\f[B]\f[CB]Chown=\f[B]\f[R], \f[B]\f[CB]--chown\f[B]\f[R]
 By default, if \f[C]mkosi\f[R] is run inside a \f[C]sudo\f[R]
 environment all generated artifacts have their UNIX user/group ownership
 changed to the user which invoked \f[C]sudo\f[R].
-With this option this may be turned off and all generated files are
-owned by \f[C]root\f[R].
+This behaviour can be disabled with \f[C]--chown=no\f[R].
 .TP
 \f[B]\f[CB]TarStripSELinuxContext=\f[B]\f[R], \f[B]\f[CB]--tar-strip-selinux-context\f[B]\f[R]
 If running on a SELinux-enabled system (Fedora Linux, CentOS, Rocky

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -572,7 +572,7 @@ class MkosiConfig:
     image_version: Optional[str]
     image_id: Optional[str]
     hostname: Optional[str]
-    no_chown: bool
+    chown: bool
     tar_strip_selinux_context: bool
     incremental: bool
     minimize: bool
@@ -1058,7 +1058,7 @@ def chown_to_running_user(path: PathString) -> None:
 def mkdirp_chown_current_user(
     path: PathString,
     *,
-    skip_chown: bool = False,
+    chown: bool = True,
     mode: int = 0o777,
     exist_ok: bool = True
 ) -> None:
@@ -1072,10 +1072,8 @@ def mkdirp_chown_current_user(
 
         path.mkdir(mode=mode, exist_ok=exist_ok)
 
-        if skip_chown:
-            continue
-
-        chown_to_running_user(path)
+        if chown:
+            chown_to_running_user(path)
 
 
 def safe_tar_extract(tar: tarfile.TarFile, path: Path=Path("."), *, numeric_owner: bool=False) -> None:

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -97,7 +97,7 @@ class MkosiConfig:
             "mirror": None,
             "repository_key_check": True,
             "mksquashfs_tool": [],
-            "no_chown": False,
+            "chown": True,
             "nspawn_settings": None,
             "output": None,
             "output_dir": None,


### PR DESCRIPTION
Rename `--no-chown` to `--chown` and defaults to true. This will make it easier to reason with the code behaviour when this option is used.