### PR TITLE
Empty install directory before running build script

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1801,6 +1801,10 @@ def run_build_script(state: MkosiState) -> None:
     if state.config.build_script is None or state.for_cache:
         return
 
+    # Make sure that if mkosi.installdir/ is used, any leftover files from a previous run are removed.
+    if state.config.install_dir:
+        empty_directory(state.config.install_dir)
+
     with complete_step("Running build script…"), mount_build_overlay(state, read_only=True):
         bwrap: list[PathString] = [
             "--bind", state.config.build_sources, "/work/src",


### PR DESCRIPTION
The install directory is shared between distros, and depending on the distro, different files might be installed. Let's make sure we empty the install directory before running the build so that files from different distros don't end up mixed in the install directory.