### PR TITLE
opensuse: Install repositories into image if zypper is installed

### DIFF
--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -131,6 +131,8 @@ class DebianInstaller(DistributionInstaller):
         policyrcd.write_text("#!/bin/sh\nexit 101\n")
         policyrcd.chmod(0o755)
 
+        before = state.root.joinpath("usr/bin/apt").exists()
+
         setup_apt(state, cls.repositories(state))
         invoke_apt(state, "update")
         invoke_apt(state, "install", packages)
@@ -138,7 +140,7 @@ class DebianInstaller(DistributionInstaller):
         policyrcd.unlink()
 
         sources = state.root / "etc/apt/sources.list"
-        if not sources.exists() and state.root.joinpath("usr/bin/apt").exists():
+        if not sources.exists() and not before and state.root.joinpath("usr/bin/apt").exists():
             with sources.open("w") as f:
                 for repo in cls.repositories(state, local=False):
                     f.write(f"{repo}\n")

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -48,12 +48,14 @@ class OpensuseInstaller(DistributionInstaller):
 
     @classmethod
     def install_packages(cls, state: MkosiState, packages: Sequence[str]) -> None:
+        before = state.root.joinpath("usr/bin/zypper").exists()
+
         setup_zypper(state, cls.repositories(state))
         invoke_zypper(state, "install", ["-y", "--download-in-advance", "--no-recommends"], packages)
 
         for (id, url) in cls.repositories(state, local=False):
             path = state.root / f"etc/zypp/repos.d/{id}.repo"
-            if not path.exists() and state.root.joinpath("usr/bin/zypper").exists():
+            if not path.exists() and not before and state.root.joinpath("usr/bin/zypper").exists():
                 path.write_text(
                     dedent(
                         f"""\


### PR DESCRIPTION
Like Debian, OpenSUSE does not provide packages to install the repos into the image so let's adopt the same fix and install the repositories in the image if zypper is installed into the image.