### PR TITLE
Always use mkosi.extra/ and mkosi.skeleton/ if they exist

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,6 +58,8 @@
   runtime. Use the new `--qemu-gui` option to start qemu in its graphical interface.
 - Removed `--netdev`. Can be replaced by manually installing systemd-networkd, putting a network file in the
   image and enabling systemd-networkd.
+- If `mkosi.extra/` or `mkosi.skeleton/` exist, they are now always used instead of only when no explicit
+  extra/skeleton trees are defined.
 
 ## v14
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2161,10 +2161,6 @@ def parse_boolean(s: str) -> bool:
 
 
 def find_extra(args: argparse.Namespace) -> None:
-
-    if len(args.extra_trees) > 0:
-        return
-
     if os.path.isdir("mkosi.extra"):
         args.extra_trees.append((Path("mkosi.extra"), None))
     if os.path.isfile("mkosi.extra.tar"):
@@ -2172,10 +2168,6 @@ def find_extra(args: argparse.Namespace) -> None:
 
 
 def find_skeleton(args: argparse.Namespace) -> None:
-
-    if len(args.skeleton_trees) > 0:
-        return
-
     if os.path.isdir("mkosi.skeleton"):
         args.skeleton_trees.append((Path("mkosi.skeleton"), None))
     if os.path.isfile("mkosi.skeleton.tar"):


### PR DESCRIPTION
These should be additive instead of only being used when no explicit extra/skeleton trees are configured.