### PR TITLE
Stop copying the cached build overlay

### DIFF
--- a/mkosi/mounts.py
+++ b/mkosi/mounts.py
@@ -89,7 +89,8 @@ def mount_overlay(
     lower: Path,
     upper: Path,
     workdir: Path,
-    where: Path
+    where: Path,
+    read_only: bool = True,
 ) -> Iterator[Path]:
     options = [f"lowerdir={lower}", f"upperdir={upper}", f"workdir={workdir}"]
 
@@ -98,7 +99,7 @@ def mount_overlay(
         options.append("userxattr")
 
     try:
-        with mount("overlay", where, options=options, type="overlay"):
+        with mount("overlay", where, options=options, type="overlay", read_only=read_only):
             yield where
     finally:
         with complete_step("Cleaning up overlayfs"):


### PR DESCRIPTION
The build overlay is not modified during the final build, it's only used to run the build script which cannot touch the build image. Let's enforce this even more by mounting the build overlay read-only when running the script.

With this assurance, we can stop copying the cached build overlay every time and just use it directly since we're certain it cannot be modified anyway.