### PR TITLE
Allow RPM to return total file sizes larger than 4GB

### DIFF
--- a/mkosi/manifest.py
+++ b/mkosi/manifest.py
@@ -106,7 +106,7 @@ class Manifest:
 
         c = run(
             ["rpm", f"--root={root}", f"--dbpath={dbpath}", "-qa", "--qf",
-             r"%{NEVRA}\t%{SOURCERPM}\t%{NAME}\t%{ARCH}\t%{SIZE}\t%{INSTALLTIME}\n"],
+             r"%{NEVRA}\t%{SOURCERPM}\t%{NAME}\t%{ARCH}\t%{LONGSIZE}\t%{INSTALLTIME}\n"],
             stdout=PIPE,
             text=True,
         )


### PR DESCRIPTION
When an RPM has a total content size over 4GB, the --qf parameter needs to use LONGSIZE instead of SIZE to display the total package content file size, likely to keep compatibility with code expecting 32 bit friendly values.

Otherwise, if a package is larger than 4GB, RPM returns (none). Since this is later given as input to Python's int(), it will throw an exception due to (none) not being a number.

For more information, see:
https://rpm.org/devel_doc/large_files.html

The line where the exception is thrown is:
https://github.com/systemd/mkosi/blob/af87828065c8eb65e4c089f6d07a6e231a3dafc0/mkosi/manifest.py#L130

Not sure if it makes sense to also add:
```python
if size != "(none)":
  size = int(size)
else:
  size = 0
```
here to prevent further crashes, similar as the code for dpkg does. However, judging from the comment, the size field is optional for dpkg, whereas it seems to be mandatory for RPM? So not sure if does make sense to `0` this, if the 4GB case now seemed to be one of the few triggers to actually return `(none)` and thus catch a bug?
