### PR TITLE
Use an overlay for the build image instead of a full image

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,9 @@
 - Dropped `--include-dir` option. Usage can be replaced by using `--incremental` and reading includes from
   the cached build image tree.
 - Removed `--machine-id` in favor of shipping images without a machine ID at all.
+- Removed `--skip-final-phase` as we only have a single phase now.
+- The post install script is only called for the final image now and not for the build image anymore. Use the
+  prepare script instead.
 
 ## v14
 

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -93,7 +93,7 @@ def install_arch(state: MkosiState) -> None:
     packages = state.config.packages.copy()
     add_packages(state.config, packages, "base")
 
-    if not state.do_run_build_script and state.config.bootable:
+    if state.config.bootable:
         add_packages(state.config, packages, "dracut")
 
     official_kernel_packages = {
@@ -104,14 +104,11 @@ def install_arch(state: MkosiState) -> None:
     }
 
     has_kernel_package = official_kernel_packages.intersection(state.config.packages)
-    if not state.do_run_build_script and state.config.bootable and not has_kernel_package:
+    if state.config.bootable and not has_kernel_package:
         # No user-specified kernel
         add_packages(state.config, packages, "linux")
 
-    if state.do_run_build_script:
-        packages += state.config.build_packages
-
-    if not state.do_run_build_script and state.config.ssh:
+    if state.config.ssh:
         add_packages(state.config, packages, "openssh")
 
     invoke_pacman(state, packages)

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -71,23 +71,18 @@ class CentosInstaller(DistributionInstaller):
 
         packages = state.config.packages.copy()
         add_packages(state.config, packages, "systemd", "rpm")
-        if not state.do_run_build_script:
-            if state.config.bootable:
-                add_packages(state.config, packages, "kernel", "dracut", "dracut-config-generic")
-                add_packages(state.config, packages, "systemd-udev", conditional="systemd")
-            if state.config.ssh:
-                add_packages(state.config, packages, "openssh-server")
-
-        if state.do_run_build_script:
-            packages += state.config.build_packages
+        if state.config.bootable:
+            add_packages(state.config, packages, "kernel", "dracut", "dracut-config-generic")
+            add_packages(state.config, packages, "systemd-udev", conditional="systemd")
+        if state.config.ssh:
+            add_packages(state.config, packages, "openssh-server")
 
         if "epel" in state.config.repositories:
             add_packages(state.config, packages, "epel-release")
-            if not state.do_run_build_script:
-                if state.config.netdev:
-                    add_packages(state.config, packages, "systemd-networkd", conditional="systemd")
-                if state.config.distribution != Distribution.centos and release >= 9:
-                    add_packages(state.config, packages, "systemd-boot", conditional="systemd")
+            if state.config.netdev:
+                add_packages(state.config, packages, "systemd-networkd", conditional="systemd")
+            if state.config.distribution != Distribution.centos and release >= 9:
+                add_packages(state.config, packages, "systemd-boot", conditional="systemd")
 
         # Make sure we only install the minimal language files by default on CentOS Stream 8 which still
         # defaults to all langpacks.

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -102,12 +102,10 @@ def install_fedora(state: MkosiState) -> None:
     packages = state.config.packages.copy()
     add_packages(state.config, packages, "systemd", "util-linux", "rpm")
 
-    if not state.do_run_build_script and state.config.bootable:
+    if state.config.bootable:
         add_packages(state.config, packages, "kernel-core", "kernel-modules", "dracut", "dracut-config-generic")
         add_packages(state.config, packages, "systemd-udev", conditional="systemd")
-    if state.do_run_build_script:
-        packages += state.config.build_packages
-    if not state.do_run_build_script and state.config.netdev:
+    if state.config.netdev:
         add_packages(state.config, packages, "systemd-networkd", conditional="systemd")
     if state.config.ssh:
         add_packages(state.config, packages, "openssh-server")

--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -324,8 +324,6 @@ class Gentoo:
         self.invoke_emerge(actions=["--depclean"])
 
     def merge_user_pkgs(self) -> None:
-        if self.state.do_run_build_script:
-            self.invoke_emerge(pkgs=self.state.config.build_packages)
         if self.state.config.packages:
             self.invoke_emerge(pkgs=self.state.config.packages)
 

