### PR TITLE
Make sure a stable path to the output path exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,19 +178,6 @@ jobs:
         Format=${{ matrix.format }}
         EOF
 
-    # Make sure systemd-repart and split artifacts generates a usable output for systemd-sysupdate
-    - name: Configure ${{ matrix.distro }}/${{ matrix.format }} repart
-      if: matrix.format == 'disk'
-      run: |
-        tee mkosi.conf.d/01-repart.conf <<- EOF
-        [Output]
-        SplitArtifacts=yes
-        CompressOutput=xz
-
-        [Validation]
-        Checksum=yes
-        EOF
-
     - name: Resolve Arch geo mirror location
       if: matrix.distro == 'arch'
       run: curl -I geo.mirror.pkgbuild.com
@@ -198,37 +185,12 @@ jobs:
     - name: Build ${{ matrix.distro }}/${{ matrix.format }}
       run: python3 -m mkosi build
 
-    - name: Confirm ${{ matrix.distro }}/${{ matrix.format }} repart output
-      if: matrix.format == 'disk'
-      run: |
-        # Check for SHA256SUMS file. It cannot have a prefix.
-        [ -f SHA256SUMS ]
-
-        # Check for a compressed raw disk image
-        grep -q image.raw.xz SHA256SUMS
-
-        # Check for a compressed root split image
-        grep -q image.root-x86-64.raw.xz SHA256SUMS
-
     # systemd-resolved is enabled by default in Arch/Debian/Ubuntu (systemd default preset) but fails to
     # start in a systemd-nspawn container with --private-users so we mask it out here to avoid CI failures.
     # FIXME: Remove when Arch/Debian/Ubuntu ship systemd v253
     - name: Mask systemd-resolved
       if: matrix.format == 'directory'
       run: sudo systemctl --root image mask systemd-resolved
-
-    # The systemd-repart test **needs** compressed artifacts to confirm proper hash output.
-    # Those compressed artifacts are useless for booting. Only decompress what we need.
-    - name: Decompress ${{ matrix.distro }}/${{ matrix.format }} artifacts
-      if: matrix.format == 'disk' || matrix.format == 'directory'
-      run: |
-        if [ -f mkosi.conf.d/01-repart.conf ] ; then rm mkosi.conf.d/01-repart.conf ; fi
-
-        if [ -f mkosi.output/image.efi.xz  ] ; then xz --decompress mkosi.output/image.efi.xz  ; fi
-        if [ -f mkosi.output/image.efi.zst ] ; then zst -d --rm     mkosi.output/image.efi.zst ; fi
-
-        if [ -f mkosi.output/image.raw.xz  ] ; then xz --decompress mkosi.output/image.raw.xz  ; fi
-        if [ -f mkosi.output/image.raw.zst ] ; then zst -d --rm     mkosi.output/image.raw.zst ; fi
 
     - name: Boot ${{ matrix.distro }}/${{ matrix.format }} systemd-nspawn
       if: matrix.format == 'disk' || matrix.format == 'directory'

--- a/man/mkosi.1
+++ b/man/mkosi.1
@@ -118,8 +118,10 @@ images, for example via \f[V]machinectl pull-raw \&...\f[R] and
 \f[V]machinectl   pull-tar \&...\f[R].
 .TP
 \f[V]bump\f[R]
-Bumps the image version from \f[V]mkosi.version\f[R] and writes the
-resulting version string to \f[V]mkosi.version\f[R].
+Determines the current image version string (as configured with
+\f[V]ImageVersion=\f[R]/\f[V]--image-version=\f[R]), increases its last
+dot-separated component by one and writes the resulting version string
+to \f[V]mkosi.version\f[R].
 This is useful for implementing a simple versioning scheme: each time
 this verb is called the version is bumped in preparation for the
 subsequent build.
@@ -257,116 +259,16 @@ either \[lq]1\[rq], \[lq]yes\[rq], or \[lq]true\[rq] to enable, or
 .TP
 \f[V]Distribution=\f[R]
 Matches against the configured distribution.
-Multiple distributions may be specified, separated by spaces.
-If multiple distributions are specified, the condition is satisfied if
-the current distribution equals any of the specified distributions.
 .TP
 \f[V]Release=\f[R]
 Matches against the configured distribution release.
 If this condition is used and no distribution has been explicitly
 configured yet, the host distribution and release are used.
-Multiple releases may be specified, separated by spaces.
-If multiple releases are specified, the condition is satisfied if the
-current release equals any of the specified releases.
 .TP
 \f[V]PathExists=\f[R]
 This condition is satisfied if the given path exists.
 Relative paths are interpreted relative to the parent directory of the
 config file that the condition is read from.
-.TP
-\f[V]ImageId=\f[R]
-Matches against the configured image ID, supporting globs.
-If this condition is used and no image ID has been explicitly configured
-yet, this condition fails.
-Multiple image IDs may be specified, separated by spaces.
-If multiple image IDs are specified, the condition is satisfied if the
-configured image ID equals any of the specified image IDs.
-.TP
-\f[V]ImageVersion=\f[R]
-Matches against the configured image version.
-Image versions can be prepended by the operators \f[V]==\f[R],
-\f[V]!=\f[R], \f[V]>=\f[R], \f[V]<=\f[R], \f[V]<\f[R], \f[V]>\f[R] for
-rich version comparisons according to the UAPI group version format
-specification.
-If no operator is prepended, the equality operator is assumed by default
-If this condition is used and no image Version has be explicitly
-configured yet, this condition fails.
-Multiple image version constraints can be specified as a space-separated
-list.
-If multiple image version constraints are specified, all must be
-satisfied for the match to succeed.
-.PP
-.TS
-tab(@);
-lw(14.2n) lw(14.2n) lw(5.8n) lw(15.0n) lw(20.8n).
-T{
-Matcher
-T}@T{
-Multiple Values
-T}@T{
-Globs
-T}@T{
-Rich Comparisons
-T}@T{
-Default
-T}
-_
-T{
-\f[V]Distribution=\f[R]
-T}@T{
-yes
-T}@T{
-no
-T}@T{
-no
-T}@T{
-match host distribution
-T}
-T{
-\f[V]Release=\f[R]
-T}@T{
-yes
-T}@T{
-no
-T}@T{
-no
-T}@T{
-match host release
-T}
-T{
-\f[V]PathExists=\f[R]
-T}@T{
-no
-T}@T{
-no
-T}@T{
-no
-T}@T{
-match fails
-T}
-T{
-\f[V]ImageId=\f[R]
-T}@T{
-yes
-T}@T{
-yes
-T}@T{
-no
-T}@T{
-match fails
-T}
-T{
-\f[V]ImageVersion=\f[R]
-T}@T{
-yes
-T}@T{
-no
-T}@T{
-yes
-T}@T{
-match fails
-T}
-.TE
 .SS [Distribution] Section
 .TP
 \f[V]Distribution=\f[R], \f[V]--distribution=\f[R], \f[V]-d\f[R]
