### PR TITLE
fix qemu write lock error

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1263,7 +1263,8 @@ def qcow2_output(state: MkosiState) -> None:
     with complete_step("Converting image file to qcow2…"):
         run(["qemu-img", "convert", "-onocow=on", "-fraw", "-Oqcow2",
              state.staging / state.config.output.name,
-             state.staging / state.config.output.name])
+             state.workspace / "qemu.img"])
+        os.rename(state.workspace / "qemu.img", state.staging / state.config.output.name)
 
 
 def copy_nspawn_settings(state: MkosiState) -> None:


### PR DESCRIPTION
This fixes  #1291 . However, it is not the cleanest approach. 

Maybe all the previous artifacts should be build in a `tmp-dir` and we should afterward copy the requested files to `state.staging`

so something like 
```python
    with complete_step("Converting image file to qcow2…"):
        run(["qemu-img", "convert", "-onocow=on", "-fraw", "-Oqcow2",
             state.tmp / state.config.output.name,
             state.staging / (state.config.output.name)])
```
Right now the `raw` image is also in the directory even if we specified `qcow2`. I assume this is not the intended behavior?