### PR TITLE
Add support for PackageDirectories

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -136,6 +136,7 @@ in consecutive runs with data from the cached one.
 * Run build script on image + build overlay if a build script is configured (`mkosi.build`)
 * Copy the build script outputs into the image
 * Copy the extra trees into the image (`mkosi.extra`)
+* Install package files (`mkosi.packagedir`)
 * Run `kernel-install`
 * Install systemd-boot
 * Run post-install script (`mkosi.postinst`)
@@ -584,6 +585,14 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   would remove the apache2 package. To replace the apache2 package by
   the httpd package just add -p "!apache2,httpd" to the command line
   arguments. To remove all packages use "!\*".
+
+`PackageDirectories=`, `--package-dir=`
+
+: Install package files (i.e. .rpm or .deb archives) from the specified
+  directories into the image. Place packages that cannot be fetched using the
+  package manager into this directory. This step is performed after the build
+  script is run to support installing built package files. Note that
+  `mkosi.installdir` is **not** automatically processed.
 
 : Example: when using an distro that uses `dnf`,
   `Packages=meson libfdisk-devel.i686 git-* prebuilt/rpms/systemd-249-rc1.local.rpm /usr/bin/ld @development-tools python3dist(mypy)`

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -33,7 +33,7 @@ from mkosi.config import (
 from mkosi.install import add_dropin_config_from_resource, copy_path, flock
 from mkosi.log import Style, color_error, complete_step, die, log_step
 from mkosi.manifest import Manifest
-from mkosi.mounts import dissect_and_mount, mount_overlay, scandir_recursive
+from mkosi.mounts import dissect_and_mount, mount_bind, mount_overlay, scandir_recursive
 from mkosi.pager import page
 from mkosi.remove import unlink_try_hard
 from mkosi.run import (
@@ -569,6 +569,18 @@ def install_extra_trees(state: MkosiState) -> None:
                 copy_path(source, t, preserve_owner=False)
             else:
                 shutil.unpack_archive(source, t)
+
+
+def install_pkgdirs(state: MkosiState) -> None:
+    '''Add packages to image from package files'''
+
+    if not state.config.package_dirs:
+        return
+
+    for dir in state.config.package_dirs:
+        with complete_step(f"Installing packages from files in {dir}…"):
+            with mount_bind(dir, state.root / "packages"):
+                state.installer.install_package_files(state, dir)
 
 
 def install_build_dest(state: MkosiState) -> None:
@@ -1512,6 +1524,7 @@ def build_image(state: MkosiState, *, for_cache: bool, manifest: Optional[Manife
         run_build_script(state)
         install_build_dest(state)
         install_extra_trees(state)
+        install_pkgdirs(state)
         install_boot_loader(state)
         configure_ssh(state)
         run_postinst_script(state)

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -542,6 +542,7 @@ class MkosiConfig:
     tar_strip_selinux_context: bool
     incremental: bool
     packages: list[str]
+    package_dirs: list[Path]
     remove_packages: list[str]
     with_docs: bool
     with_tests: bool
@@ -836,6 +837,13 @@ class MkosiConfigParser:
             dest="packages",
             section="Content",
             parse=config_make_list_parser(delimiter=","),
+        ),
+        MkosiConfigSetting(
+            dest="package_dirs",
+            name="PackageDirectories",
+            section="Content",
+            parse=config_make_list_parser(delimiter=",", parse=make_path_parser()),
+            paths=("mkosi.packagedir",),
         ),
         MkosiConfigSetting(
             dest="remove_packages",
@@ -1419,6 +1427,13 @@ class MkosiConfigParser:
             action=action,
         )
         group.add_argument(
+            "--package-dirs",
+            metavar="PATH",
+            help="Add package files from this directory to the OS image",
+            dest="package_dirs",
+            action=action,
+        )
+        group.add_argument(
             "--remove-package",
             metavar="PACKAGE",
             help="Remove package from the image OS image after installation",
@@ -1677,6 +1692,7 @@ class MkosiConfigParser:
 
         return parser
 
+
     def parse(self, argv: Optional[Sequence[str]] = None) -> tuple[MkosiArgs, tuple[MkosiConfig, ...]]:
         presets = []
         namespace = argparse.Namespace()
@@ -1757,6 +1773,7 @@ class MkosiConfigParser:
 
         return args, tuple(load_config(ns) for ns in presets)
 
+
 class GenericVersion:
     def __init__(self, version: str):
         self._version = version
@@ -1796,6 +1813,7 @@ class GenericVersion:
             return False
         cmd = ["systemd-analyze", "compare-versions", self._version, "ge", other._version]
         return run(cmd, check=False).returncode == 0
+
 
 def strip_suffixes(path: Path) -> Path:
     while path.suffix in {
@@ -1847,7 +1865,6 @@ def find_password(args: argparse.Namespace) -> None:
 
     except FileNotFoundError:
         pass
-
 
 
 def machine_name(config: Union[MkosiConfig, argparse.Namespace]) -> str:

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -22,6 +22,10 @@ class DistributionInstaller:
         raise NotImplementedError
 
     @classmethod
+    def install_package_files(cls, state: "MkosiState", dir: Path) -> None:
+        raise NotImplementedError
+
+    @classmethod
     def remove_packages(cls, state: "MkosiState", packages: Sequence[str]) -> None:
         raise NotImplementedError
 

--- a/mkosi/distributions/openmandriva.py
+++ b/mkosi/distributions/openmandriva.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
+import shutil
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -17,8 +18,8 @@ class OpenmandrivaInstaller(DistributionInstaller):
     def install(cls, state: MkosiState) -> None:
         cls.install_packages(state, ["filesystem"])
 
-    @classmethod
-    def install_packages(cls, state: MkosiState, packages: Sequence[str], apivfs: bool = True) -> None:
+    @staticmethod
+    def repositories(state: MkosiState) -> list[Repo]:
         release = state.config.release.strip("'")
 
         if release[0].isdigit():
@@ -46,8 +47,32 @@ class OpenmandrivaInstaller(DistributionInstaller):
         if updates_url is not None:
             repos += [Repo("updates", updates_url, gpgpath)]
 
+        return repos
+
+    @classmethod
+    def install_packages(cls, state: MkosiState, packages: Sequence[str], apivfs: bool = True) -> None:
+        repos = cls.repositories(state)
         setup_dnf(state, repos)
         invoke_dnf(state, "install", packages, apivfs=apivfs)
+
+    @classmethod
+    def install_package_files(cls, state: MkosiState, dir: Path) -> None:
+        repos = cls.repositories(state)
+        setup_dnf(state, repos)
+
+        file_paths : list[str] = [
+            str(state.root / "packages" / p.name)
+            for p in dir.iterdir()
+            if p.name.endswith('.rpm')
+        ]
+
+        if (shutil.which('dnf5') or shutil.which('dnf') or 'yum') == 'yum':
+            verb = "localinstall"
+        else:
+            verb = "install"
+
+        if file_paths:
+            invoke_dnf(state, verb, file_paths)
 
     @classmethod
     def remove_packages(cls, state: MkosiState, packages: Sequence[str]) -> None:

--- a/mkosi/mounts.py
+++ b/mkosi/mounts.py
@@ -85,6 +85,12 @@ def mount(
 
 
 @contextlib.contextmanager
+def mount_bind(what: PathString, where: Path) -> Iterator[Path]:
+    with mount(what, where, options=["bind"]):
+        yield where
+
+
+@contextlib.contextmanager
 def mount_overlay(
     lowerdirs: Sequence[Path],
     upperdir: Path,


### PR DESCRIPTION
This change supports installing package files from within a directory. Only direct files are supported (no recursive lookups). The intent is to install downloaded packages that are not available from a repository, and to directly install built packages after running the build script.

Gentoo and OpenSuSE are not supported due to the way their package managers operate.

Distribution support needed to be re-worked to support this change. This is because the operations required before `invoke_dnf()/invoke_apt()` are now common between `install_packages()` and `install_package_files()`.