@@ -420,8 +322,8 @@ For Arch Linux, additional repositories must be passed in the form
 \f[V]<name>::<url>\f[R] (e.g.\ \f[V]myrepo::https://myrepo.net\f[R]).
 .TP
 \f[V]RepositoryDirectories\f[R], \f[V]--repo-dir=\f[R]
-This option can (for now) only be used with RPM-based distributions,
-Debian-based distributions and Arch Linux.
+This option can (for now) only be used with RPM-based distributions and
+Arch Linux.
 It takes a comma separated list of directories containing extra
 repository definitions that will be used when installing packages.
 The files are passed directly to the corresponding package manager and
@@ -492,42 +394,6 @@ It\[cq]s safe to manually remove the contents of this directory should
 an \f[V]mkosi\f[R] invocation be aborted abnormally (for example, due to
 reboot/power failure).
 .TP
-\f[V]CacheDirectory=\f[R], \f[V]--cache-dir=\f[R]
-Takes a path to a directory to use as package cache for the distribution
-package manager used.
-If this option is not used, but a \f[V]mkosi.cache/\f[R] directory is
-found in the local directory it is automatically used for this purpose.
-The directory configured this way is mounted into both the development
-and the final image while the package manager is running.
-.TP
-\f[V]BuildDirectory=\f[R], \f[V]--build-dir=\f[R]
-Takes a path of a directory to use as build directory for build systems
-that support out-of-tree builds (such as Meson).
-The directory used this way is shared between repeated builds, and
-allows the build system to reuse artifacts (such as object files,
-executable, \&...)
-generated on previous invocations.
-This directory is mounted into the development image when the build
-script is invoked.
-The build script can find the path to this directory in the
-\f[V]$BUILDDIR\f[R] environment variable.
-If this option is not specified, but a directory
-\f[V]mkosi.builddir/\f[R] exists in the local directory it is
-automatically used for this purpose (also see the \[lq]Files\[rq]
-section below).
-.TP
-\f[V]InstallDirectory=\f[R], \f[V]--install-dir=\f[R]
-Takes a path of a directory to use as the install directory.
-The directory used this way is shared between builds and allows the
-build system to not have to reinstall files that were already installed
-by a previous build and didn\[cq]t change.
-The build script can find the path to this directory in the
-\f[V]$DESTDIR\f[R] environment variable.
-If this option is not specified, but a directory
-\f[V]mkosi.installdir\f[R] exists in the local directory, it is
-automatically used for this purpose (also see the \[lq]Files\[rq]
-section below).
-.TP
 \f[V]Force=\f[R], \f[V]--force\f[R], \f[V]-f\f[R]
 Replace the output file if it already exists, when building an image.
 By default when building an image and an output artifact already exists
@@ -586,6 +452,17 @@ kernel image, if \f[V]SecureBoot=\f[R] is used.
 Path to the X.509 file containing the certificate for the signed UEFI
 kernel image, if \f[V]SecureBoot=\f[R] is used.
 .TP
+\f[V]SecureBootCommonName=\f[R], \f[V]--secure-boot-common-name=\f[R]
+Common name to be used when generating SecureBoot keys via mkosi\[cq]s
+\f[V]genkey\f[R] command.
+Defaults to \f[V]mkosi of %u\f[R], where \f[V]%u\f[R] expands to the
+username of the user invoking mkosi.
+.TP
+\f[V]SecureBootValidDays=\f[R], \f[V]--secure-boot-valid-days=\f[R]
+Number of days that the keys should remain valid when generating
+SecureBoot keys via mkosi\[cq]s \f[V]genkey\f[R] command.
+Defaults to two years (730 days).
+.TP
 \f[V]SignExpectedPCR=\f[R], \f[V]--sign-expected-pcr\f[R]
 Measure the components of the unified kernel image (UKI) using
 \f[V]systemd-measure\f[R] and embed the PCR signature into the unified
@@ -622,6 +499,13 @@ scripts invoked (which may be useful to patch it into
 \f[V]/etc/os-release\f[R] or similar, in particular the
 \f[V]IMAGE_VERSION=\f[R] field of it).
 .TP
+\f[V]AutoBump=\f[R], \f[V]--auto-bump=\f[R], \f[V]-B\f[R]
+If specified, after each successful build the the version is bumped in a
+fashion equivalent to the \f[V]bump\f[R] verb, in preparation for the
+next build.
+This is useful for simple, linear version management: each build in a
+series will have a version number one higher then the previous one.
+.TP
 \f[V]ImageId=\f[R], \f[V]--image-id=\f[R]
 Configure the image identifier.
 This accepts a freeform string that shall be used to identify the image
@@ -635,6 +519,12 @@ The identifier is also passed via the \f[V]$IMAGE_ID\f[R] to any build
 scripts invoked (which may be useful to patch it into
 \f[V]/etc/os-release\f[R] or similar, in particular the
 \f[V]IMAGE_ID=\f[R] field of it).
+.TP
+\f[V]CacheInitrd=\f[R], \f[V]--cache-initrd\f[R]
+If specified, and incremental mode is used, mkosi will build the initrd
+in the cache image and reuse it in the final image.
+Note that this means that any changes that are only applied to the final
+image and not the cached image won\[cq]t be included in the initrd.
 .TP
 \f[V]SplitArtifacts=\f[R], \f[V]--split-artifacts\f[R]
 If specified and building a disk image, pass \f[V]--split=yes\f[R] to
@@ -656,25 +546,6 @@ directory, it will be used instead.
 Note that mkosi invokes repart with \f[V]--root=\f[R] set to the root of
 the image root, so any \f[V]CopyFiles=\f[R] source paths in partition
 definition files will be relative to the image root directory.
-.IP
-:: It is recommended to have the \f[V]SplitName\f[R] parameter either
-end with \f[V]%t\f[R] or \f[V].raw\f[R] if the
-\f[V]SplitArtifacts=yes\f[R] option is set.
-This will make sure that split artifacts are compressed and the
-compressed file name is included in the checksum output if
-\f[V]Checksum=yes\f[R] is also set.
-.TP
-\f[V]Overlay=\f[R], \f[V]--overlay\f[R]
-When used together with \f[V]BaseTrees=\f[R], the output will consist
-only out of changes to the specified base trees.
-Each base tree is attached as a lower layer in an overlayfs structure,
-and the output becomes the upper layer, initially empty.
-Thus files that are not modified compared to the base trees will not be
-present in the final output.
-This option may be used to create systemd \[lq]system extensions\[rq] or
-portable services.
-See https://uapi-group.org/specifications/specs/extension_image for more
-information.
 .TP
 \f[V]TarStripSELinuxContext=\f[R], \f[V]--tar-strip-selinux-context\f[R]
 If running on a SELinux-enabled system (Fedora Linux, CentOS, Rocky
@@ -683,6 +554,12 @@ context extended attributes (\f[V]xattrs\f[R]), which may interfere with
 host SELinux rules in building or further container import stages.
 This option strips SELinux context attributes from the resulting tar
 archive.
+.TP
+\f[V]Initrd=\f[R], \f[V]--initrd\f[R]
+Use user-provided initrd(s).
+Takes a comma separated list of paths to initrd files.
+This option may be used multiple times in which case the initrd lists
+are combined.
 .SS [Content] Section
 .TP
 \f[V]Packages=\f[R], \f[V]--package=\f[R], \f[V]-p\f[R]
@@ -735,24 +612,15 @@ integration tests that are normally run during the source build process.
 Note that this option has no effect unless the \f[V]mkosi.build\f[R]
 build script honors it.
 .TP
-\f[V]BaseTrees=\f[R], \f[V]--base-tree=\f[R]
-Takes a colon separated pair of directories to use as base images.
-When used, these base images are each copied into the OS tree and form
-the base distribution instead of installing the distribution from
-scratch.
-Only extra packages are installed on top of the ones already installed
-in the base images.
-Note that for this to work properly, the base image still needs to
-contain the package manager metadata (see
-\f[V]CleanPackageMetadata=\f[R]).
-Instead of a directory, a tar file or a disk image may be provided.
-In this case it is unpacked into the OS tree.
-This mode of operation allows setting permissions and file ownership
-explicitly, in particular for projects stored in a version control
-system such as \f[V]git\f[R] which retain full file ownership and access
-mode metadata for committed files.
+\f[V]CacheDirectory=\f[R], \f[V]--cache-dir=\f[R]
+Takes a path to a directory to use as package cache for the distribution
+package manager used.
+If this option is not used, but a \f[V]mkosi.cache/\f[R] directory is
+found in the local directory it is automatically used for this purpose.
+The directory configured this way is mounted into both the development
+and the final image while the package manager is running.
 .TP
-\f[V]SkeletonTrees=\f[R], \f[V]--skeleton-tree=\f[R]
+\f[V]SkeletonTree=\f[R], \f[V]--skeleton-tree=\f[R]
 Takes a colon separated pair of paths.
 The first path refers to a directory to copy into the OS tree before
 invoking the package manager.
@@ -765,12 +633,17 @@ If this option is not used, but the \f[V]mkosi.skeleton/\f[R] directory
 is found in the local directory it is automatically used for this
 purpose with the root directory as target (also see the \[lq]Files\[rq]
 section below).
-As with the base tree logic above, instead of a directory, a tar file
-may be provided too.
-\f[V]mkosi.skeleton.tar\f[R] will be automatically used if found in the
-local directory.
+Instead of a directory, a tar file may be provided.
+In this case it is unpacked into the OS tree before the package manager
+is invoked.
+This mode of operation allows setting permissions and file ownership
+explicitly, in particular for projects stored in a version control
+system such as \f[V]git\f[R] which retain full file ownership and access
+mode metadata for committed files.
+If the tar file \f[V]mkosi.skeleton.tar\f[R] is found in the local
+directory it will be automatically used for this purpose.
 .TP
-\f[V]ExtraTrees=\f[R], \f[V]--extra-tree=\f[R]
+\f[V]ExtraTree=\f[R], \f[V]--extra-tree=\f[R]
 Takes a colon separated pair of paths.
 The first path refers to a directory to copy from the host into the
 image.
@@ -783,9 +656,9 @@ If this option is not used, but the \f[V]mkosi.extra/\f[R] directory is
 found in the local directory it is automatically used for this purpose
 with the root directory as target.
 (also see the \[lq]Files\[rq] section below).
-As with the base tree logic above, instead of a directory, a tar file
-may be provided too.
-\f[V]mkosi.extra.tar\f[R] will be automatically used if found in the
+As with the skeleton tree logic above, instead of a directory, a tar
+file may be provided too.
+\f[V]mkosi.skeleton.tar\f[R] will be automatically used if found in the
 local directory.
 .TP
 \f[V]CleanPackageMetadata=\f[R], \f[V]--clean-package-metadata=\f[R]
@@ -824,6 +697,34 @@ earlier one.
 \f[V]BuildSources=\f[R], \f[V]--build-sources=\f[R]
 Takes a path to a source tree to mount into the development image, if
 the build script is used.
+.TP
+\f[V]BuildDirectory=\f[R], \f[V]--build-dir=\f[R]
+Takes a path of a directory to use as build directory for build systems
+that support out-of-tree builds (such as Meson).
+The directory used this way is shared between repeated builds, and
+allows the build system to reuse artifacts (such as object files,
+executable, \&...)
+generated on previous invocations.
+This directory is mounted into the development image when the build
+script is invoked.
+The build script can find the path to this directory in the
+\f[V]$BUILDDIR\f[R] environment variable.
+If this option is not specified, but a directory
+\f[V]mkosi.builddir/\f[R] exists in the local directory it is
+automatically used for this purpose (also see the \[lq]Files\[rq]
+section below).
+.TP
+\f[V]InstallDirectory=\f[R], \f[V]--install-dir=\f[R]
+Takes a path of a directory to use as the install directory.
+The directory used this way is shared between builds and allows the
+build system to not have to reinstall files that were already installed
+by a previous build and didn\[cq]t change.
+The build script can find the path to this directory in the
+\f[V]$DESTDIR\f[R] environment variable.
+If this option is not specified, but a directory
+\f[V]mkosi.installdir\f[R] exists in the local directory, it is
+automatically used for this purpose (also see the \[lq]Files\[rq]
+section below).
 .TP
 \f[V]BuildPackages=\f[R], \f[V]--build-package=\f[R]
 Similar to \f[V]Packages=\f[R], but configures packages to install only
@@ -922,15 +823,18 @@ when the image is run.
 If this setting is not used but an \f[V]mkosi.nspawn\f[R] file found in
 the local directory it is automatically used for this purpose.
 .TP
-\f[V]Initrd=\f[R], \f[V]--initrd\f[R]
-Use user-provided initrd(s).
-Takes a comma separated list of paths to initrd files.
-This option may be used multiple times in which case the initrd lists
-are combined.
-.TP
-\f[V]MakeInitrd=\f[R], \f[V]--make-initrd\f[R]
-Add \f[V]/etc/initrd-release\f[R] and \f[V]/init\f[R] to the image so
-that it can be used as an initramfs.
+\f[V]BaseImage=\f[R], \f[V]--base-image=\f[R]
+Use the specified directory or file system image as the base image, and
+create the output image that consists only of changes from this base.
+The base image is attached as the lower file system in an overlayfs
+structure, and the output filesystem becomes the upper layer, initially
+empty.
+Thus files that are not modified compared to the base image are not
+present in the output image.
+This option may be used to create systemd \[lq]system extensions\[rq] or
+portable services.
+See https://systemd.io/PORTABLE_SERVICES/#extension-images for more
+information.
 .SS [Validation] Section
 .TP
 \f[V]Checksum=\f[R], \f[V]--checksum\f[R]
@@ -1063,34 +967,15 @@ removed and then re-created.
 .TP
 \f[V]--debug=\f[R]
 Enable additional debugging output.
-.TP
-\f[V]--debug-shell=\f[R]
-When executing a command in the image fails, mkosi will start an
-interactive shell in the image allowing further debugging.
+Takes a comma-separated list of arguments specifying the area of
+interest.
+Pass any invalid value (e.g.\ empty) to list currently accepted values.
 .TP
 \f[V]--version\f[R]
 Show package version.
 .TP
 \f[V]--help\f[R], \f[V]-h\f[R]
 Show brief usage information.
-.TP
-\f[V]--secure-boot-common-name=\f[R]
-Common name to be used when generating SecureBoot keys via mkosi\[cq]s
-\f[V]genkey\f[R] command.
-Defaults to \f[V]mkosi of %u\f[R], where \f[V]%u\f[R] expands to the
-username of the user invoking mkosi.
-.TP
-\f[V]--secure-boot-valid-days=\f[R]
-Number of days that the keys should remain valid when generating
-SecureBoot keys via mkosi\[cq]s \f[V]genkey\f[R] command.
-Defaults to two years (730 days).
-.TP
-\f[V]--auto-bump=\f[R], \f[V]-B\f[R]
-If specified, after each successful build the the version is bumped in a
-fashion equivalent to the \f[V]bump\f[R] verb, in preparation for the
-next build.
-This is useful for simple, linear version management: each build in a
-series will have a version number one higher then the previous one.
 .SS Supported distributions
 .PP
 Images may be created containing installations of the following
@@ -1660,6 +1545,4 @@ The mkosi OS generation tool (https://lwn.net/Articles/726655/) story on
 LWN
 .SH SEE ALSO
 .PP
-\f[V]systemd-nspawn(1)\f[R], \f[V]dnf(8)\f[R],
-.SH AUTHORS
-The mkosi Authors.
+\f[V]systemd-nspawn(1)\f[R], \f[V]dnf(8)\f[R]

--- a/mkosi.md
+++ b/mkosi.md
@@ -154,8 +154,6 @@ The following output formats are supported:
 
 * Plain directory, containing the OS tree (*directory*)
 
-* btrfs subvolume
-
 * Tar archive (*tar*)
 
 * CPIO archive (*cpio*) in the format appropriate for a kernel initrd
@@ -330,10 +328,9 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 `Format=`, `--format=`, `-t`
 
 : The image format type to generate. One of `directory` (for generating OS
-  images inside a local directory), `subvolume` (similar, but as a btrfs
-  subvolume), `tar` (similar, but a tarball of the image is generated), `cpio`
-  (similar, but a cpio archive is generated), `disk` (a block device image
-  with a GPT partition table).
+  images inside a local directory), `tar` (similar, but a tarball of the
+  image is generated), `cpio` (similar, but a cpio archive is generated),
+  `disk` (a block device image with a GPT partition table).
 
 `ManifestFormat=`, `--manifest-format=`
 
@@ -859,12 +856,10 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 
 `Ephemeral=`, `--ephemeral`
 
-: When used with the `shell`, `boot`, or `qemu` verbs, this option
-  runs the specified verb on a temporary snapshot of the output image
-  that is removed immediately when the container terminates. Taking
-  the temporary snapshot is more efficient on file systems that
-  support subvolume snapshots or 'reflinks' natively ("btrfs" or new
-  "xfs") than on more traditional file systems that do not ("ext4").
+: When used with the `shell`, `boot`, or `qemu` verbs, this option runs the specified verb on a temporary
+  snapshot of the output image that is removed immediately when the container terminates. Taking the
+  temporary snapshot is more efficient on file systems that support reflinks natively ("btrfs" or new "xfs")
+  than on more traditional file systems that do not ("ext4").
 
 `Ssh=`, `--ssh`
 

--- a/mkosi.md
+++ b/mkosi.md
@@ -539,11 +539,6 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   image root, so any `CopyFiles=` source paths in partition definition files will
   be relative to the image root directory.
 
-  It is recommended to have the `SplitName` parameter either end with `%t` or
-  `.raw` if the `SplitArtifacts=yes` option is set. This will make sure that
-  split artifacts are compressed and the compressed file name is included in the
-  checksum output if `Checksum=yes` is also set.
-
 `Overlay=`, `--overlay`
 
 : When used together with `BaseTrees=`, the output will consist only out of

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -738,6 +738,7 @@ def install_unified_kernel(state: MkosiState, roothash: Optional[str]) -> None:
                 "build",
             ])
 
