### PR TITLE
Sort kernel modules directories by version and use the newest

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -42,10 +42,11 @@ runs:
       sudo apt-get install libfdisk-dev
       git clone https://github.com/systemd/systemd --depth=1
       meson systemd/build systemd -Drepart=true -Defi=true
-      ninja -C systemd/build systemd-nspawn systemd-repart bootctl ukify
+      ninja -C systemd/build systemd-nspawn systemd-repart bootctl ukify systemd-analyze
       sudo ln -svf $PWD/systemd/build/systemd-repart /usr/bin/systemd-repart
       sudo ln -svf $PWD/systemd/build/bootctl /usr/bin/bootctl
       sudo ln -svf $PWD/systemd/build/ukify /usr/bin/ukify
+      sudo ln -svf $PWD/systemd/build/systemd-analyze /usr/bin/systemd-analyze
       systemd-repart --version
       bootctl --version
       ukify --version

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -64,7 +64,7 @@ from mkosi.log import (
     die,
     warn,
 )
-from mkosi.manifest import Manifest
+from mkosi.manifest import GenericVersion, Manifest
 from mkosi.mounts import dissect_and_mount, mount_overlay, scandir_recursive
 from mkosi.remove import unlink_try_hard
 from mkosi.run import (
@@ -769,10 +769,11 @@ def gen_kernel_images(state: MkosiState) -> Iterator[tuple[str, Path]]:
     if not state.root.joinpath("lib/modules").exists():
         return
 
-    for kver in state.root.joinpath("lib/modules").iterdir():
-        if not kver.is_dir():
-            continue
-
+    for kver in sorted(
+        (k for k in state.root.joinpath("lib/modules").iterdir() if k.is_dir()),
+        key=lambda k: GenericVersion(k.name),
+        reverse=True
+    ):
         kimg = state.installer.kernel_image(kver.name, state.config.architecture)
 
         yield kver.name, kimg

--- a/mkosi/manifest.py
+++ b/mkosi/manifest.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 import dataclasses
+import functools
 import json
 from datetime import datetime
 from pathlib import Path
@@ -280,3 +281,21 @@ class Manifest:
         for package in self.source_packages.values():
             print(f"\n{80*'-'}\n", file=out)
             out.write(package.report())
+
+
+@functools.total_ordering
+class GenericVersion:
+    def __init__(self, version: str):
+        self._version = version
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, GenericVersion):
+            return False
+        cmd = ["systemd-analyze", "compare-versions", self._version, "eq", other._version]
+        return run(cmd, check=False).returncode == 0
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, GenericVersion):
+            return False
+        cmd = ["systemd-analyze", "compare-versions", self._version, "lt", other._version]
+        return run(cmd, check=False).returncode == 0


### PR DESCRIPTION
This fixes a rare edge case when there are multiple kernels in the image and their versions don't compare correctly when compared lexicographically.