### PR TITLE
Fix signing of checksums, especially for non-root user

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -848,7 +848,21 @@ def calculate_signature(state: MkosiState) -> None:
             state.staging / state.config.output_checksum.name,
         ]
 
-        run(cmdline)
+        run(
+            cmdline,
+            # Do not output warnings about keyring permissions
+            stderr=subprocess.DEVNULL,
+            env={
+                # Set the path of the keyring to use based on the environment
+                # if possible and fallback to the default path. Without this the
+                # keyring for the root user will instead be used which will fail
+                # for a non-root build.
+                'GNUPGHOME': os.environ.get(
+                    'GNUPGHOME',
+                    Path(os.environ['HOME']).joinpath('.gnupg')
+                )
+            }
+        )
 
 
 def acl_toggle_remove(config: MkosiConfig, root: Path, uid: int, *, allow: bool) -> None:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -837,15 +837,16 @@ def calculate_signature(state: MkosiState) -> None:
         return None
 
     with complete_step("Signing SHA256SUMS…"):
-        cmdline: list[PathString] = [
-            "gpg",
-            "--detach-sign",
-            "-o", state.staging / state.config.output_signature.name,
-            state.staging / state.config.output_checksum.name,
-        ]
+        cmdline: list[PathString] = ["gpg", "--detach-sign"]
 
+        # Need to specify key before file to sign
         if state.config.key is not None:
             cmdline += ["--default-key", state.config.key]
+
+        cmdline += [
+            "--output", state.staging / state.config.output_signature.name,
+            state.staging / state.config.output_checksum.name,
+        ]
 
         run(cmdline)
 


### PR DESCRIPTION
Signing is failing when using the below configuration snippet.

```ini
[Validation]
Checksum   = yes
Sign       = yes
Key        = ...
```

This is occurring for two reasons:

  * The option `--default-key` needs to be specified before the file to sign
  * The keyring path is incorrect when running as a non-root user

I'm happy to split these patches into two PRs. I'm also happy to take any feedback since I'm munging environment variables and there's likely a nicer way to get this done.