+            unlink_output(args, presets[0])
             build_stuff(state.uid, state.gid, args, presets[0])
 
             initrds = [presets[0].output_compressed]

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -122,12 +122,6 @@ def mount_image(state: MkosiState) -> Iterator[None]:
         yield
 
 
-def prepare_tree_root(state: MkosiState) -> None:
-    if state.config.output_format == OutputFormat.subvolume:
-        with complete_step("Setting up OS tree root…"):
-            btrfs_subvol_create(state.root)
-
-
 def clean_paths(
         root: Path,
         globs: Sequence[str],
@@ -858,7 +852,7 @@ def hash_file(of: TextIO, path: Path) -> None:
 
 
 def calculate_sha256sum(state: MkosiState) -> None:
-    if state.config.output_format in (OutputFormat.directory, OutputFormat.subvolume):
+    if state.config.output_format == OutputFormat.directory:
         return None
 
     if not state.config.checksum:
@@ -949,7 +943,7 @@ def print_output_size(config: MkosiConfig) -> None:
     if not config.output_compressed.exists():
         return
 
-    if config.output_format in (OutputFormat.directory, OutputFormat.subvolume):
+    if config.output_format == OutputFormat.directory:
         log_step("Resulting image size is " + format_bytes(dir_size(config.output)) + ".")
     else:
         st = os.stat(config.output_compressed)
@@ -1736,7 +1730,7 @@ def acl_toggle_boot(config: MkosiConfig) -> Iterator[None]:
 def run_shell(args: MkosiArgs, config: MkosiConfig) -> None:
     cmdline: list[PathString] = ["systemd-nspawn", "--quiet"]
 
-    if config.output_format in (OutputFormat.directory, OutputFormat.subvolume):
+    if config.output_format == OutputFormat.directory:
         cmdline += ["--directory", config.output]
 
         owner = os.stat(config.output).st_uid
@@ -2129,7 +2123,6 @@ def run_verb(args: MkosiArgs, presets: Sequence[MkosiConfig]) -> None:
 
     if args.verb == Verb.qemu and last.output_format in (
         OutputFormat.directory,
-        OutputFormat.subvolume,
         OutputFormat.tar,
     ):
         die(f"{last.output_format} images cannot be booted in qemu.")

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -824,12 +824,10 @@ def compress_output(config: MkosiConfig, src: Path, uid: int, gid: int) -> None:
         return
 
     if not config.compress_output:
-        # If we shan't compress, then at least make the output file sparse
-        with complete_step(f"Digging holes into output file {src}…"):
-            run(["fallocate", "--dig-holes", src], user=uid, group=gid)
-    else:
-        with complete_step(f"Compressing output file {src}…"):
-            run(compressor_command(config.compress_output, src), user=uid, group=gid)
+        return
+
+    with complete_step(f"Compressing output file {src}…"):
+        run(compressor_command(config.compress_output, src), user=uid, group=gid)
 
 
 def copy_nspawn_settings(state: MkosiState) -> None:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -23,13 +23,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Callable, ContextManager, Optional, TextIO, TypeVar, Union, cast
 
-from mkosi.config import (
-    GenericVersion,
-    MkosiArgs,
-    MkosiConfig,
-    MkosiConfigParser,
-    machine_name,
-)
+from mkosi.config import GenericVersion, MkosiArgs, MkosiConfig, MkosiConfigParser
 from mkosi.install import add_dropin_config_from_resource, copy_path, flock
 from mkosi.log import Style, color_error, complete_step, die, log_step
 from mkosi.manifest import Manifest
@@ -444,7 +438,7 @@ def run_finalize_script(state: MkosiState) -> None:
 
     with complete_step("Running finalize script…"):
         run([state.config.finalize_script],
-            env={**state.environment, "BUILDROOT": str(state.root), "OUTPUTDIR": str(state.config.output_dir or Path.cwd())})
+            env={**state.environment, "BUILDROOT": str(state.root), "OUTPUTDIR": str(state.config.output_dir)})
 
 
 def install_boot_loader(state: MkosiState) -> None:
