### PR TITLE
btrfs: fix subvolume snapshots

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1724,8 +1724,9 @@ def build_image(uid: int, gid: int, args: MkosiArgs, config: MkosiConfig) -> Non
         for f in state.staging.iterdir():
             if not f.is_dir():
                 os.chown(f, uid, gid)
-
-            shutil.move(f, state.config.output_dir)
+                shutil.move(f, state.config.output_dir)
+            else:
+                btrfs_maybe_snapshot_subvolume(state.config, f, state.config.output_dir.joinpath(f.name), move = True)
 
         if not state.config.output_dir.joinpath(state.config.output).exists():
             state.config.output_dir.joinpath(state.config.output).symlink_to(state.config.output_with_compression)

--- a/mkosi/btrfs.py
+++ b/mkosi/btrfs.py
@@ -23,26 +23,22 @@ def btrfs_maybe_make_subvolume(config: MkosiConfig, path: Path, mode: int) -> No
         path.mkdir(mode)
 
 
-def btrfs_maybe_snapshot_subvolume(config: MkosiConfig, src: Path, dst: Path) -> None:
-    subvolume = (config.use_subvolumes == ConfigFeature.enabled or
-                 config.use_subvolumes == ConfigFeature.auto and shutil.which("btrfs") is not None)
-
+def btrfs_maybe_snapshot_subvolume(config: MkosiConfig, src: Path, dst: Path, move: bool = False) -> None:
     if config.use_subvolumes == ConfigFeature.enabled and not shutil.which("btrfs"):
         die("Subvolumes requested but the btrfs command was not found")
 
-    # Subvolumes always have inode 256 so we can use that to check if a directory is a subvolume.
-    if not subvolume or src.stat().st_ino != 256 or (dst.exists() and any(dst.iterdir())):
-        return copy_path(src, dst)
+    subvolume = (config.use_subvolumes == ConfigFeature.enabled or
+                 config.use_subvolumes == ConfigFeature.auto and shutil.which("btrfs") is not None)
 
-    # btrfs can't snapshot to an existing directory so make sure the destination does not exist.
-    if dst.exists():
-        dst.rmdir()
+    # Subvolumes always have inode 256
+    if subvolume and src.stat().st_ino == 256:
+        if dst.exists():
+            dst.rmdir()
+        if run(["btrfs", "subvolume", "snapshot", src, dst],
+               check=config.use_subvolumes == ConfigFeature.enabled).returncode == 0:
+            return
 
-    if shutil.which("btrfs"):
-        result = run(["btrfs", "subvolume", "snapshot", src, dst],
-                    check=config.use_subvolumes == ConfigFeature.enabled).returncode
+    if move:
+        shutil.move(src, dst)
     else:
-        result = 1
-
-    if result != 0:
         copy_path(src, dst)


### PR DESCRIPTION
Refactor and add option to fall-back to a move not just a copy_path. Always try to snapshot from workspace to the output directory but fall-back to using move.

Fixes: #1569

--

I explored extending `shutil.move()` with a copy function but that is only called if a rename cannot be done, and as a rename can be done, the copy function never gets called and therefore no way to use that to hook in the btrfs snapshot operation.

Since snapshot only applies to directories it is straight-forward to simply always call `btrfs_maybe_snapshot_subvolume()` and let its fall-back operation handle the not-a-subvol case.

Existing fall-back only does `copy_path()` so I extend the function parameters with `move: bool = False` so the caller can specify whether the fall-back will do `shutil.move()` or `copy_path()`.

I've also refactored to avoid duplicate code for handling the non-subvolume and fall-back-on-failure and lose the `result` value dance.