### PR TITLE
Use kernel-core instead of kernel in CI for some distros

### DIFF
--- a/.github/mkosi.conf.d/20-alma.conf
+++ b/.github/mkosi.conf.d/20-alma.conf
@@ -5,7 +5,7 @@ Distribution=alma
 Repositories=epel
 
 [Content]
-Packages=kernel
+Packages=kernel-core
          systemd
          systemd-boot
          systemd-udev

--- a/.github/mkosi.conf.d/20-centos.conf
+++ b/.github/mkosi.conf.d/20-centos.conf
@@ -2,7 +2,7 @@
 Distribution=centos
 
 [Content]
-Packages=kernel
+Packages=kernel-core
          systemd
          systemd-boot
          systemd-udev

--- a/.github/mkosi.conf.d/20-fedora.conf
+++ b/.github/mkosi.conf.d/20-fedora.conf
@@ -2,7 +2,7 @@
 Distribution=fedora
 
 [Content]
-Packages=kernel
+Packages=kernel-core
          systemd
          systemd-boot
          systemd-udev

--- a/.github/mkosi.conf.d/20-rocky.conf
+++ b/.github/mkosi.conf.d/20-rocky.conf
@@ -5,7 +5,7 @@ Distribution=rocky
 Repositories=epel
 
 [Content]
-Packages=kernel
+Packages=kernel-core
          systemd
          systemd-boot
          systemd-udev


### PR DESCRIPTION
kernel-core is smaller and has fewer dependencies.