### PR TITLE
Enable unprivileged image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
           - fedora
           - rocky
           - alma
-          - gentoo
+          # gentoo (see https://github.com/systemd/mkosi/pull/1313#issuecomment-1406277198)
           - opensuse
         format:
           - directory
@@ -202,7 +202,14 @@ jobs:
         EOF
 
     - name: Build ${{ matrix.distro }}/${{ matrix.format }}
-      run: sudo python3 -m mkosi build
+      run: python3 -m mkosi build
+
+    # systemd-resolved is enabled by default in Arch/Debian/Ubuntu (systemd default preset) but fails to
+    # start in a systemd-nspawn container with --private-users so we mask it out here to avoid CI failures.
+    # FIXME: Remove when Arch/Debian/Ubuntu ship systemd v253
+    - name: Mask systemd-resolved
+      if: matrix.format == 'directory'
+      run: sudo systemctl --root mkosi.output/${{ matrix.distro }}~*/image mask systemd-resolved
 
     - name: Boot ${{ matrix.distro }}/${{ matrix.format }} systemd-nspawn
       if: matrix.format == 'disk' || matrix.format == 'directory'
@@ -214,7 +221,7 @@ jobs:
 
     - name: Boot ${{ matrix.distro }}/${{ matrix.format }} UEFI
       if: matrix.format == 'disk'
-      run: sudo timeout -k 30 10m python3 -m mkosi qemu
+      run: timeout -k 30 10m python3 -m mkosi qemu
 
     - name: Check ${{ matrix.distro }}/${{ matrix.format }} UEFI
       if: matrix.format == 'disk' || matrix.format == 'directory'

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,10 +2,6 @@
 
 ## v15
 
-- Rename `--no-chown` to `--chown` and set it to default to `True`, preserving
-  current behaviour.
-- Add `--idmap` option to run `--systemd-nspawn` with ID mapping support. Defaults
-  to `True`. `--idmap=no` can be used to prevent usage of ID mapping.
 - Migrated to systemd-repart. Many options are dropped in favor of specifying them directly
   in repart partition definition files:
     - Format=gpt_xxx options are replaced with a single "disk" options. Filesystem to use can now be specified with repart's Format= option
@@ -41,6 +37,12 @@
 - Removed default kernel command line arguments `rhgb`, `selinux=0` and `audit=0`.
 - Dropped --all and --all-directory as this functionality is better implemented by
   using a build system.
+- mkosi now builds images without needing root privileges.
+- Removed `--no-chown`, `--idmap` and `--nspawn-keep-unit` options as they were made obsolete by moving to
+  rootless builds.
+- Removed `--source-file-transfer`, `--source-file-transfer-final`, `--source-resolve-symlinks` and
+  `--source-resolve-symlinks-final` in favor of always mounting the source directory into the build image.
+  `--source-file-transfer-final` might be reimplemented in the future using virtiofsd.
 
 ## v14
 

--- a/action.yaml
+++ b/action.yaml
@@ -26,7 +26,8 @@ runs:
         squashfs-tools \
         btrfs-progs \
         mtools \
-        python3-pefile
+        python3-pefile \
+        bubblewrap
 
       sudo pacman-key --init
       sudo pacman-key --populate archlinux
@@ -41,17 +42,13 @@ runs:
       sudo apt-get install libfdisk-dev
       git clone https://github.com/systemd/systemd --depth=1
       meson systemd/build systemd -Drepart=true -Defi=true
-      ninja -C systemd/build systemd-nspawn systemd-dissect systemd-repart systemd-analyze bootctl ukify
-      sudo ln -svf $PWD/systemd/build/systemd-nspawn /usr/bin/systemd-nspawn
-      sudo ln -svf $PWD/systemd/build/systemd-dissect /usr/bin/systemd-dissect
+      ninja -C systemd/build systemd-nspawn systemd-repart bootctl ukify
       sudo ln -svf $PWD/systemd/build/systemd-repart /usr/bin/systemd-repart
