### PR TITLE
Add MakeInitrd=

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
     - name: Build ${{ matrix.distro }} initrd
       if: matrix.prebuilt-initrd == 'yes'
       # Run the build in .github/workflows/ so we don't pick up any of the configuration files in .github/
-      run: python3 -m mkosi -d ${{ matrix.distro }} -t cpio -p systemd -p udev -p kmod -o $PWD/initrd build
+      run: python3 -m mkosi -d ${{ matrix.distro }} -t cpio -p systemd -p udev -p kmod --make-initrd -o $PWD/initrd build
       working-directory: ./.github/workflows
 
     - name: Configure ${{ matrix.distro }}/${{ matrix.format }}

--- a/mkosi.md
+++ b/mkosi.md
@@ -798,6 +798,11 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   files. This option may be used multiple times in which case the initrd lists
   are combined.
 
+`MakeInitrd=`, `--make-initrd`
+
+: Add `/etc/initrd-release` and `/init` to the image so that it can be
+  used as an initramfs.
+
 ### [Validation] Section
 
 `Checksum=`, `--checksum`

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1570,7 +1570,7 @@ def configure_ssh(state: MkosiState) -> None:
 
 
 def configure_initrd(state: MkosiState) -> None:
-    if state.for_cache or not state.config.output_format == OutputFormat.cpio:
+    if state.for_cache or not state.config.make_initrd:
         return
 
     if not state.root.joinpath("init").exists():

--- a/mkosi/backend.py
+++ b/mkosi/backend.py
@@ -277,6 +277,7 @@ class MkosiConfig:
     auto_bump: bool
     workspace_dir: Optional[Path]
     initrds: list[Path]
+    make_initrd: bool
     kernel_command_line_extra: list[str]
     acl: bool
     pager: bool

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -636,6 +636,11 @@ class MkosiConfigParser:
             parse=config_make_list_parser(delimiter=",", parse=make_path_parser(required=False)),
         ),
         MkosiConfigSetting(
+            dest="make_initrd",
+            section="Content",
+            parse=config_parse_boolean,
+        ),
+        MkosiConfigSetting(
             dest="checksum",
             section="Validation",
             parse=config_parse_boolean,
@@ -1223,6 +1228,13 @@ class MkosiConfigParser:
             help="Add a user-provided initrd to image",
             metavar="PATH",
             dest="initrds",
+            action=action,
+        )
+        group.add_argument(
+            "--make-initrd",
+            help="Make sure the image can be used as an initramfs",
+            metavar="BOOL",
+            nargs="?",
             action=action,
         )
 


### PR DESCRIPTION
Instead of automatically making cpio's initrds, let's put this behind a MakeInitrd= option. This allows booting directly into cpios with systemd when they're not configured as an initramfs.