@@ -578,19 +572,6 @@ def gzip_binary() -> str:
     return "pigz" if shutil.which("pigz") else "gzip"
 
 
-def compressor_command(compression: Compression, src: Path) -> list[PathString]:
-    """Returns a command suitable for compressing archives."""
-
-    if compression == Compression.gz:
-        return [gzip_binary(), "--fast", src]
-    elif compression == Compression.xz:
-        return ["xz", "--check=crc32", "--fast", "-T0", src]
-    elif compression == Compression.zst:
-        return ["zstd", "-q", "-T0", "--rm", src]
-    else:
-        die(f"Unknown compression {compression}")
-
-
 def tar_binary() -> str:
     # Some distros (Mandriva) install BSD tar as "tar", hence prefer
     # "gtar" if it exists, which should be GNU tar wherever it exists.
@@ -606,11 +587,15 @@ def make_tar(state: MkosiState) -> None:
     if state.config.output_format != OutputFormat.tar:
         return
 
-    cmd: list[PathString] = [tar_binary(), "-C", state.root, "-c", "--xattrs", "--xattrs-include=*"]
-    if state.config.tar_strip_selinux_context:
-        cmd += ["--xattrs-exclude=security.selinux"]
-
-    cmd += [".", "-f", state.staging / state.config.output.name]
+    cmd: list[PathString] = [
+        tar_binary(),
+        "-C", state.root,
+        "-c", "--xattrs",
+        "--xattrs-include=*",
+        "--file", state.staging / state.config.output_with_format,
+        *(["--xattrs-exclude=security.selinux"] if state.config.tar_strip_selinux_context else []),
+        ".",
+    ]
 
     with complete_step("Creating archive…"):
         run(cmd)
@@ -626,7 +611,7 @@ def make_initrd(state: MkosiState) -> None:
     if state.config.output_format != OutputFormat.cpio:
         return
 
