### PR TITLE
Opensuse: use zypper if present, fallback to dnf if not

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -46,7 +46,8 @@ runs:
         squashfs-tools \
         swtpm \
         systemd-container \
-        xfsprogs
+        xfsprogs \
+        zypper
 
       sudo pacman-key --init
       sudo pacman-key --populate archlinux

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -254,7 +254,7 @@ def config_default_mirror(namespace: argparse.Namespace) -> Optional[str]:
         else:
             return "https://geo.mirror.pkgbuild.com"
     elif d == Distribution.opensuse:
-        return "https://download.opensuse.org"
+        return "http://download.opensuse.org"
     elif d == Distribution.fedora and r == "eln":
         return "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose"
     elif d == Distribution.gentoo:

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -1,14 +1,15 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
-import urllib.request
-import xml.etree.ElementTree as ElementTree
 from collections.abc import Sequence
+from textwrap import dedent
 
 from mkosi.architecture import Architecture
 from mkosi.distributions import DistributionInstaller
-from mkosi.distributions.fedora import Repo, invoke_dnf, setup_dnf
+from mkosi.distributions.fedora import fixup_rpmdb_location
 from mkosi.log import die
+from mkosi.run import bwrap
 from mkosi.state import MkosiState
+from mkosi.types import PathString
 
 
 class OpensuseInstaller(DistributionInstaller):
@@ -35,22 +36,22 @@ class OpensuseInstaller(DistributionInstaller):
             release_url = f"{state.config.mirror}/tumbleweed/repo/oss/"
             updates_url = f"{state.config.mirror}/update/tumbleweed/"
         elif release in ("current", "stable"):
-            release_url = f"{state.config.mirror}/distribution/openSUSE-{release}/repo/oss/"
+            release_url = f"{state.config.mirror}/distribution/openSUSE-stable/repo/oss/"
             updates_url = f"{state.config.mirror}/update/openSUSE-{release}/"
         else:
             release_url = f"{state.config.mirror}/distribution/leap/{release}/repo/oss/"
             updates_url = f"{state.config.mirror}/update/leap/{release}/oss/"
 
-        repos = [Repo("repo-oss", f"baseurl={release_url}", fetch_gpgurls(release_url))]
+        repos = [("repo-oss", release_url)]
         if updates_url is not None:
-            repos += [Repo("repo-update", f"baseurl={updates_url}", fetch_gpgurls(updates_url))]
+            repos += [("repo-update", updates_url)]
 
-        setup_dnf(state, repos)
-        invoke_dnf(state, "install", packages, apivfs=apivfs)
+        setup_zypper(state, repos)
+        invoke_zypper(state, "install", ["-y", "--download-in-advance", "--no-recommends"], packages, apivfs=apivfs)
 
     @classmethod
     def remove_packages(cls, state: MkosiState, packages: Sequence[str]) -> None:
-        invoke_dnf(state, "remove", packages)
+        invoke_zypper(state, "remove", ["-y", "--clean-deps"], packages)
 
     @staticmethod
     def architecture(arch: Architecture) -> str:
@@ -64,20 +65,56 @@ class OpensuseInstaller(DistributionInstaller):
         return a
 
 
-def fetch_gpgurls(repourl: str) -> list[str]:
-    gpgurls = [f"{repourl}/repodata/repomd.xml.key"]
+def setup_zypper(state: MkosiState, repos: Sequence[tuple[str, str]] = ()) -> None:
+    with state.workspace.joinpath("zypp.conf").open("w") as f:
+        f.write(
+            dedent(
+                f"""\
+                [main]
+                rpm.install.excludedocs = {"no" if state.config.with_docs else "yes"}
+                """
+            )
+        )
 
-    with urllib.request.urlopen(f"{repourl}/repodata/repomd.xml") as f:
-        xml = f.read().decode()
-        root = ElementTree.fromstring(xml)
+    state.workspace.joinpath("zypp.repos.d").mkdir(exist_ok=True)
 
-        tags = root.find("{http://linux.duke.edu/metadata/repo}tags")
-        if not tags:
-            die("repomd.xml missing <tags> element")
+    with state.workspace.joinpath("zypp.repos.d/mkosi.repo").open("w") as f:
+        for id, url in repos:
+            f.write(
+                dedent(
+                    f"""\
+                    [{id}]
+                    name={id}
+                    baseurl={url}
+                    autorefresh=0
+                    enabled=1
+                    keeppackages=1
+                    """
+                )
+            )
 
-        for child in tags.iter("{http://linux.duke.edu/metadata/repo}content"):
-            if child.text and child.text.startswith("gpg-pubkey"):
-                gpgkey = child.text.partition("?")[0]
-                gpgurls += [f"{repourl}{gpgkey}"]
 
-    return gpgurls
+def invoke_zypper(
+    state: MkosiState,
+    verb: str,
+    options: Sequence[str],
+    packages: Sequence[str],
+    apivfs: bool = True
+) -> None:
+    cmdline: list[PathString] = [
+        "zypper",
+        "--root", state.root,
+        f"--cache-dir={state.cache_dir}",
+        f"--reposd-dir={state.workspace / 'zypp.repos.d'}",
+        "--gpg-auto-import-keys" if state.config.repository_key_check else "--no-gpg-checks",
+        "--non-interactive",
+        verb,
+        *options,
+        *packages,
+    ]
+
+    env = dict(ZYPP_CONF=str(state.workspace / "zypp.conf"), KERNEL_INSTALL_BYPASS="1") | state.environment
+
+    bwrap(cmdline, apivfs=state.root if apivfs else None, env=env)
+
+    fixup_rpmdb_location(state.root)


### PR DESCRIPTION
The reasoning in #1536 perhaps considers only cross-distro builds.
zypper is just fine when building openSUSE image on openSUSE host and yet another package manager needn't be installed on the host. (I'm not even sure dnf would run various transaction hooks/scriptlets equally as zypper.)

The commit dc8560f049b220f3b67ce201acf5e75081ed1c8d breaks mkosi image builds on my openSUSE host where I don't deem dnf necessary.

This is a revert that enables oS builds on oS again (mkosi from `main` (8e9f84d), systemd image from its `main` (.600bf76c17).)
