### PR TITLE
Replace _run() with an extra argument log

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1994,7 +1994,7 @@ def run_shell(config: MkosiConfig) -> None:
         acl_toggle_remove(config, config.output, uid, allow=False)
 
     try:
-        run(cmdline, stdout=sys.stdout, env=os.environ)
+        run(cmdline, stdout=sys.stdout, env=os.environ, log=False)
     finally:
         if config.output_format == OutputFormat.directory:
             acl_toggle_remove(config, config.output, uid, allow=True)
@@ -2259,7 +2259,7 @@ def run_qemu(config: MkosiConfig) -> None:
         cmdline += config.qemu_args
         cmdline += config.cmdline
 
-        run(cmdline, stdout=sys.stdout, env=os.environ)
+        run(cmdline, stdout=sys.stdout, env=os.environ, log=False)
 
 
 def run_ssh(config: MkosiConfig) -> None:
@@ -2275,7 +2275,7 @@ def run_ssh(config: MkosiConfig) -> None:
 
     cmd += config.cmdline
 
-    run(cmd, stdout=sys.stdout, env=os.environ)
+    run(cmd, stdout=sys.stdout, env=os.environ, log=False)
 
 
 def run_serve(config: MkosiConfig) -> None:


### PR DESCRIPTION
Let's just add an argument log to run that's true by default which allows us to disable logging if the command failed. We also disable logging in run_ssh(), run_qemu() and run_shell() since we expect those to fail and shouldn't log if they do (like we did before).