### PR TITLE
Remove several repository config options

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -337,16 +337,6 @@ they should be specified with a boolean argument: either "1", "yes", or "true" t
 : The mirror to use for downloading the distribution packages. Expects
   a mirror URL as argument.
 
-`LocalMirror=`, `--local-mirror=`
-
-: The mirror will be used as a local, plain and direct mirror instead
-  of using it as a prefix for the full set of repositories normally supported
-  by distributions. Useful for fully offline builds with a single repository.
-  Supported on deb/rpm/arch based distributions. Overrides `--mirror=` but only
-  for the local mkosi build, it will not be configured inside the final image,
-  `--mirror=` (or the default repository) will be configured inside the final
-  image instead.
-
 `RepositoryKeyCheck=`, `--repository-key-check=`
 
 : Controls signature/key checks when using repositories, enabled by default.

--- a/mkosi.md
+++ b/mkosi.md
@@ -337,12 +337,6 @@ they should be specified with a boolean argument: either "1", "yes", or "true" t
 : The mirror to use for downloading the distribution packages. Expects
   a mirror URL as argument.
 
-`RepositoryKeyCheck=`, `--repository-key-check=`
-
-: Controls signature/key checks when using repositories, enabled by default.
-  Useful to disable checks when combined with `--local-mirror=` and using only
-  a repository from a local filesystem. Not used for DNF-based distros yet.
-
 `Repositories=`, `--repositories=`
 
 : Additional package repositories to use during installation. Expects

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -832,7 +832,6 @@ def install_unified_kernel(state: MkosiState, roothash: Optional[str]) -> None:
                 "--release", state.config.release,
                 "--architecture", str(state.config.architecture),
                 *(["--mirror", state.config.mirror] if state.config.mirror else []),
-                "--repository-key-check", yes_no(state.config.repository_key_check),
                 "--repositories", ",".join(state.config.repositories),
                 "--package-manager-tree", ",".join(format_source_target(s, t) for s, t in state.config.package_manager_trees),
                 *(["--compress-output", str(state.config.compress_output)] if state.config.compress_output else []),
@@ -1299,7 +1298,6 @@ def summary(args: MkosiArgs, config: MkosiConfig) -> str:
                        Release: {bold(none_to_na(config.release))}
                   Architecture: {config.architecture}
                         Mirror: {none_to_default(config.mirror)}
-      Repo Signature/Key check: {yes_no(config.repository_key_check)}
                   Repositories: {",".join(config.repositories)}
 
     {bold("OUTPUT")}:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1299,7 +1299,6 @@ def summary(args: MkosiArgs, config: MkosiConfig) -> str:
                        Release: {bold(none_to_na(config.release))}
                   Architecture: {config.architecture}
                         Mirror: {none_to_default(config.mirror)}
-          Local Mirror (build): {none_to_none(config.local_mirror)}
       Repo Signature/Key check: {yes_no(config.repository_key_check)}
                   Repositories: {",".join(config.repositories)}
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -585,7 +585,6 @@ class MkosiConfig:
     distribution: Distribution
     release: str
     mirror: Optional[str]
-    repository_key_check: bool
     repositories: list[str]
     repart_dirs: list[Path]
     overlay: bool
@@ -783,15 +782,6 @@ class MkosiConfigParser:
             section="Distribution",
             default_factory=config_default_mirror,
             help="Distribution mirror to use",
