### PR TITLE
Ensure that username and uid are consistent

### DIFF
--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -245,9 +245,7 @@ class InvokingUser:
 
     @classmethod
     def name(cls) -> str:
-        if uid := cls._uid_from_env():
-            return pwd.getpwuid(uid).pw_name
-        return getpass.getuser()
+        return pwd.getpwuid(cls.uid()).pw_name
 
     @classmethod
     def home(cls) -> Path:


### PR DESCRIPTION
While SUDO_UID and SUDO_GID are useful, since sudo allows to run things as different UID and GID, SUDO_USER is less useful, since it can't change the mapping from UID to name in the namespace it's in. Let's cut out the middleman of getpass.getuser, that looks through several more environment variables (LOGNAME, USER, LNAME, USERNAME) before falling back to os.getuid and looking up the corresponding name and do that right away.