### PR TITLE
Kernel modules initrd improvements

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -822,6 +822,29 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 : Add `/etc/initrd-release` and `/init` to the image so that it can be
   used as an initramfs.
 
+`KernelModulesInitrd=`, `--kernel-modules-initrd=`
+
+: Enable/Disable generation of the kernel modules initrd when building a bootable image. Enabled by default.
+  If enabled, when building a bootable image, for each kernel that we assemble a unified kernel image for, we
+  generate an extra initrd containing only the kernel modules for that kernel version and append it to the
+  prebuilt initrd. This allows generating kernel indepedent initrds which are augmented with the necessary
+  kernel modules when the UKI is assembled. By default all kernel modules and their required firmware files
+  are included.
+
+`KernelModulesInitrdInclude=`, `--kernel-modules-initrd-include=`
+
+: Takes a list of regex patterns that specify modules to include in the kernel modules initrd. Patterns
+  should be relative to the `/usr/lib/modules/<kver>/kernel` directory. mkosi checks for a match anywhere in
+  the module path (e.g. "i915" will match against "drivers/gpu/drm/i915.ko") All modules that match any of
+  the specified patterns are included in the kernel modules initrd. All module and firmware dependencies of
+  the matched modules are included in the kernel modules initrd as well.
+
+`KernelModulesInitrdExclude=`, `--kernel-modules-initrd-exclude=`
+
+: Takes a list of regex patterns that specify modules to exclude from the kernel modules initrd. Behaves the
+  same as `KernelModulesInitrdInclude=` except that all modules that match any of the specified patterns are
+  excluded from the kernel modules initrd. This setting takes priority over `KernelModulesInitrdInclude=`.
+
 ### [Validation] Section
 
 `Checksum=`, `--checksum`

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -606,6 +606,9 @@ class MkosiConfig:
     workspace_dir: Optional[Path]
     initrds: list[Path]
     make_initrd: bool
+    kernel_modules_initrd: bool
+    kernel_modules_initrd_include: list[str]
+    kernel_modules_initrd_exclude: list[str]
     kernel_command_line_extra: list[str]
     acl: bool
     bootable: ConfigFeature
@@ -1009,6 +1012,22 @@ class MkosiConfigParser:
             dest="make_initrd",
             section="Content",
             parse=config_parse_boolean,
+        ),
+        MkosiConfigSetting(
+            dest="kernel_modules_initrd",
+            section="Content",
+            parse=config_parse_boolean,
+            default=True,
+        ),
+        MkosiConfigSetting(
+            dest="kernel_modules_initrd_include",
+            section="Content",
+            parse=config_make_list_parser(delimiter=","),
+        ),
+        MkosiConfigSetting(
+            dest="kernel_modules_initrd_exclude",
+            section="Content",
+            parse=config_make_list_parser(delimiter=","),
         ),
         MkosiConfigSetting(
             dest="checksum",
@@ -1620,6 +1639,25 @@ class MkosiConfigParser:
             help="Make sure the image can be used as an initramfs",
             metavar="BOOL",
             nargs="?",
+            action=action,
+        )
+        group.add_argument(
+            "--kernel-modules-initrd",
+            help="When building a bootable image, add an extra initrd containing the kernel modules",
+            metavar="BOOL",
+            nargs="?",
+            action=action,
+        )
+        group.add_argument(
+            "--kernel-modules-initrd-include",
+            help="When building a kernel modules initrd, only include the specified kernel modules",
+            metavar="REGEX",
+            action=action,
+        )
+        group.add_argument(
+            "--kernel-modules-initrd-exclude",
+            help="When building a kernel modules initrd, exclude the specified kernel modules",
+            metavar="REGEX",
             action=action,
         )
 


### PR DESCRIPTION
- Let's compress the kernel modules initrd on Debian to at least reduce the disk usage required for the initrd. Not required for other distros since those compress their kernel modules already individually.
- Add option --kernel-modules-initrd to enable/disable usage of the kernel modules initrd. Can be used to disable it if the main initrd already contains the necessary kernel modules
- Add options --kernel-modules-initrd-include/exclude to allow including/excluding the initrds to put in the kernel modules initrd by regex patterns.