### PR TITLE
Match: allow multiple distributions

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -216,6 +216,8 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 `Distribution=`
 
 : Matches against the configured distribution.
+  Matches any one of multiple distributions. Separate multiple distribution
+  names with "|" e.g: "debian|ubuntu".
 
 `Release=`
 


### PR DESCRIPTION
For distributions like Debian and Ubuntu that share common infrastructure this allows sharing common settings such as Packages= and BuildPackages=

Fixes: Issue #1483