### PR TITLE
overlayfs: avoid userxattr if kernel version is < 5.11

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2590,6 +2590,11 @@ def load_args(args: argparse.Namespace) -> MkosiConfig:
             if not p.is_file():
                 die(f"Initrd {p} is not a file")
 
+    # For unprivileged builds we need the userxattr OverlayFS mount option, which is only available in Linux v5.11 and later.
+    with prepend_to_environ_path(args.extra_search_paths):
+        if (args.build_script is not None or args.base_image is not None) and GenericVersion(platform.release()) < GenericVersion("5.11") and os.geteuid() != 0:
+            die("This unprivileged build configuration requires at least Linux v5.11")
+
     return MkosiConfig(**vars(args))
 
 

--- a/mkosi/mounts.py
+++ b/mkosi/mounts.py
@@ -3,12 +3,14 @@
 import collections
 import contextlib
 import os
+import platform
 import stat
 from collections.abc import Iterator, Sequence
 from pathlib import Path
 from typing import Callable, Deque, Optional, TypeVar, Union, cast
 
 from mkosi.log import complete_step
+from mkosi.manifest import GenericVersion
 from mkosi.run import run
 from mkosi.types import PathString
 
@@ -89,7 +91,11 @@ def mount_overlay(
     workdir: Path,
     where: Path
 ) -> Iterator[Path]:
-    options = [f"lowerdir={lower}", f"upperdir={upper}", f"workdir={workdir}", "userxattr"]
+    options = [f"lowerdir={lower}", f"upperdir={upper}", f"workdir={workdir}"]
+
+    # userxattr is only supported on overlayfs since kernel 5.11
+    if GenericVersion(platform.release()) >= GenericVersion("5.11"):
+        options.append("userxattr")
 
     try:
         with mount("overlay", where, options=options, type="overlay"):


### PR DESCRIPTION
userxattr was added as a mount option for overlayfs only in kernel 5.11, so avoid it on older versions (like Debian stable):

‣   Running build script…
mount: /home/bluca/git/systemd/.mkosi.tmpzt2q0dyp/root: wrong fs type, bad option, bad superblock on overlay, missing codepage or helper program, or other error.
umount: /home/bluca/git/systemd/.mkosi.tmpzt2q0dyp/root: not mounted