### PR TITLE
Fix installation of essential packages on Debian stretch

### DIFF
--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -101,6 +101,12 @@ class DebianInstaller(DistributionInstaller):
                 run(["dpkg-deb", "--fsys-tarfile", deb], stdout=f)
                 run(["tar", "-C", state.root, "--keep-directory-symlink", "--extract", "--file", f.name])
 
+        # There is a bug in Debian stretch where libuuid1 (which is essential) unecessarily depends on passwd,
+        # which breaks the installation as passwd is then configured before base-passwd
+
+        if state.config.release == "stretch":
+            cls.install_packages(state, ["base-passwd"])
+
         # Finally, run apt to properly install packages in the chroot without having to worry that maintainer
         # scripts won't find basic tools that they depend on.
 


### PR DESCRIPTION
There is a bug in Debian stretch where `libuuid1` (which is essential) unnecessarily depends on `passwd`. When configuring the essential packages and their dependencies, `passwd` is configured before `base-passwd` and the installation fails.

debootstrap did not have this issue because it explicitly orders the installation of some essential packages, including `base-passwd`.

By explicitly installing `base-passwd` first, the rest of the essential packages can then be configured without failure.

There is no hope for a fix from Debian as the package was fixed in 2017 but only released for buster. I also could not find a fix that would work by putting some files in mkosi.skeleton and/or setting some environment variables.