### PR TITLE
Add preset support

### DIFF
--- a/.github/mkosi.conf.d/10-common.conf
+++ b/.github/mkosi.conf.d/10-common.conf
@@ -1,7 +1,6 @@
 [Output]
 CacheDirectory=mkosi.cache
-KernelCommandLine=console=hvc0
-                  systemd.unit=mkosi-check-and-shutdown.service
+KernelCommandLine=systemd.unit=mkosi-check-and-shutdown.service
                   systemd.log_target=console
                   systemd.default_standard_output=journal+console
 

--- a/.github/mkosi.conf.d/10-common.conf
+++ b/.github/mkosi.conf.d/10-common.conf
@@ -4,5 +4,8 @@ KernelCommandLine=systemd.unit=mkosi-check-and-shutdown.service
                   systemd.log_target=console
                   systemd.default_standard_output=journal+console
 
+[Content]
+Bootable=yes
+
 [Host]
 Autologin=yes

--- a/.github/mkosi.conf.d/20-alma.conf
+++ b/.github/mkosi.conf.d/20-alma.conf
@@ -9,4 +9,3 @@ Packages=kernel-core
          systemd
          systemd-boot
          systemd-udev
-         dracut

--- a/.github/mkosi.conf.d/20-arch.conf
+++ b/.github/mkosi.conf.d/20-arch.conf
@@ -4,4 +4,3 @@ Distribution=arch
 [Content]
 Packages=linux
          systemd
-         dracut

--- a/.github/mkosi.conf.d/20-centos.conf
+++ b/.github/mkosi.conf.d/20-centos.conf
@@ -6,4 +6,3 @@ Packages=kernel-core
          systemd
          systemd-boot
          systemd-udev
-         dracut

--- a/.github/mkosi.conf.d/20-debian.conf
+++ b/.github/mkosi.conf.d/20-debian.conf
@@ -7,5 +7,4 @@ Packages=linux-image-cloud-amd64
          systemd-boot
          systemd-sysv
          udev
-         dracut
          dbus

--- a/.github/mkosi.conf.d/20-fedora.conf
+++ b/.github/mkosi.conf.d/20-fedora.conf
@@ -6,5 +6,4 @@ Packages=kernel-core
          systemd
          systemd-boot
          systemd-udev
-         dracut
          util-linux

--- a/.github/mkosi.conf.d/20-opensuse.conf
+++ b/.github/mkosi.conf.d/20-opensuse.conf
@@ -3,6 +3,5 @@ Distribution=opensuse
 
 [Content]
 Packages=kernel-default
-         dracut
          systemd
          udev

--- a/.github/mkosi.conf.d/20-rocky.conf
+++ b/.github/mkosi.conf.d/20-rocky.conf
@@ -9,4 +9,3 @@ Packages=kernel-core
          systemd
          systemd-boot
          systemd-udev
-         dracut

--- a/.github/mkosi.conf.d/20-ubuntu.conf
+++ b/.github/mkosi.conf.d/20-ubuntu.conf
@@ -9,5 +9,4 @@ Packages=linux-virtual
          systemd
          systemd-sysv
          udev
-         dracut
          dbus

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: unit-test
     concurrency:
-      group: ${{ github.workflow }}-${{ matrix.distro }}-${{ matrix.format }}-${{ matrix.prebuilt-initrd }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ matrix.distro }}-${{ matrix.format }}-${{ github.ref }}
       cancel-in-progress: true
     defaults:
       run:
@@ -118,19 +118,14 @@ jobs:
           - fedora
           - rocky
           - alma
-          - gentoo
+          # Disabled until gentoo supports prebuilt initrds.
+          # - gentoo
           - opensuse
         format:
           - directory
           - tar
           - cpio
           - disk
-        prebuilt-initrd:
-          - no
-          - yes
-        exclude:
-          - distro: gentoo
-            prebuilt-initrd: yes
 
     steps:
     - uses: actions/checkout@v3
@@ -173,12 +168,6 @@ jobs:
     - name: Install
       run: sudo python3 -m pip install ..
 
-    - name: Build ${{ matrix.distro }} initrd
-      if: matrix.prebuilt-initrd == 'yes'
-      # Run the build in .github/workflows/ so we don't pick up any of the configuration files in .github/
-      run: python3 -m mkosi -d ${{ matrix.distro }} -t cpio -p systemd -p udev -p kmod --make-initrd -o $PWD/initrd build
-      working-directory: ./.github/workflows
-
     - name: Configure ${{ matrix.distro }}/${{ matrix.format }}
       run: |
         tee mkosi.conf.d/00-ci.conf <<- EOF
