### PR TITLE
fedora: Add Enterprise Linux Next (ELN) support

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -222,6 +222,7 @@ def config_default_mirror(namespace: argparse.Namespace) -> Optional[str]:
         setattr(namespace, "architecture", Architecture.native())
 
     d = getattr(namespace, "distribution")
+    r = getattr(namespace, "release", None)
     a = getattr(namespace, "architecture")
 
     if d == Distribution.debian:
@@ -238,6 +239,8 @@ def config_default_mirror(namespace: argparse.Namespace) -> Optional[str]:
             return "https://geo.mirror.pkgbuild.com"
     elif d == Distribution.opensuse:
         return "https://download.opensuse.org"
+    elif d == Distribution.fedora and r == "eln":
+        return "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose"
 
     return None
 

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -36,20 +36,17 @@ class FedoraInstaller(DistributionInstaller):
             release_url = f"baseurl={state.config.local_mirror}"
             updates_url = None
         elif state.config.mirror:
-            baseurl = urllib.parse.urljoin(state.config.mirror, f"releases/{release}/Everything/$basearch/os/")
-            media = urllib.parse.urljoin(baseurl.replace("$basearch", state.installer.architecture(state.config.architecture)), "media.repo")
-            if not url_exists(media):
-                baseurl = urllib.parse.urljoin(state.config.mirror, f"development/{release}/Everything/$basearch/os/")
-
-            release_url = f"baseurl={baseurl}"
-            updates_url = f"baseurl={state.config.mirror}/updates/{release}/Everything/$basearch/"
+            directory = "development" if release == "rawhide" else "releases"
+            release_url = f"baseurl={state.config.mirror}/{directory}/$releasever/Everything/$basearch/os/"
+            updates_url = f"baseurl={state.config.mirror}/updates/$releasever/Everything/$basearch/"
         else:
             release_url = f"metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-{release}&arch=$basearch"
             updates_url = (
                 "metalink=https://mirrors.fedoraproject.org/metalink?"
                 f"repo=updates-released-f{release}&arch=$basearch"
             )
-        if release == 'rawhide':
+
+        if release == "rawhide":
             # On rawhide, the "updates" repo is the same as the "fedora" repo.
             # In other versions, the "fedora" repo is frozen at release, and "updates" provides any new packages.
             updates_url = None


### PR DESCRIPTION
Let's add support for ELN (https://docs.fedoraproject.org/en-US/eln/)
which builds Fedora with the RHEL toolchain.