### PR TITLE
Rework configuration parsing ordering and overrides

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -150,6 +150,7 @@ in consecutive runs with data from the cached one.
 * Run SELinux relabel is a SELinux policy is installed
 * Generate unified kernel image
 * Generate final output format
+
 ## Supported output formats
 
 The following output formats are supported:
@@ -176,10 +177,54 @@ single-letter shortcut is also allowed. In the configuration files,
 the setting must be in the appropriate section, so the settings are
 grouped by section below.
 
+Configuration is parsed in the following order:
+
+* The command line arguments are parsed
+* `mkosi.conf` is parsed if it exists in the directory set with
+  `--directory=` or the current working directory if `--directory=` is
+  not used.
+* `mkosi.conf.d/` is parsed in the same directory if it exists. Each
+  directory and each file with the `.conf` extension in `mkosi.conf.d/`
+  is parsed. Any directory in `mkosi.conf.d` is parsed as if it were
+  a regular top level directory.
+* Any default paths (depending on the option) are configured if the
+  corresponding path exists.
+
+If a setting is specified multiple times across the different sources
+of configuration, the first assignment that is found is used. For example,
+a setting specified on the command line will always take precedence over
+the same setting configured in a config file. To override settings in a
+dropin file, make sure your dropin file is alphanumerically ordered
+before the config file that you're trying to override.
+
+Settings that take a list of values are merged by prepending each value
+to the previously configured values. If a value of a list setting is
+prefixed with `!`, if any later assignment of that setting tries to add
+the same value, that value is ignored. Values prefixed with `!` can be
+globs to ignore more than one value.
+
+To conditionally include configuration files, the `[Match]` section can
+be used. A configuration file is only included if all the conditions in the
+`[Match]` block are satisfied. If a condition in `[Match]` depends on a
+setting and the setting has not been explicitly configured when the condition
+is evaluated, the setting is assigned its default value.
+
 Command line options that take no argument are shown without "=" in
 their long version. In the config files, they should be specified with
 a boolean argument: either "1", "yes", or "true" to enable, or "0",
 "no", "false" to disable.