@@ -187,14 +176,6 @@ jobs:
 
         [Output]
         Format=${{ matrix.format }}
-        EOF
-
-    - name: Configure ${{ matrix.distro }}/${{ matrix.format }} initrd
-      if: matrix.prebuilt-initrd == 'yes'
-      run: |
-        tee mkosi.conf.d/00-initrd.conf <<- EOF
-        [Distribution]
-        Initrds=workflows/initrd.zst
         EOF
 
     - name: Resolve Arch geo mirror location

--- a/docs/bootable.md
+++ b/docs/bootable.md
@@ -10,7 +10,6 @@ distributions:
 [Content]
 Packages=linux
          systemd
-         dracut
 ```
 
 ## Fedora
@@ -21,7 +20,6 @@ Packages=kernel
          systemd
          systemd-boot
          systemd-udev
-         dracut
          util-linux
 ```
 
@@ -33,7 +31,6 @@ Packages=kernel
          systemd
          systemd-boot
          systemd-udev
-         dracut
 ```
 
 ## Debian
@@ -45,7 +42,6 @@ Packages=linux-image-generic
          systemd-boot
          systemd-sysv
          udev
-         dracut
          dbus
 ```
 
@@ -58,7 +54,6 @@ Packages=linux-image-generic
          systemd
          systemd-sysv
          udev
-         dracut
          dbus
 ```
 
@@ -67,7 +62,6 @@ Packages=linux-image-generic
 ```
 [Content]
 Packages=kernel-default
-         dracut
          systemd
          udev
 ```

--- a/mkosi.md
+++ b/mkosi.md
@@ -1380,7 +1380,7 @@ required components and let `mkosi` call `qemu` with all the right options:
 ```console
 $ mkosi -d fedora \
     --autologin \
-    -p systemd-udev,systemd-boot,dracut,kernel-core \
+    -p systemd-udev,systemd-boot,kernel-core \
     build
 $ mkosi -d fedora qemu
 ...

--- a/mkosi.md
+++ b/mkosi.md
@@ -729,7 +729,7 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 `Autologin=`, `--autologin`
 
 : Enable autologin for the `root` user on `/dev/pts/0` (nspawn),
-  `/dev/tty1` and `/dev/hvc0`.
+  `/dev/tty1` and `/dev/ttyS0`.
 
 `BuildScript=`, `--build-script=`
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2028,7 +2028,7 @@ def generate_secure_boot_key(args: MkosiArgs) -> None:
     cn = expand_specifier(args.secure_boot_common_name)
 
     for f in ("mkosi.secure-boot.key", "mkosi.secure-boot.crt"):
-        if f and not args.force:
+        if Path(f).exists() and not args.force:
             die(f"{f} already exists",
                 hint=("To generate new secure boot keys, "
                       "first remove mkosi.secure-boot.key and mkosi.secure-boot.crt"))

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -576,10 +576,16 @@ def install_build_dest(state: MkosiState) -> None:
         copy_path(install_dir(state), state.root, preserve_owner=False)
 
 
+def gzip_binary() -> str:
+    return "pigz" if shutil.which("pigz") else "gzip"
+
+
 def compressor_command(compression: Compression, src: Path) -> list[PathString]:
     """Returns a command suitable for compressing archives."""
 
-    if compression == Compression.xz:
+    if compression == Compression.gz:
+        return [gzip_binary(), "--fast", src]
+    elif compression == Compression.xz:
         return ["xz", "--check=crc32", "--fast", "-T0", src]
     elif compression == Compression.zst:
         return ["zstd", "-q", "-T0", "--rm", src]

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1071,7 +1071,7 @@ def check_inputs(config: MkosiConfig) -> None:
                      config.finalize_script):
             check_script_input(path)
     except OSError as e:
-        die(f'{e.filename} {e.strerror}')
+        die(f'{e.filename}: {e.strerror}')
 
 
 def check_outputs(config: MkosiConfig) -> None:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1296,7 +1296,7 @@ def configure_ssh(state: MkosiState) -> None:
 
     presetdir = state.root / "etc/systemd/system-preset"
     presetdir.mkdir(exist_ok=True, mode=0o755)
-    presetdir.joinpath("80-mkosi-ssh.preset").write_text("enable ssh.socket")
+    presetdir.joinpath("80-mkosi-ssh.preset").write_text("enable ssh.socket\n")
 
 
 def configure_initrd(state: MkosiState) -> None:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -576,15 +576,11 @@ def install_build_dest(state: MkosiState) -> None:
         copy_path(install_dir(state), state.root, preserve_owner=False)
 
 
