### PR TITLE
debian: Stop setting DPkg::Path

### DIFF
--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -267,7 +267,6 @@ def run_with_apivfs(
     cmd: Sequence[PathString],
     bwrap_params: Sequence[PathString] = tuple(),
     stdout: _FILE = None,
-    stderr: _FILE = None,
     env: Mapping[str, PathString] = {},
 ) -> CompletedProcess:
     cmdline: list[PathString] = [
@@ -306,7 +305,7 @@ def run_with_apivfs(
 
     try:
         return _run([*cmdline, template.format(shlex.join(str(s) for s in cmd))],
-                   text=True, stdout=stdout, stderr=stderr, env=env)
+                   text=True, stdout=stdout, env=env)
     except subprocess.CalledProcessError as e:
         if "run" in ARG_DEBUG:
             _run([*cmdline, template.format("sh")], check=False, env=env)


### PR DESCRIPTION
While this achieved the desired effect of dpkg being looked up in the PATH, it also modified the PATH variable for everything executed by dpkg, which we don't want. Let's just lookup dpkg in PATH before running apt and put the result in Dir::Bin::dpkg which looks up dpkg in the PATH without modifying the PATH used by dpkg itself.

Fixes #1456