### PR TITLE
Add --needed to pacman invocation

### DIFF
--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -94,6 +94,7 @@ def invoke_pacman(state: MkosiState, packages: Sequence[str]) -> None:
         "pacman",
         "--config", state.workspace / "pacman.conf",
         "--noconfirm",
+        "--needed",
         "-Sy", *sort_packages(packages),
     ]
 


### PR DESCRIPTION
When installing build packages, we might install packages that were already installed previously. Let's make sure we don't reinstall those.