### PR TITLE
bootctl: use '--all-architectures' for cross-builds

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -478,7 +478,7 @@ def install_boot_loader(state: MkosiState) -> None:
                     die("One of sbsign or pesign is required to use SecureBoot=")
 
     with complete_step("Installing boot loader…"):
-        run(["bootctl", "install", "--root", state.root], env={"SYSTEMD_ESP_PATH": "/efi"})
+        run(["bootctl", "install", "--all-architectures", "--root", state.root], env={"SYSTEMD_ESP_PATH": "/efi"})
 
     if state.config.secure_boot:
         assert state.config.secure_boot_key


### PR DESCRIPTION
Do not restrict to the native architecture, if there's an EFI binary install it. Even if there are multiple ones it won't cause issues, as they are all suffixed by the architecture.