### PR TITLE
Drop --include-dir

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,8 @@
 - Removed `--source-file-transfer`, `--source-file-transfer-final`, `--source-resolve-symlinks` and
   `--source-resolve-symlinks-final` in favor of always mounting the source directory into the build image.
   `--source-file-transfer-final` might be reimplemented in the future using virtiofsd.
+- Dropped `--include-dir` option. Usage can be replaced by using `--incremental` and reading includes from
+  the cached build image tree.
 
 ## v14
 

--- a/mkosi.md
+++ b/mkosi.md
@@ -714,18 +714,6 @@ a machine ID.
   is automatically used for this purpose (also see the "Files" section
   below).
 
-`IncludeDirectory=`, `--include-directory=`
-
-: Takes a path of a directory to use as the include directory. This
-  directory is mounted at `/usr/include` when building the build image
-  and running the build script. This means all include files installed
-  to `/usr/include` will be stored in this directory. This is useful
-  to make include files available on the host system for use by
-  language servers to provide code completion. If this option is not
-  specified, but a directory `mkosi.includedir/` exists in the local
-  directory, it is automatically used for this purpose (also see the
-  "Files" section below).
-
 `InstallDirectory=`, `--install-directory=`
 
 : Takes a path of a directory to use as the install directory. The

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -289,7 +289,6 @@ class MkosiConfig:
     environment: dict[str, str]
     build_sources: Path
     build_dir: Optional[Path]
-    include_dir: Optional[Path]
     install_dir: Optional[Path]
     build_packages: list[str]
     skip_final_phase: bool

--- a/mkosi/mounts.py
+++ b/mkosi/mounts.py
@@ -6,7 +6,7 @@ import os
 import stat
 from collections.abc import Iterator, Sequence
 from pathlib import Path
-from typing import Callable, ContextManager, Deque, Optional, TypeVar, Union, cast
+from typing import Callable, Deque, Optional, TypeVar, Union, cast
 
 from mkosi.log import complete_step
 from mkosi.run import run
@@ -80,15 +80,6 @@ def mount(
         yield where
     finally:
         run(["umount", "--no-mtab", "--recursive", where])
-
-
-def mount_bind(what: Path, where: Optional[Path] = None, read_only: bool = False) -> ContextManager[Path]:
-    if where is None:
-        where = what
-
-    os.makedirs(what, 0o755, True)
-    os.makedirs(where, 0o755, True)
-    return mount(what, where, operation="--bind")
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Let's get rid of one more source of mounts. --include-dir can be replaced by using --incremental and reading includes from the cached build image tree. In the future, once build images become regular images, users can read includes by simply using --directory output and reading includes from the regular image output tree.