### PR TITLE
Remove PathString in favour of CommandLine types

### DIFF
--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -7,7 +7,7 @@ from mkosi.backend import MkosiState, add_packages, disable_pam_securetty, sort_
 from mkosi.distributions import DistributionInstaller
 from mkosi.log import complete_step
 from mkosi.run import run_with_apivfs
-from mkosi.types import PathString
+from mkosi.types import MutableCommandLine
 
 
 class ArchInstaller(DistributionInstaller):
@@ -124,7 +124,7 @@ def install_arch(state: MkosiState) -> None:
 
 
 def invoke_pacman(state: MkosiState, packages: Sequence[str]) -> None:
-    cmdline: list[PathString] = [
+    cmdline: MutableCommandLine = [
         "pacman",
         "--config", state.workspace / "pacman.conf",
         "--noconfirm",

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -11,7 +11,7 @@ from mkosi.backend import MkosiState, add_packages, disable_pam_securetty
 from mkosi.distributions import DistributionInstaller
 from mkosi.install import install_skeleton_trees, write_resource
 from mkosi.run import run, run_with_apivfs
-from mkosi.types import _FILE, CompletedProcess, PathString
+from mkosi.types import _FILE, CompletedProcess, Environment, PathString
 
 
 class DebianInstaller(DistributionInstaller):
@@ -305,7 +305,7 @@ def invoke_apt(
         operation,
         *extra,
     ]
-    env: dict[str, PathString] = dict(
+    env: Environment = dict(
         APT_CONFIG=config_file,
         DEBIAN_FRONTEND="noninteractive",
         DEBCONF_INTERACTIVE_SEEN="true",

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -11,7 +11,7 @@ from mkosi.backend import MkosiState, add_packages, disable_pam_securetty
 from mkosi.distributions import DistributionInstaller
 from mkosi.install import install_skeleton_trees, write_resource
 from mkosi.run import run, run_with_apivfs
-from mkosi.types import _FILE, CompletedProcess, Environment, PathString
+from mkosi.types import _FILE, CompletedProcess, Environment, MutableCommandLine
 
 
 class DebianInstaller(DistributionInstaller):
@@ -64,7 +64,7 @@ class DebianInstaller(DistributionInstaller):
 
         # debootstrap fails if a base image is used with an already populated root, so skip it.
         if state.config.base_image is None:
-            cmdline: list[PathString] = [
+            cmdline: MutableCommandLine = [
                 "debootstrap",
                 "--variant=minbase",
                 "--include=ca-certificates",

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -3,10 +3,10 @@
 import shutil
 import urllib.parse
 import urllib.request
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Sequence
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, NamedTuple, Optional
+from typing import NamedTuple, Optional
 
 from mkosi.backend import (
     Distribution,
@@ -19,6 +19,7 @@ from mkosi.distributions import DistributionInstaller
 from mkosi.log import MkosiPrinter, complete_step, warn
 from mkosi.remove import unlink_try_hard
 from mkosi.run import run_with_apivfs
+from mkosi.types import Environment
 
 FEDORA_KEYS_MAP = {
     "36": "53DED2CB922D8B8D9E63FD18999F7CBF38AB71F4",
@@ -167,7 +168,7 @@ def setup_dnf(state: MkosiState, repos: Sequence[Repo] = ()) -> None:
             )
 
 
-def invoke_dnf(state: MkosiState, command: str, packages: Iterable[str], env: Mapping[str, Any] = {}) -> None:
+def invoke_dnf(state: MkosiState, command: str, packages: Iterable[str], env: Environment = {}) -> None:
     if state.config.distribution == Distribution.fedora:
         release, _ = parse_fedora_release(state.config.release)
     else:

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -9,7 +9,7 @@ from mkosi.backend import MkosiState, add_packages, patch_file
 from mkosi.distributions import DistributionInstaller
 from mkosi.log import complete_step
 from mkosi.run import run, run_with_apivfs
-from mkosi.types import PathString
+from mkosi.types import CommandArgument, MutableCommandLine
 
 
 class OpensuseInstaller(DistributionInstaller):
@@ -48,10 +48,10 @@ def invoke_zypper(state: MkosiState,
                   global_opts: list[str],
                   verb: str,
                   verb_opts: list[str],
-                  *args: PathString,
+                  *args: CommandArgument,
                   with_apivfs: bool = False) -> None:
 
-    cmdline: list[PathString] = ["zypper", "--root", state.root, *global_opts, verb, *verb_opts, *args]
+    cmdline: MutableCommandLine = ["zypper", "--root", state.root, *global_opts, verb, *verb_opts, *args]
     env={"ZYPP_CONF": state.root.joinpath("etc/zypp/zypp.conf")}
 
     if with_apivfs:

--- a/mkosi/mounts.py
+++ b/mkosi/mounts.py
@@ -10,7 +10,7 @@ from typing import Callable, Deque, Optional, TypeVar, Union, cast
 
 from mkosi.log import complete_step
 from mkosi.run import run
-from mkosi.types import PathString
+from mkosi.types import CommandArgument, MutableCommandLine
 
 T = TypeVar("T")
 
@@ -50,7 +50,7 @@ def delete_whiteout_files(path: Path) -> None:
 
 @contextlib.contextmanager
 def mount(
-    what: PathString,
+    what: CommandArgument,
     where: Path,
     operation: Optional[str] = None,
     options: Sequence[str] = (),
@@ -62,7 +62,7 @@ def mount(
     if read_only:
         options = ["ro", *options]
 
-    cmd: list[PathString] = ["mount", "--no-mtab"]
+    cmd: MutableCommandLine = ["mount", "--no-mtab"]
 
     if operation:
         cmd += [operation]

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -11,7 +11,7 @@ import sys
 import traceback
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Callable, Mapping, Optional, Sequence, Type, TypeVar
+from typing import Any, Callable, Optional, Sequence, Type, TypeVar
 
 from mkosi.backend import MkosiState
 from mkosi.log import ARG_DEBUG, MkosiPrinter, die
@@ -20,6 +20,7 @@ from mkosi.types import (
     CommandArgument,
     CommandLine,
     CompletedProcess,
+    Environment,
     PathString,
     Popen,
 )
@@ -208,7 +209,7 @@ def run(
     check: bool = True,
     stdout: _FILE = None,
     stderr: _FILE = None,
-    env: Mapping[str, PathString] = {},
+    env: Environment = {},
     **kwargs: Any,
 ) -> CompletedProcess:
     cmd = [_stringify(x) for x in cmdline]
@@ -265,7 +266,7 @@ def run_with_apivfs(
     cmd: Sequence[PathString],
     bwrap_params: Sequence[PathString] = tuple(),
     stdout: _FILE = None,
-    env: Mapping[str, PathString] = {},
+    env: Environment = {},
 ) -> CompletedProcess:
     cmdline: list[PathString] = [
         "bwrap",
@@ -301,7 +302,7 @@ def run_workspace_command(
     bwrap_params: Sequence[PathString] = tuple(),
     network: bool = False,
     stdout: _FILE = None,
-    env: Mapping[str, PathString] = {},
+    env: Environment = {},
 ) -> CompletedProcess:
     cmdline: list[PathString] = [
         "bwrap",

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -11,11 +11,18 @@ import sys
 import traceback
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Callable, Iterable, Mapping, Optional, Sequence, Type, TypeVar
+from typing import Any, Callable, Mapping, Optional, Sequence, Type, TypeVar
 
 from mkosi.backend import MkosiState
 from mkosi.log import ARG_DEBUG, MkosiPrinter, die
-from mkosi.types import _FILE, CompletedProcess, CommandArgument, PathString, Popen
+from mkosi.types import (
+    _FILE,
+    CommandArgument,
+    CommandLine,
+    CompletedProcess,
+    PathString,
+    Popen,
+)
 
 CLONE_NEWNS = 0x00020000
 CLONE_NEWUSER = 0x10000000
@@ -87,7 +94,7 @@ def become_root() -> tuple[int, int]:
             SUBRANGE - 100, os.getuid(), 1,
             SUBRANGE - 100 + 1, subuid + SUBRANGE - 100 + 1, 99
         ]
-        run((str(x) for x in newuidmap))
+        run([str(x) for x in newuidmap])
 
         newgidmap = [
             "newgidmap", pid,
@@ -95,7 +102,7 @@ def become_root() -> tuple[int, int]:
             SUBRANGE - 100, os.getgid(), 1,
             SUBRANGE - 100 + 1, subgid + SUBRANGE - 100 + 1, 99
         ]
-        run(str(x) for x in newgidmap)
+        run([str(x) for x in newgidmap])
 
         sys.stdout.flush()
         sys.stderr.flush()
@@ -199,7 +206,7 @@ def _stringify(x: CommandArgument) -> str:
 
 
 def run(
-    cmdline: Iterable[PathString],
+    cmdline: CommandLine,
     check: bool = True,
     stdout: _FILE = None,
     stderr: _FILE = None,
@@ -234,7 +241,7 @@ def run(
 
 
 def spawn(
-    cmdline: Sequence[PathString],
+    cmdline: CommandLine,
     stdout: _FILE = None,
     stderr: _FILE = None,
     **kwargs: Any,

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -88,21 +88,19 @@ def become_root() -> tuple[int, int]:
         # we can run still chown stuff to that user or run stuff as that user which will make sure any
         # generated files are owned by that user. We don't map to the last user in the range as the last user
         # is sometimes used in tests as a default value and mapping to that user might break those tests.
-        newuidmap = [
+        run([
             "newuidmap", pid,
             0, subuid, SUBRANGE - 100,
             SUBRANGE - 100, os.getuid(), 1,
             SUBRANGE - 100 + 1, subuid + SUBRANGE - 100 + 1, 99
-        ]
-        run([str(x) for x in newuidmap])
+        ])
 
-        newgidmap = [
+        run([
             "newgidmap", pid,
             0, subgid, SUBRANGE - 100,
             SUBRANGE - 100, os.getgid(), 1,
             SUBRANGE - 100 + 1, subgid + SUBRANGE - 100 + 1, 99
-        ]
-        run([str(x) for x in newgidmap])
+        ])
 
         sys.stdout.flush()
         sys.stderr.flush()

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -11,7 +11,7 @@ import sys
 import traceback
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Callable, Optional, Sequence, Type, TypeVar
+from typing import Any, Callable, Optional, Type, TypeVar
 
 from mkosi.backend import MkosiState
 from mkosi.log import ARG_DEBUG, MkosiPrinter, die
@@ -21,7 +21,7 @@ from mkosi.types import (
     CommandLine,
     CompletedProcess,
     Environment,
-    PathString,
+    MutableCommandLine,
     Popen,
 )
 
@@ -263,12 +263,12 @@ def spawn(
 
 def run_with_apivfs(
     state: MkosiState,
-    cmd: Sequence[PathString],
-    bwrap_params: Sequence[PathString] = tuple(),
+    cmd: CommandLine,
+    bwrap_params: CommandLine = tuple(),
     stdout: _FILE = None,
     env: Environment = {},
 ) -> CompletedProcess:
-    cmdline: list[PathString] = [
+    cmdline: MutableCommandLine = [
         "bwrap",
         # Required to make chroot detection via /proc/1/root work properly.
         "--unshare-pid",
@@ -298,13 +298,13 @@ def run_with_apivfs(
 
 def run_workspace_command(
     state: MkosiState,
-    cmd: Sequence[PathString],
-    bwrap_params: Sequence[PathString] = tuple(),
+    cmd: CommandLine,
+    bwrap_params: CommandLine = tuple(),
     network: bool = False,
     stdout: _FILE = None,
     env: Environment = {},
 ) -> CompletedProcess:
-    cmdline: list[PathString] = [
+    cmdline: MutableCommandLine = [
         "bwrap",
         "--unshare-ipc",
         "--unshare-pid",

--- a/mkosi/types.py
+++ b/mkosi/types.py
@@ -15,3 +15,5 @@ else:
 # Borrowed from https://github.com/python/typeshed/blob/3d14016085aed8bcf0cf67e9e5a70790ce1ad8ea/stdlib/3/subprocess.pyi#L24
 _FILE = Union[None, int, IO[Any]]
 PathString = Union[Path, str]
+
+CommandArgument = Union[str, Path]

--- a/mkosi/types.py
+++ b/mkosi/types.py
@@ -1,6 +1,6 @@
 import subprocess
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, Union
+from typing import IO, TYPE_CHECKING, Any, Sequence, Union
 
 # These types are only generic during type checking and not at runtime, leading
 # to a TypeError during compilation.
@@ -16,4 +16,6 @@ else:
 _FILE = Union[None, int, IO[Any]]
 PathString = Union[Path, str]
 
-CommandArgument = Union[str, Path]
+CommandArgument = Union[str, Path, int]
+CommandLine = Sequence[CommandArgument]
+MutableCommandLine = list[CommandArgument]

--- a/mkosi/types.py
+++ b/mkosi/types.py
@@ -14,7 +14,6 @@ else:
 
 # Borrowed from https://github.com/python/typeshed/blob/3d14016085aed8bcf0cf67e9e5a70790ce1ad8ea/stdlib/3/subprocess.pyi#L24
 _FILE = Union[None, int, IO[Any]]
-PathString = Union[Path, str]
 
 Environment = Mapping[str, Union[str, Path]]
 CommandArgument = Union[str, Path, int]

--- a/mkosi/types.py
+++ b/mkosi/types.py
@@ -1,6 +1,6 @@
 import subprocess
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, Sequence, Union
+from typing import IO, TYPE_CHECKING, Any, Mapping, Sequence, Union
 
 # These types are only generic during type checking and not at runtime, leading
 # to a TypeError during compilation.
@@ -16,6 +16,7 @@ else:
 _FILE = Union[None, int, IO[Any]]
 PathString = Union[Path, str]
 
+Environment = Mapping[str, Union[str, Path]]
 CommandArgument = Union[str, Path, int]
 CommandLine = Sequence[CommandArgument]
 MutableCommandLine = list[CommandArgument]


### PR DESCRIPTION
This is a followup to #1320, but can wait until after #1313, if it makes rebasing harder.

Except for two remaining uses, where using the explicit `Union[Path, str]`, which we will at some point be able to exchange for `Path | str`, is no bother and doesn't warrant keeping around an additional type alias, the remaining users for `PathString` are either `list[PathString]`, `Sequence[PathString]` or `Iterable[PathString]`.

The latter can be exchanged for `Sequence[PathString]`, leaving us with one mutable and one immutable version, that can be nicely aliased as `CommandLine` and `CommandLineReadOnly`, making clearer what is being handled and expected.