### PR TITLE
opensuse: Use dnf instead of zypper

### DIFF
--- a/.github/mkosi.conf.d/20-opensuse.conf
+++ b/.github/mkosi.conf.d/20-opensuse.conf
@@ -2,6 +2,6 @@
 Distribution=opensuse
 
 [Content]
-Packages=kernel-default
+Packages=kernel-kvmsmall
          systemd
          udev

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -173,7 +173,7 @@ def config_default_release(namespace: argparse.Namespace) -> Any:
         Distribution.centos: "9",
         Distribution.rocky: "9",
         Distribution.alma: "9",
-        Distribution.mageia: "7",
+        Distribution.mageia: "cauldron",
         Distribution.debian: "testing",
         Distribution.ubuntu: "jammy",
         Distribution.opensuse: "tumbleweed",

--- a/mkosi/distributions/alma.py
+++ b/mkosi/distributions/alma.py
@@ -1,24 +1,16 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
-from pathlib import Path
-
 from mkosi.distributions.centos import CentosInstaller
 
 
 class AlmaInstaller(CentosInstaller):
     @staticmethod
-    def _gpg_locations(release: int) -> tuple[Path, str]:
-        return (
-            Path("/etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-$releasever"),
-            "https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux-$releasever",
-        )
+    def _gpgurl(release: int) -> str:
+        return "https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux-$releasever"
 
     @staticmethod
-    def _extras_gpg_locations(release: int) -> tuple[Path, str]:
-        return (
-            Path("/etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-$releasever"),
-            "https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux-$releasever",
-        )
+    def _extras_gpgurl(release: int) -> str:
+        return "https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux-$releasever"
 
     @classmethod
     def _mirror_directory(cls) -> str:

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -144,8 +144,8 @@ class CentosInstaller(DistributionInstaller):
             epel_testing_url = "metalink=https://mirrors.fedoraproject.org/metalink?repo=testing-epel$releasever&arch=$basearch"
 
         return [
-            Repo("epel", epel_url, epel_gpgurl, enabled=False),
-            Repo("epel-testing", epel_testing_url, epel_gpgurl, enabled=False),
+            Repo("epel", epel_url, [epel_gpgurl], enabled=False),
+            Repo("epel-testing", epel_testing_url, [epel_gpgurl], enabled=False),
         ]
 
     @classmethod
@@ -179,15 +179,15 @@ class CentosInstaller(DistributionInstaller):
                 crb_url = None
                 powertools_url = f"mirrorlist={cls._mirror_repo_url('PowerTools')}"
 
-        repos = [Repo("appstream", appstream_url, gpgurl)]
+        repos = [Repo("appstream", appstream_url, [gpgurl])]
         if baseos_url is not None:
-            repos += [Repo("baseos", baseos_url, gpgurl)]
+            repos += [Repo("baseos", baseos_url, [gpgurl])]
         if extras_url is not None:
-            repos += [Repo("extras", extras_url, gpgurl)]
+            repos += [Repo("extras", extras_url, [gpgurl])]
         if crb_url is not None:
-            repos += [Repo("crb", crb_url, gpgurl)]
+            repos += [Repo("crb", crb_url, [gpgurl])]
         if powertools_url is not None:
-            repos += [Repo("powertools", powertools_url, gpgurl)]
+            repos += [Repo("powertools", powertools_url, [gpgurl])]
         repos += cls._epel_repos(config)
 
         return repos
@@ -213,13 +213,13 @@ class CentosInstaller(DistributionInstaller):
             extras_url = "metalink=https://mirrors.centos.org/metalink?repo=centos-extras-sig-extras-common-$stream&arch=$basearch&protocol=https,http"
             crb_url = "metalink=https://mirrors.centos.org/metalink?repo=centos-crb-$stream&arch=$basearch&protocol=https,http"
 
-        repos = [Repo("appstream", appstream_url, gpgurl)]
+        repos = [Repo("appstream", appstream_url, [gpgurl])]
         if baseos_url is not None:
-            repos += [Repo("baseos", baseos_url, gpgurl)]
+            repos += [Repo("baseos", baseos_url, [gpgurl])]
         if extras_url is not None:
-            repos += [Repo("extras", extras_url, extras_gpgurl)]
+            repos += [Repo("extras", extras_url, [extras_gpgurl])]
         if crb_url is not None:
-            repos += [Repo("crb", crb_url, gpgurl)]
+            repos += [Repo("crb", crb_url, [gpgurl])]
         repos += cls._epel_repos(config)
 
         return repos

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -110,25 +110,16 @@ class CentosInstaller(DistributionInstaller):
         invoke_dnf(state, "remove", packages)
 
     @staticmethod
-    def _gpg_locations(release: int) -> tuple[Path, str]:
-        return (
-            Path("/etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial"),
-            "https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official"
-        )
+    def _gpgurl(release: int) -> str:
+        return "https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official"
 
     @staticmethod
-    def _epel_gpg_locations() -> tuple[Path, str]:
-        return (
-            Path("/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-$releasever"),
-            "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever",
-        )
+    def _epel_gpgurl() -> str:
+        return "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever"
 
     @staticmethod
-    def _extras_gpg_locations(release: int) -> tuple[Path, str]:
-        return (
-            Path("/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Extras-SHA512"),
-            "https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Extras"
-        )
+    def _extras_gpgurl(release: int) -> str:
+        return "https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Extras"
 
     @classmethod
     def _mirror_directory(cls) -> str:
@@ -140,7 +131,7 @@ class CentosInstaller(DistributionInstaller):
 
     @classmethod
     def _epel_repos(cls, config: MkosiConfig) -> list[Repo]:
-        epel_gpgpath, epel_gpgurl = cls._epel_gpg_locations()
+        epel_gpgurl = cls._epel_gpgurl()
 
         if config.local_mirror:
             return []
@@ -153,8 +144,8 @@ class CentosInstaller(DistributionInstaller):
             epel_testing_url = "metalink=https://mirrors.fedoraproject.org/metalink?repo=testing-epel$releasever&arch=$basearch"
 
         return [
-            Repo("epel", epel_url, epel_gpgpath, epel_gpgurl, enabled=False),
-            Repo("epel-testing", epel_testing_url, epel_gpgpath, epel_gpgurl, enabled=False),
+            Repo("epel", epel_url, epel_gpgurl, enabled=False),
+            Repo("epel-testing", epel_testing_url, epel_gpgurl, enabled=False),
         ]
 
     @classmethod
@@ -162,7 +153,7 @@ class CentosInstaller(DistributionInstaller):
         # Repos for CentOS Linux 8, CentOS Stream 8 and CentOS variants
 
         directory = cls._mirror_directory()
-        gpgpath, gpgurl = cls._gpg_locations(release)
+        gpgurl = cls._gpgurl(release)
 
         if config.local_mirror:
             appstream_url = f"baseurl={config.local_mirror}"
@@ -188,15 +179,15 @@ class CentosInstaller(DistributionInstaller):
                 crb_url = None
                 powertools_url = f"mirrorlist={cls._mirror_repo_url('PowerTools')}"
 
-        repos = [Repo("appstream", appstream_url, gpgpath, gpgurl)]
+        repos = [Repo("appstream", appstream_url, gpgurl)]
         if baseos_url is not None:
-            repos += [Repo("baseos", baseos_url, gpgpath, gpgurl)]
+            repos += [Repo("baseos", baseos_url, gpgurl)]
         if extras_url is not None:
-            repos += [Repo("extras", extras_url, gpgpath, gpgurl)]
+            repos += [Repo("extras", extras_url, gpgurl)]
         if crb_url is not None:
-            repos += [Repo("crb", crb_url, gpgpath, gpgurl)]
+            repos += [Repo("crb", crb_url, gpgurl)]
         if powertools_url is not None:
-            repos += [Repo("powertools", powertools_url, gpgpath, gpgurl)]
+            repos += [Repo("powertools", powertools_url, gpgurl)]
         repos += cls._epel_repos(config)
 
         return repos