--- a/mkosi/distributions/mageia.py
+++ b/mkosi/distributions/mageia.py
@@ -63,7 +63,7 @@ def install_mageia(state: MkosiState) -> None:
 
     packages = state.config.packages.copy()
     add_packages(state.config, packages, "basesystem-minimal", "dnf")
-    if not state.do_run_build_script and state.config.bootable:
+    if state.config.bootable:
         add_packages(state.config, packages, "kernel-server-latest", "dracut")
         # Mageia ships /etc/50-mageia.conf that omits systemd from the initramfs and disables hostonly.
         # We override that again so our defaults get applied correctly on Mageia as well.
@@ -73,9 +73,6 @@ def install_mageia(state: MkosiState) -> None:
         )
     if state.config.ssh:
         add_packages(state.config, packages, "openssh-server")
-
-    if state.do_run_build_script:
-        packages += state.config.build_packages
 
     invoke_dnf(state, "install", packages)
 

--- a/mkosi/distributions/openmandriva.py
+++ b/mkosi/distributions/openmandriva.py
@@ -65,15 +65,12 @@ def install_openmandriva(state: MkosiState) -> None:
     packages = state.config.packages.copy()
     # well we may use basesystem here, but that pulls lot of stuff
     add_packages(state.config, packages, "basesystem-minimal", "systemd", "dnf")
-    if not state.do_run_build_script and state.config.bootable:
+    if state.config.bootable:
         add_packages(state.config, packages, "systemd-boot", "systemd-cryptsetup", conditional="systemd")
         add_packages(state.config, packages, "kernel-release-server", "dracut", "timezone")
     if state.config.netdev:
         add_packages(state.config, packages, "systemd-networkd", conditional="systemd")
     if state.config.ssh:
         add_packages(state.config, packages, "openssh-server")
-
-    if state.do_run_build_script:
-        packages += state.config.build_packages
 
     invoke_dnf(state, "install", packages)

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -155,16 +155,13 @@ def install_opensuse(state: MkosiState) -> None:
     else:
         add_packages(state.config, packages, "patterns-base-minimal_base")
 
-    if not state.do_run_build_script and state.config.bootable:
+    if state.config.bootable:
         add_packages(state.config, packages, "kernel-default", "dracut")
 
     if state.config.netdev:
         add_packages(state.config, packages, "systemd-network")
 
-    if state.do_run_build_script:
-        packages += state.config.build_packages
-
-    if not state.do_run_build_script and state.config.ssh:
+    if state.config.ssh:
         add_packages(state.config, packages, "openssh-server")
 
     zypper_install(state, packages)
@@ -201,7 +198,7 @@ def install_opensuse(state: MkosiState) -> None:
                     shutil.copy2(state.root / f"usr/{prefix}/pam.d/login", state.root / "etc/pam.d/login")
                     break
 
-    if state.config.bootable and not state.do_run_build_script:
+    if state.config.bootable:
         dracut_dir = state.root / "etc/dracut.conf.d"
         dracut_dir.mkdir(mode=0o755, exist_ok=True)
 

--- a/mkosi/mounts.py
+++ b/mkosi/mounts.py
@@ -89,7 +89,7 @@ def mount_overlay(
     workdir: Path,
     where: Path
 ) -> Iterator[Path]:
-    options = [f'lowerdir={lower}', f'upperdir={upper}', f'workdir={workdir}']
+    options = [f"lowerdir={lower}", f"upperdir={upper}", f"workdir={workdir}", "userxattr"]
 
     try:
         with mount("overlay", where, options=options, type="overlay"):

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -336,4 +336,5 @@ def run_workspace_command(
         die(f"\"{shlex.join(str(s) for s in cmd)}\" returned non-zero exit code {e.returncode}.")
     finally:
         if state.workspace.joinpath("resolv.conf").is_symlink():
+            resolve.unlink(missing_ok=True)
             shutil.move(state.workspace.joinpath("resolv.conf"), resolve)


### PR DESCRIPTION
Instead of building a second image for the build image, let's just make it an overlay for the final image since the only difference between the two is the list of installed packages. This speeds up image builds and allows us to simplify the internal logic as well