### PR TITLE
fix invalid cross-device link

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3867,12 +3867,14 @@ def build_stuff(config: MkosiConfig) -> None:
 
         for p in state.config.output_paths():
             if state.staging.joinpath(p.name).exists():
-                os.rename(str(state.staging / p.name), str(p))
+                shutil.move(str(state.staging / p.name), str(p))
                 if p in (state.config.output, state.config.output_split_kernel):
                     compress_output(state.config, p)
+            if state.config.chown and p.exists(): 
+                chown_to_running_user(p)
 
         for p in state.staging.iterdir():
-            os.rename(str(p), str(state.config.output.parent / p.name))
+            shutil.move(str(p), str(state.config.output.parent / p.name))
             if p.name.startswith(state.config.output.name):
                 compress_output(state.config, p)
 


### PR DESCRIPTION
when the workspace directory is on another filesystem (i.e. /tmp) mkosi fails.
replace os.rename with shutil.move when we may cross filesystem boundaries. Furthermore, chown the resulting files if the flag is set accordingly.

config to reproduce:
```
[Distribution]
Distribution=arch

[Output]
Format=disk
Bootable=yes
QCow2=yes
Output=image.qcow2
WorkspaceDirectory=/tmp
ExtraSearchPaths=/home/bschlueter/University/Github/systemd/build

[Packages]
Packages=
         openssh
         vim
         crictl
         critest
         kubeadm
         kubectl
         socat
         kubelet
         ethtool
         containerd

[Validation]
Password=password

[Content]
Cache=.cache
Autologin=yes

[Host]
QemuHeadless=yes
```