### PR TITLE
Allow booting cpio images in qemu

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -605,7 +605,7 @@ def compressor_command(option: Union[str, bool], src: Path) -> list[PathString]:
     if option == "xz":
         return [xz_binary(), "--check=crc32", "--lzma2=dict=1MiB", "-T0", src]
     elif option == "zstd":
-        return ["zstd", "-15", "-q", "-T0", "--rm", src]
+        return ["zstd", "-q", "-T0", "--rm", src]
     else:
         die(f"Unknown compression {option}")
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1606,6 +1606,14 @@ def run_kernel_install(state: MkosiState, cached: bool) -> None:
         shutil.rmtree(p)
 
 
+def run_sysusers(state: MkosiState) -> None:
+    if state.for_cache:
+        return
+
+    with complete_step("Generating system users"):
+        run(["systemd-sysusers", "--root", state.root])
+
+
 def run_preset_all(state: MkosiState) -> None:
     if state.for_cache:
         return
@@ -1772,6 +1780,7 @@ def build_image(state: MkosiState, *, manifest: Optional[Manifest] = None) -> No
         install_boot_loader(state)
         configure_ssh(state)
         run_postinst_script(state)
+        run_sysusers(state)
         run_preset_all(state)
         remove_packages(state)
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1568,6 +1568,9 @@ def run_kernel_install(state: MkosiState, cached: bool) -> None:
     if state.config.bootable is False:
         return
 
+    if state.config.bootable is None and state.config.output_format == OutputFormat.cpio:
+        return
+
     # CentOS Stream 8 has an old version of kernel-install that unconditionally writes initrds to
     # /boot/<machine-id>/<kver>, so let's detect that and move them to the correct location.
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -372,6 +372,8 @@ def configure_autologin(state: MkosiState) -> None:
     with complete_step("Setting up autologin…"):
         add_dropin_config_from_resource(state.root, "console-getty.service", "autologin",
                                         "mkosi.resources", "console_getty_autologin.conf")
+        add_dropin_config_from_resource(state.root, "serial-getty@ttyS0.service", "autologin",
+                                        "mkosi.resources", "serial_getty_autologin.conf")
         add_dropin_config_from_resource(state.root, "serial-getty@hvc0.service", "autologin",
                                         "mkosi.resources", "serial_getty_autologin.conf")
         add_dropin_config_from_resource(state.root, "getty@tty1.service", "autologin",
@@ -1101,6 +1103,9 @@ def load_kernel_command_line_extra(args: argparse.Namespace) -> list[str]:
         f"systemd.tty.term.hvc0={os.getenv('TERM', 'vt220')}",
         f"systemd.tty.columns.hvc0={columns}",
         f"systemd.tty.rows.hvc0={lines}",
+        f"systemd.tty.term.ttyS0={os.getenv('TERM', 'vt220')}",
+        f"systemd.tty.columns.ttyS0={columns}",
+        f"systemd.tty.rows.ttyS0={lines}",
         "console=hvc0",
     ]
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -684,7 +684,9 @@ def gen_kernel_images(state: MkosiState) -> Iterator[tuple[str, Path]]:
         key=lambda k: GenericVersion(k.name),
         reverse=True
     ):
