### PR TITLE
Drop --netdev

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,8 @@
 - Only configuration files matching `*.conf` are parsed in dropin directories now.
 - Removed `--qemu-headless`, we now start qemu in the terminal by default and configure the serial console at
   runtime. Use the new `--qemu-gui` option to start qemu in its graphical interface.
+- Removed `--netdev`. Can be replaced by manually installing systemd-networkd, putting a network file in the
+  image and enabling systemd-networkd.
 
 ## v14
 

--- a/mkosi.md
+++ b/mkosi.md
@@ -809,14 +809,6 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 : Space-delimited list of additional arguments to pass when invoking
   qemu.
 
-`Netdev=`, `--netdev`
-
-: When used with the boot or qemu verbs, this option creates a virtual
-  ethernet link between the host and the container/VM. The host
-  interface is automatically picked up by systemd-networkd as documented
-  in systemd-nspawn's man page:
-  https://www.freedesktop.org/software/systemd/man/systemd-nspawn.html#-n
-
 `Ephemeral=`, `--ephemeral`
 
 : When used with the `shell`, `boot`, or `qemu` verbs, this option

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -182,14 +182,6 @@ def is_dnf_distribution(d: Distribution) -> bool:
     )
 
 
-def is_centos_variant(d: Distribution) -> bool:
-    return d in (
-        Distribution.centos,
-        Distribution.alma,
-        Distribution.rocky,
-    )
-
-
 class OutputFormat(Parseable, enum.Enum):
     directory = enum.auto()
     subvolume = enum.auto()
@@ -296,7 +288,6 @@ class MkosiConfig:
     password_is_hashed: bool
     autologin: bool
     extra_search_paths: list[Path]
-    netdev: bool
     ephemeral: bool
     ssh: bool
     credentials: dict[str, str]

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -108,8 +108,6 @@ class CentosInstaller(DistributionInstaller):
 
         if "epel" in state.config.repositories:
             add_packages(state.config, packages, "epel-release")
-            if state.config.netdev:
-                add_packages(state.config, packages, "systemd-networkd", conditional="systemd")
 
         # Make sure we only install the minimal language files by default on CentOS Stream 8 which still
         # defaults to all langpacks.

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -104,8 +104,6 @@ def install_fedora(state: MkosiState) -> None:
         add_packages(state.config, packages, "systemd-udev", conditional="systemd")
         if not state.config.initrds:
             add_packages(state.config, packages, "dracut", "dracut-config-generic")
-    if  state.config.netdev:
-        add_packages(state.config, packages, "systemd-networkd", conditional="systemd")
     if state.config.ssh:
         add_packages(state.config, packages, "openssh-server")
 

--- a/mkosi/distributions/openmandriva.py
+++ b/mkosi/distributions/openmandriva.py
@@ -70,8 +70,6 @@ def install_openmandriva(state: MkosiState) -> None:
         add_packages(state.config, packages, "kernel-release-server", "timezone")
         if not state.config.initrds:
             add_packages(state.config, packages, "dracut")
-    if state.config.netdev:
-        add_packages(state.config, packages, "systemd-networkd", conditional="systemd")
     if state.config.ssh:
         add_packages(state.config, packages, "openssh-server")
 

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -181,9 +181,6 @@ def install_opensuse(state: MkosiState) -> None:
             if not state.config.initrds:
                 add_packages(state.config, packages, "dracut")
 
-        if state.config.netdev:
-            add_packages(state.config, packages, "systemd-network")
-
         if state.config.ssh:
             add_packages(state.config, packages, "openssh-server")
 


### PR DESCRIPTION
Let's not configure systemd-networkd in mkosi, but leave this up to users instead. As our SSH support now works on top of vsock, we don't need this option anymore to make the SSH support work.

We add network devices by default now when starting a container or VM.