@@ -205,8 +196,8 @@ class CentosInstaller(DistributionInstaller):
     def _stream_repos(cls, config: MkosiConfig, release: int) -> list[Repo]:
         # Repos for CentOS Stream 9 and later
 
-        gpgpath, gpgurl = cls._gpg_locations(release)
-        extras_gpgpath, extras_gpgurl = cls._extras_gpg_locations(release)
+        gpgurl = cls._gpgurl(release)
+        extras_gpgurl = cls._extras_gpgurl(release)
 
         if config.local_mirror:
             appstream_url = f"baseurl={config.local_mirror}"
@@ -222,13 +213,13 @@ class CentosInstaller(DistributionInstaller):
             extras_url = "metalink=https://mirrors.centos.org/metalink?repo=centos-extras-sig-extras-common-$stream&arch=$basearch&protocol=https,http"
             crb_url = "metalink=https://mirrors.centos.org/metalink?repo=centos-crb-$stream&arch=$basearch&protocol=https,http"
 
-        repos = [Repo("appstream", appstream_url, gpgpath, gpgurl)]
+        repos = [Repo("appstream", appstream_url, gpgurl)]
         if baseos_url is not None:
-            repos += [Repo("baseos", baseos_url, gpgpath, gpgurl)]
+            repos += [Repo("baseos", baseos_url, gpgurl)]
         if extras_url is not None:
-            repos += [Repo("extras", extras_url, extras_gpgpath, extras_gpgurl)]
+            repos += [Repo("extras", extras_url, extras_gpgurl)]
         if crb_url is not None:
-            repos += [Repo("crb", crb_url, gpgpath, gpgurl)]
+            repos += [Repo("crb", crb_url, gpgurl)]
         repos += cls._epel_repos(config)
 
         return repos

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -52,13 +52,12 @@ class FedoraInstaller(DistributionInstaller):
             # In other versions, the "fedora" repo is frozen at release, and "updates" provides any new packages.
             updates_url = None
 
-        gpgpath = Path(f"/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-{releasever}-{state.config.architecture}")
         # See: https://fedoraproject.org/security/
         gpgurl = "https://fedoraproject.org/fedora.gpg"
 
-        repos = [Repo("fedora", release_url, gpgpath, gpgurl)]
+        repos = [Repo("fedora", release_url, gpgurl)]
         if updates_url is not None:
-            repos += [Repo("updates", updates_url, gpgpath, gpgurl)]
+            repos += [Repo("updates", updates_url, gpgurl)]
 
         setup_dnf(state, repos)
         invoke_dnf(state, "install", packages, apivfs=apivfs)
@@ -90,7 +89,6 @@ def url_exists(url: str) -> bool:
 class Repo(NamedTuple):
     id: str
     url: str
-    gpgpath: Path
     gpgurl: str
     enabled: bool = True
 
@@ -98,19 +96,13 @@ class Repo(NamedTuple):
 def setup_dnf(state: MkosiState, repos: Sequence[Repo] = ()) -> None:
     with state.workspace.joinpath("dnf.conf").open("w") as f:
         for repo in repos:
