### PR TITLE
Remove annotations import from __future__

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
-from __future__ import annotations
-
 import argparse
 import configparser
 import contextlib

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
-from __future__ import annotations
-
 import argparse
 import ast
 import collections
@@ -283,7 +281,7 @@ class SourceFileTransfer(enum.Enum):
         return self.value
 
     @classmethod
-    def doc(cls) -> Dict[SourceFileTransfer, str]:
+    def doc(cls) -> Dict["SourceFileTransfer", str]:
         return {
             cls.copy_all: "normal file copy",
             cls.copy_git_cached: "use git ls-files --cached, ignoring any file that git itself ignores",
@@ -324,11 +322,6 @@ def strip_suffixes(path: Path) -> Path:
     while path.suffix in KNOWN_SUFFIXES:
         path = path.with_suffix("")
     return path
-
-
-def build_auxiliary_output_path(args: Union[argparse.Namespace, MkosiConfig], suffix: str) -> Path:
-    output = strip_suffixes(args.output)
-    return output.with_name(f"{output.name}{suffix}")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -505,6 +498,11 @@ class MkosiConfig:
             self.output_manifest,
             self.output_changelog,
         )
+
+
+def build_auxiliary_output_path(args: Union[argparse.Namespace, MkosiConfig], suffix: str) -> Path:
+    output = strip_suffixes(args.output)
+    return output.with_name(f"{output.name}{suffix}")
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
PEP 563 is a PEP that stringifies type annotations. The feature was made available as opt in. It is still very much in flux or under consideration upstream and has fallen so much out of favour that the Python steering council added [the note](https://docs.python.org/3.11/whatsnew/3.11.html#pep-563-may-not-be-the-future)

> PEP 563 Postponed Evaluation of Annotations (the from __future__ import annotations future statement) that was originally planned for release in Python 3.10 has been put on hold indefinitely. See this message from the Steering Council for more information.

in the release notes of CPython 3.11 after punting on accepting the PEP for two releases. The import does a lot more, but we only use the type stringification. There is little gain from using this, but with one of the main features of the import indefinitely on hold, it seems prudent not to use it, since removing it doesn't cost as much.