### PR TITLE
Make sure the /efi mountpoint exists for every distro

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -280,6 +280,13 @@ def install_distribution(state: MkosiState, cached: bool) -> None:
     else:
         with complete_step(f"Installing {str(state.config.distribution).capitalize()}"):
             state.installer.install(state)
+
+            # Ensure /efi exists so that the ESP is mounted there, as recommended by
+            # https://0pointer.net/blog/linux-boot-partitions.html. Use the most restrictive access mode we
+            # can without tripping up mkfs tools since this directory is only meant to be overmounted and
+            # should not be read from or written to.
+            state.root.joinpath("efi").mkdir(mode=0o500, exist_ok=True)
+
             if state.config.packages:
                 state.installer.install_packages(state, state.config.packages)
 

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -117,9 +117,6 @@ class DebianInstaller(DistributionInstaller):
 
         cls.install_packages(state, [Path(deb).name.partition("_")[0] for deb in essential])
 
-        # Ensure /efi exists so that the ESP is mounted there, and we never run dpkg -i on vfat
-        state.root.joinpath("efi").mkdir(mode=0o755, exist_ok=True)
-
     @classmethod
     def install_packages(cls, state: MkosiState, packages: Sequence[str]) -> None:
         # Debian policy is to start daemons by default. The policy-rc.d script can be used choose which ones to


### PR DESCRIPTION
https://0pointer.net/blog/linux-boot-partitions.html recommends using the /efi mountpoint universally so let's accomodate that and do it for every distro.