### PR TITLE
Mount package cache for all scripts

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -393,6 +393,9 @@ def run_prepare_script(state: MkosiState, build: bool) -> None:
         "--chdir", "/root/src",
     ]
 
+    if state.installer.cache_path():
+        bwrap.extend(["--bind", state.cache, cast(Path, state.installer.cache_path())])
+
     def clean() -> None:
         srcdir = state.root / "root/src"
         if srcdir.exists():
@@ -430,6 +433,9 @@ def run_postinst_script(state: MkosiState) -> None:
         bwrap: list[PathString] = [
             "--bind", state.config.postinst_script, "/root/postinst",
         ]
+
+    if state.installer.cache_path():
+        bwrap.extend(["--bind", state.cache, cast(Path, state.installer.cache_path())])
 
         run_workspace_command(state.root, ["/root/postinst", "final"], bwrap_params=bwrap,
                               network=state.config.with_network, env=state.environment)
@@ -1570,6 +1576,9 @@ def run_build_script(state: MkosiState) -> None:
             "--bind", install_dir(state), "/work/dest",
             "--chdir", "/work/src",
         ]
+
+        if state.installer.cache_path():
+            bwrap.extend(["--bind", state.cache, cast(Path, state.installer.cache_path())])
 
         env = dict(
             WITH_DOCS=one_zero(state.config.with_docs),

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from mkosi.state import MkosiState
@@ -32,6 +32,10 @@ class DistributionInstaller:
     @classmethod
     def filesystem(cls) -> str:
         raise NotImplementedError
+
+    @classmethod
+    def cache_path(cls) -> Optional[Path]:
+        return None
 
     @classmethod
     def filesystem_options(cls, state: "MkosiState") -> dict[str, list[str]]:

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 from collections.abc import Sequence
+from pathlib import Path
 from textwrap import dedent
+from typing import Optional
 
 from mkosi.distributions import DistributionInstaller
 from mkosi.run import bwrap
@@ -14,6 +16,10 @@ class ArchInstaller(DistributionInstaller):
     @classmethod
     def filesystem(cls) -> str:
         return "ext4"
+
+    @classmethod
+    def cache_path(cls) -> Optional[Path]:
+        return Path("/var/cache/pacman/pkg/")
 
     @classmethod
     def install(cls, state: MkosiState) -> None:

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -5,6 +5,7 @@ import tempfile
 from collections.abc import Sequence
 from pathlib import Path
 from textwrap import dedent
+from typing import Optional
 
 from mkosi.distributions import DistributionInstaller
 from mkosi.run import bwrap, run
@@ -16,6 +17,10 @@ class DebianInstaller(DistributionInstaller):
     @classmethod
     def filesystem(cls) -> str:
         return "ext4"
+
+    @classmethod
+    def cache_path(cls) -> Optional[Path]:
+        return Path("/var/cache/apt/")
 
     @staticmethod
     def kernel_image(name: str, architecture: str) -> Path:

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -23,6 +23,10 @@ class FedoraInstaller(DistributionInstaller):
         return "btrfs"
 
     @classmethod
+    def cache_path(cls) -> Optional[Path]:
+        return Path("/var/cache/dnf")
+
+    @classmethod
     def install(cls, state: MkosiState) -> None:
         cls.install_packages(state, ["filesystem"], apivfs=False)
 

--- a/mkosi/distributions/mageia.py
+++ b/mkosi/distributions/mageia.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Optional
 
 from mkosi.distributions import DistributionInstaller
 from mkosi.distributions.fedora import Repo, invoke_dnf, setup_dnf
@@ -12,6 +13,10 @@ class MageiaInstaller(DistributionInstaller):
     @classmethod
     def filesystem(cls) -> str:
         return "ext4"
+
+    @classmethod
+    def cache_path(cls) -> Optional[Path]:
+        return Path("/var/cache/dnf")
 
     @classmethod
     def install(cls, state: MkosiState) -> None:

--- a/mkosi/distributions/openmandriva.py
+++ b/mkosi/distributions/openmandriva.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Optional
 
 from mkosi.distributions import DistributionInstaller
 from mkosi.distributions.fedora import Repo, invoke_dnf, setup_dnf
@@ -12,6 +13,10 @@ class OpenmandrivaInstaller(DistributionInstaller):
     @classmethod
     def filesystem(cls) -> str:
         return "ext4"
+
+    @classmethod
+    def cache_path(cls) -> Optional[Path]:
+        return Path("/var/cache/dnf")
 
     @classmethod
     def install(cls, state: MkosiState) -> None:

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -3,6 +3,7 @@
 from collections.abc import Sequence
 from pathlib import Path
 from textwrap import dedent
+from typing import Optional
 
 from mkosi.distributions import DistributionInstaller
 from mkosi.run import bwrap
@@ -14,6 +15,10 @@ class OpensuseInstaller(DistributionInstaller):
     @classmethod
     def filesystem(cls) -> str:
         return "btrfs"
+
+    @classmethod
+    def cache_path(cls) -> Optional[Path]:
+        return Path("/var/cache/zypp")
 
     @classmethod
     def install(cls, state: MkosiState) -> None:


### PR DESCRIPTION
A script may need to add additional packages at any time, even during post-install. As a result it is worth the effort to mount the package cache during every execution of a user provided script.

As an example, here is what an adjusted systemd build would look like under Ubuntu:

mkosi.build:
```shell
# Install build dependencies for systemd
mkdir /var/tmp/systemd && cd /var/tmp/systemd
pull-lp-source systemd $(lsb_release -cs)
cd $(find -mindepth 1 -maxdepth 1 -type d)
/usr/lib/pbuilder/pbuilder-satisfydepends-apt --control ../*.dsc

# Enable sysupdate support
sed -i s/"sysupdate=false"/"sysupdate=true"/ debian/rules

# Bump version
dch --increment "Enabled additional options"

# Build source
dpkg-buildpackage --build=source --unsigned-source --unsigned-changes --no-check-builddeps

# Build binary
dpkg-buildpackage --build=binary --unsigned-source --unsigned-changes

# Prune and copy packages
rm ../systemd-standalone*.deb
mv ../*.deb "$DESTDIR/"
```

mkosi.postinst:
```shell
# There are no additional dependencies installed, but just pretend there are.
apt-get install --yes -o Dpkg::Progress-Fancy="0" /*.deb
```