### PR TITLE
Remove default kernel command line arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,7 @@
   the EPEL repository.
 - Removed `-stream` from CentOS release specifiers. Instead of specifying `8-stream`,
   you know just specify `8`.
+- Removed default kernel command line arguments `rhgb`, `selinux=0` and `audit=0`.
 
 ## v14
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1770,7 +1770,7 @@ def create_parser() -> ArgumentParserMkosi:
         "--kernel-command-line",
         metavar="OPTIONS",
         action=SpaceDelimitedListAction,
-        default=["rhgb", "selinux=0", "audit=0"],
+        default=[],
         help="Set the kernel command line (only bootable images)",
     )
     group.add_argument(

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -83,7 +83,7 @@ class MkosiConfig:
             "include_dir": None,
             "incremental": False,
             "install_dir": None,
-            "kernel_command_line": ["rhgb", "selinux=0", "audit=0"],
+            "kernel_command_line": [],
             "key": None,
             "local_mirror": None,
             "manifest_format": None,


### PR DESCRIPTION
The defaults are rather intrusive so let's not enable them by default but leave them for users to configure manually.