-      sudo ln -svf $PWD/systemd/build/systemd-analyze /usr/bin/systemd-analyze
       sudo ln -svf $PWD/systemd/build/bootctl /usr/bin/bootctl
       sudo ln -svf $PWD/systemd/build/ukify /usr/bin/ukify
-      systemd-nspawn --version
-      systemd-dissect --version
       systemd-repart --version
       bootctl --version
+      ukify --version
 
   - name: Install
     shell: bash

--- a/mkosi/__main__.py
+++ b/mkosi/__main__.py
@@ -8,7 +8,8 @@ from collections.abc import Iterator
 from subprocess import CalledProcessError
 
 from mkosi import parse_args, run_verb
-from mkosi.backend import MkosiException, die
+from mkosi.log import MkosiException, die
+from mkosi.run import excepthook
 
 
 @contextlib.contextmanager
@@ -36,4 +37,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    sys.excepthook = excepthook
     main()

--- a/mkosi/distributions/mageia.py
+++ b/mkosi/distributions/mageia.py
@@ -2,9 +2,10 @@
 
 from pathlib import Path
 
-from mkosi.backend import MkosiState, add_packages, complete_step, disable_pam_securetty
+from mkosi.backend import MkosiState, add_packages, disable_pam_securetty
 from mkosi.distributions import DistributionInstaller
 from mkosi.distributions.fedora import Repo, install_packages_dnf, invoke_dnf, setup_dnf
+from mkosi.log import complete_step
 
 
 class MageiaInstaller(DistributionInstaller):

--- a/mkosi/distributions/openmandriva.py
+++ b/mkosi/distributions/openmandriva.py
@@ -2,9 +2,10 @@
 
 from pathlib import Path
 
-from mkosi.backend import MkosiState, add_packages, complete_step
+from mkosi.backend import MkosiState, add_packages
 from mkosi.distributions import DistributionInstaller
 from mkosi.distributions.fedora import Repo, install_packages_dnf, invoke_dnf, setup_dnf
+from mkosi.log import complete_step
 
 
 class OpenmandrivaInstaller(DistributionInstaller):

--- a/mkosi/log.py
+++ b/mkosi/log.py
@@ -1,0 +1,83 @@
+import contextlib
+import sys
+from typing import Any, Iterator, NoReturn, Optional
+
+# This global should be initialized after parsing arguments
+ARG_DEBUG: set[str] = set()
+
+
+class MkosiException(Exception):
+    """Leads to sys.exit"""
+
+
+class MkosiNotSupportedException(MkosiException):
+    """Leads to sys.exit when an invalid combination of parsed arguments happens"""
+
+
+def die(message: str, exception: type[MkosiException] = MkosiException) -> NoReturn:
+    MkosiPrinter.warn(f"Error: {message}")
+    raise exception(message)
+
+
+def warn(message: str) -> None:
+    MkosiPrinter.warn(f"Warning: {message}")
+
+
+class MkosiPrinter:
+    out_file = sys.stderr
+    isatty = out_file.isatty()
+
+    bold = "\033[0;1;39m" if isatty else ""
+    red = "\033[31;1m" if isatty else ""
+    reset = "\033[0m" if isatty else ""
+
+    prefix = "‣ "
+
+    level = 0
+
+    @classmethod
+    def _print(cls, text: str) -> None:
+        cls.out_file.write(text)
+
+    @classmethod
+    def color_error(cls, text: Any) -> str:
+        return f"{cls.red}{text}{cls.reset}"
+
+    @classmethod
+    def print_step(cls, text: str) -> None:
+        prefix = cls.prefix + " " * cls.level
+        if sys.exc_info()[0]:
+            # We are falling through exception handling blocks.
+            # De-emphasize this step here, so the user can tell more
+            # easily which step generated the exception. The exception
+            # or error will only be printed after we finish cleanup.
+            cls._print(f"{prefix}({text})\n")
+        else:
+            cls._print(f"{prefix}{cls.bold}{text}{cls.reset}\n")
+
+    @classmethod
+    def info(cls, text: str) -> None:
+        cls._print(text + "\n")
+
+    @classmethod
+    def warn(cls, text: str) -> None:
+        cls._print(f"{cls.prefix}{cls.color_error(text)}\n")
+
+    @classmethod
+    @contextlib.contextmanager
+    def complete_step(cls, text: str, text2: Optional[str] = None) -> Iterator[list[Any]]:
+        cls.print_step(text)
+
+        cls.level += 1
+        try:
+            args: list[Any] = []
+            yield args
+        finally:
+            cls.level -= 1
+            assert cls.level >= 0
+
+        if text2 is not None:
+            cls.print_step(text2.format(*args))
+
+
+complete_step = MkosiPrinter.complete_step

