### PR TITLE
Rework architecture handling

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -402,9 +402,32 @@ a boolean argument: either "1", "yes", or "true" to enable, or "0",
 
 `Architecture=`, `--architecture=`
 
-: The architecture to build the image for. Note that this currently
-  only works for architectures compatible with the host's
+: The architecture to build the image for. A number of architectures can be specified, but which ones are
+  actually supported depends on the distribution used and whether a bootable image is requested or not. When
+  building for a foreign architecture, you'll also need to install and register a user mode emulator for that
   architecture.
+
+  The following architectures can be specified:
+
+  - alpha
+  - arc
+  - arm
+  - arm64
+  - ia64
+  - loongarch64
+  - mips64-le
+  - mips-le
+  - parisc
+  - ppc
+  - ppc64
+  - ppc64-le
+  - riscv32
+  - riscv64
+  - s390
+  - s390x
+  - tilegx
+  - x86
+  - x86-64
 
 ### [Output] Section
 

--- a/mkosi/architecture.py
+++ b/mkosi/architecture.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
+import enum
+import platform
+
+from mkosi.log import die
+
+
+class Architecture(enum.Enum):
+    alpha       = "alpha"
+    arc         = "arc"
+    arm         = "arm"
+    arm64       = "arm64"
+    ia64        = "ia64"
+    loongarch64 = "loongarch64"
+    mips_le     = "mips-le"
+    mips64_le   = "mips64-le"
+    parisc      = "parisc"
+    ppc         = "ppc"
+    ppc64       = "ppc64"
+    ppc64_le    = "ppc64-le"
+    riscv32     = "riscv32"
+    riscv64     = "riscv64"
+    s390        = "s390"
+    s390x       = "s390x"
+    tilegx      = "tilegx"
+    x86         = "x86"
+    x86_64      = "x86-64"
+
+    def __str__(self) -> str:
+        return self.value
+
+    @staticmethod
+    def from_uname(s: str) -> "Architecture":
+        a = {
+            "aarch64"     : Architecture.arm64,
+            "aarch64_be"  : Architecture.arm64,
+            "armv8l"      : Architecture.arm,
+            "armv8b"      : Architecture.arm,
+            "armv7ml"     : Architecture.arm,
+            "armv7mb"     : Architecture.arm,
+            "armv7l"      : Architecture.arm,
+            "armv7b"      : Architecture.arm,
+            "armv6l"      : Architecture.arm,
+            "armv6b"      : Architecture.arm,
+            "armv5tl"     : Architecture.arm,
+            "armv5tel"    : Architecture.arm,
+            "armv5tejl"   : Architecture.arm,
+            "armv5tejb"   : Architecture.arm,
+            "armv5teb"    : Architecture.arm,
+            "armv5tb"     : Architecture.arm,
+            "armv4tl"     : Architecture.arm,
+            "armv4tb"     : Architecture.arm,
+            "armv4l"      : Architecture.arm,
+            "armv4b"      : Architecture.arm,
+            "alpha"       : Architecture.alpha,
+            "arc"         : Architecture.arc,
+            "arceb"       : Architecture.arc,
+            "x86_64"      : Architecture.x86_64,
+            "i686"        : Architecture.x86,
+            "i586"        : Architecture.x86,
+            "i486"        : Architecture.x86,
+            "i386"        : Architecture.x86,
+            "ia64"        : Architecture.ia64,
+            "parisc64"    : Architecture.parisc,
+            "parisc"      : Architecture.parisc,
+            "loongarch64" : Architecture.loongarch64,
+            "mips64"      : Architecture.mips64_le,
+            "mips"        : Architecture.mips_le,
+            "ppc64le"     : Architecture.ppc64_le,
+            "ppc64"       : Architecture.ppc64,
+            "ppc"         : Architecture.ppc,
+            "riscv64"     : Architecture.riscv64,
+            "riscv32"     : Architecture.riscv32,
+            "riscv"       : Architecture.riscv64,
+            "s390x"       : Architecture.s390x,
+            "s390"        : Architecture.s390,
+            "tilegx"      : Architecture.tilegx,
+        }.get(s)
+
+        if not a:
+            die(f"Architecture {a} is not supported")
+
+        return a
+
+    def to_efi(self) -> str:
+        a = {
+            Architecture.x86_64      : "x64",
+            Architecture.x86         : "ia32",
+            Architecture.arm64       : "aa64",
+            Architecture.arm         : "arm",
+            Architecture.riscv64     : "riscv64",
+            Architecture.loongarch64 : "loongarch64",
+        }.get(self)
+
+        if not a:
+            die(f"Architecture {self} does not support UEFI")
+
+        return a
+
+    def to_qemu(self) -> str:
+        a = {
+            Architecture.alpha: "alpha",
+            Architecture.arm: "arm",
+            Architecture.arm64: "aarch64",
+            Architecture.loongarch64: "loongarch64",
+            Architecture.mips64_le: "mips",
+            Architecture.mips_le: "mips",
+            Architecture.parisc: "hppa",
+            Architecture.ppc: "ppc",
+            Architecture.ppc64: "ppc",
+            Architecture.ppc64_le: "ppc",
+            Architecture.riscv32: "riscv32",
+            Architecture.riscv64: "riscv64",
+            Architecture.s390x: "s390x",
+            Architecture.x86: "i386",
+            Architecture.x86_64: "x86_64",
+        }.get(self)
+
+        if not a:
+            die(f"Architecture {self} not supported by QEMU")
+
+        return a
+
+    def is_native(self) -> bool:
+        return self == self.native()
+
+    @classmethod
+    def native(cls) -> "Architecture":
+        return cls.from_uname(platform.machine())
+

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -4,6 +4,8 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from mkosi.architecture import Architecture
+
 if TYPE_CHECKING:
     from mkosi.state import MkosiState
 
