### PR TITLE
Remove --qemu-boot option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,16 +206,8 @@ jobs:
 
     - name: Boot ${{ matrix.distro }}/${{ matrix.format }} UEFI
       if: matrix.format == 'disk'
-      run: sudo timeout -k 30 10m python3 -m mkosi --qemu-boot=uefi qemu
+      run: sudo timeout -k 30 10m python3 -m mkosi qemu
 
     - name: Check ${{ matrix.distro }}/${{ matrix.format }} UEFI
-      if: matrix.format == 'disk' || matrix.format == 'directory'
-      run: sudo python3 -m mkosi shell bash -c "[[ -e /testok ]] || { cat /failed-services; exit 1; }"
-
-    - name: Boot ${{ matrix.distro }}/${{ matrix.format}} QEMU Linux Boot
-      if: matrix.format == 'disk'
-      run: sudo timeout -k 30 10m python3 -m mkosi --qemu-boot=linux qemu
-
-    - name: Check ${{ matrix.distro }}/${{ matrix.format }} QEMU Linux Boot
       if: matrix.format == 'disk' || matrix.format == 'directory'
       run: sudo python3 -m mkosi shell bash -c "[[ -e /testok ]] || { cat /failed-services; exit 1; }"

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@
 
     We also remove the WithoutUnifiedKernelImages= switch as building unified
     kernel images is trivial and fast these days.
+- Support for --qemu-boot was dropped
 
 ## v14
 

--- a/mkosi.md
+++ b/mkosi.md
@@ -984,12 +984,6 @@ a machine ID.
   scope unit for the containers. This option should be used when mkosi is
   run by a service unit.
 
