### PR TITLE
Fix bind mounting resolv.conf when it's a symlink

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4064,7 +4064,7 @@ def expand_paths(paths: Sequence[str]) -> list[Path]:
     expanded = []
     for path in paths:
         try:
-            expanded += [Path(string.Template(path).substitute(environ))]
+            expanded += [Path(string.Template(str(path)).substitute(environ))]
         except KeyError:
             # Skip path if it uses a variable not defined.
             pass


### PR DESCRIPTION
bwrap doesn't support mounting over symlinks, so let's take that into account.