@@ -11,23 +13,23 @@ if TYPE_CHECKING:
 class DistributionInstaller:
     @classmethod
     def install(cls, state: "MkosiState") -> None:
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @staticmethod
-    def kernel_image(kver: str, architecture: str) -> Path:
+    def kernel_image(kver: str, architecture: Architecture) -> Path:
         return Path("usr/lib/modules") / kver / "vmlinuz"
 
     @classmethod
     def install_packages(cls, state: "MkosiState", packages: Sequence[str]) -> None:
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @classmethod
     def remove_packages(cls, state: "MkosiState", packages: Sequence[str]) -> None:
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @classmethod
     def filesystem(cls) -> str:
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @classmethod
     def filesystem_options(cls, state: "MkosiState") -> dict[str, list[str]]:
@@ -36,3 +38,7 @@ class DistributionInstaller:
     @staticmethod
     def kernel_command_line(state: "MkosiState") -> list[str]:
         return []
+
+    @staticmethod
+    def architecture(arch: Architecture) -> str:
+        raise NotImplementedError()

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -5,6 +5,7 @@ import shutil
 from collections.abc import Sequence
 from pathlib import Path
 
+from mkosi.architecture import Architecture
 from mkosi.config import MkosiConfig
 from mkosi.distributions import DistributionInstaller
 from mkosi.distributions.fedora import Repo, invoke_dnf, setup_dnf
@@ -108,6 +109,20 @@ class CentosInstaller(DistributionInstaller):
     @classmethod
     def remove_packages(cls, state: MkosiState, packages: Sequence[str]) -> None:
         invoke_dnf(state, "remove", packages)
