### PR TITLE
Change default suffix for verity signature partition

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -6662,7 +6662,8 @@ def load_args(args: argparse.Namespace) -> MkosiConfig:
         if args.verity:
             args.output_split_verity = build_auxiliary_output_path(args, f"{root_or_usr(args)}.verity", True)
             if args.verity == "signed":
-                args.output_split_verity_sig = build_auxiliary_output_path(args, f"{roothash_suffix(args)}.p7s", True)
+                args.output_split_verity_sig = build_auxiliary_output_path(args,
+                                                                           f"{root_or_usr(args)}.verity-sig", True)
         if args.bootable:
             args.output_split_kernel = build_auxiliary_output_path(args, ".efi", True)
 


### PR DESCRIPTION
Currently the filename suffix used for the `roothash` (or `usrhash`) signature file and the filename suffix used for the partition image of the verity signature partition conflict. Consequently, it is not currently possible to successfully complete a build with both the `SplitArtifacts=yes` and `Verity=signed` options due to a file conflict.

This PR changes the output file suffix of the verity partition image to `*.verity-sig` instead `*.roothash.p7s`, which on review I believe of available options most closely maps the expected naming scheme for partitions and files.

Fixes #1274 