### PR TITLE
Fix stdin being redirect to /dev/null when running ssh, shell or qemu

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1987,7 +1987,7 @@ def run_shell(config: MkosiConfig) -> None:
         acl_toggle_remove(config, config.output, uid, allow=False)
 
     try:
-        run(cmdline, stdout=sys.stdout, env=os.environ, log=False)
+        run(cmdline, stdin=sys.stdin, stdout=sys.stdout, env=os.environ, log=False)
     finally:
         if config.output_format == OutputFormat.directory:
             acl_toggle_remove(config, config.output, uid, allow=True)
@@ -2240,7 +2240,7 @@ def run_qemu(config: MkosiConfig) -> None:
         cmdline += config.qemu_args
         cmdline += config.cmdline
 
-        run(cmdline, stdout=sys.stdout, env=os.environ, log=False)
+        run(cmdline, stdin=sys.stdin, stdout=sys.stdout, env=os.environ, log=False)
 
 
 def run_ssh(config: MkosiConfig) -> None:
@@ -2256,7 +2256,7 @@ def run_ssh(config: MkosiConfig) -> None:
 
     cmd += config.cmdline
 
-    run(cmd, stdout=sys.stdout, env=os.environ, log=False)
+    run(cmd, stdin=sys.stdin, stdout=sys.stdout, env=os.environ, log=False)
 
 
 def run_serve(config: MkosiConfig) -> None:


### PR DESCRIPTION
30b8996a22022289bbf9820b6a04c5bfaf771d5e changed the default of stdin to /dev/null, which is great, but for the ssh, shell, boot and qemu commands, we actually need it connected to stdin of the calling terminal, so let's fix that.