--- a/mkosi/manifest.py
+++ b/mkosi/manifest.py
@@ -8,7 +8,8 @@ from subprocess import DEVNULL, PIPE
 from textwrap import dedent
 from typing import IO, Any, Optional
 
-from mkosi.backend import Distribution, ManifestFormat, MkosiConfig, PackageType, run
+from mkosi.backend import Distribution, ManifestFormat, MkosiConfig, PackageType
+from mkosi.run import run
 
 
 @dataclasses.dataclass

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -1,0 +1,325 @@
+import ctypes
+import ctypes.util
+import multiprocessing
+import os
+import pwd
+import shlex
+import signal
+import subprocess
+import sys
+import traceback
+from pathlib import Path
+from types import TracebackType
+from typing import Any, Callable, Iterable, Mapping, Optional, Sequence, Type, TypeVar
+
+from mkosi.backend import MkosiState
+from mkosi.log import ARG_DEBUG, MkosiPrinter, die
+from mkosi.types import _FILE, CompletedProcess, PathString, Popen
+
+CLONE_NEWNS = 0x00020000
+CLONE_NEWUSER = 0x10000000
+
+SUBRANGE = 65536
+
+T = TypeVar("T")
+
+
+def unshare(flags: int) -> None:
+    libc_name = ctypes.util.find_library("c")
+    if libc_name is None:
+        die("Could not find libc")
+    libc = ctypes.CDLL(libc_name, use_errno=True)
+
+    if libc.unshare(ctypes.c_int(flags)) != 0:
+        e = ctypes.get_errno()
+        raise OSError(e, os.strerror(e))
+
+
+def read_subrange(path: Path) -> int:
+    uid = str(os.getuid())
+    try:
+        user = pwd.getpwuid(os.getuid()).pw_name
+    except KeyError:
+        user = None
+
+    for line in path.read_text().splitlines():
+        name, start, count = line.split(":")
+
+        if name == uid or name == user:
+            break
+    else:
+        die(f"No mapping found for {user or uid} in {path}")
+
+    if int(count) < SUBRANGE:
+        die(f"subuid/subgid range length must be at least {SUBRANGE}, got {count} for {user or uid} from line '{line}'")
+
+    return int(start)
+
+
+def become_root() -> tuple[int, int]:
+    """
+    Set up a new user namespace mapping using /etc/subuid and /etc/subgid.
+
+    The current user will be mapped to root and 65436 will be mapped to the UID/GID of the invoking user.
+    The other IDs will be mapped through.
+
+    The function returns the UID-GID pair of the invoking user in the namespace (65436, 65436).
+    """
+    subuid = read_subrange(Path("/etc/subuid"))
+    subgid = read_subrange(Path("/etc/subgid"))
+
+    event = multiprocessing.Event()
+    pid = os.getpid()
+
+    child = os.fork()
+    if child == 0:
+        event.wait()
+
+        # We map the private UID range configured in /etc/subuid and /etc/subgid into the container using
+        # newuidmap and newgidmap. On top of that, we also make sure to map in the user running mkosi so that
+        # we can run still chown stuff to that user or run stuff as that user which will make sure any
+        # generated files are owned by that user. We don't map to the last user in the range as the last user
+        # is sometimes used in tests as a default value and mapping to that user might break those tests.
+        newuidmap = [
+            "newuidmap", pid,
+            0, subuid, SUBRANGE - 100,
+            SUBRANGE - 100, os.getuid(), 1,
+            SUBRANGE - 100 + 1, subuid + SUBRANGE - 100 + 1, 99
+        ]
+        run((str(x) for x in newuidmap))
+
+        newgidmap = [
+            "newgidmap", pid,
+            0, subgid, SUBRANGE - 100,
+            SUBRANGE - 100, os.getgid(), 1,
+            SUBRANGE - 100 + 1, subgid + SUBRANGE - 100 + 1, 99
+        ]
+        run(str(x) for x in newgidmap)
+
+        sys.stdout.flush()
+        sys.stderr.flush()
+
+        os._exit(0)
+
+    unshare(CLONE_NEWUSER)
+    event.set()
+    os.waitpid(child, 0)
+
+    # By default, we're root in the user namespace because if we were our current user by default, we
+    # wouldn't be able to chown stuff to be owned by root while the reverse is possible.
+    os.setresuid(0, 0, 0)
+    os.setresgid(0, 0, 0)
+    os.setgroups([0])
+
+    return SUBRANGE - 100, SUBRANGE - 100
+
+
+def init_mount_namespace() -> None:
+    unshare(CLONE_NEWNS)
+    run(["mount", "--make-rslave", "/"])
+
+
+def foreground() -> None:
+    """
+    If we're connected to a terminal, put the process in a new process group and make that the foreground
+    process group so that only this process receives SIGINT.
+    """
+    if sys.stdin.isatty():
+        os.setpgrp()
+        old = signal.signal(signal.SIGTTOU, signal.SIG_IGN)
+        os.tcsetpgrp(0, os.getpgrp())
+        signal.signal(signal.SIGTTOU, old)
+
+
+class RemoteException(Exception):
+    """
+    Stores the exception from a subprocess along with its traceback. We have to do this explicitly because
+    the original traceback object cannot be pickled. When stringified, produces the subprocess stacktrace
+    plus the exception message.
+    """
+    def __init__(self, e: BaseException, tb: traceback.StackSummary):
+        self.exception = e
+        self.tb = tb
+
+    def __str__(self) -> str:
+        return f"Traceback (most recent call last):\n{''.join(self.tb.format()).strip()}\n{type(self.exception).__name__}: {self.exception}"
+
+
+def excepthook(exctype: Type[BaseException], exc: BaseException, tb: Optional[TracebackType]) -> None:
+    """Attach to sys.excepthook to automically format exceptions with a RemoteException attached correctly."""
+    if isinstance(exc.__cause__, RemoteException):
+        print(exc.__cause__, file=sys.stderr)
+    else:
+        sys.__excepthook__(exctype, exc, tb)
+
+
+def fork_and_wait(target: Callable[[], T]) -> T:
+    """Run the target function in the foreground in a child process and collect its backtrace if there is one."""
+    pout, pin = multiprocessing.Pipe(duplex=False)
+
+    pid = os.fork()
+    if pid == 0:
+        foreground()
+
+        try:
+            result = target()
+        except BaseException as e:
+            # Just getting the stacktrace from the traceback doesn't get us the parent frames for some reason
+            # so we have to attach those manually.
+            tb = traceback.StackSummary.from_list(traceback.extract_stack()[:-1] + traceback.extract_tb(e.__traceback__))
+            pin.send(RemoteException(e, tb))
+        else:
+            pin.send(result)
+        finally:
+            pin.close()
+
+        sys.stdout.flush()
+        sys.stderr.flush()
+
+        os._exit(0)
+
+    os.waitpid(pid, 0)
+    result = pout.recv()
+    if isinstance(result, RemoteException):
+        # Reraise the original exception and attach the remote exception with full traceback as the cause.
+        raise result.exception from result
+
+    return result
+
+
+def run(
+    cmdline: Iterable[PathString],
+    check: bool = True,
+    stdout: _FILE = None,
+    stderr: _FILE = None,
+    env: Optional[Mapping[str, Any]] = None,
+    **kwargs: Any,
+) -> CompletedProcess:
+    cmdline = [os.fspath(x) for x in cmdline]
+
+    if "run" in ARG_DEBUG:
+        MkosiPrinter.info(f"+ {shlex.join(str(s) for s in cmdline)}")
+
+    if not stdout and not stderr:
+        # Unless explicit redirection is done, print all subprocess
+        # output on stderr, since we do so as well for mkosi's own
+        # output.
+        stdout = sys.stderr
+
+    if env is None:
+        env = os.environ
+    else:
+        env = dict(
+            PATH=os.environ["PATH"],
+            TERM=os.getenv("TERM", "vt220"),
+        ) | env
+
+    try:
+        return subprocess.run(cmdline, check=check, stdout=stdout, stderr=stderr, env=env, **kwargs,
+                              preexec_fn=foreground)
+    except FileNotFoundError:
+        die(f"{cmdline[0]} not found in PATH.")
+
+
+def spawn(
+    cmdline: Sequence[PathString],
+    stdout: _FILE = None,
+    stderr: _FILE = None,
+    **kwargs: Any,
+) -> Popen:
+    if "run" in ARG_DEBUG:
+        MkosiPrinter.info(f"+ {shlex.join(str(s) for s in cmdline)}")
+
+    if not stdout and not stderr:
+        # Unless explicit redirection is done, print all subprocess
+        # output on stderr, since we do so as well for mkosi's own
+        # output.
+        stdout = sys.stderr
+
+    try:
+        return subprocess.Popen(cmdline, stdout=stdout, stderr=stderr, **kwargs, preexec_fn=foreground)
+    except FileNotFoundError:
+        die(f"{cmdline[0]} not found in PATH.")
+
+
+def run_with_apivfs(
+    state: MkosiState,
+    cmd: Sequence[PathString],
+    bwrap_params: Sequence[PathString] = tuple(),
+    stdout: _FILE = None,
+    env: Mapping[str, Any] = {},
+) -> CompletedProcess:
+    cmdline: list[PathString] = [
+        "bwrap",
+        # Required to make chroot detection via /proc/1/root work properly.
+        "--unshare-pid",
+        "--dev-bind", "/", "/",
+        "--tmpfs", state.root / "run",
+        "--tmpfs", state.root / "tmp",
+        "--proc", state.root / "proc",
+        "--dev", state.root / "dev",
+        "--ro-bind", "/sys", state.root / "sys",
+        "--bind", state.var_tmp(), state.root / "var/tmp",
+        *bwrap_params,
+        "sh", "-c",
+    ]
+
+    env = env | state.environment
+
+    template = f"chmod 1777 {state.root / 'tmp'} {state.root / 'var/tmp'} {state.root / 'dev/shm'} && exec {{}} || exit $?"
+
+    try:
+        return run([*cmdline, template.format(shlex.join(str(s) for s in cmd))],
+                   text=True, stdout=stdout, env=env)
+    except subprocess.CalledProcessError as e:
+        if "run" in ARG_DEBUG:
+            run([*cmdline, template.format("sh")], check=False, env=env)
+        die(f"\"{shlex.join(str(s) for s in cmd)}\" returned non-zero exit code {e.returncode}.")
+
+
+def run_workspace_command(
+    state: MkosiState,
+    cmd: Sequence[PathString],
+    bwrap_params: Sequence[PathString] = tuple(),
+    network: bool = False,
+    stdout: _FILE = None,
+    env: Mapping[str, Any] = {},
+) -> CompletedProcess:
+    cmdline: list[PathString] = [
+        "bwrap",
+        "--unshare-ipc",
+        "--unshare-pid",
+        "--unshare-cgroup",
+        "--bind", state.root, "/",
+        "--tmpfs", "/run",
+        "--tmpfs", "/tmp",
+        "--dev", "/dev",
+        "--proc", "/proc",
+        "--ro-bind", "/sys", "/sys",
+        "--bind", state.var_tmp(), "/var/tmp",
+        *bwrap_params,
+    ]
+
+    if network:
+        # If we're using the host network namespace, use the same resolver
+        cmdline += ["--ro-bind", "/etc/resolv.conf", "/etc/resolv.conf"]
+    else:
+        cmdline += ["--unshare-net"]
+
+    cmdline += ["sh", "-c"]
+
+    env = dict(
+        container="mkosi",
+        SYSTEMD_OFFLINE=str(int(network)),
+        HOME="/",
+    ) | env | state.environment
+
+    template = "chmod 1777 /tmp /var/tmp /dev/shm && exec {} || exit $?"
+
+    try:
+        return run([*cmdline, template.format(shlex.join(str(s) for s in cmd))],
+                   text=True, stdout=stdout, env=env)
+    except subprocess.CalledProcessError as e:
+        if "run" in ARG_DEBUG:
+            run([*cmdline, template.format("sh")], check=False, env=env)
+        die(f"\"{shlex.join(str(s) for s in cmd)}\" returned non-zero exit code {e.returncode}.")

