### PR TITLE
fedora: use dnf5 if available

### DIFF
--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -159,9 +159,10 @@ def invoke_dnf(state: MkosiState, command: str, packages: Iterable[str], env: Ma
     state.workspace.joinpath("vars").mkdir(exist_ok=True)
 
     cmdline = [
-        'dnf' if shutil.which('dnf') else 'yum',
+        shutil.which('dnf5') or shutil.which('dnf') or 'yum',
         "-y",
         f"--config={state.workspace.joinpath('dnf.conf')}",
+        command,
         "--best",
         "--allowerasing",
         f"--releasever={release}",
@@ -191,7 +192,7 @@ def invoke_dnf(state: MkosiState, command: str, packages: Iterable[str], env: Ma
     if not state.config.with_docs:
         cmdline += ["--nodocs"]
 
-    cmdline += [command, *sort_packages(packages)]
+    cmdline += sort_packages(packages)
 
     run_with_apivfs(state, cmdline, env=dict(KERNEL_INSTALL_BYPASS="1") | env)
 


### PR DESCRIPTION
Fedora plans to switch to dnf5 for F40. For now, the new binary is called 'dnf5', and the old 'dnf'. Let's try to call 'dnf5' if available. It is generally faster. E.g.
'mkosi build' in the mkosi directory after all packages have been downloaded:
   950 ms with dnf5
  1350 ms with dnf

Dnf5 also doesn't download file metadata by default, so it'll be faster if downloads are necessary too.

Let's try the new shiny to save some time on installations.

For some reason, dnf5 doesn't like it if command options are before the command. Old dnf is fine with either order, so let's just move the command earlier.