### PR TITLE
debian: Simplify cmdline to get the list of packages to install

### DIFF
--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -220,7 +220,7 @@ def _run(
 
     try:
         return subprocess.run(cmdline, check=check, stdout=stdout, stderr=stderr, env=env, **kwargs,
-                              preexec_fn=foreground, close_fds=False)
+                              preexec_fn=foreground)
     except FileNotFoundError as e:
         die(f"{cmdline[0]} not found in PATH.", e)
 


### PR DESCRIPTION
Let's not bother with file descriptor inheritance and just write the list of packages to a temporary file.