-        ),
-        MkosiConfigSetting(
-            dest="repository_key_check",
-            metavar="BOOL",
-            nargs="?",
-            section="Distribution",
-            default=True,
-            parse=config_parse_boolean,
-            help="Controls signature and key checks on repositories",
         ),
         MkosiConfigSetting(
             dest="repositories",

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -585,7 +585,6 @@ class MkosiConfig:
     distribution: Distribution
     release: str
     mirror: Optional[str]
-    local_mirror: Optional[str]
     repository_key_check: bool
     repositories: list[str]
     repart_dirs: list[Path]
@@ -784,11 +783,6 @@ class MkosiConfigParser:
             section="Distribution",
             default_factory=config_default_mirror,
             help="Distribution mirror to use",
-        ),
-        MkosiConfigSetting(
-            dest="local_mirror",
-            section="Distribution",
-            help="Use a single local, flat and plain mirror to build the image",
         ),
         MkosiConfigSetting(
             dest="repository_key_check",

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -44,13 +44,10 @@ class ArchInstaller(DistributionInstaller):
 def setup_pacman(state: MkosiState) -> None:
     assert state.config.mirror
 
-    if state.config.local_mirror:
-        server = f"Server = {state.config.local_mirror}"
+    if state.config.architecture == Architecture.arm64:
+        server = f"Server = {state.config.mirror}/$arch/$repo"
     else:
-        if state.config.architecture == Architecture.arm64:
-            server = f"Server = {state.config.mirror}/$arch/$repo"
-        else:
-            server = f"Server = {state.config.mirror}/$repo/os/$arch"
+        server = f"Server = {state.config.mirror}/$repo/os/$arch"
 
     if state.config.repository_key_check:
         sig_level = "Required DatabaseOptional"
@@ -78,20 +75,12 @@ def setup_pacman(state: MkosiState) -> None:
 
                 [core]
                 {server}
+
+                [extra]
+                {server}
                 """
             )
         )
-
-        if not state.config.local_mirror:
-            f.write(
-                dedent(
-                    f"""\
-
-                    [extra]
-                    {server}
-                    """
-                )
-            )
 
         if any(state.pkgmngr.joinpath("etc/pacman.d/").glob("*.conf")):
             f.write(

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -49,13 +49,6 @@ def setup_pacman(state: MkosiState) -> None:
     else:
         server = f"Server = {state.config.mirror}/$repo/os/$arch"
 
-    if state.config.repository_key_check:
-        sig_level = "Required DatabaseOptional"
-    else:
-        # If we are using a single local mirror built on the fly there
-        # will be no signatures
-        sig_level = "Never"
-
     # Create base layout for pacman and pacman-key
     state.root.joinpath("var/lib/pacman").mkdir(mode=0o755, exist_ok=True, parents=True)
 
@@ -70,7 +63,7 @@ def setup_pacman(state: MkosiState) -> None:
             dedent(
                 f"""\
                 [options]
-                SigLevel = {sig_level}
+                SigLevel = Required DatabaseOptional
                 ParallelDownloads = 5
 
                 [core]

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -144,9 +144,6 @@ class CentosInstaller(DistributionInstaller):
     def _epel_repos(cls, config: MkosiConfig) -> list[Repo]:
         epel_gpgurl = "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever"
 
-        if config.local_mirror:
-            return []
-
         if config.mirror:
             epel_url = f"baseurl={config.mirror}/epel/$releasever/Everything/$basearch"
             epel_next_url = f"baseurl={config.mirror}/epel/next/$releasever/Everything/$basearch"
@@ -169,10 +166,7 @@ class CentosInstaller(DistributionInstaller):
         directory = cls._mirror_directory()
         gpgurl = cls._gpgurl(release)
 
-        if config.local_mirror:
-            appstream_url = f"baseurl={config.local_mirror}"
-            baseos_url = extras_url = powertools_url = crb_url = None
-        elif config.mirror:
+        if config.mirror:
             appstream_url = f"baseurl={config.mirror}/{directory}/$stream/AppStream/$basearch/os"
             baseos_url = f"baseurl={config.mirror}/{directory}/$stream/BaseOS/$basearch/os"
             extras_url = f"baseurl={config.mirror}/{directory}/$stream/extras/$basearch/os"
@@ -211,10 +205,7 @@ class CentosInstaller(DistributionInstaller):
         gpgurl = cls._gpgurl(release)
         extras_gpgurl = cls._extras_gpgurl(release)
 
-        if config.local_mirror:
-            appstream_url = f"baseurl={config.local_mirror}"
-            baseos_url = extras_url = crb_url = None
-        elif config.mirror:
+        if config.mirror:
             appstream_url = f"baseurl={config.mirror}/centos-stream/$stream/AppStream/$basearch/os"
             baseos_url = f"baseurl={config.mirror}/centos-stream/$stream/BaseOS/$basearch/os"
             extras_url = f"baseurl={config.mirror}/centos-stream/SIGS/$stream/extras/$basearch/extras-common"

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -24,11 +24,8 @@ class DebianInstaller(DistributionInstaller):
         return Path(f"boot/vmlinuz-{name}")
 
     @staticmethod
-    def repositories(state: MkosiState, local: bool = True) -> list[str]:
+    def repositories(state: MkosiState) -> list[str]:
         repos = ' '.join(("main", *state.config.repositories))
-
-        if state.config.local_mirror and local:
-            return [f"deb [trusted=yes] {state.config.local_mirror} {state.config.release} {repos}"]
 
         main = f"deb {state.config.mirror} {state.config.release} {repos}"
 
@@ -124,7 +121,7 @@ class DebianInstaller(DistributionInstaller):
         setup_apt(state, cls.repositories(state))
         invoke_apt(state, "update", apivfs=False)
         invoke_apt(state, "install", packages, apivfs=apivfs)
-        install_apt_sources(state, cls.repositories(state, local=False))
+        install_apt_sources(state, cls.repositories(state))
 
         policyrcd.unlink()
 

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -31,9 +31,7 @@ class FedoraInstaller(DistributionInstaller):
         release = parse_fedora_release(state.config.release)
         release_url = updates_url = appstream_url = baseos_url = extras_url = crb_url = None
 
-        if state.config.local_mirror:
-            release_url = f"baseurl={state.config.local_mirror}"
-        elif release == "eln":
+        if release == "eln":
             assert state.config.mirror
             appstream_url = f"baseurl={state.config.mirror}/AppStream/$basearch/os"
             baseos_url = f"baseurl={state.config.mirror}/BaseOS/$basearch/os"
@@ -214,7 +212,7 @@ def invoke_dnf(
         cmdline += [f"{opt}={repo}" for repo in state.config.repositories]
 
     # TODO: this breaks with a local, offline repository created with 'createrepo'
-    if state.config.cache_only and not state.config.local_mirror:
+    if state.config.cache_only:
         cmdline += ["--cacheonly"]
 
     if not state.config.architecture.is_native():

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -204,9 +204,6 @@ def invoke_dnf(
              and fedora_release_at_least(release, '38'))):
         cmdline += ["--setopt=optional_metadata_types=filelists"]
 
-    if not state.config.repository_key_check:
-        cmdline += ["--nogpgcheck"]
-
     if state.config.repositories:
         opt = "--enable-repo" if dnf.endswith("dnf5") else "--enablerepo"
         cmdline += [f"{opt}={repo}" for repo in state.config.repositories]

--- a/mkosi/distributions/mageia.py
+++ b/mkosi/distributions/mageia.py
@@ -23,10 +23,7 @@ class MageiaInstaller(DistributionInstaller):
         release = state.config.release.strip("'")
         arch = state.installer.architecture(state.config.architecture)
 
-        if state.config.local_mirror:
-            release_url = f"baseurl={state.config.local_mirror}"
-            updates_url = None
-        elif state.config.mirror:
+        if state.config.mirror:
             baseurl = f"{state.config.mirror}/distrib/{release}/{arch}/media/core/"
             release_url = f"baseurl={baseurl}/release/"
             if release == "cauldron":

--- a/mkosi/distributions/openmandriva.py
+++ b/mkosi/distributions/openmandriva.py
@@ -30,10 +30,7 @@ class OpenmandrivaInstaller(DistributionInstaller):
         else:
             release_model = release
 
-        if state.config.local_mirror:
-            release_url = f"baseurl={state.config.local_mirror}"
-            updates_url = None
-        elif state.config.mirror:
+        if state.config.mirror:
             baseurl = f"{state.config.mirror}/{release_model}/repository/{arch}/main"
             release_url = f"baseurl={baseurl}/release/"
             updates_url = f"baseurl={baseurl}/updates/"

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -28,9 +28,6 @@ class OpensuseInstaller(DistributionInstaller):
 
         # If the release looks like a timestamp, it's Tumbleweed. 13.x is legacy
         # (14.x won't ever appear). For anything else, let's default to Leap.
-        if state.config.local_mirror:
-            release_url = f"{state.config.local_mirror}"
-            updates_url = None
         if release.isdigit() or release == "tumbleweed":
             release_url = f"{state.config.mirror}/tumbleweed/repo/oss/"
             updates_url = f"{state.config.mirror}/update/tumbleweed/"

--- a/mkosi/distributions/ubuntu.py
+++ b/mkosi/distributions/ubuntu.py
@@ -7,11 +7,8 @@ from mkosi.state import MkosiState
 
 class UbuntuInstaller(DebianInstaller):
     @staticmethod
-    def repositories(state: MkosiState, local: bool = True) -> list[str]:
+    def repositories(state: MkosiState) -> list[str]:
         repos = ' '.join(("main", *state.config.repositories))
-
-        if state.config.local_mirror and local:
-            return [f"deb [trusted=yes] {state.config.local_mirror} {state.config.release} {repos}"]
 
         main = f"deb {state.config.mirror} {state.config.release} {repos}"
         updates = f"deb {state.config.mirror} {state.config.release}-updates {repos}"


### PR DESCRIPTION
This PR removes the options `LocalMirror=`, `RepositoryKeycheck=` and `Repositories=`. This PR is a draft, because I'm not sure about all changes, so see this as a discussion piece.

`LocalMirror=` and `RepositoryKeycheck=` are removed since they were workarounds to configure repositories, which can now be done via `PackageManagerTrees=` (which can use paths outside the image) and `SkeletonTrees=` in a natural way by passing a tree with config for the package manager, which should mostly allow to configure it without us needing to add any further options to mkosi.

`Repositories=` is removed because the semantics are different between distros. In Debian it sets the components in `sources.list` whereas for Fedora it adds config switches to enable repos. This is a slightly regressive change, since for Debian this now means that if people want more than `main`, they will have to add a `sources.list`. For DNF-based distros  I assume this is a transparent change, since the written repo files already have an `enabled=1` line by default. 

/cc @bluca since your OBS usage might be most in need of change if this PR would go in.