### PR TITLE
Tighten types on functions that have no or very few str callers

### DIFF
--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -709,10 +709,8 @@ def patch_file(filepath: Path, line_rewriter: Callable[[str], str]) -> None:
     shutil.move(temp_new_filepath, filepath)
 
 
-def path_relative_to_cwd(path: PathString) -> Path:
+def path_relative_to_cwd(path: Path) -> Path:
     "Return path as relative to $PWD if underneath, absolute path otherwise"
-    path = Path(path)
-
     try:
         return path.relative_to(os.getcwd())
     except ValueError:
@@ -785,7 +783,7 @@ class MkosiPrinter:
             cls.print_step(text2.format(*args))
 
 
-def chown_to_running_user(path: PathString) -> None:
+def chown_to_running_user(path: Path) -> None:
     uid = int(os.getenv("SUDO_UID") or os.getenv("PKEXEC_UID") or str(os.getuid()))
     user = pwd.getpwuid(uid).pw_name
     gid = pwd.getpwuid(uid).pw_gid

--- a/mkosi/install.py
+++ b/mkosi/install.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Optional
 
-from mkosi.backend import MkosiState, PathString, complete_step, run
+from mkosi.backend import MkosiState, complete_step, run
 
 
 def make_executable(path: Path) -> None:
@@ -47,7 +47,7 @@ def add_dropin_config_from_resource(
 
 
 @contextlib.contextmanager
-def flock(path: PathString) -> Iterator[Path]:
+def flock(path: Path) -> Iterator[Path]:
     fd = os.open(path, os.O_CLOEXEC|os.O_DIRECTORY|os.O_RDONLY)
     try:
         fcntl.fcntl(fd, fcntl.FD_CLOEXEC)
@@ -57,7 +57,7 @@ def flock(path: PathString) -> Iterator[Path]:
         os.close(fd)
 
 
-def copy_path(src: PathString, dst: PathString, parents: bool = False) -> None:
+def copy_path(src: Path, dst: Path, parents: bool = False) -> None:
     run(["cp", "--archive", "--no-target-directory", "--reflink=auto", src, dst])
 
 

--- a/mkosi/remove.py
+++ b/mkosi/remove.py
@@ -6,7 +6,7 @@ import subprocess
 from pathlib import Path
 from typing import Optional
 
-from mkosi.backend import PathString, run
+from mkosi.backend import run
 
 
 def btrfs_subvol_delete(path: Path) -> None:
@@ -30,7 +30,7 @@ def btrfs_subvol_delete(path: Path) -> None:
         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 
-def unlink_try_hard(path: Optional[PathString]) -> None:
+def unlink_try_hard(path: Optional[Path]) -> None:
     if path is None:
         return
 


### PR DESCRIPTION
Looking at #1319 I wondered whether some of these functions taking `PathString` were called with string arguments. Some are not and those that are, are so only in one or two places. 

A followup would be to remove the remaining usages of `PathString`, since those are usually in the form `list[PathString]` for command lines, i.e. a potential new type `CommandLine = list[Union[Path, str]]`, but I didn't do this yet because I don't want to make #1313 harder to rebase.