### PR TITLE
Drop --qemu-headless

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,6 @@ jobs:
 
         [Host]
         Autologin=yes
-        QemuHeadless=yes
 
         [Content]
         ExtraTrees=.github/mkosi.extra

--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,8 @@
   `machinectl` to access images booted with `mkosi boot`. Use --extra-tree or --credential with the
   `.ssh.authorized_keys.root` credentials as alternatives for provisioning the public key inside the image.
 - Only configuration files matching `*.conf` are parsed in dropin directories now.
+- Removed `--qemu-headless`, we now start qemu in the terminal by default and configure the serial console at
+  runtime. Use the new `--qemu-gui` option to start qemu in its graphical interface.
 
 ## v14
 

--- a/mkosi.md
+++ b/mkosi.md
@@ -672,8 +672,7 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 `Autologin=`, `--autologin`
 
 : Enable autologin for the `root` user on `/dev/pts/0` (nspawn),
-  `/dev/tty1` (QEMU) and `/dev/ttyS0` (QEMU with `QemuHeadless=yes`)
-  by patching `/etc/pam.d/login`.
+  `/dev/tty1` and `/dev/ttyS0` by patching `/etc/pam.d/login`.
 
 `BuildScript=`, `--build-script=`
 
@@ -784,20 +783,10 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 : List of colon-separated paths to look for tools in, before using the
   regular `$PATH` search path.
 
-`QemuHeadless=`, `--qemu-headless=`
+`QemuGui=`, `--qemu-gui=`
 
-: When used with the `build` verb, this option adds `console=ttyS0` to
-  the image's kernel command line and sets the terminal type of the
-  serial console in the image to the terminal type of the host (more
-  specifically, the value of the `$TERM` environment variable passed
-  to mkosi). This makes sure that all terminal features such as colors
-  and shortcuts still work as expected when connecting to the qemu VM
-  over the serial console (for example via `-nographic`).
-
-: When used with the `qemu` verb, this option adds the `-nographic`
-  option to `qemu`'s command line so qemu starts a headless vm and
-  connects to its serial console from the current terminal instead of
-  launching the VM in a separate window.
+: If enabled, qemu is executed with its graphical interface instead of
+  with a serial console.
 
 `QemuSmp=`, `--qemu-smp=`
 

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -310,7 +310,7 @@ class MkosiConfig:
     acl: bool
 
     # QEMU-specific options
-    qemu_headless: bool
+    qemu_gui: bool
     qemu_smp: str
     qemu_mem: str
     qemu_kvm: bool

--- a/mkosi/install.py
+++ b/mkosi/install.py
@@ -8,7 +8,6 @@ import shutil
 import stat
 from collections.abc import Iterator
 from pathlib import Path
-from textwrap import dedent
 from typing import Optional
 
 from mkosi.backend import MkosiState
@@ -30,14 +29,6 @@ def write_resource(
         where.chmod(mode)
     elif executable:
         make_executable(where)
-
-
-def add_dropin_config(root: Path, unit: str, name: str, content: str) -> None:
-    """Add a dropin config `name.conf` in /etc/systemd/system for `unit`."""
-    dropin = root / f"etc/systemd/system/{unit}.d/{name}.conf"
-    dropin.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
-    dropin.write_text(dedent(content))
-    dropin.chmod(0o644)
 
 
 def add_dropin_config_from_resource(


### PR DESCRIPTION
Instead, we add extra kernel command line arguments that configure term and the tty size at runtime. We start qemu in the terminal on a serial tty by default now as well.

Depends on https://github.com/systemd/systemd/pull/26889