### PR TITLE
Improve basename symlinks

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1730,6 +1730,7 @@ def build_image(uid: int, gid: int, args: MkosiArgs, config: MkosiConfig) -> Non
 
         if not state.config.output_dir.joinpath(state.config.output).exists():
             state.config.output_dir.joinpath(state.config.output).symlink_to(state.config.output_with_compression)
+            os.chown(state.config.output_dir.joinpath(state.config.output), uid, gid, follow_symlinks=False)
 
     print_output_size(config.output_dir / config.output)
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1728,9 +1728,11 @@ def build_image(uid: int, gid: int, args: MkosiArgs, config: MkosiConfig) -> Non
 
             shutil.move(f, state.config.output_dir)
 
-        if not state.config.output_dir.joinpath(state.config.output).exists():
-            state.config.output_dir.joinpath(state.config.output).symlink_to(state.config.output_with_compression)
-            os.chown(state.config.output_dir.joinpath(state.config.output), uid, gid, follow_symlinks=False)
+        output_base = state.config.output_dir.joinpath(state.config.output)
+        if not output_base.exists() or output_base.is_symlink():
+            output_base.unlink(missing_ok=True)
+            output_base.symlink_to(state.config.output_with_compression)
+            os.chown(output_base, uid, gid, follow_symlinks=False)
 
     print_output_size(config.output_dir / config.output)
 


### PR DESCRIPTION
Fixes the symlink having the wrong uid:gid (root inside the uid namespace)
Always creates the symlink so it points to the newest version of the image
The link is created in the staging area first to make the change atomic