### PR TITLE
Ensure we return the same exit code in debug mode

### DIFF
--- a/mkosi/__main__.py
+++ b/mkosi/__main__.py
@@ -10,7 +10,7 @@ from collections.abc import Iterator
 from mkosi import run_verb
 from mkosi.config import MkosiConfigParser
 from mkosi.log import ARG_DEBUG, log_setup
-from mkosi.run import excepthook
+from mkosi.run import ensure_exc_info, excepthook
 
 
 @contextlib.contextmanager
@@ -21,18 +21,19 @@ def propagate_failed_return() -> Iterator[None]:
         yield
     except SystemExit as e:
         if ARG_DEBUG.get():
-            raise e
+            sys.excepthook(*ensure_exc_info())
 
         sys.exit(e.code)
-    except KeyboardInterrupt as e:
+    except KeyboardInterrupt:
         if ARG_DEBUG.get():
-            raise e
+            sys.excepthook(*ensure_exc_info())
+        else:
+            logging.error("Interrupted")
 
-        logging.error("Interrupted")
         sys.exit(1)
     except subprocess.CalledProcessError as e:
         if ARG_DEBUG.get():
-            raise e
+            sys.excepthook(*ensure_exc_info())
 
         # We always log when subprocess.CalledProcessError is raised, so we don't log again here.
         sys.exit(e.returncode)

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -19,7 +19,17 @@ import threading
 import traceback
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence, Type, TypeVar
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+)
 
 from mkosi.log import ARG_DEBUG, ARG_DEBUG_SHELL, die
 from mkosi.types import _FILE, CompletedProcess, PathString, Popen
@@ -152,6 +162,14 @@ class RemoteException(Exception):
 
     def __str__(self) -> str:
         return f"Traceback (most recent call last):\n{''.join(self.tb.format()).strip()}\n{type(self.exception).__name__}: {self.exception}"
+
+
+def ensure_exc_info() -> Tuple[Type[BaseException], BaseException, TracebackType]:
+    exctype, exc, tb = sys.exc_info()
+    assert exctype
+    assert exc
+    assert tb
+    return (exctype, exc, tb)
 
 
 def excepthook(exctype: Type[BaseException], exc: BaseException, tb: Optional[TracebackType]) -> None:


### PR DESCRIPTION
When running in debug mode, we shouldn't return a different exit code compared to when we run outside of debug mode.