### PR TITLE
Remove --install-directory= option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -83,6 +83,10 @@
   the time.
 - Disk images are now resized to 8G when booted to give some disk space to play around with in the booted
   image.
+- Removed `--install-directory=` option. This was originally added for caching the installation results, but
+  this doesn't work properly as it might result in leftover files in the install directory from a previous
+  installation, so we have to empty the directory before reusing it, invalidating the caching, so the option
+  was removed.
 
 ## v14
 

--- a/mkosi.md
+++ b/mkosi.md
@@ -470,17 +470,6 @@ they should be specified with a boolean argument: either "1", "yes", or "true" t
   is automatically used for this purpose (also see the "Files" section
   below).
 
-`InstallDirectory=`, `--install-dir=`
-
-: Takes a path of a directory to use as the install directory. The
-  directory used this way is shared between builds and allows the
-  build system to not have to reinstall files that were already
-  installed by a previous build and didn't change. The build script
-  can find the path to this directory in the `$DESTDIR` environment
-  variable. If this option is not specified, but a directory
-  `mkosi.installdir` exists in the local directory, it is automatically
-  used for this purpose (also see the "Files" section below).
-
 `UseSubvolumes=`, `--use-subvolumes=`
 
 : Takes a boolean or `auto`. Enables or disables use of btrfs subvolumes for

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -610,7 +610,6 @@ class MkosiConfig:
     environment: dict[str, str]
     build_sources: Path
     build_dir: Optional[Path]
-    install_dir: Optional[Path]
     build_packages: list[str]
     build_script: Optional[Path]
     prepare_script: Optional[Path]
@@ -827,13 +826,6 @@ class MkosiConfigParser:
             section="Output",
             parse=config_make_path_parser(required=False),
             paths=("mkosi.builddir",),
-        ),
-        MkosiConfigSetting(
-            dest="install_dir",
-            name="InstallDirectory",
-            section="Output",
-            parse=config_make_path_parser(required=False),
-            paths=("mkosi.installdir",),
         ),
         MkosiConfigSetting(
             dest="compress_output",
@@ -1517,12 +1509,6 @@ class MkosiConfigParser:
             "--build-dir",
             metavar="PATH",
             help="Path to use as persistent build directory",
-            action=action,
-        )
-        group.add_argument(
-            "--install-dir",
-            metavar="PATH",
-            help="Path to use as persistent install directory",
             action=action,
         )
         group.add_argument(

--- a/mkosi/state.py
+++ b/mkosi/state.py
@@ -42,9 +42,9 @@ class MkosiState:
         self.workdir.mkdir()
         self.staging.mkdir()
         self.pkgmngr.mkdir()
+        self.install_dir.mkdir(exist_ok=True)
 
         self.cache_dir.mkdir(parents=True, exist_ok=True)
-        self.install_dir.mkdir(parents=True, exist_ok=True)
 
     @property
     def workspace(self) -> Path:
@@ -72,4 +72,4 @@ class MkosiState:
 
     @property
     def install_dir(self) -> Path:
-        return self.config.install_dir or self.workspace / "dest"
+        return self.workspace / "dest"


### PR DESCRIPTION
We don't benefit from the caching anymore since we started emptying the directory completely on reuse as otherwise old leftover files might get installed. Without the caching, the option does not have a ton of use anymore, so let's remove it.