### PR TITLE
Seed package manager config

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,8 +26,7 @@
     kernel images is trivial and fast these days.
 - Support for --qemu-boot was dropped
 - Support for --use-host-repositories was dropped, use --repository-directory instead
-- `RepositoryDirectory` was renamed to `RepositoryDirectories` and now takes a comma-separated
-  list of directories to look for extra repository files.
+- `RepositoryDirectory` was removed, use `PackageManagerTrees=` or `SkeletonTrees=` instead.
 - `--repositories` is now only usable on Debian/RPM based distros and can only be used to enable additional
   repositories. Specifically, it cannot be used on Arch Linux anymore to add new repositories.
 - The `_epel` distributions were removed. Use `--repositories=epel` instead to enable

--- a/mkosi.md
+++ b/mkosi.md
@@ -699,6 +699,19 @@ they should be specified with a boolean argument: either "1", "yes", or "true" t
   file may be provided too. `mkosi.skeleton.tar` will be automatically
   used if found in the local directory.
 
+`PackageManagerTrees=`, `--package-manager-tree=`
+
+: This option mirrors the above `SkeletonTrees=` option and defaults to the
+  same value if not configured otherwise, but installs the files to a
+  subdirectory of the workspace directory instead of the OS tree. This
+  subdirectory of the workspace is used to configure the package manager.
+
+: `SkeletonTrees=` and `PackageManagerTrees=` fulfill similar roles. Use
+  `SkeletonTrees=` if you want the files to be present in the final image. Use
+  `PackageManagerTrees=` if you don't want the files to be present in the final
+  image, e.g. when building an initrd or if you want to refer to paths outside
+  of the image in your repository configuration.
+
 `ExtraTrees=`, `--extra-tree=`
 
 : Takes a colon separated pair of paths. The first path refers to a

--- a/mkosi.md
+++ b/mkosi.md
@@ -375,15 +375,6 @@ they should be specified with a boolean argument: either "1", "yes", or "true" t
   Linux, additional repositories must be passed in the form `<name>::<url>`
   (e.g. `myrepo::https://myrepo.net`).
 
-`RepositoryDirectories`, `--repo-dir=`
-
-: This option can (for now) only be used with RPM-based distributions,
-  Debian-based distributions and Arch Linux. It takes a comma separated list of
-  directories containing extra repository definitions that will be used when
-  installing packages. The files are passed directly to the corresponding
-  package manager and should be written in the format expected by the package
-  manager of the image's distro.
-
 `Architecture=`, `--architecture=`
 
 : The architecture to build the image for. A number of architectures can be specified, but which ones are
@@ -1313,10 +1304,6 @@ local directory:
   shall be built from the same working directory, as otherwise the
   build result of a preceding run might be copied into a build image
   as part of the source tree (see above).
-
-* The **`mkosi.reposdir/`** directory, if it exists, is automatically
-  used as the repository directory for extra repository files. See
-  the `RepositoryDirectories` option for more information.
 
 * The **`mkosi.credentials/`** directory is used as a
   source of extra credentials similar to the `Credentials=` option. For

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -523,6 +523,24 @@ def install_skeleton_trees(state: MkosiState) -> None:
                 shutil.unpack_archive(source, t)
 
 
+def install_package_manager_trees(state: MkosiState) -> None:
+    if not state.config.package_manager_trees:
+        return
+
+    with complete_step("Copying in package maneger file trees…"):
+        for source, target in state.config.package_manager_trees:
+            t = state.workspace / "pkgmngr"
+            if target:
+                t = state.workspace / "pkgmngr" / target.relative_to("/")
+
+            t.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
+
+            if source.is_dir() or target:
+                copy_path(source, t, preserve_owner=False)
+            else:
+                shutil.unpack_archive(source, t)
+
+
 def install_extra_trees(state: MkosiState) -> None:
     if not state.config.extra_trees:
         return

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -833,7 +833,7 @@ def install_unified_kernel(state: MkosiState, roothash: Optional[str]) -> None:
                 *(["--mirror", state.config.mirror] if state.config.mirror else []),
                 "--repository-key-check", yes_no(state.config.repository_key_check),
                 "--repositories", ",".join(state.config.repositories),
