### PR TITLE
distro: debian: allow RemovePackages

### DIFF
--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -174,6 +174,8 @@ def setup_apt(state: MkosiState, repos: Sequence[str]) -> None:
             APT::Install-Recommends "false";
             APT::Get::Assume-Yes "true";
             APT::Get::AutomaticRemove "true";
+            APT::Get::Allow-Change-Held-Packages "true";
+            APT::Get::Allow-Remove-Essential "true";
             APT::Sandbox::User "root";
             Dir::Cache "{state.cache}";
             Dir::State "{state.workspace / "apt"}";


### PR DESCRIPTION
When using `RemovePackages`= apt may refuse to remove what it considers essential packages even when they are effectively empty meta packages or contain only `usr/share/doc/${package}/`

This causes build failure like this:
```
Reading state information...
Package 'netcat-openbsd' is not installed, so not removed Package 'net-tools' is not installed, so not removed Package 'man-db' is not installed, so not removed
Package 'groff-base' is not installed, so not removed The following packages will be REMOVED:
  cron* dmidecode* fdisk* ifupdown* init* iproute2* iputils-ping*
  isc-dhcp-client* isc-dhcp-common* kmod* libbpf0* libbsd0* libcap2-bin*
  libdns-export1110* libedit2* libelf1* libfdisk1* libisc-export1105*
  libjansson4* libmd0* libmnl0* libnftables1* libnftnl11* libxtables12*
nano*
  netbase* nftables* udev* vim-common* vim-tiny* xxd*
WARNING: The following essential packages will be removed. This should NOT be done unless you know exactly what you are doing!
  init
0 upgraded, 0 newly installed, 31 to remove and 0 not upgraded. E: Essential packages were removed and -y was used without --allow-remove-essential.
‣ "apt-get purge vim-tiny vim-common nano nftables netcat-openbsd netbase net-tools isc-dhcp-common isc-dhcp-client iputils-ping iprout e2 udev kmod fdisk dmidecode man-db init ifupdown groff-base cron" returned non-zero exit code 100.
Traceback (most recent call last):
File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
```
As we do know what we are doing to have configured these removals, tell apt to allow it.