-    make_cpio(state.root, find_files(state.root, state.root), state.staging / state.config.output.name)
+    make_cpio(state.root, find_files(state.root, state.root), state.staging / state.config.output_with_format)
 
 
 def make_cpio(root: Path, files: Iterator[Path], output: Path) -> None:
@@ -649,7 +634,7 @@ def make_directory(state: MkosiState) -> None:
     if state.config.output_format != OutputFormat.directory:
         return
 
-    os.rename(state.root, state.staging / state.config.output.name)
+    state.root.rename(state.staging / state.config.output_with_format)
 
 
 def gen_kernel_images(state: MkosiState) -> Iterator[tuple[str, Path]]:
@@ -695,7 +680,7 @@ def install_unified_kernel(state: MkosiState, roothash: Optional[str]) -> None:
         return
 
     for kver, kimg in gen_kernel_images(state):
-        copy_path(state.root / kimg, state.staging / state.config.output_split_kernel.name)
+        copy_path(state.root / kimg, state.staging / state.config.output_split_kernel)
         break
 
     if state.config.output_format == OutputFormat.cpio and state.config.bootable is None:
@@ -738,10 +723,11 @@ def install_unified_kernel(state: MkosiState, roothash: Optional[str]) -> None:
                 "build",
             ])
 
-            unlink_output(args, presets[0])
-            build_stuff(state.uid, state.gid, args, presets[0])
+            config = presets[0]
+            unlink_output(args, config)
+            build_stuff(state.uid, state.gid, args, config)
 
-            initrds = [presets[0].output_compressed]
+            initrds = [config.output_dir / config.output]
 
     for kver, kimg in gen_kernel_images(state):
         with complete_step(f"Generating unified kernel image for {kimg}"):
@@ -813,22 +799,42 @@ def install_unified_kernel(state: MkosiState, roothash: Optional[str]) -> None:
 
             run(cmd)
 
-            if not state.staging.joinpath(state.config.output_split_uki.name).exists():
-                copy_path(boot_binary, state.staging / state.config.output_split_uki.name)
+            if not state.staging.joinpath(state.config.output_split_uki).exists():
+                copy_path(boot_binary, state.staging / state.config.output_split_uki)
 
-    if state.config.bootable is True and not state.staging.joinpath(state.config.output_split_uki.name).exists():
+    if state.config.bootable is True and not state.staging.joinpath(state.config.output_split_uki).exists():
         die("A bootable image was requested but no kernel was found")
 
 
-def compress_output(config: MkosiConfig, src: Path, uid: int, gid: int) -> None:
-    if not src.is_file():
+def compressor_command(compression: Compression) -> list[PathString]:
+    """Returns a command suitable for compressing archives."""
+
+    if compression == Compression.gz:
+        return [gzip_binary(), "--fast", "--stdout", "-"]
+    elif compression == Compression.xz:
+        return ["xz", "--check=crc32", "--fast", "-T0", "--stdout", "-"]
+    elif compression == Compression.zst:
+        return ["zstd", "-q", "-T0", "--stdout", "-"]
+    else:
+        die(f"Unknown compression {compression}")
+
+
+def maybe_compress(state: MkosiState, src: Path, dst: Optional[Path] = None) -> None:
+    if not state.config.compress_output or src.is_dir():
+        if dst:
+            shutil.move(src, dst)
         return
 
-    if not config.compress_output:
-        return
+    if not dst:
+        dst = src.parent / f"{src.name}.{state.config.compress_output}"
 
-    with complete_step(f"Compressing output file {src}…"):
-        run(compressor_command(config.compress_output, src), user=uid, group=gid)
+    with complete_step(f"Compressing {src}"):
+        with src.open("rb") as i:
+            src.unlink() # if src == dst, make sure dst doesn't truncate the src file but creates a new file.
+
+            with dst.open("wb") as o:
+                run(compressor_command(state.config.compress_output),
+                    user=state.uid, group=state.gid, stdin=i, stdout=o)
 
 
 def copy_nspawn_settings(state: MkosiState) -> None:
@@ -836,7 +842,7 @@ def copy_nspawn_settings(state: MkosiState) -> None:
         return None
 
     with complete_step("Copying nspawn settings file…"):
-        copy_path(state.config.nspawn_settings, state.staging / state.config.output_nspawn_settings.name)
+        copy_path(state.config.nspawn_settings, state.staging / state.config.output_nspawn_settings)
 
 
 def hash_file(of: TextIO, path: Path) -> None:
@@ -858,11 +864,11 @@ def calculate_sha256sum(state: MkosiState) -> None:
         return None
 
     with complete_step("Calculating SHA256SUMS…"):
-        with open(state.workspace / state.config.output_checksum.name, "w") as f:
+        with open(state.workspace / state.config.output_checksum, "w") as f:
             for p in state.staging.iterdir():
                 hash_file(f, p)
 
-        os.rename(state.workspace / state.config.output_checksum.name, state.staging / state.config.output_checksum.name)
+        state.workspace.joinpath(state.config.output_checksum).rename(state.staging / state.config.output_checksum)
 
 
 def calculate_signature(state: MkosiState) -> None:
