### PR TITLE
Cache only files installed on top of base trees

### DIFF
--- a/mkosi/state.py
+++ b/mkosi/state.py
@@ -40,12 +40,17 @@ class MkosiState:
 
         self.root.mkdir(exist_ok=True, mode=0o755)
         self.build_overlay.mkdir(exist_ok=True, mode=0o755)
+        self.cache_overlay.mkdir(exist_ok=True, mode=0o755)
         self.workdir.mkdir(exist_ok=True)
         self.staging.mkdir(exist_ok=True)
 
     @property
     def root(self) -> Path:
         return self.workspace / "root"
+
+    @property
+    def cache_overlay(self) -> Path:
+        return self.workspace / "cache-overlay"
 
     @property
     def build_overlay(self) -> Path:


### PR DESCRIPTION
Currently, when base trees are used in incremental mode, we cache the base trees as well. When running from a cache copy, any changes to the base trees are not taken into account. Let's change this and only cache the files we add/change/delete on top of the base layers. This makes sure that we can still use our cache even if the base layer changes, since we won't ignore all changes made to the base layer.