### PR TITLE
Adopt systemd-firstboot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,6 @@
 /mkosi.nspawn
 /mkosi.rootpw
 /mkosi.conf
-/mkosi.secure-boot.key
-/mkosi.secure-boot.crt
+/mkosi.key
+/mkosi.crt
 __pycache__

--- a/NEWS.md
+++ b/NEWS.md
@@ -82,6 +82,8 @@
 - `--base-image` is split into `--base-tree` and `--overlay`.
 - Removed `--cache-initrd`, instead, use a prebuilt initrd with `Initrds=` to avoid rebuilding the initrd all
   the time.
+- Disk images are now resized to 8G when booted to give some disk space to play around with in the booted
+  image.
 
 ## v14
 

--- a/action.yaml
+++ b/action.yaml
@@ -44,13 +44,14 @@ runs:
       sudo apt-get install libfdisk-dev
 
       git clone https://github.com/systemd/systemd --depth=1
-      meson setup systemd/build systemd -Drepart=true -Defi=true -Dbootloader=true -Dukify=true
+      meson setup systemd/build systemd -Drepart=true -Defi=true -Dbootloader=true -Dukify=true -Dfirstboot=true
 
       BINARIES=(
         bootctl
         systemctl
         systemd-analyze
         systemd-dissect
+        systemd-firstboot
         systemd-nspawn
         systemd-repart
         ukify

--- a/mkosi.md
+++ b/mkosi.md
@@ -990,16 +990,15 @@ Those settings cannot be configured in the configuration files.
 
 : Show brief usage information.
 
-`--secure-boot-common-name=`
+`--genkey-common-name=`
 
-: Common name to be used when generating SecureBoot keys via mkosi's `genkey`
-  command. Defaults to `mkosi of %u`, where `%u` expands to the username of the
-  user invoking mkosi.
+: Common name to be used when generating keys via mkosi's `genkey` command. Defaults to `mkosi of %u`, where
+  `%u` expands to the username of the user invoking mkosi.
 
-`--secure-boot-valid-days=`
+`--genkey-valid-days=`
 
-: Number of days that the keys should remain valid when generating SecureBoot
-  keys via mkosi's `genkey` command. Defaults to two years (730 days).
+: Number of days that the keys should remain valid when generating keys via mkosi's `genkey` command.
+  Defaults to two years (730 days).
 
 `--auto-bump=`, `-B`
 
@@ -1169,11 +1168,8 @@ local directory:
   file does not exist and encryption is requested, the user is queried
   instead.
 
-* The **`mkosi.secure-boot.crt`** and **`mkosi.secure-boot.key`**
-  files contain an X.509 certificate and PEM private key to use when
-  UEFI SecureBoot support is enabled. All EFI binaries included in the
-  image's ESP are signed with this key, as a late step in the build
-  process.
+* The **`mkosi.crt`** and **`mkosi.key`** files contain an X.509 certificate and PEM private key to use when
+  signing is required (UEFI SecureBoot, verity, ...).
 
 * The **`mkosi.output/`** directory will be used for all build
   artifacts, if the image output path is not configured (i.e. no

--- a/mkosi.md
+++ b/mkosi.md
@@ -122,6 +122,82 @@ The following command line verbs are known:
 : This verb is equivalent to the `--help` switch documented below: it
   shows a brief usage explanation.
 
+## Commandline-only Options
+
+Those settings cannot be configured in the configuration files.
+
+`--force`, `-f`
+
+: Replace the output file if it already exists, when building an
+  image. By default when building an image and an output artifact
+  already exists `mkosi` will refuse operation. Specify this option
+  once to delete all build artifacts from a previous run before
+  re-building the image. If incremental builds are enabled,
+  specifying this option twice will ensure the intermediary
+  cache files are removed, too, before the re-build is initiated. If a
+  package cache is used (also see the "Files" section below),
+  specifying this option thrice will ensure the package cache is
+  removed too, before the re-build is initiated. For the `clean`
+  operation this option has a slightly different effect: by default
+  the verb will only remove build artifacts from a previous run, when
+  specified once the incremental cache files are deleted too, and when
+  specified twice the package cache is also removed.
+
+`--directory=`, `-C`
+
+: Takes a path to a directory. `mkosi` switches to this directory
+  before doing anything. Note that the various `mkosi.*` files are
+  searched for only after changing to this directory, hence using this
+  option is an effective way to build a project located in a specific
+  directory.
+
+`--config=`
+
+: Loads additional settings from the specified settings file. Most
+  command line options may also be configured in a settings file. See
+  the table below to see which command line options match which
+  settings file option. If this option is not used, but a file
+  `mkosi.conf` is found in the local directory it is automatically
+  used for this purpose. If a setting is configured both on the
+  command line and in the settings file, the command line generally
+  wins, except for options taking lists in which case both lists are
+  combined.
+
+`--debug=`
+
+: Enable additional debugging output.
+
+`--debug-shell=`
+
+: When executing a command in the image fails, mkosi will start an interactive
+  shell in the image allowing further debugging.
+
+`--version`
+
+: Show package version.
+
+`--help`, `-h`
+
+: Show brief usage information.
+
+`--genkey-common-name=`
+
+: Common name to be used when generating keys via mkosi's `genkey` command. Defaults to `mkosi of %u`, where
+  `%u` expands to the username of the user invoking mkosi.
+
+`--genkey-valid-days=`
+
+: Number of days that the keys should remain valid when generating keys via mkosi's `genkey` command.
+  Defaults to two years (730 days).
+
+`--auto-bump=`, `-B`
+
+: If specified, after each successful build the the version is bumped
+  in a fashion equivalent to the `bump` verb, in preparation for the
+  next build. This is useful for simple, linear version management:
+  each build in a series will have a version number one higher then
+  the previous one.
+
 ## Execution Flow
 
 Execution flow for `mkosi build`. Default values/calls are shown in parentheses.
@@ -419,38 +495,6 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   `mkosi.installdir` exists in the local directory, it is automatically
   used for this purpose (also see the "Files" section below).
 
-`Force=`, `--force`, `-f`
-
-: Replace the output file if it already exists, when building an
-  image. By default when building an image and an output artifact
-  already exists `mkosi` will refuse operation. Specify this option
-  once to delete all build artifacts from a previous run before
-  re-building the image. If incremental builds are enabled,
-  specifying this option twice will ensure the intermediary
-  cache files are removed, too, before the re-build is initiated. If a
-  package cache is used (also see the "Files" section below),
-  specifying this option thrice will ensure the package cache is
-  removed too, before the re-build is initiated. For the `clean`
-  operation this option has a slightly different effect: by default
-  the verb will only remove build artifacts from a previous run, when
-  specified once the incremental cache files are deleted too, and when
-  specified twice the package cache is also removed.
-
-  <!--  FIXME: allow `Force=<n>` -->
-
-`Bootable=`, `--bootable=`
-
-: Takes a boolean or `auto`. Enables or disables generation of a bootable
-  image. If enabled, mkosi will install systemd-boot, run kernel-install,
-  generate unified kernel images for installed kernels and add an ESP
-  partition when the disk image output is used. If systemd-boot is not
-  installed or no kernel images can be found, the build will fail. `auto`
-  behaves as if the option was enabled, but the build won't fail if either
-  no kernel images or systemd-boot can't be found. If disabled, systemd-boot
-  won't be installed even if found inside the image, kernel-install won't be
-  executed, no unified kernel images will be generated and no ESP partition
-  will be added to the image if the disk output format is used.
-
 `UseSubvolumes=`, `--use-subvolumes=`
 
 : Takes a boolean or `auto`. Enables or disables use of btrfs subvolumes for
@@ -460,43 +504,6 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   explicitly enabled and `btrfs` is not installed or subvolumes cannot be
   created, an error is raised. If `auto`, missing `btrfs` or failures to
   create subvolumes are ignored.
-
-`KernelCommandLine=`, `--kernel-command-line=`
-
-: Use the specified kernel command line when building images. By default
-  command line arguments get appended. To remove all arguments from the
-  current list pass "!\*". To remove specific arguments add a space
-  separated list of "!" prefixed arguments. For example adding
-  "!\* console=ttyS0 rw" to a `mkosi.conf` file or the command line
-  arguments passes "console=ttyS0 rw" to the kernel in any case. Just
-  adding "console=ttyS0 rw" would append these two arguments to the kernel
-  command line created by lower priority configuration files or previous
-  `KernelCommandLine=` command line arguments.
-
-`SecureBoot=`, `--secure-boot`
-
-: Sign the resulting kernel/initrd image for UEFI SecureBoot.
-
-`SecureBootKey=`, `--secure-boot-key=`
-
-: Path to the PEM file containing the secret key for signing the
-  UEFI kernel image, if `SecureBoot=` is used.
-
-`SecureBootCertificate=`, `--secure-boot-certificate=`
-
-: Path to the X.509 file containing the certificate for the signed
-  UEFI kernel image, if `SecureBoot=` is used.
-
-[//]: # (Please add external tools to the list here.)
-
-`SignExpectedPCR=`, `--sign-expected-pcr`
-
-: Measure the components of the unified kernel image (UKI) using
-  `systemd-measure` and embed the PCR signature into the unified kernel
-  image. This option takes a boolean value or the special value `auto`,
-  which is the default, which is equal to a true value if the
-  [`cryptography`](https://cryptography.io/) module is importable and
-  the `systemd-measure` binary is in `PATH`.
 
 `CompressOutput=`, `--compress-output=`
 
@@ -626,6 +633,31 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   build script to bypass any unit or integration tests that are
   normally run during the source build process. Note that this option
   has no effect unless the `mkosi.build` build script honors it.
+
+`Bootable=`, `--bootable=`
+
+: Takes a boolean or `auto`. Enables or disables generation of a bootable
+  image. If enabled, mkosi will install systemd-boot, run kernel-install,
+  generate unified kernel images for installed kernels and add an ESP
+  partition when the disk image output is used. If systemd-boot is not
+  installed or no kernel images can be found, the build will fail. `auto`
+  behaves as if the option was enabled, but the build won't fail if either
+  no kernel images or systemd-boot can't be found. If disabled, systemd-boot
+  won't be installed even if found inside the image, kernel-install won't be
+  executed, no unified kernel images will be generated and no ESP partition
+  will be added to the image if the disk output format is used.
+
+`KernelCommandLine=`, `--kernel-command-line=`
+
+: Use the specified kernel command line when building images. By default
+  command line arguments get appended. To remove all arguments from the
+  current list pass "!\*". To remove specific arguments add a space
+  separated list of "!" prefixed arguments. For example adding
+  "!\* console=ttyS0 rw" to a `mkosi.conf` file or the command line
+  arguments passes "console=ttyS0 rw" to the kernel in any case. Just
+  adding "console=ttyS0 rw" would append these two arguments to the kernel
+  command line created by lower priority configuration files or previous
+  `KernelCommandLine=` command line arguments.
 
 `BaseTrees=`, `--base-tree=`
 
@@ -789,15 +821,6 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   reproducibility, as long as the package data cache is already fully
   populated.
 
-`Settings=`, `--settings=`
-
-: Specifies a `.nspawn` settings file for `systemd-nspawn` to use in
-  the `boot` and `shell` verbs, and to place next to the generated
-  image file. This is useful to configure the `systemd-nspawn`
-  environment when the image is run. If this setting is not used but
-  an `mkosi.nspawn` file found in the local directory it is
-  automatically used for this purpose.
-
 `Initrd=`, `--initrd`
 
 : Use user-provided initrd(s). Takes a comma separated list of paths to initrd
@@ -847,6 +870,29 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 
 ### [Validation] Section
 
+`SecureBoot=`, `--secure-boot`
+
+: Sign the resulting kernel/initrd image for UEFI SecureBoot.
+
+`SecureBootKey=`, `--secure-boot-key=`
+
+: Path to the PEM file containing the secret key for signing the
+  UEFI kernel image, if `SecureBoot=` is used.
+
+`SecureBootCertificate=`, `--secure-boot-certificate=`
+
+: Path to the X.509 file containing the certificate for the signed
+  UEFI kernel image, if `SecureBoot=` is used.
+
+`SignExpectedPCR=`, `--sign-expected-pcr`
+
+: Measure the components of the unified kernel image (UKI) using
+  `systemd-measure` and embed the PCR signature into the unified kernel
+  image. This option takes a boolean value or the special value `auto`,
+  which is the default, which is equal to a true value if the
+  [`cryptography`](https://cryptography.io/) module is importable and
+  the `systemd-measure` binary is in `PATH`.
+
 `Checksum=`, `--checksum`
 
 : Generate a `SHA256SUMS` file of all generated artifacts after the
@@ -862,6 +908,32 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
   be already present in the `gpg` keyring.
 
 ### [Host] Section
+
+`Incremental=`, `--incremental=`, `-i`
+
+: Enable incremental build mode. This only applies if the two-phase
+  `mkosi.build` build script logic is used. In this mode, a copy of
+  the OS image is created immediately after all OS packages are
+  unpacked but before the `mkosi.build` script is invoked in the
+  development container. Similarly, a copy of the final image is
+  created immediately before the build artifacts from the
+  `mkosi.build` script are copied in. On subsequent invocations of
+  `mkosi` with the `-i` switch these cached images may be used to skip
+  the OS package unpacking, thus drastically speeding up repetitive
+  build times. Note that when this is used and a pair of cached
+  incremental images exists they are not automatically regenerated,
+  even if options such as `Packages=` are modified. In order to force
+  rebuilding of these cached images, combine `-i` with `-ff` to ensure
+  cached images are first removed and then re-created.
+
+`NSpawnSettings=`, `--settings=`
+
+: Specifies a `.nspawn` settings file for `systemd-nspawn` to use in
+  the `boot` and `shell` verbs, and to place next to the generated
+  image file. This is useful to configure the `systemd-nspawn`
+  environment when the image is run. If this setting is not used but
+  an `mkosi.nspawn` file found in the local directory it is
+  automatically used for this purpose.
 
 `ExtraSearchPaths=`, `--extra-search-path=`
 

--- a/mkosi.md
+++ b/mkosi.md
@@ -727,19 +727,6 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 : Packages are appended to the list. Packages prefixed with "!" are
   removed from the list. "!\*" removes all packages from the list.
 
-`Password=`, `--password=`
-
-: Set the password of the `root` user. By default the `root` account
-  is locked. If this option is not used, but a file `mkosi.rootpw`
-  exists in the local directory, the root password is automatically
-  read from it.
-
-`PasswordIsHashed=`, `--password-is-hashed`
-
-: Indicate that the password supplied for the `root` user has already been
-  hashed, so that the string supplied with `Password=` or `mkosi.rootpw` will
-  be written to `/etc/shadow` literally.
-
 `Autologin=`, `--autologin`
 
 : Enable autologin for the `root` user on `/dev/pts/0` (nspawn),
@@ -844,6 +831,19 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 : Takes a list of regex patterns that specify modules to exclude from the kernel modules initrd. Behaves the
   same as `KernelModulesInitrdInclude=` except that all modules that match any of the specified patterns are
   excluded from the kernel modules initrd. This setting takes priority over `KernelModulesInitrdInclude=`.
+
+`Locale=`, `--locale=`,
+`LocaleMessages=`, `--locale-messages=`,
+`Keymap=`, `--keymap=`,
+`Timezone=`, `--timezone=`,
+`Hostname=`, `--hostname=`,
+`RootPassword=`, `--root-password=`,
+`RootPasswordHashed=`, `--root-password-hashed=`,
+`RootPasswordFile=`, `--root-password-file=`,
+`RootShell=`, `--root-shell=`
+
+: These settings correspond to the identically named systemd-firstboot options. See the systemd firstboot
+  [manpage](https://www.freedesktop.org/software/systemd/man/systemd-firstboot.html) for more information.
 
 ### [Validation] Section
 

--- a/mkosi.md
+++ b/mkosi.md
@@ -836,15 +836,16 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 
 : Takes a list of regex patterns that specify kernel modules to include in the image. Patterns should be
   relative to the `/usr/lib/modules/<kver>/kernel` directory. mkosi checks for a match anywhere in the module
-  path (e.g. "i915" will match against "drivers/gpu/drm/i915.ko") All modules that match any of the specified
-  patterns are included in the image. All module and firmware dependencies of the matched modules are
-  included in the image as well. If not specified, all kernel modules are included in the final image.
+  path (e.g. "i915" will match against "drivers/gpu/drm/i915.ko"). All modules that match any of the
+  specified patterns are included in the image. All module and firmware dependencies of the matched modules
+  are included in the image as well. This setting takes priority over `KernelModulesExclude=` and only makes
+  sense when used in combination with it because all kernel modules are included in the image by default.
 
 `KernelModulesExclude=`, `--kernel-modules-exclude=`
 
 : Takes a list of regex patterns that specify modules to exclude from the image. Behaves the same as
   `KernelModulesInclude=` except that all modules that match any of the specified patterns are excluded from
-  the image. This setting takes priority over `KernelModulesInclude=`.
+  the image.
 
 `KernelModulesInitrd=`, `--kernel-modules-initrd=`
 

--- a/mkosi.md
+++ b/mkosi.md
@@ -832,28 +832,35 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 : Add `/etc/initrd-release` and `/init` to the image so that it can be
   used as an initramfs.
 
+`KernelModulesInclude=`, `--kernel-modules-include=`
+
+: Takes a list of regex patterns that specify kernel modules to include in the image. Patterns should be
+  relative to the `/usr/lib/modules/<kver>/kernel` directory. mkosi checks for a match anywhere in the module
+  path (e.g. "i915" will match against "drivers/gpu/drm/i915.ko") All modules that match any of the specified
+  patterns are included in the image. All module and firmware dependencies of the matched modules are
+  included in the image as well. If not specified, all kernel modules are included in the final image.
+
+`KernelModulesExclude=`, `--kernel-modules-exclude=`
+
+: Takes a list of regex patterns that specify modules to exclude from the image. Behaves the same as
+  `KernelModulesInclude=` except that all modules that match any of the specified patterns are excluded from
+  the image. This setting takes priority over `KernelModulesInclude=`.
+
 `KernelModulesInitrd=`, `--kernel-modules-initrd=`
 
 : Enable/Disable generation of the kernel modules initrd when building a bootable image. Enabled by default.
-  If enabled, when building a bootable image, for each kernel that we assemble a unified kernel image for, we
+  If enabled, when building a bootable image, for each kernel that we assemble a unified kernel image for we
   generate an extra initrd containing only the kernel modules for that kernel version and append it to the
-  prebuilt initrd. This allows generating kernel indepedent initrds which are augmented with the necessary
-  kernel modules when the UKI is assembled. By default all kernel modules and their required firmware files
-  are included.
+  prebuilt initrd. This allows generating kernel independent initrds which are augmented with the necessary
+  kernel modules when the UKI is assembled.
 
 `KernelModulesInitrdInclude=`, `--kernel-modules-initrd-include=`
 
-: Takes a list of regex patterns that specify modules to include in the kernel modules initrd. Patterns
-  should be relative to the `/usr/lib/modules/<kver>/kernel` directory. mkosi checks for a match anywhere in
-  the module path (e.g. "i915" will match against "drivers/gpu/drm/i915.ko") All modules that match any of
-  the specified patterns are included in the kernel modules initrd. All module and firmware dependencies of
-  the matched modules are included in the kernel modules initrd as well.
+: Like `KernelModulesInclude=`, but applies to the kernel modules included in the kernel modules initrd.
 
 `KernelModulesInitrdExclude=`, `--kernel-modules-initrd-exclude=`
 
-: Takes a list of regex patterns that specify modules to exclude from the kernel modules initrd. Behaves the
-  same as `KernelModulesInitrdInclude=` except that all modules that match any of the specified patterns are
-  excluded from the kernel modules initrd. This setting takes priority over `KernelModulesInitrdInclude=`.
+: Like `KernelModulesExclude=`, but applies to the kernel modules included in the kernel modules initrd.
 
 `Locale=`, `--locale=`,
 `LocaleMessages=`, `--locale-messages=`,

--- a/mkosi.md
+++ b/mkosi.md
@@ -884,6 +884,16 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 : Path to the X.509 file containing the certificate for the signed
   UEFI kernel image, if `SecureBoot=` is used.
 
+`VerityKey=`, `--verity-key=`
+
+: Path to the PEM file containing the secret key for signing the verity signature, if a verity signature
+  partition is added with systemd-repart.
+
+`VerityCertificate=`, `--verity-certificate=`
+
+: Path to the X.509 file containing the certificate for signing the verity signature, if a verity signature
+  partition is added with systemd-repart.
+
 `SignExpectedPCR=`, `--sign-expected-pcr`
 
 : Measure the components of the unified kernel image (UKI) using

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1132,11 +1132,12 @@ def check_inputs(config: MkosiConfig) -> None:
                      config.finalize_script):
             check_script_input(path)
 
-        for p in config.initrds:
-            if not p.exists():
-                die(f"Initrd {p} not found")
-            if not p.is_file():
-                die(f"Initrd {p} is not a file")
+        if config.bootable != ConfigFeature.disabled:
+            for p in config.initrds:
+                if not p.exists():
+                    die(f"Initrd {p} not found")
+                if not p.is_file():
+                    die(f"Initrd {p} is not a file")
 
     except OSError as e:
         die(f'{e.filename}: {e.strerror}')

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1229,7 +1229,6 @@ def print_summary(args: MkosiArgs, config: MkosiConfig) -> None:
           Local Mirror (build): {none_to_none(config.local_mirror)}
       Repo Signature/Key check: {yes_no(config.repository_key_check)}
                   Repositories: {",".join(config.repositories)}
-                       Initrds: {",".join(os.fspath(p) for p in config.initrds)}
 
     {bold("OUTPUT")}:
                       Image ID: {config.image_id}
@@ -1238,30 +1237,24 @@ def print_summary(args: MkosiArgs, config: MkosiConfig) -> None:
               Manifest Formats: {maniformats}
               Output Directory: {none_to_default(config.output_dir)}
            Workspace Directory: {none_to_default(config.workspace_dir)}
+               Cache Directory: {none_to_none(config.cache_dir)}
+               Build Directory: {none_to_none(config.build_dir)}
+             Install Directory: {none_to_none(config.install_dir)}
                         Output: {bold(config.output_with_compression)}
                Output Checksum: {none_to_na(config.output_checksum if config.checksum else None)}
               Output Signature: {none_to_na(config.output_signature if config.sign else None)}
         Output nspawn Settings: {none_to_na(config.output_nspawn_settings if config.nspawn_settings is not None else None)}
-                   Incremental: {yes_no(config.incremental)}
                    Compression: {config.compress_output.name}
-                      Bootable: {yes_no_auto(config.bootable)}
-           Kernel Command Line: {" ".join(config.kernel_command_line)}
-               UEFI SecureBoot: {yes_no(config.secure_boot)}
-           SecureBoot Sign Key: {none_to_none(config.secure_boot_key)}
-        SecureBoot Certificate: {none_to_none(config.secure_boot_certificate)}
 
     {bold("CONTENT")}:
                       Packages: {line_join_list(config.packages)}
             With Documentation: {yes_no(config.with_docs)}
-                 Package Cache: {none_to_none(config.cache_dir)}
                 Skeleton Trees: {line_join_source_target_list(config.skeleton_trees)}
                    Extra Trees: {line_join_source_target_list(config.extra_trees)}
         Clean Package Metadata: {yes_no_auto(config.clean_package_metadata)}
                   Remove Files: {line_join_list(config.remove_files)}
                Remove Packages: {line_join_list(config.remove_packages)}
                  Build Sources: {config.build_sources}
-               Build Directory: {none_to_none(config.build_dir)}
-             Install Directory: {none_to_none(config.install_dir)}
                 Build Packages: {line_join_list(config.build_packages)}
                   Build Script: {path_or_none(config.build_script, check_script_input)}
      Run Tests in Build Script: {yes_no(config.with_tests)}
@@ -1270,7 +1263,9 @@ def print_summary(args: MkosiArgs, config: MkosiConfig) -> None:
                Finalize Script: {path_or_none(config.finalize_script, check_script_input)}
             Script Environment: {line_join_list(env)}
           Scripts with network: {yes_no(config.with_network)}
-               nspawn Settings: {none_to_none(config.nspawn_settings)}
+                      Bootable: {yes_no_auto(config.bootable)}
+           Kernel Command Line: {" ".join(config.kernel_command_line)}
+                       Initrds: {",".join(os.fspath(p) for p in config.initrds)}
                         Locale: {none_to_default(config.locale)}
                Locale Messages: {none_to_default(config.locale_messages)}
                         Keymap: {none_to_default(config.keymap)}
@@ -1281,6 +1276,8 @@ def print_summary(args: MkosiArgs, config: MkosiConfig) -> None:
                      Autologin: {yes_no(config.autologin)}
 
     {bold("HOST CONFIGURATION")}:
+                   Incremental: {yes_no(config.incremental)}
+               NSpawn Settings: {none_to_none(config.nspawn_settings)}
             Extra search paths: {line_join_list(config.extra_search_paths)}
           QEMU Extra Arguments: {line_join_list(config.qemu_args)}
         """
@@ -1289,6 +1286,9 @@ def print_summary(args: MkosiArgs, config: MkosiConfig) -> None:
         summary += f"""\
 
     {bold("VALIDATION")}:
+               UEFI SecureBoot: {yes_no(config.secure_boot)}
+           SecureBoot Sign Key: {none_to_none(config.secure_boot_key)}
+        SecureBoot Certificate: {none_to_none(config.secure_boot_certificate)}
                       Checksum: {yes_no(config.checksum)}
                           Sign: {yes_no(config.sign)}
                        GPG Key: ({"default" if config.key is None else config.key})

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1519,8 +1519,8 @@ def invoke_repart(state: MkosiState, skip: Sequence[str] = [], split: bool = Fal
                         Type=esp
                         Format=vfat
                         CopyFiles=/boot:/
-                        SizeMinBytes=1024M
-                        SizeMaxBytes=1024M
+                        SizeMinBytes=512M
+                        SizeMaxBytes=512M
                         """
                     )
                 )

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1332,7 +1332,7 @@ def configure_ssh(state: MkosiState) -> None:
     if not state.config.ssh:
         return
 
-    state.root.joinpath("etc/systemd/system/ssh.socket").write_text(
+    state.root.joinpath("usr/lib/systemd/system/ssh.socket").write_text(
         dedent(
             """\
             [Unit]
@@ -1350,7 +1350,7 @@ def configure_ssh(state: MkosiState) -> None:
         )
     )
 
-    state.root.joinpath("etc/systemd/system/ssh@.service").write_text(
+    state.root.joinpath("usr/lib/systemd/system/ssh@.service").write_text(
         dedent(
             """\
             [Unit]
@@ -1370,8 +1370,7 @@ def configure_ssh(state: MkosiState) -> None:
         )
     )
 
-    presetdir = state.root / "etc/systemd/system-preset"
-    presetdir.mkdir(exist_ok=True, mode=0o755)
+    presetdir = state.root / "usr/lib/systemd/system-preset"
     presetdir.joinpath("80-mkosi-ssh.preset").write_text("enable ssh.socket\n")
 
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2264,6 +2264,10 @@ def run_verb(args: MkosiArgs, presets: Sequence[MkosiConfig]) -> None:
     if build and args.auto_bump:
         bump_image_version()
 
+    # Give disk images some space to play around with if we're booting one.
+    if args.verb in (Verb.shell, Verb.boot, Verb.qemu) and last.output_format == OutputFormat.disk:
+        run(["truncate", "--size", "8G", last.output_dir / last.output])
+
     with prepend_to_environ_path(last.extra_search_paths):
         if args.verb in (Verb.shell, Verb.boot):
             run_shell(args, last)

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -874,6 +874,8 @@ def install_unified_kernel(state: MkosiState, roothash: Optional[str]) -> None:
             if not state.staging.joinpath(state.config.output_split_uki).exists():
                 copy_path(boot_binary, state.staging / state.config.output_split_uki)
 
+            print_output_size(boot_binary)
+
     if state.config.bootable == ConfigFeature.enabled and not state.staging.joinpath(state.config.output_split_uki).exists():
         die("A bootable image was requested but no kernel was found")
 
@@ -1021,17 +1023,13 @@ def save_manifest(state: MkosiState, manifest: Manifest) -> None:
                     manifest.write_package_report(f)
 
 
-def print_output_size(config: MkosiConfig) -> None:
-    if not config.output_dir.joinpath(config.output).exists():
-        return
-
-    if config.output_format == OutputFormat.directory:
-        log_step("Resulting image size is " + format_bytes(dir_size(config.output_dir / config.output)) + ".")
+def print_output_size(path: Path) -> None:
+    if path.is_dir():
+        log_step(f"{path} size is " + format_bytes(dir_size(path)) + ".")
     else:
-        st = config.output_dir.joinpath(config.output).stat()
-        size = format_bytes(st.st_size)
-        space = format_bytes(st.st_blocks * 512)
-        log_step(f"Resulting image size is {size}, consumes {space}.")
+        size = format_bytes(path.stat().st_size)
+        space = format_bytes(path.stat().st_blocks * 512)
+        log_step(f"{path} size is {size}, consumes {space}.")
 
 
 def empty_directory(path: Path) -> None:
@@ -1800,7 +1798,7 @@ def build_stuff(uid: int, gid: int, args: MkosiArgs, config: MkosiConfig) -> Non
         if not state.config.output_dir.joinpath(state.config.output).exists():
             state.config.output_dir.joinpath(state.config.output).symlink_to(state.config.output_with_compression)
 
-    print_output_size(config)
+    print_output_size(config.output_dir / config.output)
 
 
 def check_root() -> None:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1287,8 +1287,10 @@ def print_summary(args: MkosiArgs, config: MkosiConfig) -> None:
 
     {bold("VALIDATION")}:
                UEFI SecureBoot: {yes_no(config.secure_boot)}
-           SecureBoot Sign Key: {none_to_none(config.secure_boot_key)}
+        SecureBoot Signing Key: {none_to_none(config.secure_boot_key)}
         SecureBoot Certificate: {none_to_none(config.secure_boot_certificate)}
+            Verity Signing Key: {none_to_none(config.verity_key)}
+            Verity Certificate: {none_to_none(config.verity_certificate)}
                       Checksum: {yes_no(config.checksum)}
                           Sign: {yes_no(config.sign)}
                        GPG Key: ({"default" if config.key is None else config.key})
@@ -1486,10 +1488,10 @@ def invoke_repart(state: MkosiState, skip: Sequence[str] = [], split: bool = Fal
         cmdline += ["--empty=create"]
     if state.config.passphrase:
         cmdline += ["--key-file", state.config.passphrase]
-    if state.config.secure_boot_key:
-        cmdline += ["--private-key", state.config.secure_boot_key]
-    if state.config.secure_boot_certificate:
-        cmdline += ["--certificate", state.config.secure_boot_certificate]
+    if state.config.verity_key:
+        cmdline += ["--private-key", state.config.verity_key]
+    if state.config.verity_certificate:
+        cmdline += ["--certificate", state.config.verity_certificate]
     if skip:
         cmdline += ["--defer-partitions", ",".join(skip)]
     if split and state.config.split_artifacts:

--- a/mkosi/btrfs.py
+++ b/mkosi/btrfs.py
@@ -12,7 +12,8 @@ def btrfs_maybe_make_subvolume(config: MkosiConfig, path: Path, mode: int) -> No
         die("Subvolumes requested but the btrfs command was not found")
 
     if config.use_subvolumes != ConfigFeature.disabled:
-        result = run(["btrfs", "subvolume", "create", path], check=config.use_subvolumes == ConfigFeature.enabled).returncode
+        result = run(["btrfs", "subvolume", "create", path],
+                     check=config.use_subvolumes == ConfigFeature.enabled).returncode
     else:
         result = 1
 
@@ -37,5 +38,8 @@ def btrfs_maybe_snapshot_subvolume(config: MkosiConfig, src: Path, dst: Path) ->
     if dst.exists():
         dst.rmdir()
 
-    run(["btrfs", "subvolume", "snapshot", src, dst],
-        check=config.use_subvolumes == ConfigFeature.enabled)
+    result = run(["btrfs", "subvolume", "snapshot", src, dst],
+                 check=config.use_subvolumes == ConfigFeature.enabled).returncode
+
+    if result != 0:
+        copy_path(src, dst)

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -536,8 +536,8 @@ class MkosiArgs:
     debug: bool
     debug_shell: bool
     pager: bool
-    secure_boot_valid_days: str
-    secure_boot_common_name: str
+    genkey_valid_days: str
+    genkey_common_name: str
     auto_bump: bool
     presets: list[str]
 
@@ -830,13 +830,13 @@ class MkosiConfigParser:
             dest="secure_boot_key",
             section="Output",
             parse=config_make_path_parser(required=False),
-            paths=("mkosi.secure-boot.key",),
+            paths=("mkosi.key",),
         ),
         MkosiConfigSetting(
             dest="secure_boot_certificate",
             section="Output",
             parse=config_make_path_parser(required=False),
-            paths=("mkosi.secure-boot.crt",),
+            paths=("mkosi.crt",),
         ),
         MkosiConfigSetting(
             dest="sign_expected_pcr",
@@ -1319,16 +1319,16 @@ class MkosiConfigParser:
             help="Enable paging for long output",
         )
         parser.add_argument(
-            "--secure-boot-valid-days",
+            "--genkey-valid-days",
             metavar="DAYS",
-            help="Number of days UEFI SecureBoot keys should be valid when generating keys",
+            help="Number of days keys should be valid when generating keys",
             action=action,
             default="730",
         )
         parser.add_argument(
-            "--secure-boot-common-name",
+            "--genkey-common-name",
             metavar="CN",
-            help="Template for the UEFI SecureBoot CN when generating keys",
+            help="Template for the CN when generating keys",
             action=action,
             default="mkosi of %u",
         )
@@ -2129,11 +2129,11 @@ def load_config(args: argparse.Namespace) -> MkosiConfig:
     if args.secure_boot and args.verb != Verb.genkey:
         if args.secure_boot_key is None:
             die("UEFI SecureBoot enabled, but couldn't find private key.",
-                hint="Consider placing it in mkosi.secure-boot.key")
+                hint="Consider placing it in mkosi.key")
 
         if args.secure_boot_certificate is None:
             die("UEFI SecureBoot enabled, but couldn't find certificate.",
-                hint="Consider placing it in mkosi.secure-boot.crt")
+                hint="Consider placing it in mkosi.crt")
 
     if args.sign_expected_pcr is True and not shutil.which("systemd-measure"):
         die("Couldn't find systemd-measure needed for the --sign-expected-pcr option.")

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2113,6 +2113,9 @@ def load_kernel_command_line_extra(args: argparse.Namespace) -> list[str]:
     columns, lines = shutil.get_terminal_size()
 
     cmdline = [
+        f"systemd.tty.term.console={os.getenv('TERM', 'vt220')}",
+        f"systemd.tty.columns.console={columns}",
+        f"systemd.tty.rows.console={lines}",
         f"systemd.tty.term.ttyS0={os.getenv('TERM', 'vt220')}",
         f"systemd.tty.columns.ttyS0={columns}",
         f"systemd.tty.rows.ttyS0={lines}",

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -797,57 +797,23 @@ class MkosiConfigParser:
         MkosiConfigSetting(
             dest="cache_dir",
             name="CacheDirectory",
-            section="Content",
+            section="Output",
             parse=config_make_path_parser(required=False),
             paths=("mkosi.cache",),
         ),
         MkosiConfigSetting(
             dest="build_dir",
             name="BuildDirectory",
-            section="Content",
+            section="Output",
             parse=config_make_path_parser(required=False),
             paths=("mkosi.builddir",),
         ),
         MkosiConfigSetting(
             dest="install_dir",
             name="InstallDirectory",
-            section="Content",
+            section="Output",
             parse=config_make_path_parser(required=False),
             paths=("mkosi.installdir",),
-        ),
-        MkosiConfigSetting(
-            dest="kernel_command_line",
-            section="Output",
-            parse=config_make_list_parser(delimiter=" "),
-            default=["console=ttyS0"],
-        ),
-        MkosiConfigSetting(
-            dest="secure_boot",
-            section="Output",
-            parse=config_parse_boolean,
-        ),
-        MkosiConfigSetting(
-            dest="secure_boot_key",
-            section="Output",
-            parse=config_make_path_parser(),
-            paths=("mkosi.key",),
-        ),
-        MkosiConfigSetting(
-            dest="secure_boot_certificate",
-            section="Output",
-            parse=config_make_path_parser(),
-            paths=("mkosi.crt",),
-        ),
-        MkosiConfigSetting(
-            dest="sign_expected_pcr",
-            section="Output",
-            parse=config_parse_feature,
-        ),
-        MkosiConfigSetting(
-            dest="passphrase",
-            section="Output",
-            parse=config_make_path_parser(required=False),
-            paths=("mkosi.passphrase",),
         ),
         MkosiConfigSetting(
             dest="compress_output",
@@ -866,11 +832,6 @@ class MkosiConfigParser:
         ),
         MkosiConfigSetting(
             dest="tar_strip_selinux_context",
-            section="Output",
-            parse=config_parse_boolean,
-        ),
-        MkosiConfigSetting(
-            dest="incremental",
             section="Output",
             parse=config_parse_boolean,
         ),
@@ -916,6 +877,12 @@ class MkosiConfigParser:
             section="Content",
             parse=config_parse_boolean,
             default=True,
+        ),
+        MkosiConfigSetting(
+            dest="kernel_command_line",
+            section="Content",
+            parse=config_make_list_parser(delimiter=" "),
+            default=["console=ttyS0"],
         ),
         MkosiConfigSetting(
             dest="bootable",
@@ -1007,13 +974,6 @@ class MkosiConfigParser:
             parse=config_parse_boolean,
         ),
         MkosiConfigSetting(
-            dest="nspawn_settings",
-            name="NSpawnSettings",
-            section="Content",
-            parse=config_make_path_parser(),
-            paths=("mkosi.nspawn",),
-        ),
-        MkosiConfigSetting(
             dest="initrds",
             section="Content",
             parse=config_make_list_parser(delimiter=",", parse=make_path_parser(required=False)),
@@ -1086,6 +1046,34 @@ class MkosiConfigParser:
             parse=config_parse_string,
         ),
         MkosiConfigSetting(
+            dest="secure_boot",
+            section="Validation",
+            parse=config_parse_boolean,
+        ),
+        MkosiConfigSetting(
+            dest="secure_boot_key",
+            section="Validation",
+            parse=config_make_path_parser(),
+            paths=("mkosi.key",),
+        ),
+        MkosiConfigSetting(
+            dest="secure_boot_certificate",
+            section="Validation",
+            parse=config_make_path_parser(),
+            paths=("mkosi.crt",),
+        ),
+        MkosiConfigSetting(
+            dest="sign_expected_pcr",
+            section="Validation",
+            parse=config_parse_feature,
+        ),
+        MkosiConfigSetting(
+            dest="passphrase",
+            section="Validation",
+            parse=config_make_path_parser(required=False),
+            paths=("mkosi.passphrase",),
+        ),
+        MkosiConfigSetting(
             dest="checksum",
             section="Validation",
             parse=config_parse_boolean,
@@ -1098,6 +1086,18 @@ class MkosiConfigParser:
         MkosiConfigSetting(
             dest="key",
             section="Validation",
+        ),
+        MkosiConfigSetting(
+            dest="incremental",
+            section="Host",
+            parse=config_parse_boolean,
+        ),
+        MkosiConfigSetting(
+            dest="nspawn_settings",
+            name="NSpawnSettings",
+            section="Host",
+            parse=config_make_path_parser(),
+            paths=("mkosi.nspawn",),
         ),
         MkosiConfigSetting(
             dest="extra_search_paths",
@@ -1449,43 +1449,6 @@ class MkosiConfigParser:
             action=action,
         )
         group.add_argument(
-            "--kernel-command-line",
-            metavar="OPTIONS",
-            help="Set the kernel command line (only bootable images)",
-            action=action,
-        )
-        group.add_argument(
-            "--secure-boot",
-            metavar="BOOL",
-            help="Sign the resulting kernel/initrd image for UEFI SecureBoot",
-            nargs="?",
-            action=action,
-        )
-        group.add_argument(
-            "--secure-boot-key",
-            metavar="PATH",
-            help="UEFI SecureBoot private key in PEM format",
-            action=action,
-        )
-        group.add_argument(
-            "--secure-boot-certificate",
-            metavar="PATH",
-            help="UEFI SecureBoot certificate in X509 format",
-            action=action,
-        )
-        group.add_argument(
-            "--sign-expected-pcr",
-            metavar="FEATURE",
-            help="Measure the components of the unified kernel image (UKI) and embed the PCR signature into the UKI",
-            action=action,
-        )
-        group.add_argument(
-            "--passphrase",
-            metavar="PATH",
-            help="Path to a file containing the passphrase to use when LUKS encryption is selected",
-            action=action,
-        )
-        group.add_argument(
             "--compress-output",
             metavar="ALG",
             help="Enable whole-output compression (with images or archives)",
@@ -1498,13 +1461,6 @@ class MkosiConfigParser:
             "--tar-strip-selinux-context",
             metavar="BOOL",
             help="Do not include SELinux file context information in tar. Not compatible with bsdtar.",
-            nargs="?",
-            action=action,
-        )
-        group.add_argument(
-            "-i", "--incremental",
-            metavar="BOOL",
-            help="Make use of and generate intermediary cache images",
             nargs="?",
             action=action,
         )
@@ -1572,6 +1528,12 @@ class MkosiConfigParser:
             metavar="FEATURE",
             help="Generate ESP partition with systemd-boot and UKIs for installed kernels",
             nargs="?",
+            action=action,
+        )
+        group.add_argument(
+            "--kernel-command-line",
+            metavar="OPTIONS",
+            help="Set the kernel command line (only bootable images)",
             action=action,
         )
         group.add_argument(
@@ -1671,13 +1633,6 @@ class MkosiConfigParser:
             action=action,
         )
         group.add_argument(
-            "--settings",
-            metavar="PATH",
-            help="Add in .nspawn settings file",
-            dest="nspawn_settings",
-            action=action,
-        )
-        group.add_argument(
             "--initrd",
             help="Add a user-provided initrd to image",
             metavar="PATH",
@@ -1767,6 +1722,37 @@ class MkosiConfigParser:
 
         group = parser.add_argument_group("Validation options")
         group.add_argument(
+            "--secure-boot",
+            metavar="BOOL",
+            help="Sign the resulting kernel/initrd image for UEFI SecureBoot",
+            nargs="?",
+            action=action,
+        )
+        group.add_argument(
+            "--secure-boot-key",
+            metavar="PATH",
+            help="UEFI SecureBoot private key in PEM format",
+            action=action,
+        )
+        group.add_argument(
+            "--secure-boot-certificate",
+            metavar="PATH",
+            help="UEFI SecureBoot certificate in X509 format",
+            action=action,
+        )
+        group.add_argument(
+            "--sign-expected-pcr",
+            metavar="FEATURE",
+            help="Measure the components of the unified kernel image (UKI) and embed the PCR signature into the UKI",
+            action=action,
+        )
+        group.add_argument(
+            "--passphrase",
+            metavar="PATH",
+            help="Path to a file containing the passphrase to use when LUKS encryption is selected",
+            action=action,
+        )
+        group.add_argument(
             "--checksum",
             metavar="BOOL",
             help="Write SHA256SUMS file",
@@ -1783,6 +1769,20 @@ class MkosiConfigParser:
         group.add_argument("--key", help="GPG key to use for signing", action=action)
 
         group = parser.add_argument_group("Host configuration options")
+        group.add_argument(
+            "-i", "--incremental",
+            metavar="BOOL",
+            help="Make use of and generate intermediary cache images",
+            nargs="?",
+            action=action,
+        )
+        group.add_argument(
+            "--settings",
+            metavar="PATH",
+            help="Add in .nspawn settings file",
+            dest="nspawn_settings",
+            action=action,
+        )
         group.add_argument(
             "--extra-search-path",
             help="List of colon-separated paths to look for programs before looking in PATH",

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -829,13 +829,13 @@ class MkosiConfigParser:
         MkosiConfigSetting(
             dest="secure_boot_key",
             section="Output",
-            parse=config_make_path_parser(required=False),
+            parse=config_make_path_parser(),
             paths=("mkosi.key",),
         ),
         MkosiConfigSetting(
             dest="secure_boot_certificate",
             section="Output",
-            parse=config_make_path_parser(required=False),
+            parse=config_make_path_parser(),
             paths=("mkosi.crt",),
         ),
         MkosiConfigSetting(

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -576,6 +576,8 @@ class MkosiConfig:
     secure_boot: bool
     secure_boot_key: Optional[Path]
     secure_boot_certificate: Optional[Path]
+    verity_key: Optional[Path]
+    verity_certificate: Optional[Path]
     sign_expected_pcr: bool
     compress_output: Compression
     image_version: Optional[str]
@@ -1058,6 +1060,18 @@ class MkosiConfigParser:
         ),
         MkosiConfigSetting(
             dest="secure_boot_certificate",
+            section="Validation",
+            parse=config_make_path_parser(),
+            paths=("mkosi.crt",),
+        ),
+        MkosiConfigSetting(
+            dest="verity_key",
+            section="Validation",
+            parse=config_make_path_parser(),
+            paths=("mkosi.key",),
+        ),
+        MkosiConfigSetting(
+            dest="verity_certificate",
             section="Validation",
             parse=config_make_path_parser(),
             paths=("mkosi.crt",),
@@ -1738,6 +1752,18 @@ class MkosiConfigParser:
             "--secure-boot-certificate",
             metavar="PATH",
             help="UEFI SecureBoot certificate in X509 format",
+            action=action,
+        )
+        group.add_argument(
+            "--verity-key",
+            metavar="PATH",
+            help="Private key for signing verity signature in PEM format",
+            action=action,
+        )
+        group.add_argument(
+            "--verity-certificate",
+            metavar="PATH",
+            help="Certificate for signing verity signature in X509 format",
             action=action,
         )
         group.add_argument(

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -618,6 +618,8 @@ class MkosiConfig:
     workspace_dir: Optional[Path]
     initrds: list[Path]
     make_initrd: bool
+    kernel_modules_include: list[str]
+    kernel_modules_exclude: list[str]
     kernel_modules_initrd: bool
     kernel_modules_initrd_include: list[str]
     kernel_modules_initrd_exclude: list[str]
@@ -984,6 +986,16 @@ class MkosiConfigParser:
             dest="make_initrd",
             section="Content",
             parse=config_parse_boolean,
+        ),
+        MkosiConfigSetting(
+            dest="kernel_modules_include",
+            section="Content",
+            parse=config_make_list_parser(delimiter=","),
+        ),
+        MkosiConfigSetting(
+            dest="kernel_modules_exclude",
+            section="Content",
+            parse=config_make_list_parser(delimiter=","),
         ),
         MkosiConfigSetting(
             dest="kernel_modules_initrd",
@@ -1658,6 +1670,18 @@ class MkosiConfigParser:
             help="Make sure the image can be used as an initramfs",
             metavar="BOOL",
             nargs="?",
+            action=action,
+        )
+        group.add_argument(
+            "--kernel-modules-include",
+            help="Only include the specified kernel modules in the image",
+            metavar="REGEX",
+            action=action,
+        )
+        group.add_argument(
+            "--kernel-modules-exclude",
+            help="Exclude the specified kernel modules from the image",
+            metavar="REGEX",
             action=action,
         )
         group.add_argument(

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -3,6 +3,7 @@
 from collections.abc import Sequence
 from textwrap import dedent
 
+from mkosi.config import ConfigFeature
 from mkosi.distributions import DistributionInstaller
 from mkosi.run import bwrap
 from mkosi.state import MkosiState
@@ -94,7 +95,9 @@ def invoke_pacman(state: MkosiState, packages: Sequence[str], apivfs: bool = Tru
         "-Sy", *sort_packages(packages),
     ]
 
-    if state.config.initrds:
+    # If we're generating a bootable image, we'll do so with a prebuilt initramfs, so no need for an
+    # initramfs generator.
+    if state.config.bootable != ConfigFeature.disabled:
         cmdline += ["--assume-installed", "initramfs"]
 
     bwrap(cmdline, apivfs=state.root if apivfs else None, env=dict(KERNEL_INSTALL_BYPASS="1") | state.environment)

--- a/mkosi/install.py
+++ b/mkosi/install.py
@@ -31,7 +31,7 @@ def write_resource(
 def add_dropin_config_from_resource(
     root: Path, unit: str, name: str, resource: str, key: str
 ) -> None:
-    dropin = root / f"etc/systemd/system/{unit}.d/{name}.conf"
+    dropin = root / f"usr/lib/systemd/system/{unit}.d/{name}.conf"
     dropin.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
     write_resource(dropin, resource, key, mode=0o644)
 

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -9,7 +9,6 @@ import os
 import pwd
 import re
 import resource
-import shutil
 import sys
 import tempfile
 from collections.abc import Iterable, Iterator, Sequence
@@ -188,18 +187,6 @@ def format_rlimit(rlimit: int) -> str:
 def tmp_dir() -> Path:
     path = os.environ.get("TMPDIR") or "/var/tmp"
     return Path(path)
-
-
-def patch_file(filepath: Path, line_rewriter: Callable[[str], str]) -> None:
-    temp_new_filepath = filepath.with_suffix(filepath.suffix + ".tmp.new")
-
-    with filepath.open("r") as old, temp_new_filepath.open("w") as new:
-        for line in old:
-            new.write(line_rewriter(line))
-
-    shutil.copystat(filepath, temp_new_filepath)
-    os.remove(filepath)
-    shutil.move(temp_new_filepath, filepath)
 
 
 def sort_packages(packages: Iterable[str]) -> list[str]:


### PR DESCRIPTION
We keep it simple and just adopt the same settings that firstboot
has and pass them through directly.

This commit also reworks how we reset the machine ID, random seed
and a few other files.

This is on top of #1542 