### PR TITLE
Simplify kernel image and initrd handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,7 @@
   `--source-file-transfer-final` might be reimplemented in the future using virtiofsd.
 - Dropped `--include-dir` option. Usage can be replaced by using `--incremental` and reading includes from
   the cached build image tree.
+- Removed `--machine-id` in favor of shipping images without a machine ID at all.
 
 ## v14
 

--- a/mkosi.md
+++ b/mkosi.md
@@ -543,12 +543,6 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   in building or further container import stages.  This option strips
   SELinux context attributes from the resulting tar archive.
 
-`MachineID=`, `--machine-id`
-
-: Set the machine's ID to the specified value. If unused, a random ID will
-be used while building the image and the final image will be shipped without
-a machine ID.
-
 ### [Content] Section
 
 `BasePackages=`, `--base-packages`

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -321,7 +321,6 @@ class MkosiConfig:
     debug: list[str]
     auto_bump: bool
     workspace_dir: Optional[Path]
-    machine_id: Optional[str]
 
     # QEMU-specific options
     qemu_headless: bool
@@ -396,7 +395,6 @@ class MkosiState:
     workspace: Path
     cache: Path
     do_run_build_script: bool
-    machine_id: str
     for_cache: bool
     environment: dict[str, str] = dataclasses.field(init=False)
     installer: DistributionInstaller = dataclasses.field(init=False)
@@ -418,20 +416,21 @@ class MkosiState:
             die("No installer for this distribution.")
         self.installer = instance
 
+        self.root.mkdir(exist_ok=True, mode=0o755)
+        self.var_tmp.mkdir(exist_ok=True)
+        self.staging.mkdir(exist_ok=True)
+
     @property
     def root(self) -> Path:
         return self.workspace / "root"
 
+    @property
     def var_tmp(self) -> Path:
-        p = self.workspace / "var-tmp"
-        p.mkdir(exist_ok=True)
-        return p
+        return self.workspace / "var-tmp"
 
     @property
     def staging(self) -> Path:
-        p = self.workspace / "staging"
-        p.mkdir(exist_ok=True)
-        return p
+        return self.workspace / "staging"
 
 
 def should_compress_output(config: Union[argparse.Namespace, MkosiConfig]) -> Union[bool, str]:
@@ -447,10 +446,6 @@ def should_compress_output(config: Union[argparse.Namespace, MkosiConfig]) -> Un
     if c is True:
         return "xz"  # default compression
     return False if c is None else c
-
-
-def workspace(root: Path) -> Path:
-    return root.parent
 
 
 def format_rlimit(rlimit: int) -> str:

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -15,8 +15,12 @@ class DistributionInstaller:
         raise NotImplementedError
 
     @staticmethod
-    def kernel_image(name: str, architecture: str) -> Path:
-        return Path("lib/modules") / name / "vmlinuz"
+    def kernel_image(kver: str, architecture: str) -> Path:
+        return Path("lib/modules") / kver / "vmlinuz"
+
+    @staticmethod
+    def initrd_path(kver: str) -> Path:
+        return Path("boot") / f"initramfs-{kver}.img"
 
     @classmethod
     def cache_path(cls) -> list[str]:

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -45,6 +45,10 @@ class DebianInstaller(DistributionInstaller):
     def kernel_image(name: str, architecture: str) -> Path:
         return Path(f"boot/vmlinuz-{name}")
 
+    @staticmethod
+    def initrd_path(kver: str) -> Path:
+        return Path("boot") / f"initrd.img-{kver}"
+
     @classmethod
     def install(cls, state: "MkosiState") -> None:
         # Either the image builds or it fails and we restart, we don't need safety fsyncs when bootstrapping

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 import shutil
+from pathlib import Path
 
 from mkosi.backend import MkosiState, add_packages, patch_file, sort_packages
 from mkosi.distributions import DistributionInstaller
@@ -21,6 +22,10 @@ class OpensuseInstaller(DistributionInstaller):
     @classmethod
     def install(cls, state: "MkosiState") -> None:
         return install_opensuse(state)
+
+    @staticmethod
+    def initrd_path(kver: str) -> Path:
+        return Path("boot") / f"initrd-{kver}"
 
 
 @complete_step("Installing openSUSE…")

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -260,7 +260,7 @@ def run_with_apivfs(
         "--proc", state.root / "proc",
         "--dev", state.root / "dev",
         "--ro-bind", "/sys", state.root / "sys",
-        "--bind", state.var_tmp(), state.root / "var/tmp",
+        "--bind", state.var_tmp, state.root / "var/tmp",
         *bwrap_params,
         "sh", "-c",
     ]
@@ -297,7 +297,7 @@ def run_workspace_command(
         "--dev", "/dev",
         "--proc", "/proc",
         "--ro-bind", "/sys", "/sys",
-        "--bind", state.var_tmp(), "/var/tmp",
+        "--bind", state.var_tmp, "/var/tmp",
         *bwrap_params,
     ]
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -13,7 +13,6 @@ from mkosi.backend import (
     safe_tar_extract,
     set_umask,
     strip_suffixes,
-    workspace,
 )
 from mkosi.log import MkosiException
 
@@ -35,13 +34,6 @@ def test_set_umask() -> None:
     assert tmp1 == 0o767
     assert tmp2 == 0o757
     assert tmp3 == 0o777
-
-
-def test_workspace() -> None:
-    assert workspace(Path("/home/folder/mkosi/mkosi")) == Path("/home/folder/mkosi")
-    assert workspace(Path("/home/../home/folder/mkosi/mkosi")) == Path("/home/../home/folder/mkosi")
-    assert workspace(Path("/")) == Path("/")
-    assert workspace(Path()) == Path()
 
 
 def test_safe_tar_extract(tmp_path: Path) -> None:

--- a/tests/test_parse_load_args.py
+++ b/tests/test_parse_load_args.py
@@ -2,7 +2,6 @@
 
 import argparse
 import tempfile
-import uuid
 from contextlib import contextmanager
 from os import chdir, getcwd
 from pathlib import Path
@@ -60,28 +59,6 @@ def test_os_distribution() -> None:
             config.write_text(f"[Distribution]\nDistribution={dist}")
             assert parse([]).distribution == dist
 
-def test_machine_id() -> None:
-    id = uuid.uuid4().hex
-    load_args = parse(["--machine-id", id])
-
-    assert load_args.machine_id == id
-
-    with pytest.raises(MkosiException):
-        parse(["--machine-id", "notValidKey"])
-    with pytest.raises(tuple((argparse.ArgumentError, SystemExit))):
-        parse(["--machine-id"])
-
-    with cd_temp_dir():
-        config = Path("mkosi.conf")
-        config.write_text(f"[Output]\nMachineID={id}")
-        load_args = parse([])
-        assert load_args.machine_id == id
-
-    with cd_temp_dir():
-        config = Path("mkosi.conf")
-        config.write_text("[Output]\nMachineID=")
-        with pytest.raises(MkosiException):
-            parse([])
 
 def test_hostname() -> None:
     assert parse(["--hostname", "name"]).hostname == "name"


### PR DESCRIPTION
- Let's stop writing files in /etc in favor of passing the
information via other ways
- Let's stop defaulting to "bls" layout which is intended
for type 1 images, we only use UKIs so we don't need the
"bls" layout
- kernel-install now defaults to the "other" layout, which
means it won't create the entry directory in /boot anymore.
We update the initrd find logic to take this into account
- Remove --machine-id as it was only really there for testing
the config parsing which we now deal with by not storing the
machine ID at all