-                "--repo-dir", ",".join(str(p) for p in state.config.repo_dirs),
+                *(["--package-manager-tree", str(state.config.package_manager_trees)] if state.config.package_manager_trees else []),
                 *(["--compress-output", str(state.config.compress_output)] if state.config.compress_output else []),
                 "--with-network", yes_no(state.config.with_network),
                 "--cache-only", yes_no(state.config.cache_only),

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -572,7 +572,6 @@ class MkosiConfig:
     local_mirror: Optional[str]
     repository_key_check: bool
     repositories: list[str]
-    repo_dirs: list[Path]
     repart_dirs: list[Path]
     overlay: bool
     architecture: Architecture
@@ -783,13 +782,6 @@ class MkosiConfigParser:
             dest="repositories",
             section="Distribution",
             parse=config_make_list_parser(delimiter=","),
-        ),
-        MkosiConfigSetting(
-            dest="repo_dirs",
-            name="RepositoryDirectories",
-            section="Distribution",
-            parse=config_make_list_parser(delimiter=",", parse=make_path_parser()),
-            paths=("mkosi.reposdir",),
         ),
         MkosiConfigSetting(
             dest="output_format",
@@ -1480,13 +1472,6 @@ class MkosiConfigParser:
             "--repositories",
             metavar="REPOS",
             help="Repositories to use",
-            action=action,
-        )
-        group.add_argument(
-            "--repo-dir",
-            metavar="PATH",
-            help="Specify a directory containing extra distribution specific repository files",
-            dest="repo_dirs",
             action=action,
         )
 
@@ -2258,13 +2243,6 @@ def load_config(args: argparse.Namespace) -> MkosiConfig:
         if args.secure_boot_certificate is None:
             die("UEFI SecureBoot enabled, but couldn't find certificate.",
                 hint="Consider placing it in mkosi.crt")
-
-    if args.repo_dirs and not (
-        is_dnf_distribution(args.distribution)
-        or is_apt_distribution(args.distribution)
-        or args.distribution == Distribution.arch
-    ):
-        die("--repo-dir is only supported on DNF/Debian based distributions and Arch")
 
     if args.qemu_kvm == ConfigFeature.enabled and not qemu_check_kvm_support():
         die("Sorry, the host machine does not support KVM acceleration.")

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -39,6 +39,7 @@ class ArchInstaller(DistributionInstaller):
 
         pacman_conf = state.workspace / "pkgmngr/etc/pacman.conf"
         pacman_conf.parent.mkdir(mode=0o755, exist_ok=True, parents=True)
+
         if state.config.repository_key_check:
             sig_level = "Required DatabaseOptional"
         else:
@@ -83,8 +84,15 @@ class ArchInstaller(DistributionInstaller):
                     )
                 )
 
-            for d in state.config.repo_dirs:
-                f.write(f"Include = {d}/*\n")
+            if state.workspace.joinpath("pkgmngr/etc/pacman.d/conf/").glob("*"):
+                f.write(
+                    dedent(
+                        f"""\
+
+                        Include = {state.workspace}/pkgmngr/etc/pacman.d/conf/*
+                        """
+                    )
+                )
 
         return invoke_pacman(state, packages, apivfs=apivfs)
 

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -37,7 +37,8 @@ class ArchInstaller(DistributionInstaller):
         # Create base layout for pacman and pacman-key
         state.root.joinpath("var/lib/pacman").mkdir(mode=0o755, exist_ok=True, parents=True)
 
-        pacman_conf = state.workspace / "pacman.conf"
+        pacman_conf = state.workspace / "pkgmngr/etc/pacman.conf"
+        pacman_conf.parent.mkdir(mode=0o755, exist_ok=True, parents=True)
         if state.config.repository_key_check:
             sig_level = "Required DatabaseOptional"
         else:
@@ -103,7 +104,7 @@ class ArchInstaller(DistributionInstaller):
 def invoke_pacman(state: MkosiState, packages: Sequence[str], apivfs: bool = True) -> None:
     cmdline: list[PathString] = [
         "pacman",
-        "--config", state.workspace / "pacman.conf",
+        "--config", state.workspace / "pkgmngr/etc/pacman.conf",
         "--noconfirm",
         "--needed",
         "-Sy", *sort_packages(packages),

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -208,9 +208,11 @@ def setup_apt(state: MkosiState, repos: Sequence[str]) -> None:
         )
     )
 
