### PR TITLE
Check for btrfs before invoking run()

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -377,6 +377,9 @@ def install_boot_loader(state: MkosiState) -> None:
     if state.config.output_format == OutputFormat.cpio and state.config.bootable == ConfigFeature.auto:
         return
 
+    if not any(gen_kernel_images(state)) and state.config.bootable == ConfigFeature.auto:
+        return
+
     directory = state.root / "usr/lib/systemd/boot/efi"
     if not directory.exists() or not any(directory.iterdir()):
         if state.config.bootable == ConfigFeature.enabled:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -380,6 +380,11 @@ def install_boot_loader(state: MkosiState) -> None:
     if not any(gen_kernel_images(state)) and state.config.bootable == ConfigFeature.auto:
         return
 
+    if not shutil.which("bootctl"):
+        if state.config.bootable == ConfigFeature.enabled:
+            die("A bootable image was requested but bootctl was not found")
+        return
+
     directory = state.root / "usr/lib/systemd/boot/efi"
     if not directory.exists() or not any(directory.iterdir()):
         if state.config.bootable == ConfigFeature.enabled:

--- a/mkosi/btrfs.py
+++ b/mkosi/btrfs.py
@@ -11,7 +11,7 @@ def btrfs_maybe_make_subvolume(config: MkosiConfig, path: Path, mode: int) -> No
     if config.use_subvolumes == ConfigFeature.enabled and not shutil.which("btrfs"):
         die("Subvolumes requested but the btrfs command was not found")
 
-    if config.use_subvolumes != ConfigFeature.disabled:
+    if config.use_subvolumes != ConfigFeature.disabled and shutil.which("btrfs") is not None:
         result = run(["btrfs", "subvolume", "create", path],
                      check=config.use_subvolumes == ConfigFeature.enabled).returncode
     else:
@@ -38,8 +38,11 @@ def btrfs_maybe_snapshot_subvolume(config: MkosiConfig, src: Path, dst: Path) ->
     if dst.exists():
         dst.rmdir()
 
-    result = run(["btrfs", "subvolume", "snapshot", src, dst],
-                 check=config.use_subvolumes == ConfigFeature.enabled).returncode
+    if shutil.which("btrfs"):
+        result = run(["btrfs", "subvolume", "snapshot", src, dst],
+                    check=config.use_subvolumes == ConfigFeature.enabled).returncode
+    else:
+        result = 1
 
     if result != 0:
         copy_path(src, dst)


### PR DESCRIPTION
check= does not handle missing binaries so let's check explicitly before running btrfs.