### PR TITLE
Store file hash and signature in output directory

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -608,11 +608,11 @@ class MkosiConfig:
 
     @property
     def output_checksum(self) -> Path:
-        return Path("SHA256SUMS")
+        return build_auxiliary_output_path(self, ".SHA256SUMS")
 
     @property
     def output_signature(self) -> Path:
-        return Path("SHA256SUMS.gpg")
+        return build_auxiliary_output_path(self, ".SHA256SUMS.gpg")
 
     @property
     def output_sshkey(self) -> Path:


### PR DESCRIPTION
Every other output file is stored within the output directory from what I could see, so the hash and signature should be stored there too.