### PR TITLE
Fix cache directory logic

### DIFF
--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -50,7 +50,7 @@ class ArchInstaller(DistributionInstaller):
                     [options]
                     RootDir = {state.root}
                     LogFile = /dev/null
-                    CacheDir = {state.cache}
+                    CacheDir = {state.cache_dir}
                     GPGDir = /etc/pacman.d/gnupg/
                     HookDir = {state.root}/etc/pacman.d/hooks/
                     HoldPkg = pacman glibc

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -177,7 +177,7 @@ def setup_apt(state: MkosiState, repos: Sequence[str]) -> None:
             APT::Get::Allow-Change-Held-Packages "true";
             APT::Get::Allow-Remove-Essential "true";
             APT::Sandbox::User "root";
-            Dir::Cache "{state.cache}";
+            Dir::Cache "{state.cache_dir}";
             Dir::State "{state.workspace / "apt"}";
             Dir::State::status "{state.root / "var/lib/dpkg/status"}";
             Dir::Etc "{state.workspace / "apt"}";

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -151,7 +151,7 @@ def invoke_dnf(
         f"--installroot={state.root}",
         "--setopt=keepcache=1",
         "--setopt=install_weak_deps=0",
-        f"--setopt=cachedir={state.cache}",
+        f"--setopt=cachedir={state.cache_dir}",
         f"--setopt=reposdir={' '.join(str(p) for p in state.config.repo_dirs)}",
         f"--setopt=varsdir={state.workspace / 'vars'}",
         f"--setopt=logdir={state.workspace / 'log'}",

--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -222,7 +222,7 @@ class Gentoo:
             self.portage_cfg["GENTOO_MIRRORS"],
             f"releases/{self.arch}/autobuilds/{stage3_tar}",
         )
-        stage3_tar_path = self.state.cache / stage3_tar
+        stage3_tar_path = self.state.cache_dir / stage3_tar
         stage3_tmp_extract = stage3_tar_path.with_name(stage3_tar.name + ".tmp")
         if not stage3_tar_path.is_file():
             log_step(f"Fetching {stage3_url_path}")


### PR DESCRIPTION
Let's make sure we don't create nested per distribution, release directories if --cache-dir already points to such a directory and let's make sure both the regular user and the newuidmap root user can look into the workspace to fix the cache logic if no cache directory is set.