-
-            if repo.gpgpath.exists():
-                gpgkey = f"file://{repo.gpgpath}"
-            else:
-                gpgkey = repo.gpgurl
-
             f.write(
                 dedent(
                     f"""\
                     [{repo.id}]
                     name={repo.id}
                     {repo.url}
-                    gpgkey={gpgkey}
+                    gpgkey={repo.gpgurl}
                     gpgcheck=1
                     enabled={int(repo.enabled)}
                     """

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -145,6 +145,11 @@ def invoke_dnf(
         "--noplugins",
     ]
 
+    # Make sure we download filelists so all dependencies can be resolved.
+    # See https://bugzilla.redhat.com/show_bug.cgi?id=2180842
+    if shutil.which("dnf5"):
+        cmdline += ["--setopt=optional_metadata_types=filelists"]
+
     if not state.config.repository_key_check:
         cmdline += ["--nogpgcheck"]
 

--- a/mkosi/distributions/mageia.py
+++ b/mkosi/distributions/mageia.py
@@ -40,10 +40,11 @@ class MageiaInstaller(DistributionInstaller):
                 updates_url = f"mirrorlist={baseurl}&repo=updates"
 
         gpgpath = Path("/etc/pki/rpm-gpg/RPM-GPG-KEY-Mageia")
+        gpgurl = f"https://mirrors.kernel.org/mageia/distrib/{release}/{state.config.architecture}/media/core/release/media_info/pubkey"
 
-        repos = [Repo(f"mageia-{release}", release_url, gpgpath)]
+        repos = [Repo(f"mageia-{release}", release_url, gpgpath, gpgurl)]
         if updates_url is not None:
-            repos += [Repo(f"mageia-{release}-updates", updates_url, gpgpath)]
+            repos += [Repo(f"mageia-{release}-updates", updates_url, gpgpath, gpgurl)]
 
         setup_dnf(state, repos)
         invoke_dnf(state, "install", packages, apivfs=apivfs)

--- a/mkosi/distributions/mageia.py
+++ b/mkosi/distributions/mageia.py
@@ -40,9 +40,9 @@ class MageiaInstaller(DistributionInstaller):
 
         gpgurl = f"https://mirrors.kernel.org/mageia/distrib/{release}/{state.config.architecture}/media/core/release/media_info/pubkey"
 
-        repos = [Repo(f"mageia-{release}", release_url, gpgurl)]
+        repos = [Repo(f"mageia-{release}", release_url, [gpgurl])]
         if updates_url is not None:
-            repos += [Repo(f"mageia-{release}-updates", updates_url, gpgurl)]
+            repos += [Repo(f"mageia-{release}-updates", updates_url, [gpgurl])]
 
         setup_dnf(state, repos)
         invoke_dnf(state, "install", packages, apivfs=apivfs)

--- a/mkosi/distributions/mageia.py
+++ b/mkosi/distributions/mageia.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 from collections.abc import Sequence
-from pathlib import Path
 
 from mkosi.distributions import DistributionInstaller
 from mkosi.distributions.fedora import Repo, invoke_dnf, setup_dnf
@@ -39,12 +38,11 @@ class MageiaInstaller(DistributionInstaller):
             else:
                 updates_url = f"mirrorlist={baseurl}&repo=updates"
 
-        gpgpath = Path("/etc/pki/rpm-gpg/RPM-GPG-KEY-Mageia")
         gpgurl = f"https://mirrors.kernel.org/mageia/distrib/{release}/{state.config.architecture}/media/core/release/media_info/pubkey"
 
-        repos = [Repo(f"mageia-{release}", release_url, gpgpath, gpgurl)]
+        repos = [Repo(f"mageia-{release}", release_url, gpgurl)]
         if updates_url is not None:
-            repos += [Repo(f"mageia-{release}-updates", updates_url, gpgpath, gpgurl)]
+            repos += [Repo(f"mageia-{release}-updates", updates_url, gpgurl)]
 
         setup_dnf(state, repos)
         invoke_dnf(state, "install", packages, apivfs=apivfs)

--- a/mkosi/distributions/openmandriva.py
+++ b/mkosi/distributions/openmandriva.py
@@ -41,9 +41,9 @@ class OpenmandrivaInstaller(DistributionInstaller):
 
         gpgurl = "https://raw.githubusercontent.com/OpenMandrivaAssociation/openmandriva-repos/master/RPM-GPG-KEY-OpenMandriva"
 
-        repos = [Repo("openmandriva", release_url, gpgurl)]
+        repos = [Repo("openmandriva", release_url, [gpgurl])]
         if updates_url is not None:
-            repos += [Repo("updates", updates_url, gpgurl)]
+            repos += [Repo("updates", updates_url, [gpgurl])]
 
         setup_dnf(state, repos)
         invoke_dnf(state, "install", packages, apivfs=apivfs)

--- a/mkosi/distributions/openmandriva.py
+++ b/mkosi/distributions/openmandriva.py
@@ -41,10 +41,11 @@ class OpenmandrivaInstaller(DistributionInstaller):
             updates_url = f"mirrorlist={baseurl}&release=updates"
 
         gpgpath = Path("/etc/pki/rpm-gpg/RPM-GPG-KEY-OpenMandriva")
+        gpgurl = "https://raw.githubusercontent.com/OpenMandrivaAssociation/openmandriva-repos/master/RPM-GPG-KEY-OpenMandriva"
 
-        repos = [Repo("openmandriva", release_url, gpgpath)]
+        repos = [Repo("openmandriva", release_url, gpgpath, gpgurl)]
         if updates_url is not None:
-            repos += [Repo("updates", updates_url, gpgpath)]
+            repos += [Repo("updates", updates_url, gpgpath, gpgurl)]
 
         setup_dnf(state, repos)
         invoke_dnf(state, "install", packages, apivfs=apivfs)

--- a/mkosi/distributions/openmandriva.py
+++ b/mkosi/distributions/openmandriva.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 from collections.abc import Sequence
-from pathlib import Path
 
 from mkosi.distributions import DistributionInstaller
 from mkosi.distributions.fedora import Repo, invoke_dnf, setup_dnf
@@ -40,12 +39,11 @@ class OpenmandrivaInstaller(DistributionInstaller):
             release_url = f"mirrorlist={baseurl}&release=release"
             updates_url = f"mirrorlist={baseurl}&release=updates"
 
-        gpgpath = Path("/etc/pki/rpm-gpg/RPM-GPG-KEY-OpenMandriva")
         gpgurl = "https://raw.githubusercontent.com/OpenMandrivaAssociation/openmandriva-repos/master/RPM-GPG-KEY-OpenMandriva"
 
-        repos = [Repo("openmandriva", release_url, gpgpath, gpgurl)]
+        repos = [Repo("openmandriva", release_url, gpgurl)]
         if updates_url is not None:
-            repos += [Repo("updates", updates_url, gpgpath, gpgurl)]
+            repos += [Repo("updates", updates_url, gpgurl)]
 
         setup_dnf(state, repos)
         invoke_dnf(state, "install", packages, apivfs=apivfs)

--- a/mkosi/distributions/rocky.py
+++ b/mkosi/distributions/rocky.py
@@ -1,26 +1,18 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
-from pathlib import Path
-
 from mkosi.distributions.centos import CentosInstaller
 
 
 class RockyInstaller(CentosInstaller):
     @staticmethod
-    def _gpg_locations(release: int) -> tuple[Path, str]:
+    def _gpgurl(release: int) -> str:
         keyname = "Rocky-$releasever" if release >= 9 else "rockyofficial"
-        return (
-             Path(f"/etc/pki/rpm-gpg/RPM-GPG-KEY-{keyname}"),
-             f"https://download.rockylinux.org/pub/rocky/RPM-GPG-KEY-{keyname}"
-        )
+        return f"https://download.rockylinux.org/pub/rocky/RPM-GPG-KEY-{keyname}"
 
     @staticmethod
-    def _extras_gpg_locations(release: int) -> tuple[Path, str]:
+    def _extras_gpgurl(release: int) -> str:
         keyname = "Rocky-$releasever" if release >= 9 else "rockyofficial"
-        return (
-             Path(f"/etc/pki/rpm-gpg/RPM-GPG-KEY-{keyname}"),
-             f"https://download.rockylinux.org/pub/rocky/RPM-GPG-KEY-{keyname}"
-        )
+        return f"https://download.rockylinux.org/pub/rocky/RPM-GPG-KEY-{keyname}"
 
     @classmethod
     def _mirror_directory(cls) -> str:


### PR DESCRIPTION
Let's reduce the number of package managers we use by using dnf to
build opensuse images.

The only caveat is that extra GPG keys are listed in repomd.xml for
the opensuse repos, so we have to download that file and parse it to
figure out the extra keys that we have to write to the repo configs.