### PR TITLE
Drop --hostname and default locale configuration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -161,6 +161,9 @@
   image. Note that this option is currently only supported for `pacman` and
   `dnf`-based distros.
 - Option `--skeleton-tree` is now supported on Debian-based distros.
+- Removed `--hostname` as its trivial to configure using systemd-firstboot.
+- Removed default locale configuration as its trivial to configure using
+  systemd-firstboot and systemd writes a default locale well.
 
 
 ## v12

--- a/mkosi.md
+++ b/mkosi.md
@@ -428,10 +428,6 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   the `shell`, `boot`, `qemu` verbs are not available when this option
   is used. Implied for `tar` and `cpio`.
 
-`Hostname=`, `--hostname=`
-
-: Set the image's hostname to the specified name.
-
 `ImageVersion=`, `--image-version=`
 
 : Configure the image version. This accepts any string, but it is
@@ -1318,20 +1314,6 @@ EOF
 # chmod +x mkosi.build
 # mkosi --incremental boot
 # systemd-nspawn -bi image.raw
-```
-
-To create a *Fedora Linux* image with hostname:
-```bash
-# mkosi --distribution fedora --hostname image
-```
-
-Also you could set hostname in configuration file:
-```bash
-# cat mkosi.conf
-...
-[Output]
-Hostname=image
-...
 ```
 
 # REQUIREMENTS

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1005,24 +1005,6 @@ def find_image_version(args: argparse.Namespace) -> None:
         pass
 
 
-DISABLED = Path('DISABLED')  # A placeholder value to suppress autodetection.
-                             # This is used as a singleton, i.e. should be compared with
-                             # 'is' in other parts of the code.
-
-def script_path(value: Optional[str]) -> Optional[Path]:
-    if value is None:
-        return None
-    if value == '':
-        return DISABLED
-    return Path(value)
-
-
-def normalize_script(path: Optional[Path]) -> Optional[Path]:
-    if not path or path is DISABLED:
-        return None
-    return Path(path).absolute()
-
-
 def load_credentials(args: argparse.Namespace) -> dict[str, str]:
     creds = {}
 

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -226,7 +226,6 @@ class MkosiConfig:
     compress_output: Union[None, str, bool]
     image_version: Optional[str]
     image_id: Optional[str]
-    hostname: Optional[str]
     tar_strip_selinux_context: bool
     incremental: bool
     cache_initrd: bool

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -419,10 +419,6 @@ class MkosiConfigParser:
             parse=config_parse_compression,
         ),
         MkosiConfigSetting(
-            dest="hostname",
-            section="Output",
-        ),
-        MkosiConfigSetting(
             dest="image_version",
             section="Output",
         ),
@@ -967,7 +963,6 @@ class MkosiConfigParser:
             nargs="?",
             action=action,
         )
-        group.add_argument("--hostname", help="Set hostname", action=action)
         group.add_argument("--image-version", help="Set version for image", action=action)
         group.add_argument("--image-id", help="Set ID for image", action=action)
         group.add_argument(

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -134,11 +134,6 @@ class DebianInstaller(DistributionInstaller):
             # Don't ship dpkg config files in extensions, they belong with dpkg in the base image.
             dpkg_nodoc_conf.unlink() # type: ignore
 
-        # Debian/Ubuntu use a different path to store the locale so let's make sure that path is a symlink to
-        # etc/locale.conf.
-        state.root.joinpath("etc/default/locale").unlink(missing_ok=True)
-        state.root.joinpath("etc/default/locale").symlink_to("../locale.conf")
-
         # Don't enable any services by default.
         presetdir = state.root / "etc/systemd/system-preset"
         presetdir.mkdir(exist_ok=True, mode=0o755)

--- a/tests/test_parse_load_args.py
+++ b/tests/test_parse_load_args.py
@@ -75,19 +75,6 @@ def test_parse_config_files_filter() -> None:
         assert parse([]).packages == ["yes"]
 
 
-def test_hostname() -> None:
-    with cd_temp_dir():
-        assert parse(["--hostname", "name"]).hostname == "name"
-        with pytest.raises(SystemExit):
-            parse(["--hostname", "name", "additional_name"])
-        with pytest.raises(SystemExit):
-            parse(["--hostname"])
-
-        config = Path("mkosi.conf")
-        config.write_text("[Output]\nHostname=name")
-        assert parse([]).hostname == "name"
-
-
 def test_shell_boot() -> None:
     with cd_temp_dir():
         with pytest.raises(MkosiException, match=".boot.*tar"):


### PR DESCRIPTION
These are trivial to configure manually and with credentials, so let's drop the options for them.