### PR TITLE
Drop HostonlyInitrd

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -648,14 +648,6 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   installs kernels with a separate initrd and boot loader config to
   the efi or bootloader partition.
 
-`HostonlyInitrd=`, `--hostonly-initrd`
-
-: If specified, mkosi will run the tool to create the initrd such that
-  a non-generic initrd is created that will only be able to run on the
-  system mkosi is run on. Currently mkosi uses dracut for all
-  supported distributions and this option translates to enabling dracut's
-  hostonly option.
-
 `CacheInitrd=`, `--cache-initrd`
 
 : If specified, and incremental mode is used, mkosi will build the initrd

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1669,11 +1669,6 @@ def configure_dracut(state: MkosiState, cached: bool) -> None:
     dracut_dir = state.root / "etc/dracut.conf.d"
     dracut_dir.mkdir(mode=0o755, exist_ok=True)
 
-    dracut_dir.joinpath('30-mkosi-hostonly.conf').write_text(
-        f'hostonly={yes_no(state.config.hostonly_initrd)}\n'
-        'hostonly_default_device=no\n'
-    )
-
     dracut_dir.joinpath("30-mkosi-qemu.conf").write_text('add_dracutmodules+=" qemu "\n')
 
     with dracut_dir.joinpath("30-mkosi-systemd-extras.conf").open("w") as f:
@@ -1683,11 +1678,6 @@ def configure_dracut(state: MkosiState, cached: bool) -> None:
         if state.root.joinpath("etc/systemd/system.conf.d").exists():
             for conf in state.root.joinpath("etc/systemd/system.conf.d").iterdir():
                 f.write(f'install_optional_items+=" {Path("/") / conf.relative_to(state.root)} "\n')
-
-    if state.config.hostonly_initrd:
-        dracut_dir.joinpath("30-mkosi-filesystem.conf").write_text(
-            f'filesystems+=" {(state.config.output_format.needed_kernel_module())} "\n'
-        )
 
     if state.get_partition(PartitionIdentifier.esp):
         # efivarfs must be present in order to GPT root discovery work
@@ -2213,12 +2203,6 @@ def install_mageia(state: MkosiState) -> None:
     add_packages(state.config, packages, "basesystem-minimal", "dnf")
     if not state.do_run_build_script and state.config.bootable:
         add_packages(state.config, packages, "kernel-server-latest", "dracut")
-        # Mageia ships /etc/50-mageia.conf that omits systemd from the initramfs and disables hostonly.
-        # We override that again so our defaults get applied correctly on Mageia as well.
-        state.root.joinpath("etc/dracut.conf.d/51-mkosi-override-mageia.conf").write_text(
-            'hostonly=no\n'
-            'omit_dracutmodules=""\n'
-        )
 
     if state.do_run_build_script:
         packages.update(state.config.build_packages)
@@ -5411,12 +5395,6 @@ def create_parser() -> ArgumentParserMkosi:
     )
     group.add_argument("--gpt-first-lba", type=int, help="Set the first LBA within GPT Header", metavar="FIRSTLBA")
     group.add_argument(
-        "--hostonly-initrd",
-        metavar="BOOL",
-        action=BooleanAction,
-        help="Enable dracut hostonly option",
-    )
-    group.add_argument(
         "--cache-initrd",
         metavar="BOOL",
         action=BooleanAction,
@@ -7020,7 +6998,6 @@ def print_summary(config: MkosiConfig) -> None:
             print("           UEFI SecureBoot:", yes_no(config.secure_boot))
             print("     Unified Kernel Images:", yes_no(config.with_unified_kernel_images))
             print("             GPT First LBA:", str(config.gpt_first_lba))
-            print("           Hostonly Initrd:", yes_no(config.hostonly_initrd))
 
     if config.secure_boot or config.verity == "sign":
         print("SecureBoot/Verity Sign Key:", config.secure_boot_key)

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -502,7 +502,6 @@ class MkosiConfig:
     minimize: bool
     with_unified_kernel_images: bool
     gpt_first_lba: Optional[int]
-    hostonly_initrd: bool
     cache_initrd: bool
     base_packages: Union[str, bool]
     packages: List[str]

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -299,8 +299,6 @@ class MkosiConfig:
                 self.reference_config[job_name]["with_unified_kernel_images"] = mk_config_output[
                     "WithUnifiedKernelImages"
                 ]
-            if "HostonlyInitrd" in mk_config_output:
-                self.reference_config[job_name]["hostonly_initrd"] = mk_config_output["HostonlyInitrd"]
             if "CacheInitrd" in mk_config_output:
                 self.reference_config[job_name]["cache_initrd"] = mk_config_output["CacheInitrd"]
             if "MachineID" in mk_config_output:


### PR DESCRIPTION
Adding this option was a mistake (mea culpa), we should limit host impact on image builds as much as possible so let's drop this option that makes the initrd generated by dracut host specific. This will slow down initrd generation but once we switch to generating initrds with mkosi we'll have a proper fix for that.