### PR TITLE
idmap: fix kernel version comparison

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -41,10 +41,11 @@ runs:
       sudo apt-get install libfdisk-dev
       git clone https://github.com/systemd/systemd --depth=1
       meson systemd/build systemd -Drepart=true -Defi=true
-      ninja -C systemd/build systemd-nspawn systemd-dissect systemd-repart bootctl ukify
+      ninja -C systemd/build systemd-nspawn systemd-dissect systemd-repart systemd-analyze bootctl ukify
       sudo ln -svf $PWD/systemd/build/systemd-nspawn /usr/bin/systemd-nspawn
       sudo ln -svf $PWD/systemd/build/systemd-dissect /usr/bin/systemd-dissect
       sudo ln -svf $PWD/systemd/build/systemd-repart /usr/bin/systemd-repart
+      sudo ln -svf $PWD/systemd/build/systemd-analyze /usr/bin/systemd-analyze
       sudo ln -svf $PWD/systemd/build/bootctl /usr/bin/bootctl
       sudo ln -svf $PWD/systemd/build/ukify /usr/bin/ukify
       systemd-nspawn --version

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -699,14 +699,8 @@ def nspawn_id_map_supported() -> bool:
     if nspawn_version() < 252:
         return False
 
-    try:
-        # Not part of stdlib
-        from packaging import version
-    except ImportError:
-        # If we can't check assume the kernel is new enough
-        return True
-
-    return version.parse(platform.release()) >= version.parse("5.12")
+    ret = run(["systemd-analyze", "compare-versions", platform.release(), ">=", "5.12"])
+    return ret.returncode == 0
 
 
 def nspawn_params_for_build_sources(config: MkosiConfig, sft: SourceFileTransfer) -> List[str]:


### PR DESCRIPTION
`packaging.version.parse()` would create a Version object for "5.12" and a LegacyVersion object for versions like "6.0.8-200.fc36.x86_64". This leads to failed comparison (such as "6.0.8-200.fc36.x86_64 >= 5.12").

Use `systemd-analyze compare-versions` instead, which produce the expected behaviour. This brings mkosi more in line with systemd ecosystem when it comes to version strings parsing.