-    with state.workspace.joinpath("pkgmngr/etc/apt/sources.list").open("w") as f:
-        for repo in repos:
-            f.write(f"{repo}\n")
+    sources = state.workspace.joinpath("pkgmngr/etc/apt/sources.list")
+    if not sources.exists():
+        with sources.open("w") as f:
+            for repo in repos:
+                f.write(f"{repo}\n")
 
 
 def invoke_apt(

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -159,11 +159,12 @@ class DebianInstaller(DistributionInstaller):
 
 
 def setup_apt(state: MkosiState, repos: Sequence[str]) -> None:
-    state.workspace.joinpath("apt").mkdir(exist_ok=True)
-    state.workspace.joinpath("apt/apt.conf.d").mkdir(exist_ok=True)
-    state.workspace.joinpath("apt/preferences.d").mkdir(exist_ok=True)
-    state.workspace.joinpath("apt/sources.list.d").mkdir(exist_ok=True)
-    state.workspace.joinpath("apt/log").mkdir(exist_ok=True)
+    state.workspace.joinpath("pkgmngr/etc/apt").mkdir(exist_ok=True, parents=True)
+    state.workspace.joinpath("pkgmngr/etc/apt/apt.conf.d").mkdir(exist_ok=True, parents=True)
+    state.workspace.joinpath("pkgmngr/etc/apt/preferences.d").mkdir(exist_ok=True, parents=True)
+    state.workspace.joinpath("pkgmngr/etc/apt/sources.list.d").mkdir(exist_ok=True, parents=True)
+    state.workspace.joinpath("pkgmngr/var/log/apt").mkdir(exist_ok=True, parents=True)
+    state.workspace.joinpath("pkgmngr/var/lib/apt").mkdir(exist_ok=True, parents=True)
 
     # TODO: Drop once apt 2.5.4 is widely available.
     state.root.joinpath("var").mkdir(mode=0o755, exist_ok=True)
@@ -171,7 +172,7 @@ def setup_apt(state: MkosiState, repos: Sequence[str]) -> None:
     state.root.joinpath("var/lib/dpkg").mkdir(mode=0o755, exist_ok=True)
     state.root.joinpath("var/lib/dpkg/status").touch()
 
-    config = state.workspace / "apt/apt.conf"
+    config = state.workspace / "pkgmngr/etc/apt/apt.conf"
     debarch = state.installer.architecture(state.config.architecture)
 
     config.write_text(
@@ -187,16 +188,16 @@ def setup_apt(state: MkosiState, repos: Sequence[str]) -> None:
             APT::Get::Allow-Remove-Essential "true";
             APT::Sandbox::User "root";
             Dir::Cache "{state.cache_dir}";
-            Dir::State "{state.workspace / "apt"}";
+            Dir::State "{state.workspace / "pkgmngr/var/lib/apt"}";
             Dir::State::status "{state.root / "var/lib/dpkg/status"}";
-            Dir::Etc "{state.workspace / "apt"}";
+            Dir::Etc "{state.workspace / "pkgmngr/etc/apt"}";
             Dir::Etc::trusted "/usr/share/keyrings/{state.config.release}-archive-keyring";
             Dir::Etc::trustedparts "/usr/share/keyrings";
-            Dir::Log "{state.workspace / "apt/log"}";
+            Dir::Log "{state.workspace / "pkgmngr/var/log/apt"}";
             Dir::Bin::dpkg "{shutil.which("dpkg")}";
             Debug::NoLocking "true";
             DPkg::Options:: "--root={state.root}";
-            DPkg::Options:: "--log={state.workspace / "apt/dpkg.log"}";
+            DPkg::Options:: "--log={state.workspace / "pkgmngr/var/log/apt/dpkg.log"}";
             DPkg::Options:: "--force-unsafe-io";
             DPkg::Options:: "--force-architecture";
             DPkg::Options:: "--force-depends";
@@ -207,7 +208,7 @@ def setup_apt(state: MkosiState, repos: Sequence[str]) -> None:
         )
     )
 
-    with state.workspace.joinpath("apt/sources.list").open("w") as f:
+    with state.workspace.joinpath("pkgmngr/etc/apt/sources.list").open("w") as f:
         for repo in repos:
             f.write(f"{repo}\n")
 
@@ -216,7 +217,7 @@ def setup_apt(state: MkosiState, repos: Sequence[str]) -> None:
             if not src.is_file():
                 continue
             if src.suffix in (".list", ".sources"):
