### PR TITLE
Stop mounting package caches into images when running scripts

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -500,10 +500,6 @@ def configure_serial_terminal(state: MkosiState) -> None:
                           """)
 
 
-def cache_params(state: MkosiState, root: Path) -> list[PathString]:
-    return flatten(("--bind", state.cache, root / p) for p in state.installer.cache_path())
-
-
 def mount_build_overlay(state: MkosiState) -> ContextManager[Path]:
     return mount_overlay(state.root, state.build_overlay, state.workdir, state.root)
 
@@ -519,7 +515,6 @@ def run_prepare_script(state: MkosiState, cached: bool, build: bool) -> None:
     bwrap: list[PathString] = [
         "--bind", state.config.build_sources, "/root/src",
         "--bind", state.config.prepare_script, "/root/prepare",
-        *cache_params(state, Path("/")),
         "--chdir", "/root/src",
     ]
 
@@ -561,7 +556,6 @@ def run_postinst_script(state: MkosiState) -> None:
     with complete_step("Running postinstall script…"):
         bwrap: list[PathString] = [
             "--bind", state.config.postinst_script, "/root/postinst",
-            *cache_params(state, Path("/")),
         ]
 
         run_workspace_command(state, ["/root/postinst", "final"], bwrap_params=bwrap,

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -24,10 +24,6 @@ class DistributionInstaller:
         return Path("boot") / f"initramfs-{kver}.img"
 
     @classmethod
-    def cache_path(cls) -> list[str]:
-        raise NotImplementedError
-
-    @classmethod
     def install_packages(cls, state: "MkosiState", packages: Sequence[str]) -> None:
         raise NotImplementedError
 

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -12,10 +12,6 @@ from mkosi.types import PathString
 
 class ArchInstaller(DistributionInstaller):
     @classmethod
-    def cache_path(cls) -> list[str]:
-        return ["var/cache/pacman/pkg"]
-
-    @classmethod
     def filesystem(cls) -> str:
         return "ext4"
 

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -27,9 +27,6 @@ def move_rpm_db(root: Path) -> None:
 
 
 class CentosInstaller(DistributionInstaller):
-    @classmethod
-    def cache_path(cls) -> list[str]:
-        return ["var/cache/yum", "var/cache/dnf"]
 
     @classmethod
     def filesystem(cls) -> str:

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -34,10 +34,6 @@ class DebianInstaller(DistributionInstaller):
             state.root.joinpath("etc/resolv.conf").symlink_to("../run/systemd/resolve/resolv.conf")
 
     @classmethod
-    def cache_path(cls) -> list[str]:
-        return ["var/cache/apt/archives"]
-
-    @classmethod
     def filesystem(cls) -> str:
         return "ext4"
 

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -30,10 +30,6 @@ FEDORA_KEYS_MAP = {
 
 class FedoraInstaller(DistributionInstaller):
     @classmethod
-    def cache_path(cls) -> list[str]:
-        return ["var/cache/dnf"]
-
-    @classmethod
     def filesystem(cls) -> str:
         return "btrfs"
 

--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -375,10 +375,6 @@ class Gentoo:
 
 class GentooInstaller(DistributionInstaller):
     @classmethod
-    def cache_path(cls) -> list[str]:
-        return ["var/cache/binpkgs", "var/cache/distfiles"]
-
-    @classmethod
     def filesystem(cls) -> str:
         return "ext4"
 

--- a/mkosi/distributions/mageia.py
+++ b/mkosi/distributions/mageia.py
@@ -11,10 +11,6 @@ from mkosi.log import complete_step
 
 class MageiaInstaller(DistributionInstaller):
     @classmethod
-    def cache_path(cls) -> list[str]:
-        return ["var/cache/dnf"]
-
-    @classmethod
     def filesystem(cls) -> str:
         return "ext4"
 

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -14,10 +14,6 @@ from mkosi.types import PathString
 
 class OpensuseInstaller(DistributionInstaller):
     @classmethod
-    def cache_path(cls) -> list[str]:
-        return ["var/cache/zypp/packages"]
-
-    @classmethod
     def filesystem(cls) -> str:
         return "btrfs"
 


### PR DESCRIPTION
The package manager in the container might be a very different version than the one running on the host which could cause all sorts of caching issues. Since we don't need the caches in the image anymore as we run the package managers outside of the image, let's stop mounting the cache directory into the image when running scripts as well.