### PR TITLE
subvolume: create and take advantage of copy-on-write

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -331,7 +331,8 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 
 : The image format type to generate. One of `directory` (for generating OS
   images inside a local directory), `subvolume` (similar, but as a btrfs
-  subvolume), `tar` (similar, but a tarball of the image is generated), `cpio`
+  subvolume), `subvolume_ro` (btrfs read-only subvolume),
+  `tar` (similar, but a tarball of the image is generated), `cpio`
   (similar, but a cpio archive is generated), `disk` (a block device image
   with a GPT partition table).
 

--- a/mkosi/state.py
+++ b/mkosi/state.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from mkosi.config import MkosiConfig
 from mkosi.distributions import DistributionInstaller
 from mkosi.log import die
+from mkosi.util import OutputFormat
 
 
 @dataclasses.dataclass
@@ -18,8 +19,10 @@ class MkosiState:
     config: MkosiConfig
     workspace: Path
     cache: Path
+    output_format: OutputFormat
     environment: dict[str, str] = dataclasses.field(init=False)
     installer: DistributionInstaller = dataclasses.field(init=False)
+    btrfs_snapshot: bool = False
 
     def __post_init__(self) -> None:
         self.environment = self.config.environment.copy()

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -177,6 +177,7 @@ def is_apt_distribution(d: Distribution) -> bool:
 class OutputFormat(str, enum.Enum):
     directory = "directory"
     subvolume = "subvolume"
+    subvolume_ro = "subvolume_ro"
     tar = "tar"
     cpio = "cpio"
     disk = "disk"


### PR DESCRIPTION
Ensure a subvolume is created.

When the output subvol and workspace/root are in the same BTRFS take advantage of copy-on-write and snapshots by making root a subvol and taking a snapshot of it for the output before deleting workspace.

Closes: https://github.com/systemd/mkosi/issues/1525
Closes: https://github.com/systemd/mkosi/issues/1534