### PR TITLE
Simplify autologin

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -726,7 +726,7 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 `Autologin=`, `--autologin`
 
 : Enable autologin for the `root` user on `/dev/pts/0` (nspawn),
-  `/dev/tty1` and `/dev/hvc0` by patching `/etc/pam.d/login`.
+  `/dev/tty1` and `/dev/hvc0`.
 
 `BuildScript=`, `--build-script=`
 

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -453,15 +453,6 @@ def safe_tar_extract(tar: tarfile.TarFile, path: Path=Path("."), *, numeric_owne
     tar.extractall(path, members=members, numeric_owner=numeric_owner)
 
 
-def disable_pam_securetty(root: Path) -> None:
-    def _rm_securetty(line: str) -> str:
-        if "pam_securetty.so" in line:
-            return ""
-        return line
-
-    patch_file(root / "etc/pam.d/login", _rm_securetty)
-
-
 def add_packages(
     config: MkosiConfig, packages: list[str], *names: str, conditional: Optional[str] = None
 ) -> None:

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -3,7 +3,7 @@
 from collections.abc import Sequence
 from textwrap import dedent
 
-from mkosi.backend import MkosiState, add_packages, disable_pam_securetty, sort_packages
+from mkosi.backend import MkosiState, add_packages, sort_packages
 from mkosi.distributions import DistributionInstaller
 from mkosi.log import complete_step
 from mkosi.run import run_with_apivfs
@@ -110,10 +110,6 @@ def install_arch(state: MkosiState) -> None:
     invoke_pacman(state, packages)
 
     state.root.joinpath("etc/pacman.d/mirrorlist").write_text(f"Server = {state.config.mirror}/$repo/os/$arch\n")
-
-    # Arch still uses pam_securetty which prevents root login into
-    # systemd-nspawn containers. See https://bugs.archlinux.org/task/45903.
-    disable_pam_securetty(state.root)
 
 
 def invoke_pacman(state: MkosiState, packages: Sequence[str]) -> None:

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable, Sequence
 from pathlib import Path
 from textwrap import dedent
 
-from mkosi.backend import MkosiState, add_packages, disable_pam_securetty
+from mkosi.backend import MkosiState, add_packages
 from mkosi.distributions import DistributionInstaller
 from mkosi.install import install_skeleton_trees, write_resource
 from mkosi.run import run, run_with_apivfs
@@ -172,10 +172,6 @@ class DebianInstaller(DistributionInstaller):
         if not state.config.with_docs and state.config.base_image is not None:
             # Don't ship dpkg config files in extensions, they belong with dpkg in the base image.
             dpkg_nodoc_conf.unlink() # type: ignore
-
-        if state.config.base_image is None:
-            # Debian still has pam_securetty module enabled, disable it in the base image.
-            disable_pam_securetty(state.root)
 
         cls._fixup_resolved(state, packages)
 

--- a/mkosi/distributions/mageia.py
+++ b/mkosi/distributions/mageia.py
@@ -3,7 +3,7 @@
 from collections.abc import Sequence
 from pathlib import Path
 
-from mkosi.backend import MkosiState, add_packages, disable_pam_securetty
+from mkosi.backend import MkosiState, add_packages
 from mkosi.distributions import DistributionInstaller
 from mkosi.distributions.fedora import Repo, invoke_dnf, setup_dnf
 from mkosi.log import complete_step
@@ -71,5 +71,3 @@ def install_mageia(state: MkosiState) -> None:
         add_packages(state.config, packages, "openssh-server")
 
     invoke_dnf(state, "install", packages)
-
-    disable_pam_securetty(state.root)

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -204,14 +204,6 @@ def install_opensuse(state: MkosiState) -> None:
 
         patch_file(state.root / "etc/pam.d/common-auth", jj)
 
-    if state.config.autologin:
-        # copy now, patch later (in configure_autologin())
-        if not state.root.joinpath("etc/pam.d/login").exists():
-            for prefix in ("lib", "etc"):
-                if state.root.joinpath(f"usr/{prefix}/pam.d/login").exists():
-                    shutil.copy2(state.root / f"usr/{prefix}/pam.d/login", state.root / "etc/pam.d/login")
-                    break
-
     if state.config.bootable and not state.config.initrds:
         dracut_dir = state.root / "etc/dracut.conf.d"
         dracut_dir.mkdir(mode=0o755, exist_ok=True)

--- a/mkosi/resources/console_getty_autologin.conf
+++ b/mkosi/resources/console_getty_autologin.conf
@@ -1,3 +1,5 @@
 [Service]
 ExecStart=
-ExecStart=-/sbin/agetty -o '-p -- \\u' --noclear --autologin root --keep-baud console 115200,38400,9600 $TERM
+ExecStart=-/sbin/agetty -o '-f -p -- \\u' --autologin root --noclear --keep-baud console 115200,38400,9600 $TERM
+StandardInput=tty
+StandardOutput=tty

--- a/mkosi/resources/getty_autologin.conf
+++ b/mkosi/resources/getty_autologin.conf
@@ -1,5 +1,5 @@
 [Service]
 ExecStart=
-ExecStart=-/sbin/agetty -o '-p -- \\u' --autologin root --noclear - $TERM
+ExecStart=-/sbin/agetty -o '-f -p -- \\u' --autologin root --noclear - $TERM
 StandardInput=tty
 StandardOutput=tty

--- a/mkosi/resources/serial_getty_autologin.conf
+++ b/mkosi/resources/serial_getty_autologin.conf
@@ -1,5 +1,5 @@
 [Service]
 ExecStart=
-ExecStart=-/sbin/agetty -o '-p -- \\u' --autologin root --keep-baud 115200,57600,38400,9600 - $TERM
+ExecStart=-/sbin/agetty -o '-f -p -- \\u' --autologin root --keep-baud 115200,57600,38400,9600 - $TERM
 StandardInput=tty
 StandardOutput=tty


### PR DESCRIPTION
agetty actually has a -f option to skip pam authentication, so let's use that instead of all the pam hacks to get autologin.