### PR TITLE
Propagate systemd exit status from the VM

### DIFF
--- a/.github/mkosi.conf.d/10-common.conf
+++ b/.github/mkosi.conf.d/10-common.conf
@@ -1,6 +1,7 @@
 [Output]
 CacheDirectory=mkosi.cache
-KernelCommandLine=systemd.unit=mkosi-check-and-shutdown.service
+KernelCommandLine=console=ttyS0
+                  systemd.unit=mkosi-check-and-shutdown.service
                   systemd.log_target=console
                   systemd.default_standard_output=journal+console
 

--- a/.github/mkosi.conf.d/20-alma.conf
+++ b/.github/mkosi.conf.d/20-alma.conf
@@ -1,9 +1,6 @@
 [Match]
 Distribution=alma
 
-[Distribution]
-Repositories=epel
-
 [Content]
 Packages=kernel-core
          systemd

--- a/.github/mkosi.extra/usr/lib/systemd/mkosi-check-and-shutdown.sh
+++ b/.github/mkosi.extra/usr/lib/systemd/mkosi-check-and-shutdown.sh
@@ -6,5 +6,3 @@ systemctl --failed --no-legend | tee /failed-services
 
 # Exit with non-zero EC if the /failed-services file is not empty (we have -e set)
 [[ ! -s /failed-services ]]
-
-: >/testok

--- a/.github/mkosi.extra/usr/lib/systemd/system/mkosi-check-and-shutdown.service
+++ b/.github/mkosi.extra/usr/lib/systemd/system/mkosi-check-and-shutdown.service
@@ -3,11 +3,9 @@
 Description=Check if any service failed and then shut down the machine
 After=multi-user.target network-online.target
 Requires=multi-user.target
-OnFailure=poweroff.target
-OnFailureJobMode=replace-irreversibly
+SuccessAction=exit
+FailureAction=exit
 
 [Service]
 Type=oneshot
-ExecStartPre=rm -f /failed-services /testok
 ExecStart=/usr/lib/systemd/mkosi-check-and-shutdown.sh
-ExecStartPost=systemctl poweroff --no-block

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,14 +197,6 @@ jobs:
       if: matrix.format == 'disk' || matrix.format == 'directory'
       run: sudo python3 -m mkosi boot
 
-    - name: Check ${{ matrix.distro }}/${{ matrix.format }} systemd-nspawn
-      if: matrix.format == 'disk' || matrix.format == 'directory'
-      run: sudo python3 -m mkosi shell bash -c "[[ -e /testok ]] || { cat /failed-services; exit 1; }"
-
     - name: Boot ${{ matrix.distro }}/${{ matrix.format }} UEFI
       if: matrix.format == 'disk'
       run: timeout -k 30 10m python3 -m mkosi qemu
-
-    - name: Check ${{ matrix.distro }}/${{ matrix.format }} UEFI
-      if: matrix.format == 'disk' || matrix.format == 'directory'
-      run: sudo python3 -m mkosi shell bash -c "[[ -e /testok ]] || { cat /failed-services; exit 1; }"

--- a/action.yaml
+++ b/action.yaml
@@ -5,6 +5,22 @@ runs:
   using: composite
   steps:
 
+  - name: Permit unprivileged access to kvm, vhost-vsock and vhost-net devices
+    shell: bash
+    run: |
+      sudo adduser $(id -un) kvm
+      sudo sed -i '/kvm/s/0660/0666/g'   /usr/lib/tmpfiles.d/static-nodes-permissions.conf
+      sudo sed -i '/vhost/s/0660/0666/g' /usr/lib/tmpfiles.d/static-nodes-permissions.conf
+      sudo modprobe kvm
+      sudo modprobe vhost_vsock
+      sudo modprobe vhost_net
+      [[ -e /dev/kvm ]] && sudo chmod 666 /dev/kvm
+      sudo chmod 666 /dev/vhost-vsock
+      sudo chmod 666 /dev/vhost-net
+      lsmod
+      [[ -e /dev/kvm ]] && ls -l /dev/kvm
+      ls -l /dev/vhost-*
+
   - name: Dependencies
     shell: bash
     run: |

--- a/action.yaml
+++ b/action.yaml
@@ -19,7 +19,6 @@ runs:
         dnf \
         e2fsprogs \
         erofs-utils \
-        linux-modules-extra-azure \
         makepkg \
         mtools \
         ovmf \

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1119,7 +1119,7 @@ def check_inputs(config: MkosiConfig) -> None:
 
 def check_outputs(config: MkosiConfig) -> None:
     for f in (
-        config.output,
+        config.output_with_compression,
         config.output_checksum if config.checksum else None,
         config.output_signature if config.sign else None,
         config.output_nspawn_settings if config.nspawn_settings is not None else None,

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -700,13 +700,8 @@ def gen_kernel_modules_initrd(state: MkosiState, kver: str) -> Path:
         names = [module_path_to_name(m) for m in modules]
         mods, firmware = resolve_module_dependencies(state.root, kver, names)
 
-        for m in sorted(mods):
-            logging.debug(f"Adding module {m}")
-            yield m
-
-        for fw in sorted(firmware):
-            logging.debug(f"Adding firmware {fw}")
-            yield fw
+        for p in sorted(mods) + sorted(firmware):
+            yield p
 
         for p in (state.root / modulesd).iterdir():
             if not p.name.startswith("modules"):

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2084,7 +2084,7 @@ def run_qemu(args: MkosiArgs, config: MkosiConfig) -> None:
     ]
 
     try:
-        os.open("/dev/vhost-vsock", os.R_OK|os.W_OK)
+        os.open("/dev/vhost-vsock", os.O_RDWR|os.O_CLOEXEC)
         cmdline += ["-device", f"vhost-vsock-pci,guest-cid={machine_cid(config)}"]
     except OSError as e:
         if e.errno == errno.ENOENT:


### PR DESCRIPTION
Let's make use of the new vmm.notify_socket credential to fetch
systemd's exit status from the VM and propagate it as our own exit
status, just like already happens automatically for containers with
systemd-nspawn.