-def xz_binary() -> str:
-    return "pxz" if shutil.which("pxz") else "xz"
-
-
 def compressor_command(compression: Compression, src: Path) -> list[PathString]:
     """Returns a command suitable for compressing archives."""
 
     if compression == Compression.xz:
-        return [xz_binary(), "--check=crc32", "--lzma2=dict=1MiB", "-T0", src]
+        return ["xz", "--check=crc32", "--fast", "-T0", src]
     elif compression == Compression.zst:
         return ["zstd", "-q", "-T0", "--rm", src]
     else:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -953,16 +953,11 @@ def unlink_output(args: MkosiArgs, config: MkosiConfig) -> None:
     with complete_step("Removing output files…"):
         if config.output.parent.exists():
             for p in config.output.parent.iterdir():
-                if p.name.startswith(config.output.name) and "cache" not in p.name:
+                if p.name.startswith(config.output.name):
                     unlink_try_hard(p)
+
         unlink_try_hard(Path(f"{config.output}.manifest"))
         unlink_try_hard(Path(f"{config.output}.changelog"))
-
-        if config.checksum:
-            unlink_try_hard(config.output_checksum)
-
-        if config.sign:
-            unlink_try_hard(config.output_signature)
 
         if config.output_split_kernel.parent.exists():
             for p in config.output_split_kernel.parent.iterdir():
@@ -995,20 +990,21 @@ def unlink_output(args: MkosiArgs, config: MkosiConfig) -> None:
         remove_package_cache = args.force > 2
 
     if remove_build_cache:
-        with complete_step("Removing incremental cache files…"):
-            for p in cache_tree_paths(config):
-                unlink_try_hard(p)
+        for p in cache_tree_paths(config):
+            if p.exists():
+                with complete_step(f"Removing cache directory {p}…"):
+                    unlink_try_hard(p)
 
-        if config.build_dir is not None:
+        if config.build_dir is not None and config.build_dir.exists() and any(config.build_dir.iterdir()):
             with complete_step("Clearing out build directory…"):
                 empty_directory(config.build_dir)
 
-        if config.install_dir is not None:
+        if config.install_dir is not None and config.install_dir.exists() and any(config.install_dir.iterdir()):
             with complete_step("Clearing out install directory…"):
                 empty_directory(config.install_dir)
 
     if remove_package_cache:
-        if config.cache_dir is not None:
+        if config.cache_dir is not None and config.cache_dir.exists() and any(config.cache_dir.iterdir()):
             with complete_step("Clearing out package cache…"):
                 empty_directory(config.cache_dir)
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1281,11 +1281,11 @@ def configure_ssh(state: MkosiState) -> None:
 
 
 def configure_initrd(state: MkosiState) -> None:
+    if not state.root.joinpath("init").exists() and state.root.joinpath("usr/lib/systemd/systemd").exists():
+        state.root.joinpath("init").symlink_to("/usr/lib/systemd/systemd")
+
     if not state.config.make_initrd:
         return
-
-    if not state.root.joinpath("init").exists():
-        state.root.joinpath("init").symlink_to("/usr/lib/systemd/systemd")
 
     if not state.root.joinpath("etc/initrd-release").exists():
         state.root.joinpath("etc/initrd-release").symlink_to("/etc/os-release")

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -363,8 +363,6 @@ def configure_autologin(state: MkosiState) -> None:
                                         "mkosi.resources", "console_getty_autologin.conf")
         add_dropin_config_from_resource(state.root, "serial-getty@ttyS0.service", "autologin",
                                         "mkosi.resources", "serial_getty_autologin.conf")
-        add_dropin_config_from_resource(state.root, "serial-getty@hvc0.service", "autologin",
-                                        "mkosi.resources", "serial_getty_autologin.conf")
         add_dropin_config_from_resource(state.root, "getty@tty1.service", "autologin",
                                         "mkosi.resources", "getty_autologin.conf")
 
@@ -1934,14 +1932,8 @@ def run_qemu(args: MkosiArgs, config: MkosiConfig) -> None:
             "-nographic",
             "-nodefaults",
             "-chardev", "stdio,mux=on,id=console,signal=off",
-            # Use virtconsole which appears as /dev/hvc0 in the guest on which a getty is automatically
-            # by spawned by systemd without needing a console= cmdline argument.
-            "-device", "virtio-serial",
-            "-device", "virtconsole,chardev=console",
-            "-mon", "console",
-            # EDK2 doesn't support virtio-serial, so add a regular serial console as well to get bootloader
-            # output.
             "-serial", "chardev:console",