+
+    @staticmethod
+    def architecture(arch: Architecture) -> str:
+        a = {
+            Architecture.x86_64   : "x86_64",
+            Architecture.ppc64_le : "ppc64le",
+            Architecture.s390x    : "s390x",
+            Architecture.arm64    : "aarch64",
+        }.get(arch)
+
+        if not a:
+            die(f"Architecture {a} is not supported by CentOS")
+
+        return a
 
     @staticmethod
     def _gpgurl(release: int) -> str:

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -159,7 +159,9 @@ def invoke_dnf(
     state.workspace.joinpath("log").mkdir(exist_ok=True)
     state.workspace.joinpath("persist").mkdir(exist_ok=True)
 
-    dnf = shutil.which("dnf5") or shutil.which("dnf") or "yum"
+    # dnf5 does not support building for foreign architectures yet (missing --forcearch)
+    dnf = shutil.which("dnf5") if state.config.architecture.is_native() else None
+    dnf = dnf or shutil.which("dnf") or "yum"
 
     cmdline = [
         dnf,

--- a/mkosi/distributions/mageia.py
+++ b/mkosi/distributions/mageia.py
@@ -2,8 +2,10 @@
 
 from collections.abc import Sequence
 
+from mkosi.architecture import Architecture
 from mkosi.distributions import DistributionInstaller
 from mkosi.distributions.fedora import Repo, invoke_dnf, setup_dnf
+from mkosi.log import die
 from mkosi.state import MkosiState
 
 
@@ -19,26 +21,27 @@ class MageiaInstaller(DistributionInstaller):
     @classmethod
     def install_packages(cls, state: MkosiState, packages: Sequence[str], apivfs: bool = True) -> None:
         release = state.config.release.strip("'")
+        arch = state.installer.architecture(state.config.architecture)
 
         if state.config.local_mirror:
             release_url = f"baseurl={state.config.local_mirror}"
             updates_url = None
         elif state.config.mirror:
-            baseurl = f"{state.config.mirror}/distrib/{release}/{state.config.architecture}/media/core/"
+            baseurl = f"{state.config.mirror}/distrib/{release}/{arch}/media/core/"
             release_url = f"baseurl={baseurl}/release/"
             if release == "cauldron":
                 updates_url = None
             else:
                 updates_url = f"baseurl={baseurl}/updates/"
         else:
-            baseurl = f"https://www.mageia.org/mirrorlist/?release={release}&arch={state.config.architecture}&section=core"
+            baseurl = f"https://www.mageia.org/mirrorlist/?release={release}&arch={arch}&section=core"
             release_url = f"mirrorlist={baseurl}&repo=release"
             if release == "cauldron":
                 updates_url = None
             else:
                 updates_url = f"mirrorlist={baseurl}&repo=updates"
 
-        gpgurl = f"https://mirrors.kernel.org/mageia/distrib/{release}/{state.config.architecture}/media/core/release/media_info/pubkey"
+        gpgurl = f"https://mirrors.kernel.org/mageia/distrib/{release}/{arch}/media/core/release/media_info/pubkey"
 
         repos = [Repo(f"mageia-{release}", release_url, [gpgurl])]
         if updates_url is not None:
@@ -50,3 +53,14 @@ class MageiaInstaller(DistributionInstaller):
     @classmethod
     def remove_packages(cls, state: MkosiState, packages: Sequence[str]) -> None:
         invoke_dnf(state, "remove", packages)
+
+    @staticmethod
+    def architecture(arch: Architecture) -> str:
+        a = {
+            Architecture.x86_64 : "x86_64",
+        }.get(arch)
+
+        if not a:
+            die(f"Architecture {a} is not supported by Mageia")
+
+        return a

--- a/mkosi/distributions/openmandriva.py
+++ b/mkosi/distributions/openmandriva.py
@@ -2,8 +2,10 @@
 
 from collections.abc import Sequence
 
+from mkosi.architecture import Architecture
 from mkosi.distributions import DistributionInstaller
 from mkosi.distributions.fedora import Repo, invoke_dnf, setup_dnf
+from mkosi.log import die
 from mkosi.state import MkosiState
 
 
@@ -19,6 +21,7 @@ class OpenmandrivaInstaller(DistributionInstaller):
     @classmethod
     def install_packages(cls, state: MkosiState, packages: Sequence[str], apivfs: bool = True) -> None:
         release = state.config.release.strip("'")
+        arch = state.installer.architecture(state.config.architecture)
 
         if release[0].isdigit():
             release_model = "rock"
@@ -31,11 +34,11 @@ class OpenmandrivaInstaller(DistributionInstaller):
             release_url = f"baseurl={state.config.local_mirror}"
             updates_url = None
         elif state.config.mirror:
-            baseurl = f"{state.config.mirror}/{release_model}/repository/{state.config.architecture}/main"
+            baseurl = f"{state.config.mirror}/{release_model}/repository/{arch}/main"
             release_url = f"baseurl={baseurl}/release/"
             updates_url = f"baseurl={baseurl}/updates/"
         else:
-            baseurl = f"http://mirrors.openmandriva.org/mirrors.php?platform={release_model}&arch={state.config.architecture}&repo=main"
+            baseurl = f"http://mirrors.openmandriva.org/mirrors.php?platform={release_model}&arch={arch}&repo=main"
             release_url = f"mirrorlist={baseurl}&release=release"
             updates_url = f"mirrorlist={baseurl}&release=updates"
 
@@ -51,3 +54,14 @@ class OpenmandrivaInstaller(DistributionInstaller):
     @classmethod
     def remove_packages(cls, state: MkosiState, packages: Sequence[str]) -> None:
         invoke_dnf(state, "remove", packages)
+
+    @staticmethod
+    def architecture(arch: Architecture) -> str:
+        a = {
+            Architecture.x86_64 : "x86_64",
+        }.get(arch)
+
+        if not a:
+            die(f"Architecture {a} is not supported by OpenMandriva")
+
+        return a

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -4,6 +4,7 @@ import urllib.request
 import xml.etree.ElementTree as ElementTree
 from collections.abc import Sequence
 
+from mkosi.architecture import Architecture
 from mkosi.distributions import DistributionInstaller
 from mkosi.distributions.fedora import Repo, invoke_dnf, setup_dnf
 from mkosi.log import die
@@ -50,6 +51,17 @@ class OpensuseInstaller(DistributionInstaller):
     @classmethod
     def remove_packages(cls, state: MkosiState, packages: Sequence[str]) -> None:
         invoke_dnf(state, "remove", packages)
+
+    @staticmethod
+    def architecture(arch: Architecture) -> str:
+        a = {
+            Architecture.x86_64 : "x86_64",
+        }.get(arch)
+
+        if not a:
+            die(f"Architecture {a} is not supported by OpenSUSE")
+
+        return a
 
 
 def fetch_gpgurls(repourl: str) -> list[str]:

--- a/mkosi/distributions/ubuntu.py
+++ b/mkosi/distributions/ubuntu.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
+from mkosi.architecture import Architecture
 from mkosi.distributions.debian import DebianInstaller
 from mkosi.state import MkosiState
 
@@ -16,7 +17,7 @@ class UbuntuInstaller(DebianInstaller):
         updates = f"deb {state.config.mirror} {state.config.release}-updates {repos}"
 
         # Security updates repos are never mirrored. But !x86 are on the ports server.
-        if state.config.architecture in ["x86", "x86_64"]:
+        if state.config.architecture in [Architecture.x86, Architecture.x86_64]:
             security = f"deb http://security.ubuntu.com/ubuntu/ {state.config.release}-security {repos}"
         else:
             security = f"deb http://ports.ubuntu.com/ {state.config.release}-security {repos}"

--- a/mkosi/manifest.py
+++ b/mkosi/manifest.py
@@ -255,8 +255,8 @@ class Manifest:
     def as_dict(self) -> dict[str, Any]:
         config = {
             "name": self.config.image_id or "image",
-            "distribution": self.config.distribution.name,
-            "architecture": self.config.architecture,
+            "distribution": str(self.config.distribution),
+            "architecture": str(self.config.architecture),
         }
         if self.config.image_version is not None:
             config["version"] = self.config.image_version


### PR DESCRIPTION
Let's lock architectures down by making it an enum instead of a free form string. We also introduce a bunch of mapping functions to map the Architecture enum to qemu, distribution arches, efi arches and the discoverable partitions spec arches.