### PR TITLE
Add --initrd option

### DIFF
--- a/.github/initrd/alma.conf
+++ b/.github/initrd/alma.conf
@@ -1,0 +1,13 @@
+[Distribution]
+Distribution=alma
+
+[Output]
+ImageId=initrd
+Format=cpio
+ManifestFormat=
+CompressOutput=zstd
+
+[Content]
+Packages=
+        systemd
+        systemd-udev

--- a/.github/initrd/arch.conf
+++ b/.github/initrd/arch.conf
@@ -1,0 +1,12 @@
+[Distribution]
+Distribution=arch
+
+[Output]
+ImageId=initrd
+Format=cpio
+ManifestFormat=
+CompressOutput=zstd
+
+[Content]
+Packages=
+        systemd

--- a/.github/initrd/centos.conf
+++ b/.github/initrd/centos.conf
@@ -1,0 +1,13 @@
+[Distribution]
+Distribution=centos
+
+[Output]
+ImageId=initrd
+Format=cpio
+ManifestFormat=
+CompressOutput=zstd
+
+[Content]
+Packages=
+        systemd
+        systemd-udev

--- a/.github/initrd/fedora.conf
+++ b/.github/initrd/fedora.conf
@@ -1,0 +1,13 @@
+[Distribution]
+Distribution=fedora
+
+[Output]
+ImageId=initrd
+Format=cpio
+ManifestFormat=
+CompressOutput=zstd
+
+[Content]
+Packages=
+        systemd
+        systemd-udev

--- a/.github/initrd/gentoo.conf
+++ b/.github/initrd/gentoo.conf
@@ -1,0 +1,12 @@
+[Distribution]
+Distribution=ubuntu
+
+[Output]
+ImageId=initrd
+Format=cpio
+ManifestFormat=
+CompressOutput=zstd
+
+[Content]
+Packages=
+        systemd

--- a/.github/initrd/opensuse.conf
+++ b/.github/initrd/opensuse.conf
@@ -1,0 +1,13 @@
+[Distribution]
+Distribution=ubuntu
+
+[Output]
+ImageId=initrd
+Format=cpio
+ManifestFormat=
+CompressOutput=zstd
+
+[Content]
+Packages=
+        systemd
+        udev

--- a/.github/initrd/rocky.conf
+++ b/.github/initrd/rocky.conf
@@ -1,0 +1,13 @@
+[Distribution]
+Distribution=rocky
+
+[Output]
+ImageId=initrd
+Format=cpio
+ManifestFormat=
+CompressOutput=zstd
+
+[Content]
+Packages=
+        systemd
+        systemd-udev

--- a/.github/initrd/ubuntu.conf
+++ b/.github/initrd/ubuntu.conf
@@ -1,0 +1,13 @@
+[Distribution]
+Distribution=ubuntu
+
+[Output]
+ImageId=initrd
+Format=cpio
+ManifestFormat=
+CompressOutput=zstd
+
+[Content]
+Packages=
+        systemd
+        udev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,12 @@ jobs:
           - tar
           - cpio
           - disk
+        prebuilt-initrd:
+          - no
+          - yes
+        exclude:
+          - distro: debian
+            prebuilt-initrd: yes
 
     steps:
     - uses: actions/checkout@v3
@@ -162,6 +168,10 @@ jobs:
     - name: Install
       run: sudo python3 -m pip install .
 
+    - name: Build ${{ matrix.distro }} initrd
+      if: matrix.prebuilt-initrd == 'yes'
+      run: sudo python3 -m mkosi --directory=.github/initrd --config=${{ matrix.distro }}.conf build
+
     - name: Configure ${{ matrix.distro }}/${{ matrix.format }}
       run: |
         mkdir -p mkosi.conf.d
@@ -191,6 +201,14 @@ jobs:
         tee mkosi.skeleton/etc/portage/binrepos.conf <<- EOF
         [binhost]
         sync-uri = https://raw.githubusercontent.com/257/binpkgs/master
