### PR TITLE
Compress centos 8 variant cpios with xz instead of zstd

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2188,7 +2188,10 @@ def load_config(args: argparse.Namespace) -> MkosiConfig:
         args.checksum = True
 
     if args.compress_output is None:
-        args.compress_output = Compression.zst if args.output_format == OutputFormat.cpio else Compression.none
+        if args.output_format == OutputFormat.cpio:
+            args.compress_output = Compression.xz if args.distribution.is_centos_variant() and int(args.release) <= 8 else Compression.zst
+        else:
+            args.compress_output = Compression.none
 
     if args.output is None:
         args.output = args.image_id or args.preset or "image"

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -73,6 +73,9 @@ class Distribution(enum.Enum):
     def __str__(self) -> str:
         return self.name
 
+    def is_centos_variant(self) -> bool:
+        return self in (Distribution.centos, Distribution.alma, Distribution.rocky)
+
 
 class Compression(enum.Enum):
     none = None


### PR DESCRIPTION
The kernel for CentOS 8 and its variants doesn't ship with zstd initrd compression support, so let's default to xz instead.