+            "-mon", "console",
         ]
 
     for k, v in config.credentials.items():

--- a/mkosi/__main__.py
+++ b/mkosi/__main__.py
@@ -41,12 +41,12 @@ def propagate_failed_return() -> Iterator[None]:
 @propagate_failed_return()
 def main() -> None:
     log_setup()
-    args, config = MkosiConfigParser().parse()
+    args, presets = MkosiConfigParser().parse()
 
     if ARG_DEBUG.get():
         logging.getLogger().setLevel(logging.DEBUG)
 
-    run_verb(args, config)
+    run_verb(args, presets)
 
 
 if __name__ == "__main__":

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -755,6 +755,7 @@ class MkosiConfigParser:
             dest="kernel_command_line",
             section="Output",
             parse=config_make_list_parser(delimiter=" "),
+            default=["console=ttyS0"],
         ),
         MkosiConfigSetting(
             dest="secure_boot",
@@ -1860,13 +1861,10 @@ def load_kernel_command_line_extra(args: argparse.Namespace) -> list[str]:
     columns, lines = shutil.get_terminal_size()
 
     cmdline = [
-        f"systemd.tty.term.hvc0={os.getenv('TERM', 'vt220')}",
-        f"systemd.tty.columns.hvc0={columns}",
-        f"systemd.tty.rows.hvc0={lines}",
         f"systemd.tty.term.ttyS0={os.getenv('TERM', 'vt220')}",
         f"systemd.tty.columns.ttyS0={columns}",
         f"systemd.tty.rows.ttyS0={lines}",
-        "console=hvc0",
+        "console=ttyS0",
     ]
 
     if args.output_format == OutputFormat.cpio:

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1171,7 +1171,6 @@ class MkosiConfigParser:
         parser.add_argument(
             "-C", "--directory",
             help="Change to specified directory before doing anything",
-            type=Path,
             metavar="PATH",
             default=None,
         )
@@ -1695,13 +1694,14 @@ class MkosiConfigParser:
         if args.verb == Verb.help:
             PagerHelpAction.__call__(None, argparser, namespace)  # type: ignore
 
-        if args.directory and not args.directory.is_dir():
+        if args.directory and not Path(args.directory).is_dir():
             die(f"{args.directory} is not a directory!")
 
         if args.directory:
             os.chdir(args.directory)
 
-        self.parse_config(Path("."), namespace)
+        if args.directory != "":
+            self.parse_config(Path("."), namespace)
 
         for s in self.SETTINGS:
             if s.dest in namespace:
@@ -1820,7 +1820,7 @@ def load_credentials(args: argparse.Namespace) -> dict[str, str]:
     creds = {}
 
     d = Path("mkosi.credentials")
-    if d.is_dir():
+    if args.directory != "" and d.is_dir():
         for e in d.iterdir():
             if os.access(e, os.X_OK):
                 creds[e.name] = run([e], text=True, stdout=subprocess.PIPE, env=os.environ).stdout

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1836,8 +1836,10 @@ def load_credentials(args: argparse.Namespace) -> dict[str, str]:
             ["timedatectl", "show", "-p", "Timezone", "--value"],
             text=True,
             stdout=subprocess.PIPE,
+            check=False,
         ).stdout.strip()
-        creds["firstboot.timezone"] = tz
+        if tz:
+            creds["firstboot.timezone"] = tz
 
     if "firstboot.locale" not in creds:
         creds["firstboot.locale"] = "C.UTF-8"
@@ -1851,8 +1853,10 @@ def load_credentials(args: argparse.Namespace) -> dict[str, str]:
             text=True,
             stdout=subprocess.PIPE,
             env=os.environ,
+            check=False,
         ).stdout.strip()
-        creds["ssh.authorized_keys.root"] = key
+        if key:
+            creds["ssh.authorized_keys.root"] = key
 
     return creds
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1885,8 +1885,10 @@ def load_kernel_command_line_extra(args: argparse.Namespace) -> list[str]:
 
 
 def load_args(args: argparse.Namespace) -> MkosiArgs:
