### PR TITLE
centos: Add missing base features for ext4 on c8s

### DIFF
--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -43,7 +43,23 @@ class CentosInstaller(DistributionInstaller):
 
         return {
             "8": {
-                "ext4": ["-O", "none,has_journal,extent,huge_file,flex_bg,metadata_csum,64bit,dir_nlink,extra_isize"],
+                "ext4": ["-O", ",".join([
+                    "none",
+                    "sparse_super",
+                    "large_file",
+                    "filetype",
+                    "resize_inode",
+                    "dir_index",
+                    "ext_attr",
+                    "has_journal",
+                    "extent",
+                    "huge_file",
+                    "flex_bg",
+                    "metadata_csum",
+                    "64bit",
+                    "dir_nlink",
+                    "extra_isize"
+                ])],
             },
         }.get(state.config.release, {})
 


### PR DESCRIPTION
Accidentally only added the ext4 specific features and none of the base features, let's make sure we add the base features as well, especially sparse_super is important to make repart's minimize guessing logic work properly.