### PR TITLE
Set TMPDIR when running repart

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3210,7 +3210,7 @@ def invoke_repart(state: MkosiState, skip: Sequence[str] = [], split: bool = Fal
 
     cmdline += ["--definitions", definitions]
 
-    output = json.loads(run(cmdline, stdout=subprocess.PIPE).stdout)
+    output = json.loads(run(cmdline, stdout=subprocess.PIPE, env={"TMPDIR": state.workspace}).stdout)
 
     roothash = usrhash = None
     for p in output:

--- a/mkosi/types.py
+++ b/mkosi/types.py
@@ -1,5 +1,4 @@
 import subprocess
-import tempfile
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, Union
 
@@ -9,11 +8,9 @@ from typing import IO, TYPE_CHECKING, Any, Union
 if TYPE_CHECKING:
     CompletedProcess = subprocess.CompletedProcess[Any]
     Popen = subprocess.Popen[Any]
-    TempDir = tempfile.TemporaryDirectory[str]
 else:
     CompletedProcess = subprocess.CompletedProcess
     Popen = subprocess.Popen
-    TempDir = tempfile.TemporaryDirectory
 
 # Borrowed from https://github.com/python/typeshed/blob/3d14016085aed8bcf0cf67e9e5a70790ce1ad8ea/stdlib/3/subprocess.pyi#L24
 _FILE = Union[None, int, IO[Any]]


### PR DESCRIPTION
Otherwise, repart will copy the root directory to /var/tmp which can be slow on COW filesystems if /var/tmp is on a different partition.