### PR TITLE
Packages related refactors

### DIFF
--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -513,7 +513,7 @@ def disable_pam_securetty(root: Path) -> None:
 
 
 def add_packages(
-    config: MkosiConfig, packages: set[str], *names: str, conditional: Optional[str] = None
+    config: MkosiConfig, packages: list[str], *names: str, conditional: Optional[str] = None
 ) -> None:
 
     """Add packages in @names to @packages, if enabled by --base-packages.
@@ -526,7 +526,7 @@ def add_packages(
 
     if config.base_packages is True or (config.base_packages == "conditional" and conditional):
         for name in names:
-            packages.add(f"({name} if {conditional})" if conditional else name)
+            packages.append(f"({name} if {conditional})" if conditional else name)
 
 
 def sort_packages(packages: Iterable[str]) -> list[str]:

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
+from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -27,7 +28,11 @@ class DistributionInstaller:
         raise NotImplementedError
 
     @classmethod
-    def remove_packages(cls, state: "MkosiState", remove: list[str]) -> None:
+    def install_packages(cls, state: "MkosiState", packages: Sequence[str]) -> None:
+        raise NotImplementedError
+
+    @classmethod
+    def remove_packages(cls, state: "MkosiState", packages: Sequence[str]) -> None:
         raise NotImplementedError
 
     @classmethod

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
+from collections.abc import Sequence
 from textwrap import dedent
 
 from mkosi.backend import MkosiState, add_packages, disable_pam_securetty, sort_packages
@@ -21,6 +22,10 @@ class ArchInstaller(DistributionInstaller):
     @classmethod
     def install(cls, state: MkosiState) -> None:
         return install_arch(state)
+
+    @classmethod
+    def install_packages(cls, state: MkosiState, packages: Sequence[str]) -> None:
+        return invoke_pacman(state, packages)
 
 
 @complete_step("Installing Arch Linux…")
@@ -85,13 +90,11 @@ def install_arch(state: MkosiState) -> None:
         for d in state.config.repo_dirs:
             f.write(f"Include = {d}/*\n")
 
-    packages: set[str] = set()
+    packages = state.config.packages.copy()
     add_packages(state.config, packages, "base")
 
     if not state.do_run_build_script and state.config.bootable:
         add_packages(state.config, packages, "dracut")
-
-    packages.update(state.config.packages)
 
     official_kernel_packages = {
         "linux",
@@ -106,22 +109,26 @@ def install_arch(state: MkosiState) -> None:
         add_packages(state.config, packages, "linux")
 
     if state.do_run_build_script:
-        packages.update(state.config.build_packages)
+        packages += state.config.build_packages
 
     if not state.do_run_build_script and state.config.ssh:
         add_packages(state.config, packages, "openssh")
 
-    cmdline: list[PathString] = [
-        "pacman",
-        "--config",  pacman_conf,
-        "--noconfirm",
-        "-Sy", *sort_packages(packages),
-    ]
-
-    run_with_apivfs(state, cmdline, env=dict(KERNEL_INSTALL_BYPASS="1"))
+    invoke_pacman(state, packages)
 
     state.root.joinpath("etc/pacman.d/mirrorlist").write_text(f"Server = {state.config.mirror}/$repo/os/$arch\n")
 
     # Arch still uses pam_securetty which prevents root login into
     # systemd-nspawn containers. See https://bugs.archlinux.org/task/45903.
     disable_pam_securetty(state.root)
+
+
+def invoke_pacman(state: MkosiState, packages: Sequence[str]) -> None:
+    cmdline: list[PathString] = [
+        "pacman",
+        "--config", state.workspace / "pacman.conf",
+        "--noconfirm",
+        "-Sy", *sort_packages(packages),
+    ]
+
+    run_with_apivfs(state, cmdline, env=dict(KERNEL_INSTALL_BYPASS="1"))

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
-import os
 from textwrap import dedent
 
 from mkosi.backend import MkosiState, add_packages, disable_pam_securetty, sort_packages
@@ -37,7 +36,7 @@ def install_arch(state: MkosiState) -> None:
             server = f"Server = {state.config.mirror}/$repo/os/$arch"
 
     # Create base layout for pacman and pacman-key
-    os.makedirs(state.root / "var/lib/pacman", 0o755, exist_ok=True)
+    state.root.joinpath("var/lib/pacman").mkdir(mode=0o755, exist_ok=True, parents=True)
 
     pacman_conf = state.workspace / "pacman.conf"
     if state.config.repository_key_check:

--- a/mkosi/distributions/mageia.py
+++ b/mkosi/distributions/mageia.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
+from collections.abc import Sequence
 from pathlib import Path
 
 from mkosi.backend import MkosiState, add_packages, disable_pam_securetty
 from mkosi.distributions import DistributionInstaller
-from mkosi.distributions.fedora import Repo, install_packages_dnf, invoke_dnf, setup_dnf
+from mkosi.distributions.fedora import Repo, invoke_dnf, setup_dnf
 from mkosi.log import complete_step
 
 
@@ -22,8 +23,12 @@ class MageiaInstaller(DistributionInstaller):
         return install_mageia(state)
 
     @classmethod
-    def remove_packages(cls, state: MkosiState, remove: list[str]) -> None:
-        invoke_dnf(state, 'remove', remove)
+    def install_packages(cls, state: MkosiState, packages: Sequence[str]) -> None:
+        invoke_dnf(state, "install", packages)
+
+    @classmethod
+    def remove_packages(cls, state: MkosiState, packages: Sequence[str]) -> None:
+        invoke_dnf(state, "remove", packages)
 
 
 @complete_step("Installing Mageia…")
@@ -56,7 +61,7 @@ def install_mageia(state: MkosiState) -> None:
 
     setup_dnf(state, repos)
 
-    packages = {*state.config.packages}
+    packages = state.config.packages.copy()
     add_packages(state.config, packages, "basesystem-minimal", "dnf")
     if not state.do_run_build_script and state.config.bootable:
         add_packages(state.config, packages, "kernel-server-latest", "dracut")
@@ -66,9 +71,12 @@ def install_mageia(state: MkosiState) -> None:
             'hostonly=no\n'
             'omit_dracutmodules=""\n'
         )
+    if state.config.ssh:
+        add_packages(state.config, packages, "openssh-server")
 
     if state.do_run_build_script:
-        packages.update(state.config.build_packages)
-    install_packages_dnf(state, packages)
+        packages += state.config.build_packages
+
+    invoke_dnf(state, "install", packages)
 
     disable_pam_securetty(state.root)

--- a/mkosi/distributions/ubuntu.py
+++ b/mkosi/distributions/ubuntu.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
+from collections.abc import Sequence
+
 from mkosi.backend import MkosiState, add_packages
 from mkosi.distributions.debian import DebianInstaller
 
@@ -8,11 +10,11 @@ class UbuntuInstaller(DebianInstaller):
     repositories_for_boot = {"universe"}
 
     @classmethod
-    def _add_default_kernel_package(cls, state: MkosiState, extra_packages: set[str]) -> None:
+    def _add_default_kernel_package(cls, state: MkosiState, packages: list[str]) -> None:
         # use the global metapckage linux-generic if the user didn't pick one
-        if ("linux-generic" not in extra_packages and
-            not any(package.startswith("linux-image") for package in extra_packages)):
-            add_packages(state.config, extra_packages, "linux-generic")
+        if ("linux-generic" not in packages and
+            not any(package.startswith("linux-image") for package in packages)):
+            add_packages(state.config, packages, "linux-generic")
 
     @classmethod
     def _add_apt_auxiliary_repos(cls, state: MkosiState, repos: set[str]) -> None:
@@ -31,5 +33,5 @@ class UbuntuInstaller(DebianInstaller):
         state.root.joinpath(f"etc/apt/sources.list.d/{state.config.release}-security.list").write_text(f"{security}\n")
 
     @classmethod
-    def _fixup_resolved(cls, state: MkosiState, extra_packages: set[str]) -> None:
+    def _fixup_resolved(cls, state: MkosiState, packages: Sequence[str]) -> None:
         pass


### PR DESCRIPTION
- Use Sequence as the type for passing package lists around
- Add install_packages() method to DistributionInstaller
- Remove install_packages_rpm() and use invoke_dnf() directly