### PR TITLE
Override sys.excepthook when calling main

### DIFF
--- a/mkosi/__main__.py
+++ b/mkosi/__main__.py
@@ -15,6 +15,8 @@ from mkosi.run import excepthook
 
 @contextlib.contextmanager
 def propagate_failed_return() -> Iterator[None]:
+    sys.excepthook = excepthook
+
     try:
         yield
     except SystemExit as e:
@@ -58,5 +60,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    sys.excepthook = excepthook
     main()


### PR DESCRIPTION
Overriding `sys.excepthook` with `mkosi.run.excepthook` has to happen when calling `mkosi.__main__.main()`, otherwise it is not applied when `main` is simply imported and then called (by using a zipapp or a console script entry point).

Split from #1470.