### PR TITLE
Make sure args_find_path() works with as_list

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2615,7 +2615,7 @@ def find_skeleton(args: argparse.Namespace) -> None:
 
 
 def args_find_path(args: argparse.Namespace, name: str, path: str, *, as_list: bool = False) -> None:
-    if getattr(args, name) is not None:
+    if getattr(args, name):
         return
     abspath = Path(path).absolute()
     if abspath.exists():


### PR DESCRIPTION
The default when using list arguments is [], so let's modify the check to account for this.