--- a/mkosi/types.py
+++ b/mkosi/types.py
@@ -1,0 +1,20 @@
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import IO, TYPE_CHECKING, Any, Union
+
+# These types are only generic during type checking and not at runtime, leading
+# to a TypeError during compilation.
+# Let's be as strict as we can with the description for the usage we have.
+if TYPE_CHECKING:
+    CompletedProcess = subprocess.CompletedProcess[Any]
+    Popen = subprocess.Popen[Any]
+    TempDir = tempfile.TemporaryDirectory[str]
+else:
+    CompletedProcess = subprocess.CompletedProcess
+    Popen = subprocess.Popen
+    TempDir = tempfile.TemporaryDirectory
+
+# Borrowed from https://github.com/python/typeshed/blob/3d14016085aed8bcf0cf67e9e5a70790ce1ad8ea/stdlib/3/subprocess.pyi#L24
+_FILE = Union[None, int, IO[Any]]
+PathString = Union[Path, str]

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -9,13 +9,13 @@ import pytest
 
 from mkosi.backend import (
     Distribution,
-    MkosiException,
     PackageType,
     safe_tar_extract,
     set_umask,
     strip_suffixes,
     workspace,
 )
+from mkosi.log import MkosiException
 
 
 def test_distribution() -> None:

--- a/tests/test_parse_load_args.py
+++ b/tests/test_parse_load_args.py
@@ -11,7 +11,8 @@ from typing import Iterator, List, Optional
 import pytest
 
 import mkosi
