### PR TITLE
action: Build nspawn from source

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -42,14 +42,17 @@ runs:
       sudo apt-get install libfdisk-dev
       git clone https://github.com/systemd/systemd --depth=1
       meson systemd/build systemd -Drepart=true -Defi=true
-      ninja -C systemd/build systemd-nspawn systemd-repart bootctl ukify systemd-analyze
+      ninja -C systemd/build systemd-nspawn systemd-repart bootctl ukify systemd-analyze systemd-nspawn
       sudo ln -svf $PWD/systemd/build/systemd-repart /usr/bin/systemd-repart
       sudo ln -svf $PWD/systemd/build/bootctl /usr/bin/bootctl
       sudo ln -svf $PWD/systemd/build/ukify /usr/bin/ukify
       sudo ln -svf $PWD/systemd/build/systemd-analyze /usr/bin/systemd-analyze
+      sudo ln -svf $PWD/systemd/build/systemd-nspawn /usr/bin/systemd-nspawn
       systemd-repart --version
       bootctl --version
       ukify --version
+      systemd-analyze --version
+      systemd-nspawn --version
 
   - name: Install
     shell: bash


### PR DESCRIPTION
Let's try to get rid of the spurious "Connection timed out" errors from systemd-nspawn by building the latest version from source.