### PR TITLE
Make sure we resolve relative paths in config files correctly

### DIFF
--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -467,3 +467,18 @@ def current_user_uid_gid() -> tuple[int, int]:
     uid = int(os.getenv("SUDO_UID") or os.getenv("PKEXEC_UID") or os.getuid())
     gid = pwd.getpwuid(uid).pw_gid
     return uid, gid
+
+
+@contextlib.contextmanager
+def chdir(directory: Path) -> Iterator[None]:
+    old = Path.cwd()
+
+    if old == directory:
+        yield
+        return
+
+    try:
+        os.chdir(directory)
+        yield
+    finally:
+        os.chdir(old)


### PR DESCRIPTION
Relative paths in config files should always be interpreted relative to their config file. We could pass the directory to each parse method, but that's rather verbose, so let's use chdir() so that relative paths are resolved correctly instead.