-        kimg = state.installer.kernel_image(kver.name, state.config.architecture)
+        kimg = Path("usr/lib/modules") / kver.name / "vmlinuz"
+        if not kimg.exists():
+            kimg = state.installer.kernel_image(kver.name, state.config.architecture)
 
         yield kver.name, kimg
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -26,6 +26,7 @@ from textwrap import dedent
 from typing import Callable, ContextManager, Optional, TextIO, TypeVar, Union, cast
 
 from mkosi.backend import (
+    Compression,
     Distribution,
     ManifestFormat,
     MkosiConfig,
@@ -38,7 +39,6 @@ from mkosi.backend import (
     is_dnf_distribution,
     patch_file,
     set_umask,
-    should_compress_output,
     tmp_dir,
 )
 from mkosi.install import add_dropin_config_from_resource, copy_path, flock
@@ -599,15 +599,15 @@ def xz_binary() -> str:
     return "pxz" if shutil.which("pxz") else "xz"
 
 
-def compressor_command(option: Union[str, bool], src: Path) -> list[PathString]:
+def compressor_command(compression: Compression, src: Path) -> list[PathString]:
     """Returns a command suitable for compressing archives."""
 
-    if option == "xz":
+    if compression == Compression.xz:
         return [xz_binary(), "--check=crc32", "--lzma2=dict=1MiB", "-T0", src]
-    elif option == "zstd":
+    elif compression == Compression.zst:
         return ["zstd", "-q", "-T0", "--rm", src]
     else:
-        die(f"Unknown compression {option}")
+        die(f"Unknown compression {compression}")
 
 
 def tar_binary() -> str:
@@ -801,18 +801,16 @@ def install_unified_kernel(state: MkosiState, roothash: Optional[str]) -> None:
 
 
 def compress_output(config: MkosiConfig, src: Path, uid: int, gid: int) -> None:
-    compress = should_compress_output(config)
-
     if not src.is_file():
         return
 
-    if not compress:
+    if config.compress_output == Compression.none:
         # If we shan't compress, then at least make the output file sparse
         with complete_step(f"Digging holes into output file {src}…"):
             run(["fallocate", "--dig-holes", src], user=uid, group=gid)
     else:
         with complete_step(f"Compressing output file {src}…"):
-            run(compressor_command(compress, src), user=uid, group=gid)
+            run(compressor_command(config.compress_output, src), user=uid, group=gid)
 
 
 def copy_nspawn_settings(state: MkosiState) -> None:
@@ -931,13 +929,13 @@ def save_manifest(state: MkosiState, manifest: Manifest) -> None:
 
 
 def print_output_size(config: MkosiConfig) -> None:
-    if not config.output.exists():
+    if not config.output_compressed.exists():
         return
 
     if config.output_format in (OutputFormat.directory, OutputFormat.subvolume):
         MkosiPrinter.print_step("Resulting image size is " + format_bytes(dir_size(config.output)) + ".")
     else:
-        st = os.stat(config.output)
+        st = os.stat(config.output_compressed)
         size = format_bytes(st.st_size)
         space = format_bytes(st.st_blocks * 512)
         MkosiPrinter.print_step(f"Resulting image size is {size}, consumes {space}.")
@@ -1020,8 +1018,6 @@ def require_private_file(name: Path, description: str) -> None:
 
 def find_password(args: argparse.Namespace) -> None:
     if args.password is not None:
-        return
-    if not (args.verb == Verb.summary or needs_build(args)):
         return
 
     try:
@@ -1165,6 +1161,9 @@ def load_args(args: argparse.Namespace) -> MkosiConfig:
     if args.sign:
         args.checksum = True
 
+    if args.compress_output is None:
+        args.compress_output = Compression.zst if args.output_format == OutputFormat.cpio else Compression.none
+
     if args.output is None:
         iid = args.image_id if args.image_id is not None else "image"
         prefix = f"{iid}_{args.image_version}" if args.image_version is not None else iid
@@ -1223,7 +1222,7 @@ def load_args(args: argparse.Namespace) -> MkosiConfig:
         opname = "acquire shell" if args.verb == Verb.shell else "boot"
         if args.output_format in (OutputFormat.tar, OutputFormat.cpio):
             die(f"Sorry, can't {opname} with a {args.output_format} archive.")
-        if should_compress_output(args):
+        if args.compress_output != Compression.none:
             die(f"Sorry, can't {opname} with a compressed image.")
 
     if args.verb == Verb.qemu:
@@ -1412,12 +1411,12 @@ def print_summary(config: MkosiConfig) -> None:
           Manifest Formats: {maniformats}
           Output Directory: {none_to_default(config.output_dir)}
        Workspace Directory: {none_to_default(config.workspace_dir)}
-                    Output: {bold(config.output)}
+                    Output: {bold(config.output_compressed)}
            Output Checksum: {none_to_na(config.output_checksum if config.checksum else None)}
           Output Signature: {none_to_na(config.output_signature if config.sign else None)}
     Output nspawn Settings: {none_to_na(config.output_nspawn_settings if config.nspawn_settings is not None else None)}
                Incremental: {yes_no(config.incremental)}
-               Compression: {should_compress_output(config) or "no"}
+               Compression: {config.compress_output.name}
        Kernel Command Line: {" ".join(config.kernel_command_line)}
            UEFI SecureBoot: {yes_no(config.secure_boot)}
        SecureBoot Sign Key: {none_to_none(config.secure_boot_key)}
@@ -2238,9 +2237,9 @@ def run_qemu(config: MkosiConfig) -> None:
             # CoW but later changes do not result in CoW anymore.
 
             run(["chattr", "+C", fname], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
-            copy_path(config.output, fname)
+            copy_path(config.output_compressed, fname)
         else:
-            fname = config.output
+            fname = config.output_compressed
 
         # Debian images fail to boot with virtio-scsi, see: https://github.com/systemd/mkosi/issues/725
         if config.distribution == Distribution.debian:
@@ -2432,7 +2431,7 @@ def expand_specifier(s: str) -> str:
 
 
 def needs_build(config: Union[argparse.Namespace, MkosiConfig]) -> bool:
-    return config.verb == Verb.build or (config.verb in MKOSI_COMMANDS_NEED_BUILD and (not config.output.exists() or config.force > 0))
+    return config.verb == Verb.build or (config.verb in MKOSI_COMMANDS_NEED_BUILD and (not config.output_compressed.exists() or config.force > 0))
 
 
 def run_verb(config: MkosiConfig) -> None:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1919,7 +1919,7 @@ def build_stuff(uid: int, gid: int, config: MkosiConfig) -> None:
                     os.chown(p, state.uid, state.gid)
                 else:
                     acl_toggle_remove(state.config, p, uid, allow=True)
-                if p in (state.config.output, state.config.output_split_kernel):
+                if p == state.config.output:
                     compress_output(state.config, p, uid=state.uid, gid=state.gid)
 
         for p in state.staging.iterdir():

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1551,11 +1551,8 @@ def configure_initrd(state: MkosiState) -> None:
     if not state.root.joinpath("init").exists():
         state.root.joinpath("init").symlink_to("/usr/lib/systemd/systemd")
 
-    if state.root.joinpath("etc/initrd-release").exists():
-        return
-
-    state.root.joinpath("etc/os-release").rename(state.root / "etc/initrd-release")
-    state.root.joinpath("etc/os-release").symlink_to("/etc/initrd-release")
+    if not state.root.joinpath("etc/initrd-release").exists():
+        state.root.joinpath("etc/initrd-release").symlink_to("/etc/os-release")
 
 
 def run_kernel_install(state: MkosiState, cached: bool) -> None:

--- a/mkosi/__main__.py
+++ b/mkosi/__main__.py
@@ -38,7 +38,7 @@ def propagate_failed_return() -> Iterator[None]:
         if ARG_DEBUG:
             raise e
 
-        MkosiPrinter.error("Error: mkosi failed because of an exception, rerun mkosi with --debug run to get more information")
+        MkosiPrinter.error(f"Error: {str(e)}, rerun mkosi with --debug run to get more information")
         sys.exit(1)
 
 

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -294,8 +294,12 @@ class MkosiConfig:
         return self.architecture == platform.machine()
 
     @property
-    def output_split_kernel(self) -> Path:
+    def output_split_uki(self) -> Path:
         return build_auxiliary_output_path(self, ".efi")
+
+    @property
+    def output_split_kernel(self) -> Path:
+        return build_auxiliary_output_path(self, ".vmlinuz")
 
     @property
     def output_nspawn_settings(self) -> Path:
@@ -331,6 +335,7 @@ class MkosiConfig:
     def output_paths(self) -> tuple[Path, ...]:
         return (
             self.output,
+            self.output_split_uki,
             self.output_split_kernel,
             self.output_nspawn_settings,
             self.output_checksum,

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional, Type, Union, cast
 
 from mkosi.backend import (
+    Compression,
     Distribution,
     ManifestFormat,
     OutputFormat,
@@ -97,14 +98,17 @@ def config_parse_feature(dest: str, value: Optional[str], namespace: argparse.Na
     return parse_boolean(value) if value else None
 
 
-def config_parse_compression(dest: str, value: Optional[str], namespace: argparse.Namespace) -> Union[None, str, bool]:
+def config_parse_compression(dest: str, value: Optional[str], namespace: argparse.Namespace) -> Optional[Compression]:
     if dest in namespace:
         return getattr(namespace, dest) # type: ignore
 
-    if value in ("zlib", "lzo", "zstd", "lz4", "xz"):
-        return value
+    if not value:
+        return None
 
-    return parse_boolean(value) if value else None
+    try:
+        return Compression[value]
+    except KeyError:
+        return Compression.zst if parse_boolean(value) else Compression.none
 
 
 def config_default_release(namespace: argparse.Namespace) -> Any:

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -15,7 +15,7 @@ class DistributionInstaller:
 
     @staticmethod
     def kernel_image(kver: str, architecture: str) -> Path:
-        return Path("lib/modules") / kver / "vmlinuz"
+        return Path("usr/lib/modules") / kver / "vmlinuz"
 
     @staticmethod
     def initrd_path(kver: str) -> Path:

--- a/tests/test_parse_load_args.py
+++ b/tests/test_parse_load_args.py
@@ -10,7 +10,7 @@ from typing import Iterator, List, Optional
 import pytest
 
 import mkosi
-from mkosi.backend import Distribution, MkosiConfig, Verb
+from mkosi.backend import Compression, Distribution, MkosiConfig, Verb
 from mkosi.config import MkosiConfigParser
 
 
@@ -88,5 +88,5 @@ def test_shell_boot() -> None:
 
 def test_compression() -> None:
     with cd_temp_dir():
-        assert not parse(["--format", "disk", "--compress-output", "False"]).compress_output
+        assert parse(["--format", "disk", "--compress-output", "False"]).compress_output == Compression.none
 


### PR DESCRIPTION
Let's add back some form of direct linux boot by allowing to boot
cpio images. To make this work, either the user has to pass -kernel
or a kernel has to be installed inside the cpio, which we'll copy
out and use as the -kernel argument.