### PR TITLE
Install dmsetup in the initrd on Debian/Ubuntu

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -828,6 +828,7 @@ def install_unified_kernel(state: MkosiState, roothash: Optional[str]) -> None:
                 "--package", "systemd",
                 "--package", "udev",
                 "--package", "kmod",
+                *(["--package", "dmsetup"] if is_apt_distribution(state.config.distribution) else []),
                 "--output", f"{state.config.output}-initrd",
                 *(["--image-version", state.config.image_version] if state.config.image_version else []),
                 "--make-initrd", "yes",


### PR DESCRIPTION
On other distros, just installing systemd and udev is sufficient to make verity work. On Debian and Ubuntu, we need to explicitly install dmsetup as well to make sure verity works, so let's do that.