-`QemuBoot=`, `--qemu-boot=`
-
-: When used with the `qemu` verb, this option specifies how qemu should
-  boot the image. Can be set to either `uefi` to do a UEFI boot or `linux`
-  to do a qemu direct linux boot.
-
 `Netdev=`, `--netdev`
 
 : When used with the boot or qemu verbs, this option creates a virtual

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1088,8 +1088,6 @@ def install_unified_kernel(state: MkosiState, label: Optional[str], root_hash: O
                 option = "mount.usr" if usr_only else "root"
                 boot_options = f"{boot_options} {option}=LABEL={label}"
 
-            state.staging.joinpath(state.config.output_split_cmdline).write_text(boot_options)
-
             cmd: List[PathString] = [
                 "ukify",
                 "--cmdline", boot_options,
@@ -1117,6 +1115,9 @@ def install_unified_kernel(state: MkosiState, label: Optional[str], root_hash: O
             cmd += [state.root / kimg, initrd_path(state, kver)]
 
             run(cmd)
+
+            if not state.staging.joinpath(state.staging / state.config.output_split_kernel.name).exists():
+                copy_file(boot_binary, state.staging / state.config.output_split_kernel.name)
 
 
 def secure_boot_sign(state: MkosiState, directory: Path, replace: bool = False) -> None:
@@ -1150,49 +1151,6 @@ def secure_boot_sign(state: MkosiState, directory: Path, replace: bool = False) 
 
             if replace:
                 os.rename(f"{f}.signed", f)
-
-
-def extract_unified_kernel(state: MkosiState) -> None:
-    if state.do_run_build_script or state.for_cache or not state.config.bootable:
-        return
-
-    kernel = None
-
-    for path, _, filenames in os.walk(state.root / "boot/EFI/Linux"):
-        for i in filenames:
-            if not i.endswith(".efi") and not i.endswith(".EFI"):
-                continue
-
-            if kernel is not None:
-                raise ValueError(
-                    f"Multiple kernels found, don't know which one to extract. ({kernel} vs. {path}/{i})"
-                )
-
-            kernel = os.path.join(path, i)
-
-    if kernel is None:
-        return
-
-    copy_file(kernel, state.staging / state.config.output_split_kernel.name)
-
-
-def extract_kernel_image_initrd(state: MkosiState) -> None:
-    if state.do_run_build_script or state.for_cache or not state.config.bootable:
-        return
-
-    kimgabs = None
-    initrd = None
-
-    for kver, kimg in gen_kernel_images(state):
-        kimgabs = state.root / kimg
-        initrd = initrd_path(state, kver)
-
-    if kimgabs is None:
-        return
-    assert initrd is not None
-
-    copy_file(kimgabs, state.staging / state.config.output_split_kernel_image.name)
-    copy_file(initrd, state.staging / state.config.output_split_initrd.name)
 
 
 def compress_output(config: MkosiConfig, src: Path) -> None:
@@ -2296,13 +2254,6 @@ def create_parser() -> ArgumentParserMkosi:
         help="If specified, underlying systemd-nspawn containers use the resources of the current unit.",
     )
     group.add_argument(
-        "--qemu-boot",
-        help="Configure which qemu boot protocol to use",
-        choices=["uefi", "linux", None],
-        metavar="PROTOCOL",
-        default="uefi",
-    )
-    group.add_argument(
         "--network-veth",     # Compatibility option
         dest="netdev",
         metavar="BOOL",
@@ -2635,9 +2586,6 @@ def unlink_output(config: MkosiConfig) -> None:
                     if p.name.startswith(config.output_split_kernel.name):
                         unlink_try_hard(p)
             unlink_try_hard(config.output_split_kernel)
-            unlink_try_hard(config.output_split_kernel_image)
-            unlink_try_hard(config.output_split_initrd)
-            unlink_try_hard(config.output_split_cmdline)
 
             if config.nspawn_settings is not None:
                 unlink_try_hard(config.output_nspawn_settings)
@@ -3646,9 +3594,6 @@ def build_image(state: MkosiState, *, manifest: Optional[Manifest] = None) -> No
 
     invoke_repart(state, split=True)
 
-    extract_unified_kernel(state)
-    extract_kernel_image_initrd(state)
-
     make_tar(state)
     make_cpio(state)
     make_directory(state)
@@ -4110,7 +4055,7 @@ def run_qemu(config: MkosiConfig) -> None:
     accel = "kvm" if config.qemu_kvm else "tcg"
 
     firmware, fw_supports_sb = find_qemu_firmware(config)
-    smm = "on" if fw_supports_sb and config.qemu_boot == "uefi" else "off"
+    smm = "on" if fw_supports_sb else "off"
 
     if config.architecture == "aarch64":
         machine = f"type=virt,accel={accel}"
@@ -4156,21 +4101,13 @@ def run_qemu(config: MkosiConfig) -> None:
             # after it is created.
             cmdline += ["-nic", f"tap,script=no,downscript=no,ifname={ifname},model=virtio-net-pci"]
 
-    if config.qemu_boot == "uefi":
-        cmdline += ["-drive", f"if=pflash,format=raw,readonly=on,file={firmware}"]
-
-    if config.qemu_boot == "linux":
-        cmdline += [
-            "-kernel", config.output_split_kernel_image,
-            "-initrd", config.output_split_initrd,
-            "-append", config.output_split_cmdline.read_text().strip(),
-        ]
+    cmdline += ["-drive", f"if=pflash,format=raw,readonly=on,file={firmware}"]
 
     for k, v in config.credentials.items():
         cmdline += ["-smbios", f"type=11,value=io.systemd.credential:{k}={v}"]
 
     with contextlib.ExitStack() as stack:
-        if config.qemu_boot == "uefi" and fw_supports_sb:
+        if fw_supports_sb:
             ovmf_vars = stack.enter_context(copy_file_temporary(src=find_ovmf_vars(config), dir=tmp_dir()))
             cmdline += [
                 "-global",

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -436,7 +436,6 @@ class MkosiConfig:
     qemu_mem: str
     qemu_kvm: bool
     qemu_args: Sequence[str]
-    qemu_boot: str
 
     # systemd-nspawn specific options
     nspawn_keep_unit: bool
@@ -449,18 +448,6 @@ class MkosiConfig:
     @property
     def output_split_kernel(self) -> Path:
         return build_auxiliary_output_path(self, ".efi")
-
-    @property
-    def output_split_kernel_image(self) -> Path:
-        return build_auxiliary_output_path(self, ".vmlinuz")
-
-    @property
-    def output_split_initrd(self) -> Path:
-        return build_auxiliary_output_path(self, ".initrd")
-
-    @property
-    def output_split_cmdline(self) -> Path:
-        return build_auxiliary_output_path(self, ".cmdline")
 
     @property
     def output_nspawn_settings(self) -> Path:
@@ -494,9 +481,6 @@ class MkosiConfig:
         return (
             self.output,
             self.output_split_kernel,
-            self.output_split_kernel_image,
-            self.output_split_initrd,
-            self.output_split_cmdline,
             self.output_nspawn_settings,
             self.output_checksum,
             self.output_signature,

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -133,7 +133,6 @@ class MkosiConfig:
             "qemu_kvm": mkosi.qemu_check_kvm_support(),
             "qemu_args": [],
             "nspawn_keep_unit": False,
-            "qemu_boot": "uefi",
             "netdev": False,
             "ephemeral": False,
             "cache_initrd": False,


### PR DESCRIPTION
Given that we're standardizing more and more on UEFI and unified kernel images, let's drop support for qemu direct linux boot, to drop yet another seldomly exercised codepath.