### PR TITLE
debian: Add TODO to drop /var/lib/dpkg/status logic when possible

### DIFF
--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -164,6 +164,8 @@ def setup_apt(state: MkosiState, repos: Sequence[str]) -> None:
     state.workspace.joinpath("apt/apt.conf.d").mkdir(exist_ok=True)
     state.workspace.joinpath("apt/preferences.d").mkdir(exist_ok=True)
     state.workspace.joinpath("apt/log").mkdir(exist_ok=True)
+
+    # TODO: Drop once apt 2.5.4 is widely available.
     state.root.joinpath("var").mkdir(mode=0o755, exist_ok=True)
     state.root.joinpath("var/lib").mkdir(mode=0o755, exist_ok=True)
     state.root.joinpath("var/lib/dpkg").mkdir(mode=0o755, exist_ok=True)
@@ -189,6 +191,7 @@ def setup_apt(state: MkosiState, repos: Sequence[str]) -> None:
             Dir::Etc::trustedparts "/usr/share/keyrings";
             Dir::Log "{state.workspace / "apt/log"}";
             Dir::Bin::dpkg "{shutil.which("dpkg")}";
+            Debug::NoLocking "true";
             DPkg::Options:: "--root={state.root}";
             DPkg::Options:: "--log={state.workspace / "apt/dpkg.log"}";
             DPkg::Options:: "--force-unsafe-io";


### PR DESCRIPTION
It's created automatically by apt since apt 2.5.4 so add a note that
we can drop it once that version is widely available. Also disable
dpkg locking since it causes a apt failure due to not being able to
access the lock file in /var/lib/dpkg. Since we're building in a
chroot, we don't care about locking anyway.