@@ -877,8 +883,8 @@ def calculate_signature(state: MkosiState) -> None:
             cmdline += ["--default-key", state.config.key]
 
         cmdline += [
-            "--output", state.staging / state.config.output_signature.name,
-            state.staging / state.config.output_checksum.name,
+            "--output", state.staging / state.config.output_signature,
+            state.staging / state.config.output_checksum,
         ]
 
         run(
@@ -910,7 +916,7 @@ def save_cache(state: MkosiState) -> None:
             shutil.move(state.build_overlay, build)
 
 
-def dir_size(path: PathString) -> int:
+def dir_size(path: Union[Path, os.DirEntry[str]]) -> int:
     dir_sum = 0
     for entry in os.scandir(path):
         if entry.is_symlink():
@@ -921,31 +927,31 @@ def dir_size(path: PathString) -> int:
         elif entry.is_file():
             dir_sum += entry.stat().st_blocks * 512
         elif entry.is_dir():
-            dir_sum += dir_size(entry.path)
+            dir_sum += dir_size(entry)
     return dir_sum
 
 
 def save_manifest(state: MkosiState, manifest: Manifest) -> None:
     if manifest.has_data():
         if ManifestFormat.json in state.config.manifest_format:
-            with complete_step(f"Saving manifest {state.config.output_manifest.name}"):
-                with open(state.staging / state.config.output_manifest.name, 'w') as f:
+            with complete_step(f"Saving manifest {state.config.output_manifest}"):
+                with open(state.staging / state.config.output_manifest, 'w') as f:
                     manifest.write_json(f)
 
         if ManifestFormat.changelog in state.config.manifest_format:
-            with complete_step(f"Saving report {state.config.output_changelog.name}"):
-                with open(state.staging / state.config.output_changelog.name, 'w') as f:
+            with complete_step(f"Saving report {state.config.output_changelog}"):
+                with open(state.staging / state.config.output_changelog, 'w') as f:
                     manifest.write_package_report(f)
 
 
 def print_output_size(config: MkosiConfig) -> None:
-    if not config.output_compressed.exists():
+    if not config.output_dir.joinpath(config.output).exists():
         return
 
     if config.output_format == OutputFormat.directory:
-        log_step("Resulting image size is " + format_bytes(dir_size(config.output)) + ".")
+        log_step("Resulting image size is " + format_bytes(dir_size(config.output_dir / config.output)) + ".")
     else:
-        st = os.stat(config.output_compressed)
+        st = config.output_dir.joinpath(config.output).stat()
         size = format_bytes(st.st_size)
         space = format_bytes(st.st_blocks * 512)
         log_step(f"Resulting image size is {size}, consumes {space}.")
@@ -960,44 +966,24 @@ def empty_directory(path: Path) -> None:
 
 
 def unlink_output(args: MkosiArgs, config: MkosiConfig) -> None:
-    with complete_step("Removing output files…"):
-        if config.output.parent.exists():
-            for p in config.output.parent.iterdir():
-                if p.name.startswith(config.output.name):
-                    unlink_try_hard(p)
-
-        unlink_try_hard(Path(f"{config.output}.manifest"))
-        unlink_try_hard(Path(f"{config.output}.changelog"))
-
-        if config.output_split_kernel.parent.exists():
-            for p in config.output_split_kernel.parent.iterdir():
-                if p.name.startswith(config.output_split_kernel.name):
-                    unlink_try_hard(p)
-        unlink_try_hard(config.output_split_kernel)
-
-        if config.output_split_uki.parent.exists():
-            for p in config.output_split_uki.parent.iterdir():
-                if p.name.startswith(config.output_split_uki.name):
-                    unlink_try_hard(p)
-        unlink_try_hard(config.output_split_uki)
-
-        if config.nspawn_settings is not None:
-            unlink_try_hard(config.output_nspawn_settings)
-
-    if config.ssh and config.output_sshkey is not None:
-        unlink_try_hard(config.output_sshkey)
-
-    # We remove any cached images if either the user used --force
-    # twice, or he/she called "clean" with it passed once. Let's also
-    # remove the downloaded package cache if the user specified one
-    # additional "--force".
+    # We remove any cached images if either the user used --force twice, or he/she called "clean" with it
+    # passed once. Let's also remove the downloaded package cache if the user specified one additional
+    # "--force". Let's also remove all versions if the user specified one additional "--force".
 
     if args.verb == Verb.clean:
         remove_build_cache = args.force > 0
         remove_package_cache = args.force > 1
+        prefix = config.output if args.force > 1 else config.output_with_version
     else:
         remove_build_cache = args.force > 1
         remove_package_cache = args.force > 2
+        prefix = config.output if args.force > 2 else config.output_with_version
+
+    with complete_step("Removing output files…"):
+        if config.output_dir.exists():
+            for p in config.output_dir.iterdir():
+                if p.name.startswith(prefix):
+                    unlink_try_hard(p)
 
     if remove_build_cache:
         for p in cache_tree_paths(config):
@@ -1005,33 +991,23 @@ def unlink_output(args: MkosiArgs, config: MkosiConfig) -> None:
                 with complete_step(f"Removing cache directory {p}…"):
                     unlink_try_hard(p)
 
-        if config.build_dir is not None and config.build_dir.exists() and any(config.build_dir.iterdir()):
+        if config.build_dir and config.build_dir.exists() and any(config.build_dir.iterdir()):
             with complete_step("Clearing out build directory…"):
                 empty_directory(config.build_dir)
 
-        if config.install_dir is not None and config.install_dir.exists() and any(config.install_dir.iterdir()):
+        if config.install_dir and config.install_dir.exists() and any(config.install_dir.iterdir()):
             with complete_step("Clearing out install directory…"):
                 empty_directory(config.install_dir)
 
     if remove_package_cache:
-        if config.cache_dir is not None and config.cache_dir.exists() and any(config.cache_dir.iterdir()):
+        if config.cache_dir and config.cache_dir.exists() and any(config.cache_dir.iterdir()):
             with complete_step("Clearing out package cache…"):
                 empty_directory(config.cache_dir)
 
 
 def cache_tree_paths(config: MkosiConfig) -> tuple[Path, Path]:
-
     assert config.cache_dir
-
-    # If the image ID is specified, use cache file names that are independent of the image versions, so that
-    # rebuilding and bumping versions is cheap and reuses previous versions if cached.
-    if config.image_id:
-        prefix = config.cache_dir / config.image_id
-    # Otherwise, derive the cache file names directly from the output file names.
-    else:
-        prefix = config.cache_dir / config.output.name
-
-    return (Path(f"{prefix}.cache"), Path(f"{prefix}.build.cache"))
+    return config.cache_dir / f"{config.output}.cache", config.cache_dir / f"{config.output}.build.cache"
 
 
 def check_tree_input(path: Optional[Path]) -> None:
@@ -1093,9 +1069,8 @@ def check_outputs(config: MkosiConfig) -> None:
         config.output_checksum if config.checksum else None,
         config.output_signature if config.sign else None,
         config.output_nspawn_settings if config.nspawn_settings is not None else None,
-        config.output_sshkey if config.ssh else None,
     ):
-        if f and f.exists():
+        if f and config.output_dir.joinpath(f).exists():
             die(f"Output path {f} exists already. (Consider invocation with --force.)")
 
 
@@ -1183,7 +1158,7 @@ def print_summary(args: MkosiArgs, config: MkosiConfig) -> None:
               Manifest Formats: {maniformats}
               Output Directory: {none_to_default(config.output_dir)}
            Workspace Directory: {none_to_default(config.workspace_dir)}
-                        Output: {bold(config.output_compressed)}
+                        Output: {bold(config.output_with_compression)}
                Output Checksum: {none_to_na(config.output_checksum if config.checksum else None)}
               Output Signature: {none_to_na(config.output_signature if config.sign else None)}
         Output nspawn Settings: {none_to_na(config.output_nspawn_settings if config.nspawn_settings is not None else None)}
@@ -1238,9 +1213,6 @@ def print_summary(args: MkosiArgs, config: MkosiConfig) -> None:
 
 def make_output_dir(state: MkosiState) -> None:
     """Create the output directory if set and not existing yet"""
-    if state.config.output_dir is None:
-        return
-
     run(["mkdir", "-p", state.config.output_dir], user=state.uid, group=state.gid)
 
 
@@ -1384,9 +1356,9 @@ def reuse_cache_tree(state: MkosiState) -> bool:
     return True
 
 
-def invoke_repart(state: MkosiState, skip: Sequence[str] = [], split: bool = False) -> Optional[str]:
+def invoke_repart(state: MkosiState, skip: Sequence[str] = [], split: bool = False) -> tuple[Optional[str], list[Path]]:
     if not state.config.output_format == OutputFormat.disk:
