### PR TITLE
Path expansion

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2412,8 +2412,7 @@ def run_verb(config: MkosiConfig) -> None:
 
         if needs_build(config) or config.verb == Verb.clean:
             def target() -> None:
-                if os.getuid() != 0:
-                    become_root()
+                become_root()
                 unlink_output(config)
 
             fork_and_wait(target)
@@ -2421,7 +2420,7 @@ def run_verb(config: MkosiConfig) -> None:
         if needs_build(config):
             def target() -> None:
                 # Get the user UID/GID either on the host or in the user namespace running the build
-                uid, gid = become_root() if os.getuid() != 0 else current_user_uid_gid()
+                uid, gid = become_root()
                 init_mount_namespace()
                 build_stuff(uid, gid, config)
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -33,7 +33,7 @@ from mkosi.backend import (
     MkosiState,
     OutputFormat,
     Verb,
-    current_user_uid_gid,
+    current_user,
     flatten,
     format_rlimit,
     is_dnf_distribution,
@@ -1981,7 +1981,7 @@ def run_shell(config: MkosiConfig) -> None:
         cmdline += ["--"]
         cmdline += config.cmdline
 
-    uid, _ = current_user_uid_gid()
+    uid = current_user().uid
 
     if config.output_format == OutputFormat.directory:
         acl_toggle_remove(config, config.output, uid, allow=False)
@@ -2381,9 +2381,7 @@ def prepend_to_environ_path(paths: Sequence[Path]) -> Iterator[None]:
 
 
 def expand_specifier(s: str) -> str:
-    user = os.getenv("SUDO_USER") or os.getenv("USER")
-    assert user is not None
-    return s.replace("%u", user)
+    return s.replace("%u", current_user().name)
 
 
 def needs_build(config: Union[argparse.Namespace, MkosiConfig]) -> bool:

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from types import TracebackType
 from typing import Any, Callable, Mapping, Optional, Sequence, Type, TypeVar
 
-from mkosi.backend import MkosiState, current_user_uid_gid
+from mkosi.backend import MkosiState, current_user
 from mkosi.log import ARG_DEBUG, MkosiPrinter, die
 from mkosi.types import _FILE, CompletedProcess, PathString, Popen
 
@@ -67,7 +67,9 @@ def become_root() -> tuple[int, int]:
     The function returns the UID-GID pair of the invoking user in the namespace (65436, 65436).
     """
     if os.getuid() == 0:
-        return current_user_uid_gid()
+        user = current_user()
+        return user.uid, user.gid
+
     subuid = read_subrange(Path("/etc/subuid"))
     subgid = read_subrange(Path("/etc/subgid"))
 

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from types import TracebackType
 from typing import Any, Callable, Mapping, Optional, Sequence, Type, TypeVar
 
-from mkosi.backend import MkosiState
+from mkosi.backend import MkosiState, current_user_uid_gid
 from mkosi.log import ARG_DEBUG, MkosiPrinter, die
 from mkosi.types import _FILE, CompletedProcess, PathString, Popen
 
@@ -66,6 +66,8 @@ def become_root() -> tuple[int, int]:
 
     The function returns the UID-GID pair of the invoking user in the namespace (65436, 65436).
     """
+    if os.getuid() == 0:
+        return current_user_uid_gid()
     subuid = read_subrange(Path("/etc/subuid"))
     subgid = read_subrange(Path("/etc/subgid"))
 


### PR DESCRIPTION
When the `extra_search_paths` configuration was introduced, it would perform path expansions with the environment variables (using $) and the home directories (starting with ~). Home directories would not be expanded when mkosi was run with sudo or pkexec. Instead, `$SUDO_HOME` could be used but only when run with sudo or pkexec.

However, those expansions were not applied to other paths in the configuration and were broken with the rewrite of the configuration loading, as the parser would check if the paths exist before expanding.

Those expansions are now handled directly in the parser and are performed before validation. Environment variables expansion is enabled for all paths and home directory expansion is enabled for all paths on
the host.

Furthermore, home directory expansion is always available, with `~` expanding to the user's home directory when sudo or pkexec are used (and not `/root`), replacing the need for `$SUDO_HOME`.

Split from #1470.