### PR TITLE
Change debian default preset to "ignore *"

### DIFF
--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -137,7 +137,7 @@ class DebianInstaller(DistributionInstaller):
         # Don't enable any services by default.
         presetdir = state.root / "etc/systemd/system-preset"
         presetdir.mkdir(exist_ok=True, mode=0o755)
-        presetdir.joinpath("99-mkosi-disable.preset").write_text("disable *")
+        presetdir.joinpath("99-mkosi-ignore.preset").write_text("ignore *")
 
     @classmethod
     def install_packages(cls, state: MkosiState, packages: Sequence[str]) -> None:


### PR DESCRIPTION
Instead of disabling all services on Debian, let's adopt the new preset directive "ignore" which tells preset to ignore any matching services (neither enable nor disable). This makes sure we don't override any defaults set by individual Debian services. On older systemd, preset will simply ignore any line it can't parse so this doesn't break those systems but will only result in a harmless warning message.