### PR TITLE
Enable --repo-dir for Debian and Ubuntu

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -287,11 +287,12 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 
 `RepositoryDirectories`, `--repo-dir=`
 
-: This option can (for now) only be used with RPM-based distributions and Arch
-  Linux. It takes a comma separated list of directories containing extra repository
-  definitions that will be used when installing packages. The files are passed
-  directly to the corresponding package manager and should be written in the format
-  expected by the package manager of the image's distro.
+: This option can (for now) only be used with RPM-based distributions,
+  Debian-based distributions and Arch Linux. It takes a comma separated list of
+  directories containing extra repository definitions that will be used when
+  installing packages. The files are passed directly to the corresponding
+  package manager and should be written in the format expected by the package
+  manager of the image's distro.
 
 `Architecture=`, `--architecture=`
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -29,6 +29,7 @@ from mkosi.util import (
     current_user,
     detect_distribution,
     flatten,
+    is_apt_distribution,
     is_dnf_distribution,
     prepend_to_environ_path,
     qemu_check_kvm_support,
@@ -1874,8 +1875,12 @@ def load_args(args: argparse.Namespace) -> MkosiConfig:
         if args.compress_output != Compression.none:
             die(f"Sorry, can't {opname} with a compressed image.")
 
-    if args.repo_dirs and not (is_dnf_distribution(args.distribution) or args.distribution == Distribution.arch):
-        die("--repo-dir is only supported on DNF based distributions and Arch")
+    if args.repo_dirs and not (
+        is_dnf_distribution(args.distribution)
+        or is_apt_distribution(args.distribution)
+        or args.distribution == Distribution.arch
+    ):
+        die("--repo-dir is only supported on DNF/Debian based distributions and Arch")
 
     if args.qemu_kvm is True and not qemu_check_kvm_support():
         die("Sorry, the host machine does not support KVM acceleration.")
@@ -1883,7 +1888,7 @@ def load_args(args: argparse.Namespace) -> MkosiConfig:
     if args.qemu_kvm is None:
         args.qemu_kvm = qemu_check_kvm_support()
 
-    if args.repositories and not is_dnf_distribution(args.distribution) and args.distribution not in (Distribution.debian, Distribution.ubuntu):
+    if args.repositories and not (is_dnf_distribution(args.distribution) or is_apt_distribution(args.distribution)):
         die("Sorry, the --repositories option is only supported on DNF/Debian based distributions")
 
     if args.initrds:
@@ -1903,4 +1908,3 @@ def load_args(args: argparse.Namespace) -> MkosiConfig:
             die("This unprivileged build configuration requires at least Linux v5.11")
 
     return MkosiConfig(**vars(args))
-

--- a/mkosi/install.py
+++ b/mkosi/install.py
@@ -47,11 +47,17 @@ def flock(path: Path) -> Iterator[Path]:
         os.close(fd)
 
 
-def copy_path(src: Path, dst: Path, preserve_owner: bool = True) -> None:
+def copy_path(
+    src: Path,
+    dst: Path,
+    *,
+    dereference: bool = False,
+    preserve_owner: bool = True,
+) -> None:
     run([
         "cp",
         "--recursive",
-        "--no-dereference",
+        f"--{'' if dereference else 'no-'}dereference",
         f"--preserve=mode,timestamps,links,xattr{',ownership' if preserve_owner else ''}",
         "--no-target-directory",
         "--reflink=auto",

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -169,6 +169,10 @@ def is_dnf_distribution(d: Distribution) -> bool:
     )
 
 
+def is_apt_distribution(d: Distribution) -> bool:
+    return d in (Distribution.debian, Distribution.ubuntu)
+
+
 class OutputFormat(str, enum.Enum):
     directory = "directory"
     subvolume = "subvolume"


### PR DESCRIPTION
Additional repositories can now be configured for Debian and Ubuntu.

Because APT can only be configured with a single path for `Dir::Etc::sourceparts`, the content of the directories listed in `repo_dirs` are copied in a `apt/sources.list.d` directory managed by mkosi outside the image root. Therefore, only one file will be kept if several files have the same name.

Like the main `sources.list` generated by mkosi, the additional repositories are copied in the image if APT is installed.