### PR TITLE
Rework exception handling yet again

### DIFF
--- a/mkosi/__main__.py
+++ b/mkosi/__main__.py
@@ -9,7 +9,7 @@ from collections.abc import Iterator
 
 from mkosi import load_args, run_verb
 from mkosi.config import MkosiConfigParser
-from mkosi.log import ARG_DEBUG, MkosiPrinter, die
+from mkosi.log import ARG_DEBUG, MkosiError, MkosiPrinter, die
 from mkosi.run import excepthook
 
 
@@ -34,14 +34,15 @@ def propagate_failed_return() -> Iterator[None]:
 
         # We always log when subprocess.CalledProcessError is raised, so we don't log again here.
         sys.exit(e.returncode)
-    except Exception as e:
+    except MkosiError as e:
         if ARG_DEBUG:
             raise e
-        elif not isinstance(e, RuntimeError):
-            # RuntimeError is used to wrap generic errors, and the message that was printed should be enough.
+        sys.exit(1)
+    except Exception as e:
+        if not ARG_DEBUG:
             MkosiPrinter.info(f"Hint: mkosi failed because of an internal exception {e.__class__.__name__}, "
                               "rerun mkosi with --debug to get more information")
-        sys.exit(1)
+        raise e
 
 
 @propagate_failed_return()

--- a/mkosi/log.py
+++ b/mkosi/log.py
@@ -6,6 +6,10 @@ from typing import Any, Iterator, NoReturn, Optional
 ARG_DEBUG: set[str] = set()
 
 
+class MkosiError(Exception):
+    "Exception thrown by mkosi itself after it printed an error"
+
+
 def die(
         message: str,
         exception: Optional[Exception] = None,
@@ -14,7 +18,7 @@ def die(
     MkosiPrinter.error(f"Error: {message}")
     if hint:
         MkosiPrinter.info(f"({hint})")
-    raise exception or RuntimeError(message)
+    raise MkosiError(message) from exception
 
 
 def warn(message: str) -> None:

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -183,7 +183,7 @@ def fork_and_wait(target: Callable[[], T]) -> T:
     result = pout.recv()
     if isinstance(result, RemoteException):
         # Reraise the original exception and attach the remote exception with full traceback as the cause.
-        raise result.exception from result
+        raise result
 
     return result
 

--- a/tests/test_parse_load_args.py
+++ b/tests/test_parse_load_args.py
@@ -12,6 +12,7 @@ import pytest
 import mkosi
 from mkosi.backend import Compression, Distribution, MkosiConfig, Verb
 from mkosi.config import MkosiConfigParser
+from mkosi.log import MkosiError
 
 
 @contextmanager
@@ -76,13 +77,13 @@ def test_parse_config_files_filter() -> None:
 
 def test_shell_boot() -> None:
     with cd_temp_dir():
-        with pytest.raises(RuntimeError, match=".boot.*tar"):
+        with pytest.raises(MkosiError, match=".boot.*tar"):
             parse(["--format", "tar", "boot"])
 
-        with pytest.raises(RuntimeError, match=".boot.*cpio"):
+        with pytest.raises(MkosiError, match=".boot.*cpio"):
             parse(["--format", "cpio", "boot"])
 
-        with pytest.raises(RuntimeError, match=".boot.*compressed" ):
+        with pytest.raises(MkosiError, match=".boot.*compressed" ):
             parse(["--format", "disk", "--compress-output=yes", "boot"])
 
 


### PR DESCRIPTION
e25d746f9d7668edc5134cde4ec381c8b2da0136 removed printing of the exception backtrace, except if --debug is used. (Later
afb709356fed78a1b6994e72d651e92f354be333 added back printing of the exception message, and b89db00359ad28e90a1923f3b483b63e7f47829a changed it to print the class name, but the general approach of not printing the backtrace remained.) This is not very useful.

My motivating use case was an error introduced in one of my patches. A ValueError was thrown by subprocess.run(). This would be trivial to fix except that without the backtrace I had no idea what was going on.

We shouldn't print an exception if the failure is "expected". When we call die(), then the code was written to expect a failure at this point and we print an error message and we don't need to print the backtrace. So far good. But if a different exception type is thrown, then most likely we made a programmatic error and called something with wrong arguments, or the environment unexpectedly prevents us from doing something that shouldn't fail. In that case, just the exception (class or string or whatever) is not enough to diagnose the issue, because exception names and messages are generic, and without a backtrace won't know where exactly the failure happened. Telling the user to rerun with --debug is not a good solution, because they might not be able to recreate the failure.

The code is reworked to use MkosiError for our own exceptions and we only print the error message (unless --debug is used). Other exceptions print the backtrace, on the assumption that this is a failure that should be reported to developers and fixed. (Or if a developer is using mkosi, they fix it themselves ;)). If it turns out that mkosi fails in a way that prints a backtrace in normal use, then we can always add special handling for that case. This way, we won't get backtraces in normal use, but we will get them if there's something to fix in the code.

'raise MkosiError from e' is used so that we get chained backtraces.