-        return None
+        return None, []
 
     cmdline: list[PathString] = [
         "systemd-repart",
@@ -1395,10 +1367,10 @@ def invoke_repart(state: MkosiState, skip: Sequence[str] = [], split: bool = Fal
         "--dry-run=no",
         "--json=pretty",
         "--root", state.root,
-        state.staging / state.config.output.name,
+        state.staging / state.config.output_with_format,
     ]
 
-    if not state.staging.joinpath(state.config.output.name).exists():
+    if not state.staging.joinpath(state.config.output_with_format).exists():
         cmdline += ["--empty=create"]
     if state.config.passphrase:
         cmdline += ["--key-file", state.config.passphrase]
@@ -1480,7 +1452,9 @@ def invoke_repart(state: MkosiState, skip: Sequence[str] = [], split: bool = Fal
         else:
             roothash = roothash or h
 
-    return f"roothash={roothash}" if roothash else f"usrhash={usrhash}" if usrhash else None
+    split_paths = [Path(p["split_path"]) for p in output if p.get("split_path", "-") != "-"]
+
+    return f"roothash={roothash}" if roothash else f"usrhash={usrhash}" if usrhash else None, split_paths
 
 
 def build_image(state: MkosiState, *, for_cache: bool, manifest: Optional[Manifest] = None) -> None:
@@ -1524,9 +1498,12 @@ def build_image(state: MkosiState, *, for_cache: bool, manifest: Optional[Manife
         run_finalize_script(state)
         run_selinux_relabel(state)
 
-    roothash = invoke_repart(state, skip=("esp", "xbootldr"))
+    roothash, _ = invoke_repart(state, skip=("esp", "xbootldr"))
     install_unified_kernel(state, roothash)
-    invoke_repart(state, split=True)
+    _, split_paths = invoke_repart(state, split=True)
+
+    for p in split_paths:
+        maybe_compress(state, p)
 
     make_tar(state)
     make_initrd(state)
@@ -1624,7 +1601,7 @@ def acl_toggle_build(state: MkosiState) -> Iterator[None]:
 
         yield
     finally:
-        for p in (*state.config.base_trees, state.config.cache_dir, *state.config.output_paths()):
+        for p in (*state.config.base_trees, state.config.cache_dir, state.config.output_dir / state.config.output):
             if p and p.is_dir():
                 with complete_step(f"Adding ACLs to {p}"):
                     setfacl(p, state.uid, allow=True)
@@ -1663,24 +1640,23 @@ def build_stuff(uid: int, gid: int, args: MkosiArgs, config: MkosiConfig) -> Non
             state = dataclasses.replace(state, )
             build_image(state, manifest=manifest, for_cache=False)
 
+        maybe_compress(state,
+                       state.staging / state.config.output_with_format,
+                       state.staging / state.config.output_with_compression)
+
         copy_nspawn_settings(state)
         calculate_sha256sum(state)
         calculate_signature(state)
         save_manifest(state, manifest)
 
-        for p in state.config.output_paths():
-            if state.staging.joinpath(p.name).exists():
-                shutil.move(state.staging / p.name, p)
-                if p != state.config.output or state.config.output_format != OutputFormat.directory:
-                    os.chown(p, uid, gid)
-                if p == state.config.output:
-                    compress_output(state.config, p, uid=uid, gid=gid)
+        for f in state.staging.iterdir():
+            if not f.is_dir():
+                os.chown(f, uid, gid)
 
-        for p in state.staging.iterdir():
-            shutil.move(p, state.config.output.parent / p.name)
-            os.chown(state.config.output.parent / p.name, uid, gid)
-            if p.name.startswith(state.config.output.name):
-                compress_output(state.config, p, uid=uid, gid=gid)
+            shutil.move(f, state.config.output_dir)
+
+        if not state.config.output_dir.joinpath(state.config.output).exists():
+            state.config.output_dir.joinpath(state.config.output).symlink_to(state.config.output_with_compression)
 
     print_output_size(config)
 
@@ -1691,7 +1667,7 @@ def check_root() -> None:
 
 
 def machine_cid(config: MkosiConfig) -> int:
-    cid = int.from_bytes(hashlib.sha256(machine_name(config).encode()).digest()[:4], byteorder='little')
+    cid = int.from_bytes(hashlib.sha256(config.output_with_version.encode()).digest()[:4], byteorder='little')
     # Make sure we don't return any of the well-known CIDs.
     return max(3, min(cid, 0xFFFFFFFF - 1))
 
@@ -1718,25 +1694,25 @@ def acl_toggle_boot(config: MkosiConfig) -> Iterator[None]:
     uid = InvokingUser.uid()
 
     try:
-        with complete_step(f"Removing ACLs from {config.output}"):
-            setfacl(config.output, uid, allow=False)
+        with complete_step(f"Removing ACLs from {config.output_dir / config.output}"):
+            setfacl(config.output_dir / config.output, uid, allow=False)
         yield
     finally:
-        with complete_step(f"Adding ACLs to {config.output}"):
-            setfacl(config.output, uid, allow=True)
+        with complete_step(f"Adding ACLs to {config.output_dir / config.output}"):
+            setfacl(config.output_dir / config.output, uid, allow=True)
 
 
 def run_shell(args: MkosiArgs, config: MkosiConfig) -> None:
     cmdline: list[PathString] = ["systemd-nspawn", "--quiet"]
 
     if config.output_format == OutputFormat.directory:
-        cmdline += ["--directory", config.output]
+        cmdline += ["--directory", config.output_dir / config.output]
 
-        owner = os.stat(config.output).st_uid
+        owner = os.stat(config.output_dir / config.output).st_uid
         if owner != 0:
             cmdline += [f"--private-users={str(owner)}"]
     else:
-        cmdline += ["--image", config.output]
+        cmdline += ["--image", config.output_dir / config.output]
 
     # If we copied in a .nspawn file, make sure it's actually honoured
     if config.nspawn_settings is not None:
@@ -1755,7 +1731,7 @@ def run_shell(args: MkosiArgs, config: MkosiConfig) -> None:
     if config.ephemeral:
         cmdline += ["--ephemeral"]
 
-    cmdline += ["--machine", machine_name(config)]
+    cmdline += ["--machine", config.output]
     cmdline += [f"--bind={config.build_sources}:/root/src", "--chdir=/root/src"]
 
     for k, v in config.credentials.items():
@@ -1961,7 +1937,7 @@ def run_qemu(args: MkosiArgs, config: MkosiConfig) -> None:
             ]
 
         if config.ephemeral:
-            f = stack.enter_context(tempfile.NamedTemporaryFile(prefix=".mkosi-", dir=config.output.parent))
+            f = stack.enter_context(tempfile.NamedTemporaryFile(prefix=".mkosi-", dir=config.output_dir))
             fname = Path(f.name)
 
             # So on one hand we want CoW off, since this stuff will
@@ -1973,13 +1949,13 @@ def run_qemu(args: MkosiArgs, config: MkosiConfig) -> None:
             # CoW but later changes do not result in CoW anymore.
 
             run(["chattr", "+C", fname], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
-            copy_path(config.output_compressed, fname)
+            copy_path(config.output_dir / config.output, fname)
         else:
-            fname = config.output_compressed
+            fname = config.output_dir / config.output
 
         # Debian images fail to boot with virtio-scsi, see: https://github.com/systemd/mkosi/issues/725
         if config.output_format == OutputFormat.cpio:
-            kernel = (config.output_dir or Path.cwd()) / config.output_split_kernel
+            kernel = config.output_dir / config.output_split_kernel
             if not kernel.exists() and "-kernel" not in args.cmdline:
                 die("No kernel found, please install a kernel in the cpio or provide a -kernel argument to mkosi qemu")
             cmdline += ["-kernel", kernel,
@@ -2099,7 +2075,10 @@ def expand_specifier(s: str) -> str:
 
 
 def needs_build(args: MkosiArgs, config: MkosiConfig) -> bool:
-    return args.verb == Verb.build or (args.verb in MKOSI_COMMANDS_NEED_BUILD and (not config.output_compressed.exists() or args.force > 0))
+    if args.verb == Verb.build:
+        return True
+
+    return args.verb in MKOSI_COMMANDS_NEED_BUILD and (args.force > 0 or not config.output_dir.joinpath(config.output).exists())
 
 
 def run_verb(args: MkosiArgs, presets: Sequence[MkosiConfig]) -> None:

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -616,11 +616,11 @@ class MkosiConfig:
 
     @property
     def output_checksum(self) -> Path:
-        return self.output.parent / "SHA256SUMS"
+        return build_auxiliary_output_path(self, ".SHA256SUMS")
 
     @property
     def output_signature(self) -> Path:
-        return self.output.parent / "SHA256SUMS.gpg"
+        return build_auxiliary_output_path(self, ".SHA256SUMS.gpg")
 
     @property
     def output_sshkey(self) -> Path:
@@ -1801,7 +1801,6 @@ def strip_suffixes(path: Path) -> Path:
     while path.suffix in {
         ".xz",
         ".zstd",
-        ".zst",
         ".raw",
         ".tar",
         ".cpio",

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -394,6 +394,22 @@ def config_make_path_parser(*,
     return config_parse_path
 
 
+def config_parse_filename(dest: str, value: Optional[str], namespace: argparse.Namespace) -> Optional[str]:
+    if dest in namespace:
+        return getattr(namespace, dest) # type: ignore
+
+    if not value:
+        return None
+
+    if value == "." or value == "..":
+        die(". and .. are not valid filenames")
+
+    if "/" in value:
+        die(f"{value} is not a valid filename")
+
+    return value
+
+
 def match_path_exists(value: str) -> bool:
     if not value:
         return False
@@ -529,8 +545,8 @@ class MkosiConfig:
     architecture: str
     output_format: OutputFormat
     manifest_format: list[ManifestFormat]
-    output: Path
-    output_dir: Optional[Path]
+    output: str
+    output_dir: Path
     kernel_command_line: list[str]
     secure_boot: bool
     secure_boot_key: Optional[Path]
@@ -603,56 +619,62 @@ class MkosiConfig:
         return self.architecture == platform.machine()
 
     @property
-    def output_split_uki(self) -> Path:
-        return build_auxiliary_output_path(self, ".efi")
+    def output_with_version(self) -> str:
+        output = self.output
+
+        if self.image_version:
+            output += f"_{self.image_version}"
+
+        return output
 
     @property
-    def output_split_kernel(self) -> Path:
-        return build_auxiliary_output_path(self, ".vmlinuz")
+    def output_with_format(self) -> str:
+        output = self.output_with_version
+
+        output += {
+            OutputFormat.disk: ".raw",
+            OutputFormat.cpio: ".cpio",
+            OutputFormat.tar: ".tar",
+        }.get(self.output_format, "")
+
+        return output
 
     @property
-    def output_nspawn_settings(self) -> Path:
-        return build_auxiliary_output_path(self, ".nspawn")
+    def output_with_compression(self) -> str:
+        output = self.output_with_format
+
+        if self.compress_output:
+            output += f".{self.compress_output}"
+
+        return output
 
     @property
-    def output_checksum(self) -> Path:
-        return build_auxiliary_output_path(self, ".SHA256SUMS")
+    def output_split_uki(self) -> str:
+        return f"{self.output_with_version}.efi"
 
     @property
-    def output_signature(self) -> Path:
-        return build_auxiliary_output_path(self, ".SHA256SUMS.gpg")
+    def output_split_kernel(self) -> str:
+        return f"{self.output_with_version}.vmlinuz"
 
     @property
-    def output_sshkey(self) -> Path:
-        return build_auxiliary_output_path(self, ".ssh")
+    def output_nspawn_settings(self) -> str:
+        return f"{self.output_with_version}.nspawn"
 
     @property
-    def output_manifest(self) -> Path:
-        return build_auxiliary_output_path(self, ".manifest")
+    def output_checksum(self) -> str:
+        return f"{self.output_with_version}.SHA256SUMS"
 
     @property
-    def output_changelog(self) -> Path:
-        return build_auxiliary_output_path(self, ".changelog")
+    def output_signature(self) -> str:
+        return f"{self.output_with_version}.SHA256SUMS.gpg"
 
     @property
-    def output_compressed(self) -> Path:
-        if not self.compress_output:
-            return self.output
+    def output_manifest(self) -> str:
+        return f"{self.output_with_version}.manifest"
 
-        return self.output.parent / f"{self.output.name}.{self.compress_output}"
-
-    def output_paths(self) -> tuple[Path, ...]:
-        return (
-            self.output,
-            self.output_split_uki,
-            self.output_split_kernel,
-            self.output_nspawn_settings,
-            self.output_checksum,
-            self.output_signature,
-            self.output_sshkey,
-            self.output_manifest,
-            self.output_changelog,
-        )
+    @property
+    def output_changelog(self) -> str:
+        return f"{self.output_with_version}.changelog"
 
 
 class MkosiConfigParser:
@@ -719,7 +741,7 @@ class MkosiConfigParser:
         MkosiConfigSetting(
             dest="output",
             section="Output",
-            parse=config_make_path_parser(required=False, absolute=False),
+            parse=config_parse_filename,
         ),
         MkosiConfigSetting(
             dest="output_dir",
@@ -727,6 +749,7 @@ class MkosiConfigParser:
             section="Output",
             parse=config_make_path_parser(required=False),
             paths=("mkosi.output",),
+            default=Path("."),
         ),
         MkosiConfigSetting(
             dest="workspace_dir",
@@ -908,7 +931,7 @@ class MkosiConfigParser:
             dest="build_sources",
             section="Content",
             parse=config_make_path_parser(),
-            default=".",
+            default=Path("."),
         ),
         MkosiConfigSetting(
             dest="build_packages",
@@ -1295,13 +1318,13 @@ class MkosiConfigParser:
         group.add_argument(
             "-o", "--output",
             metavar="PATH",
-            help="Output image path",
+            help="Output name",
             action=action,
         )
         group.add_argument(
             "-O", "--output-dir",
             metavar="DIR",
-            help="Output root directory",
+            help="Output directory",
             action=action,
         )
         group.add_argument(
@@ -1810,11 +1833,6 @@ def strip_suffixes(path: Path) -> Path:
     return path
 
 
-def build_auxiliary_output_path(args: Union[argparse.Namespace, MkosiConfig], suffix: str) -> Path:
-    output = strip_suffixes(args.output)
-    return output.with_name(f"{output.name}{suffix}")
-
-
 def find_image_version(args: argparse.Namespace) -> None:
     if args.image_version is not None:
         return
@@ -1849,11 +1867,6 @@ def find_password(args: argparse.Namespace) -> None:
         pass
 
 
-
-def machine_name(config: Union[MkosiConfig, argparse.Namespace]) -> str:
-    return config.image_id or config.output.with_suffix("").name.partition("_")[0]
-
-
 def load_credentials(args: argparse.Namespace) -> dict[str, str]:
     creds = {}
 
@@ -1883,7 +1896,7 @@ def load_credentials(args: argparse.Namespace) -> dict[str, str]:
         creds["firstboot.locale"] = "C.UTF-8"
 
     if "firstboot.hostname" not in creds:
-        creds["firstboot.hostname"] = machine_name(args)
+        creds["firstboot.hostname"] = args.output
 
     if args.ssh and "ssh.authorized_keys.root" not in creds and "SSH_AUTH_SOCK" in os.environ:
         key = run(
@@ -1951,26 +1964,7 @@ def load_config(args: argparse.Namespace) -> MkosiConfig:
         args.compress_output = Compression.zst if args.output_format == OutputFormat.cpio else Compression.none
 
     if args.output is None:
-        iid = args.image_id or args.preset or "image"
-        prefix = f"{iid}_{args.image_version}" if args.image_version is not None else iid
-
-        if args.output_format == OutputFormat.disk:
-            output = f"{prefix}.raw"
-        elif args.output_format == OutputFormat.tar:
-            output = f"{prefix}.tar"
-        elif args.output_format == OutputFormat.cpio:
-            output = f"{prefix}.cpio"
-        else:
-            output = prefix
-        args.output = Path(output)
-
-    if args.output_dir is not None:
-        if "/" not in str(args.output):
-            args.output = args.output_dir / args.output
-        else:
-            logging.warning("Ignoring configured output directory as output file is a qualified path.")
-
-    args.output = args.output.absolute()
+        args.output = args.image_id or args.preset or "image"
 
     if args.environment:
         env = {}

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -176,7 +176,6 @@ def is_apt_distribution(d: Distribution) -> bool:
 
 class OutputFormat(str, enum.Enum):
     directory = "directory"
-    subvolume = "subvolume"
     tar = "tar"
     cpio = "cpio"
     disk = "disk"


### PR DESCRIPTION
Rework output related logic
- Let's store the output as a "base" name without any suffixes from
which we construct all other output paths.
- Let's not allow --output to be specified as a path anymore and
always put it in the configured output directory.
- Let's return all output paths as strings instead of paths.
- Let's always create a symlink from the "base" name to the full
output path so it can be referred to regardless of the output
format, compression or image version that's used.
- Let's make sure we compress split partitions if requested