+        EOF
+
+    - name: Configure ${{ matrix.distro }}/${{ matrix.format }} initrd
+      if: matrix.prebuilt-initrd == 'yes'
+      run: |
+        tee mkosi.conf.d/initrd.conf <<- EOF
+        [Output]
+        Initrd=.github/initrd/initrd.cpio.zst
         EOF
 
     - name: Configure EPEL

--- a/docs/initrd.md
+++ b/docs/initrd.md
@@ -1,0 +1,28 @@
+# Building a custom initrd and using it in a mkosi image
+
+To build an image with a mkosi-built initrd:
+1. Build an initrd image. You can for example build a **compressed** `cpio`
+archive with mkosi containing the packages `systemd` and `udev`. Here is a
+configuration file to build such an image for `Fedora`:
+```
+[Distribution]
+Distribution=fedora
+
+[Output]
+ImageId=initrd
+Format=cpio
+ManifestFormat=
+CompressOutput=zstd
+
+[Content]
+Packages=
+        systemd
+        systemd-udev
+```
+2. Invoke `mkosi` passing the initrd image via the `--initrd` option:
+```bash
+mkosi --initrd=<path-to-initrd-image> ...
+```
+This will build an image using the provided initrd image.
+mkosi will add the kernel modules found in the distribution image to this initrd.
+

--- a/mkosi.md
+++ b/mkosi.md
@@ -556,6 +556,12 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 be used while building the image and the final image will be shipped without
 a machine ID.
 
+`Initrd=`, `--initrd`
+
+: Use user-provided initrd(s). Takes a comma separated list of paths to initrd
+  files. This option may be used multiple times in which case the initrd lists
+  are combined.
+
 ### [Content] Section
 
 `BasePackages=`, `--base-packages`

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -171,12 +171,12 @@ def dictify(f: Callable[..., Iterator[tuple[T, V]]]) -> Callable[..., dict[T, V]
 
 
 @dictify
-def read_os_release() -> Iterator[tuple[str, str]]:
+def read_os_release(root: Path = Path("/")) -> Iterator[tuple[str, str]]:
     try:
-        filename = "/etc/os-release"
+        filename = root / "/etc/os-release"
         f = open(filename)
     except FileNotFoundError:
-        filename = "/usr/lib/os-release"
+        filename = root / "/usr/lib/os-release"
         f = open(filename)
 
     with f:
@@ -395,6 +395,7 @@ class MkosiConfig:
     auto_bump: bool
     workspace_dir: Optional[Path]
     machine_id: Optional[str]
+    initrds: list[Path]
 
     # QEMU-specific options
     qemu_headless: bool

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -147,6 +147,7 @@ class MkosiConfig:
             "auto_bump": False,
             "workspace_dir": None,
             "repart_dir": None,
+            "initrds": [],
         }
 
     def __eq__(self, other: Mapping[str, Any]) -> bool: # type: ignore

--- a/tests/test_parse_load_args.py
+++ b/tests/test_parse_load_args.py
@@ -109,3 +109,20 @@ def test_shell_boot() -> None:
 def test_compression() -> None:
     assert not parse(["--format", "disk", "--compress-output", "False"]).compress_output
 
+def test_initrd() -> None:
+    with cd_temp_dir():
+        for i in range(1, 5):
+            initrd = Path(f"path-to-initrd{i}")
+            initrd.write_text("initrd{i}")
+        assert parse([
+            "--initrd",
+            "path-to-initrd1,path-to-initrd2",
+            "--initrd",
+            "path-to-initrd3,path-to-initrd4",
+        ]).initrds == [
+            Path(Path.cwd() / "path-to-initrd1"),
+            Path(Path.cwd() / "path-to-initrd2"),
+            Path(Path.cwd() / "path-to-initrd3"),
+            Path(Path.cwd() / "path-to-initrd4"),
+        ]
+


### PR DESCRIPTION
This change adds support for a `--initrd` option to provide a list of initrd files that are used in the generated image instead of the initrd generated by `dracut`. For the kernel modules, an initrd is generated from the directory `/usr/lib/modules` and is added to the list of initrds passed to `ukify`.