### PR TITLE
Set Dir::Etc from config file for apt

### DIFF
--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -177,8 +177,9 @@ def setup_apt(state: MkosiState, repos: Sequence[str]) -> None:
     # Anything that users can override with dropins is written into the config file.
     config.write_text(
         dedent(
-            """\
+            f"""\
             APT::Install-Recommends "false";
+            Dir::Etc "{state.pkgmngr / "etc/apt"}";
             """
         )
     )
@@ -223,7 +224,6 @@ def invoke_apt(
         "-o", f"Dir::Cache={state.cache_dir}",
         "-o", f"Dir::State={state.pkgmngr / 'var/lib/apt'}",
         "-o", f"Dir::State::status={state.root / 'var/lib/dpkg/status'}",
-        "-o", f"Dir::Etc={state.pkgmngr / 'etc/apt'}",
         "-o", f"Dir::Etc::trusted={trustedkeys}",
         "-o", f"Dir::Etc::trustedparts={trustedkeys_dir}",
         "-o", f"Dir::Log={state.pkgmngr / 'var/log/apt'}",


### PR DESCRIPTION
Specifying it as an argument to apt-get doesn't work. from apt.conf(5):

Dir::Etc contains the location of configuration files, sourcelist gives the location of the sourcelist and main is the default configuration file (setting has no effect, unless it is done from the config file specified by the "APT_CONFIG" environment variable).

Closes #1623.