-                shutil.copyfile(src, state.workspace.joinpath("apt/sources.list.d", src.name))
+                shutil.copyfile(src, state.workspace.joinpath("pkgmngr/etc/apt/sources.list.d", src.name))
 
 
 def invoke_apt(
@@ -226,7 +227,7 @@ def invoke_apt(
     apivfs: bool = True,
 ) -> CompletedProcess:
     env: dict[str, PathString] = dict(
-        APT_CONFIG=state.workspace / "apt/apt.conf",
+        APT_CONFIG=state.workspace / "pkgmngr/etc/apt/apt.conf",
         DEBIAN_FRONTEND="noninteractive",
         DEBCONF_INTERACTIVE_SEEN="true",
         KERNEL_INSTALL_BYPASS="1",
@@ -247,7 +248,7 @@ def install_apt_sources(state: MkosiState, repos: Sequence[str]) -> None:
                 f.write(f"{repo}\n")
 
     # Already contains a merged tree of repo_dirs after setup_apt
-    for src in state.workspace.joinpath("apt/sources.list.d").iterdir():
+    for src in state.workspace.joinpath("pkgmngr/etc/apt/sources.list.d").iterdir():
         dst = state.root.joinpath("etc/apt/sources.list.d", src.name)
         if dst.exists():
             continue

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -175,6 +175,11 @@ def setup_apt(state: MkosiState, repos: Sequence[str]) -> None:
     config = state.workspace / "pkgmngr/etc/apt/apt.conf"
     debarch = state.installer.architecture(state.config.architecture)
 
+    trustedkeys = state.workspace.joinpath("pkgmngr/etc/apt/trusted.gpg")
+    trustedkeys = trustedkeys if trustedkeys.exists() else f"/usr/share/keyrings/{state.config.release}-archive-keyring"
+    trustedkeys_dir = state.workspace.joinpath("pkgmngr/etc/apt/trusted.gpg.d")
+    trustedkeys_dir = trustedkeys_dir if trustedkeys_dir.exists() else "/usr/share/keyrings"
+
     config.write_text(
         dedent(
             f"""\
@@ -191,8 +196,8 @@ def setup_apt(state: MkosiState, repos: Sequence[str]) -> None:
             Dir::State "{state.workspace / "pkgmngr/var/lib/apt"}";
             Dir::State::status "{state.root / "var/lib/dpkg/status"}";
             Dir::Etc "{state.workspace / "pkgmngr/etc/apt"}";
-            Dir::Etc::trusted "/usr/share/keyrings/{state.config.release}-archive-keyring";
-            Dir::Etc::trustedparts "/usr/share/keyrings";
+            Dir::Etc::trusted "{trustedkeys}";
+            Dir::Etc::trustedparts "{trustedkeys_dir}";
             Dir::Log "{state.workspace / "pkgmngr/var/log/apt"}";
             Dir::Bin::dpkg "{shutil.which("dpkg")}";
             Debug::NoLocking "true";

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -212,13 +212,6 @@ def setup_apt(state: MkosiState, repos: Sequence[str]) -> None:
         for repo in repos:
             f.write(f"{repo}\n")
 
-    for repo_dir in state.config.repo_dirs:
-        for src in repo_dir.iterdir():
-            if not src.is_file():
-                continue
-            if src.suffix in (".list", ".sources"):
-                shutil.copyfile(src, state.workspace.joinpath("pkgmngr/etc/apt/sources.list.d", src.name))
-
 
 def invoke_apt(
     state: MkosiState,
@@ -246,10 +239,3 @@ def install_apt_sources(state: MkosiState, repos: Sequence[str]) -> None:
         with sources.open("w") as f:
             for repo in repos:
                 f.write(f"{repo}\n")
-
-    # Already contains a merged tree of repo_dirs after setup_apt
-    for src in state.workspace.joinpath("pkgmngr/etc/apt/sources.list.d").iterdir():
-        dst = state.root.joinpath("etc/apt/sources.list.d", src.name)
-        if dst.exists():
-            continue
-        shutil.copyfile(src, dst)

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -154,6 +154,7 @@ def invoke_dnf(
         release = state.config.release
 
     state.workspace.joinpath("pkgmngr/etc/dnf/vars").mkdir(exist_ok=True, parents=True)
+    state.workspace.joinpath("pkgmngr/etc/yum.repos.d").mkdir(exist_ok=True, parents=True)
     state.workspace.joinpath("pkgmngr/var/log").mkdir(exist_ok=True, parents=True)
     state.workspace.joinpath("pkgmngr/var/lib/dnf").mkdir(exist_ok=True, parents=True)
 
@@ -173,7 +174,7 @@ def invoke_dnf(
         "--setopt=keepcache=1",
         "--setopt=install_weak_deps=0",
         f"--setopt=cachedir={state.cache_dir}",
-        f"--setopt=reposdir={' '.join(str(p) for p in state.config.repo_dirs)}",
+        f"--setopt=reposdir={state.workspace / 'pkgmngr/etc/yum.repos.d'}",
         f"--setopt=varsdir={state.workspace / 'pkgmngr/etc/dnf/vars'}",
         f"--setopt=logdir={state.workspace / 'pkgmngr/var/log'}",
         f"--setopt=persistdir={state.workspace / 'pkgmngr/var/lib/dnf'}",

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -121,7 +121,8 @@ class Repo(NamedTuple):
 
 
 def setup_dnf(state: MkosiState, repos: Sequence[Repo]) -> None:
-    with state.workspace.joinpath("dnf.conf").open("w") as f:
+    state.workspace.joinpath("pkgmngr/etc/dnf").mkdir(exist_ok=True, parents=True)
+    with state.workspace.joinpath("pkgmngr/etc/dnf/dnf.conf").open("w") as f:
         for repo in repos:
             f.write(
                 dedent(
@@ -152,9 +153,9 @@ def invoke_dnf(
     else:
         release = state.config.release
 
-    state.workspace.joinpath("vars").mkdir(exist_ok=True)
-    state.workspace.joinpath("log").mkdir(exist_ok=True)
-    state.workspace.joinpath("persist").mkdir(exist_ok=True)
+    state.workspace.joinpath("pkgmngr/etc/dnf/vars").mkdir(exist_ok=True, parents=True)
+    state.workspace.joinpath("pkgmngr/var/log").mkdir(exist_ok=True, parents=True)
+    state.workspace.joinpath("pkgmngr/var/lib/dnf").mkdir(exist_ok=True, parents=True)
 
     # dnf5 does not support building for foreign architectures yet (missing --forcearch)
     dnf = shutil.which("dnf5") if state.config.architecture.is_native() else None
@@ -163,7 +164,7 @@ def invoke_dnf(
     cmdline = [
         dnf,
         "-y",
-        f"--config={state.workspace.joinpath('dnf.conf')}",
+        f"--config={state.workspace.joinpath('pkgmngr/etc/dnf/dnf.conf')}",
         command,
         "--best",
         "--allowerasing",
@@ -173,9 +174,9 @@ def invoke_dnf(
         "--setopt=install_weak_deps=0",
         f"--setopt=cachedir={state.cache_dir}",
         f"--setopt=reposdir={' '.join(str(p) for p in state.config.repo_dirs)}",
-        f"--setopt=varsdir={state.workspace / 'vars'}",
-        f"--setopt=logdir={state.workspace / 'log'}",
-        f"--setopt=persistdir={state.workspace / 'persist'}",
+        f"--setopt=varsdir={state.workspace / 'pkgmngr/etc/dnf/vars'}",
+        f"--setopt=logdir={state.workspace / 'pkgmngr/var/log'}",
+        f"--setopt=persistdir={state.workspace / 'pkgmngr/var/lib/dnf'}",
         "--setopt=check_config_file_age=0",
         "--no-plugins" if dnf.endswith("dnf5") else "--noplugins",
     ]


### PR DESCRIPTION
This is an idea how to address #1603. As argued there, I think skeletons are a sensible solution for this, since there is little point in having skeletons except to preseed config for the package manager, therefore I also don't think it's necessary to have a separate config for this, because either people will not want to update the image (and not care about having the same package manager config in the image as to generate it or they will already clean it up in some postinst) or they will want the same config in the image as to generate it, if they want to be able to update the image.

What this PR does, is to move the package manager config to generate the image into a separate subdirectory below the workspace and moves the files in there into their places where they should be by default, i.e. make it a normal filesystem tree. 

It still needs a few tweaks so that the package manager config can be extended with config from the skeletons (e.g. reading trusted keys for Debian), but it should allow us to remove some config of our own by punting it down to the skeletons (e.g. `repo_dirs`, which is not yet fully removed because I haven't thought about how to best change the pacman config for Arch).

For now this is a discussion piece, whether this is the way to go.