### PR TITLE
Add --die-with-parent when invoking bubblewrap

### DIFF
--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -265,6 +265,7 @@ def run_with_apivfs(
         "--dev", state.root / "dev",
         "--ro-bind", "/sys", state.root / "sys",
         "--bind", state.var_tmp, state.root / "var/tmp",
+        "--die-with-parent",
         *bwrap_params,
         "sh", "-c",
     ]
@@ -302,6 +303,7 @@ def run_workspace_command(
         "--proc", "/proc",
         "--ro-bind", "/sys", "/sys",
         "--bind", state.var_tmp, "/var/tmp",
+        "--die-with-parent",
         *bwrap_params,
     ]
 


### PR DESCRIPTION
rpm blocks most signals when doing a transaction. dnf doesn't block anything. The end result is that when we do ctrl+c when dnf is running the rpm transaction, dnf gets interrupted and exits, which means mkosi exits and tries to remove the workspace directory on which rpm is still operating, causing all kinds of nastiness.

Because we don't care about transaction safety since we're operating on a chroot, let's add --die-with-parent when running bubblewrap. This makes bubblewrap ensure cleanup of all child processes underneath it, and because rpm can't ignore SIGKILL, it also cleans up rpm properly, fixing the issue.