+
+### [Match] Section.
+
+`Distribution=`
+
+: Matches against the configured distribution.
+
+`Release=`
+
+: Matches against the configured distribution release. If this condition
+  is used and no distribution has been explicitly configured yet, the
+  host distribution and release are used.
 
 ### [Distribution] Section
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1219,6 +1219,11 @@ SETTINGS = (
         section="Output",
     ),
     MkosiConfigSetting(
+        dest="auto_bump",
+        section="Output",
+        parse=config_parse_boolean,
+    ),
+    MkosiConfigSetting(
         dest="tar_strip_selinux_context",
         section="Output",
         parse=config_parse_boolean,

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -45,6 +45,7 @@ from mkosi.backend import (
 from mkosi.config import (
     MkosiConfigParser,
     MkosiConfigSetting,
+    config_default_release,
     config_make_action,
     config_make_enum_matcher,
     config_make_enum_parser,
@@ -54,7 +55,6 @@ from mkosi.config import (
     config_parse_base_packages,
     config_parse_boolean,
     config_parse_compression,
-    config_parse_distribution,
     config_parse_feature,
     config_parse_script,
     config_parse_string,
@@ -1079,7 +1079,7 @@ SETTINGS = (
     MkosiConfigSetting(
         dest="distribution",
         section="Distribution",
-        parse=config_parse_distribution,
+        parse=config_make_enum_parser(Distribution),
         match=config_make_enum_matcher(Distribution),
         default=detect_distribution()[0],
     ),
@@ -1088,7 +1088,7 @@ SETTINGS = (
         section="Distribution",
         parse=config_parse_string,
         match=config_match_string,
-        default=detect_distribution()[1],
+        default_factory=config_default_release,
     ),
     MkosiConfigSetting(
         dest="architecture",
@@ -1483,6 +1483,7 @@ def create_argument_parser() -> argparse.ArgumentParser:
         usage=USAGE,
         add_help=False,
         allow_abbrev=False,
+        argument_default=argparse.SUPPRESS,
     )
 
     parser.add_argument(
@@ -1998,17 +1999,10 @@ def create_argument_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def parse_args(
-    argv: Optional[Sequence[str]] = None,
-    directory: Optional[Path] = None,
-    namespace: Optional[argparse.Namespace] = None
-) -> argparse.Namespace:
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     if argv is None:
         argv = sys.argv[1:]
     argv = list(argv)  # make a copy 'cause we'll be modifying the list later on
-
-    if namespace is None:
-        namespace = argparse.Namespace()
 
     # Make sure the verb command gets explicitly passed. Insert a -- before the positional verb argument
     # otherwise it might be considered as an argument of a parameter with nargs='?'. For example mkosi -i
@@ -2025,24 +2019,33 @@ def parse_args(
     else:
         argv += ["--", "build"]
 
-    for s in SETTINGS:
-        if s.dest in namespace:
-            continue
-
-        if s.default is None:
-            s.parse(s.dest, None, namespace)
-        else:
-            setattr(namespace, s.dest, s.default)
-
-    if directory:
-        namespace = MkosiConfigParser(SETTINGS, directory).parse(namespace)
-
     argparser = create_argument_parser()
-    namespace = argparser.parse_args(argv, namespace)
+    namespace = argparser.parse_args(argv)
 
     if namespace.verb == Verb.help:
         argparser.print_help()
         argparser.exit()
+
+    if "directory" not in namespace:
+        setattr(namespace, "directory", None)
+
+    if namespace.directory and not namespace.directory.is_dir():
+        die(f"Error: {namespace.directory} is not a directory!")
+
+    namespace = MkosiConfigParser(SETTINGS).parse(namespace.directory or Path("."), namespace)
+
+    for s in SETTINGS:
+        if s.dest in namespace:
+            continue
+
+        if s.default_factory:
+            default = s.default_factory(namespace)
+        elif s.default is None:
+            default = s.parse(s.dest, None, namespace)
+        else:
+            default = s.default
+
+        setattr(namespace, s.dest, default)
 
     return namespace
 

--- a/mkosi/__main__.py
+++ b/mkosi/__main__.py
@@ -5,7 +5,6 @@ import contextlib
 import os
 import sys
 from collections.abc import Iterator
-from pathlib import Path
 from subprocess import CalledProcessError
 
 from mkosi import parse_args, run_verb
@@ -34,7 +33,6 @@ def main() -> None:
         else:
             die(f"Error: {args.directory} is not a directory!")
 
-    args = parse_args(directory=Path("."))
     run_verb(args)
 
 

--- a/tests/test_parse_load_args.py
+++ b/tests/test_parse_load_args.py
@@ -27,7 +27,7 @@ def cd_temp_dir() -> Iterator[None]:
 
 
 def parse(argv: Optional[List[str]] = None) -> MkosiConfig:
-    return mkosi.load_args(mkosi.parse_args(argv, directory=Path(".")))
+    return mkosi.load_args(mkosi.parse_args(argv))
 
 
 def test_parse_load_verb() -> None:


### PR DESCRIPTION
Currently, aside from list based settings, if a setting is used
multiple times across different configuration files, the later
assignments override earlier assignments. On top of that, the CLI
arguments are parsed last and override everything from config files.

This has worked very well until now, but breaks now that we have
[Match] sections. If we override a setting using the CLI, we want
any configured [Match] sections to compare against the value specified
via the CLI. Because the CLI values are applied last, this currently
isn't the case.

Similarly, if we add 90-local.conf to override the distribution release
used for Debian, all the config files that are processed earlier will
still compare against the default release configured for Debian in
50-debian.conf. If we rename 90-local.conf to 00-local.conf, the default
release in 50-debian.conf will still override that value. Only by putting
the override after the config file that assigns the default release but
before the first config file that matches on that release can we make this
work, but depending on the configuration this might require a lot of
different override files which isn't ideal.

Also, because later values can override earlier ones, it's possible to have
[Match] sections that match against different values of the same setting
both apply, if the setting happens to be reassigned inbetween, which is not
intuitive and error prone. Ideally, [Match] settings only apply to the final
value of a setting.

To fix these problems, this commit reworks the way we order and override
settings. Instead of having later assignments override earlier ones, for
all settings aside from list settings, the first assignment is the one that
is used. All later assignments of the same setting are ignored. Along with, we
switch to parsing CLI arguments first, which means that any settings assigned
in CLI args take precedence over those configured in config files.

Because the first value is immediately the final value, any [Match] sections
will only ever see the final value. One caveat is default values for settings.
We only want to assign these at the end of parsing, if no value has been
explicitly configured, but we also want [Match] sections to apply to default
values if no value is explicitly configured. The solution to this is that if
we encounter a setting in a [Match] section and it has not been explicitly
assigned a value yet, it is assigned its default value.

For list based settings, ! now configures an ignore glob, which means that if any
later assignments try to assign values that match an ignore glob, those values
are ignored. We also prepend list values instead of appending so that list
values that are configured in a preceeding config file appear later in the final
list value than values configured in a later assignment.

Implementation wise, this commit reworks config parser functions to return the
new value that should be assigned instead of assigning it themselves. This makes
the config parsing functions slightly more generic.