-    ARG_DEBUG.set(args.debug)
-    ARG_DEBUG_SHELL.set(args.debug_shell)
+    if args.debug:
+        ARG_DEBUG.set(args.debug)
+    if args.debug_shell:
+        ARG_DEBUG_SHELL.set(args.debug_shell)
 
     return MkosiArgs.from_namespace(args)
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1432,6 +1432,7 @@ class MkosiConfigParser:
             "--bootable",
             metavar="FEATURE",
             help="Generate ESP partition with systemd-boot and UKIs for installed kernels",
+            nargs="?",
             action=action,
         )
         group.add_argument("--password", help="Set the root password", action=action)

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -392,8 +392,11 @@ def config_make_path_parser(*,
     return config_parse_path
 
 
-def match_path_exists(path: Path, value: str) -> bool:
-    return path.parent.joinpath(value).exists()
+def match_path_exists(value: str) -> bool:
+    if not value:
+        return False
+
+    return Path(value).exists()
 
 
 @dataclasses.dataclass(frozen=True)
@@ -415,7 +418,7 @@ class MkosiConfigSetting:
 @dataclasses.dataclass(frozen=True)
 class MkosiMatch:
     name: str
-    match: Callable[[Path, str], bool]
+    match: Callable[[str], bool]
 
 
 class CustomHelpFormatter(argparse.HelpFormatter):
@@ -1081,7 +1084,7 @@ class MkosiConfigParser:
                         return
 
                 elif (m := self.match_lookup.get(k)):
-                    if not m.match(path, v):
+                    if not m.match(v):
                         return
 
         parser.remove_section("Match")

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -17,10 +17,6 @@ class DistributionInstaller:
     def kernel_image(kver: str, architecture: str) -> Path:
         return Path("usr/lib/modules") / kver / "vmlinuz"
 
-    @staticmethod
-    def initrd_path(kver: str) -> Path:
-        return Path("boot") / f"initramfs-{kver}.img"
-
     @classmethod
     def install_packages(cls, state: "MkosiState", packages: Sequence[str]) -> None:
         raise NotImplementedError

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -78,7 +78,8 @@ class CentosInstaller(DistributionInstaller):
 
     @classmethod
     def install(cls, state: MkosiState) -> None:
-        cls.install_packages(state, ["filesystem"], apivfs=False)
+        # Make sure glibc-minimal-langpack is installed instead of glibc-all-langpacks.
+        cls.install_packages(state, ["filesystem", "glibc-minimal-langpack"], apivfs=False)
 
         # On Fedora, the default rpmdb has moved to /usr/lib/sysimage/rpm so if that's the case we need to
         # move it back to /var/lib/rpm on CentOS.

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -22,10 +22,6 @@ class DebianInstaller(DistributionInstaller):
         return Path(f"boot/vmlinuz-{name}")
 
     @staticmethod
-    def initrd_path(kver: str) -> Path:
-        return Path("boot") / f"initrd.img-{kver}"
-
-    @staticmethod
     def repositories(state: MkosiState, local: bool = True) -> list[str]:
         repos = ' '.join(("main", *state.config.repositories))
 

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 from collections.abc import Sequence
-from pathlib import Path
 from textwrap import dedent
 
 from mkosi.distributions import DistributionInstaller
@@ -51,10 +50,6 @@ class OpensuseInstaller(DistributionInstaller):
     @classmethod
     def remove_packages(cls, state: MkosiState, packages: Sequence[str]) -> None:
         invoke_zypper(state, "remove", ["-y", "--clean-deps"], packages)
-
-    @staticmethod
-    def initrd_path(kver: str) -> Path:
-        return Path("boot") / f"initrd-{kver}"
 
 
 def setup_zypper(state: MkosiState, repos: Sequence[tuple[str, str]] = ()) -> None:

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from textwrap import dedent
 
 from mkosi.distributions import DistributionInstaller
+from mkosi.distributions.fedora import fixup_rpmdb_location
 from mkosi.run import bwrap
 from mkosi.state import MkosiState
 from mkosi.types import PathString
@@ -108,3 +109,4 @@ def invoke_zypper(
 
     bwrap(cmdline, apivfs=state.root if apivfs else None, env=env)
 
+    fixup_rpmdb_location(state.root)


### PR DESCRIPTION
Presets can be defined in mkosi.presets/. A preset is just like a
regular config file/directory, except that mkosi can build multiple
presets sequentially.

If mkosi.presets/ exists, for each preset mkosi will read the global
configuration, followed by the individual preset configuration. It
will then build each of the presets in alpha-numerical order. Later
presets can use outputs of earlier presets, specifically using the
BaseTrees= and Initrds= options.

While this has many use cases, one promising use case is to allow
building an initrd and a final image that uses that initrd within a
single invocation of mkosi.