### PR TITLE
fix: prefix must be valid machine name

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1964,6 +1964,11 @@ def load_config(args: argparse.Namespace) -> MkosiConfig:
             output = prefix
         args.output = Path(output)
 
+    if "_" in str(args.output) and args.output_format == OutputFormat.subvolume:
+        old = str(args.output)
+        args.output = args.output.with_name(args.output.name.replace("_", "-"))
+        logging.warning(f"subvolume (systemd-machined) names cannot contain underscore(_); converting to hypen (-). {old} -> {args.output} ")
+
     if args.output_dir is not None:
         if "/" not in str(args.output):
             args.output = args.output_dir / args.output


### PR DESCRIPTION
Due to strict rules checks by machinectl using validate_hostname() underscores are invalid in machine names.

Noted in issue #1525.

Reported documentation error in
https://github.com/systemd/systemd/issues/27481