### PR TITLE
subvol: take advantage of copy-on-write

### DIFF
--- a/mkosi/state.py
+++ b/mkosi/state.py
@@ -20,6 +20,7 @@ class MkosiState:
     cache: Path
     environment: dict[str, str] = dataclasses.field(init=False)
     installer: DistributionInstaller = dataclasses.field(init=False)
+    btrfs_snapshot: bool = False
 
     def __post_init__(self) -> None:
         self.environment = self.config.environment.copy()


### PR DESCRIPTION
When the output subvol and workspace/root are in the same BTRFS take advantage of copy-on-write and snapshots by making root a subvol and taking a snapshot of it for the output before deleting workspace.

This also fixes issue #1525 (subvol: output missing!)