-from mkosi.backend import Distribution, MkosiConfig, MkosiException, Verb
+from mkosi.backend import Distribution, MkosiConfig, Verb
+from mkosi.log import MkosiException
 
 
 def parse(argv: Optional[List[str]] = None) -> MkosiConfig:


### PR DESCRIPTION
To enable this, when doing a build, we unshare a user namespace
with it's own private set of uids/gids obtained using newuidmap
and newgidmap. We also map the current user to the last UID/GID
in the UID/GID range from /etc/subuid and /etc/subgid. Together
with unsharing the mount namespace, this allows us to do
unprivileged bind and overlay mounts.

Next, we replace all usages of systemd-nspawn during the image build
with bubblewrap. systemd-nspawn cannot run as an unprivileged user
yet so we use bubblewrap which can. bubblewrap can also be used to
setup a chroot environment with API VFS filesystems so we make use
of that to setup chroot environments and remove all our homegrown
logic for it. This allows us to significantly reduce the amount of
mounts we do in mkosi itself.

To further reduce the amount of mounts, we modify the invocations
of all package managers to specify the cache directory via the
relevant option instead of mounting the cache directory into the
chroot. For apt, to accomplish this, we switch from using
DPkg::Chroot-Directory to setting the "--root" option for each
invocation of dpkg so that dpkg can access files outside of the
chroot.

Finally, we remove some options which become obsolete with this
commit, --idmap, --chown and --nspawn-keep-unit.

We also remove --source-file-transfer, --source-file-transfer-final
and the corresponding symlink options. Instead, we default to mounting
source files into the build tree. In the future, we'll add virtiofsd
support to allow accessing source files in qemu VMs.

We also move stuff around and create a few new files to store
helpers to avoid circular imports. There's also a little bit of
refactoring and cleanup all around.