### PR TITLE
Always run subprocesses with constrained environment

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3005,7 +3005,7 @@ def configure_ssh(state: MkosiState) -> None:
     if state.config.ssh_key:
         copy_path(Path(f"{state.config.ssh_key}.pub"), authorized_keys, preserve_owner=False)
     elif state.config.ssh_agent is not None:
-        env = {"SSH_AUTH_SOCK": str(state.config.ssh_agent), **os.environ}
+        env = {"SSH_AUTH_SOCK": str(state.config.ssh_agent)}
         result = run(["ssh-add", "-L"], env=env, text=True, stdout=subprocess.PIPE)
         authorized_keys.write_text(result.stdout)
     else:

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -193,7 +193,7 @@ def run(
     check: bool = True,
     stdout: _FILE = None,
     stderr: _FILE = None,
-    env: Optional[Mapping[str, Any]] = None,
+    env: Mapping[str, Any] = {},
     **kwargs: Any,
 ) -> CompletedProcess:
     cmdline = [os.fspath(x) for x in cmdline]
@@ -207,13 +207,12 @@ def run(
         # output.
         stdout = sys.stderr
 
-    if env is None:
-        env = os.environ
-    else:
-        env = dict(
-            PATH=os.environ["PATH"],
-            TERM=os.getenv("TERM", "vt220"),
-        ) | env
+    env = dict(
+        PATH=os.environ["PATH"],
+        TERM=os.getenv("TERM", "vt220"),
+        LANG="C.UTF-8",
+        **env,
+    )
 
     try:
         return subprocess.run(cmdline, check=check, stdout=stdout, stderr=stderr, env=env, **kwargs,


### PR DESCRIPTION
Also set LANG=C.UTF-8 if not set explicitly.