### PR TITLE
centos: Remove "-stream" from releases

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,8 @@
   repositories. Specifically, it cannot be used on Arch Linux anymore to add new repositories.
 - The `_epel` distributions were removed. Use `--repositories=epel` instead to enable
   the EPEL repository.
+- Removed `-stream` from CentOS release specifiers. Instead of specifying `8-stream`,
+  you know just specify `8`.
 
 ## v14
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -495,11 +495,6 @@ def remove_files(state: MkosiState) -> None:
         remove_glob(*paths)
 
 
-def parse_epel_release(release: str) -> int:
-    fields = release.split(".")
-    return int(fields[0].removesuffix("-stream"))
-
-
 def install_distribution(state: MkosiState, cached: bool) -> None:
     if cached:
         return
@@ -2785,7 +2780,7 @@ def load_args(args: argparse.Namespace) -> MkosiConfig:
         if args.distribution == Distribution.fedora:
             args.release = "36"
         elif args.distribution == Distribution.centos:
-            args.release = "9-stream"
+            args.release = "9"
         elif args.distribution == Distribution.rocky:
             args.release = "9"
         elif args.distribution == Distribution.alma:

--- a/mkosi/distributions/alma.py
+++ b/mkosi/distributions/alma.py
@@ -7,14 +7,14 @@ from mkosi.distributions.centos import CentosInstaller
 
 class AlmaInstaller(CentosInstaller):
     @staticmethod
-    def _gpg_locations(epel_release: int) -> tuple[Path, str]:
+    def _gpg_locations(release: int) -> tuple[Path, str]:
         return (
             Path("/etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-$releasever"),
             "https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux-$releasever",
         )
 
     @staticmethod
-    def _extras_gpg_locations(epel_release: int) -> tuple[Path, str]:
+    def _extras_gpg_locations(release: int) -> tuple[Path, str]:
         return (
             Path("/etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-$releasever"),
             "https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux-$releasever",

--- a/mkosi/distributions/rocky.py
+++ b/mkosi/distributions/rocky.py
@@ -7,16 +7,16 @@ from mkosi.distributions.centos import CentosInstaller
 
 class RockyInstaller(CentosInstaller):
     @staticmethod
-    def _gpg_locations(epel_release: int) -> tuple[Path, str]:
-        keyname = "Rocky-$releasever" if epel_release >= 9 else "rockyofficial"
+    def _gpg_locations(release: int) -> tuple[Path, str]:
+        keyname = "Rocky-$releasever" if release >= 9 else "rockyofficial"
         return (
              Path(f"/etc/pki/rpm-gpg/RPM-GPG-KEY-{keyname}"),
              f"https://download.rockylinux.org/pub/rocky/RPM-GPG-KEY-{keyname}"
         )
 
     @staticmethod
-    def _extras_gpg_locations(epel_release: int) -> tuple[Path, str]:
-        keyname = "Rocky-$releasever" if epel_release >= 9 else "rockyofficial"
+    def _extras_gpg_locations(release: int) -> tuple[Path, str]:
+        keyname = "Rocky-$releasever" if release >= 9 else "rockyofficial"
         return (
              Path(f"/etc/pki/rpm-gpg/RPM-GPG-KEY-{keyname}"),
              f"https://download.rockylinux.org/pub/rocky/RPM-GPG-KEY-{keyname}"


### PR DESCRIPTION
We don't support non centos stream releases anymore, so let's remove the "-stream" suffix from centos releases.