### PR TITLE
ukify: always sign kernel inside of uki if secure boot is enabled

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -857,6 +857,7 @@ def install_unified_kernel(state: MkosiState, roothash: Optional[str]) -> None:
                 cmd += [
                     "--secureboot-private-key", state.config.secure_boot_key,
                     "--secureboot-certificate", state.config.secure_boot_certificate,
+                    "--sign-kernel",
                 ]
 
                 sign_expected_pcr = (state.config.sign_expected_pcr == ConfigFeature.enabled or


### PR DESCRIPTION
This overrides the auto detection of ukify and always signs the kernel bevore embedding it in the uki (even if the kernel is already signed). Rationale: When building Fedora 37 images, the Fedora provided kernel is signed with an expired key (id 2574709492). I would like to add an additional signature with my own signing key to enable kexec and other features that require a correctly signed kernel image.