### PR TITLE
qemu: Use virtconsole serial console instead of regular serial console

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -672,7 +672,7 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 `Autologin=`, `--autologin`
 
 : Enable autologin for the `root` user on `/dev/pts/0` (nspawn),
-  `/dev/tty1` and `/dev/ttyS0` by patching `/etc/pam.d/login`.
+  `/dev/tty1` and `/dev/hvc0` by patching `/etc/pam.d/login`.
 
 `BuildScript=`, `--build-script=`
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -16,7 +16,6 @@ import os
 import platform
 import re
 import resource
-import shlex
 import shutil
 import string
 import subprocess
@@ -125,11 +124,6 @@ def list_to_string(seq: Iterator[str]) -> str:
     ['a', "b", 11] → "'a', 'b', 11"
     """
     return str(list(seq))[1:-1]
-
-
-def print_running_cmd(cmdline: Iterable[PathString]) -> None:
-    MkosiPrinter.print_step("Running command:")
-    MkosiPrinter.print_step(" ".join(shlex.quote(str(x)) for x in cmdline) + "\n")
 
 
 # EFI has its own conventions too
@@ -3493,7 +3487,6 @@ def qemu_check_kvm_support() -> bool:
 def start_swtpm() -> Iterator[Optional[Path]]:
 
     if not shutil.which("swtpm"):
-        MkosiPrinter.info("Couldn't find swtpm binary, not invoking qemu with TPM2 device.")
         yield None
         return
 
@@ -3639,7 +3632,6 @@ def run_qemu(config: MkosiConfig) -> None:
         cmdline += config.qemu_args
         cmdline += config.cmdline
 
-        print_running_cmd(cmdline)
         run(cmdline, stdout=sys.stdout, env=os.environ)
 
 


### PR DESCRIPTION
With --qemu-headless, qemu stops working when latest systemd is not
available because smbios provided kernel cmdline arguments are ignored.
This includes "console=ttyS0" meaning we don't get any output on the
serial console when booting in qemu.

As a workaround, let's use qemu's virtconsole instead. This means the
serial console will be available in the VM as /dev/hvc0, on which
systemd will automatically spawn a serial getty. This means we'll
eventually get a login prompt, even if latest systemd is not used.