### PR TITLE
Gentoo fixes

### DIFF
--- a/.github/mkosi.conf.d/20-gentoo.conf
+++ b/.github/mkosi.conf.d/20-gentoo.conf
@@ -1,10 +1,8 @@
 [Match]
 Distribution=gentoo
 
-[Distribution]
-Repositories=https://raw.githubusercontent.com/257/binpkgs/master
-
 [Content]
+Environment=PORTAGE_BINHOST=https://raw.githubusercontent.com/257/binpkgs/master
 Packages=sys-kernel/gentoo-kernel-bin
          sys-apps/systemd
          # Failed to execute /usr/lib/systemd/system-environment-generators/10-gentoo-path: No such file or directory

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -81,7 +81,7 @@ def mount_image(state: MkosiState) -> Iterator[None]:
                 else:
                     die(f"Unsupported base tree source {path}")
 
-            stack.enter_context(mount_overlay(bases, state.root, state.workdir, state.root, read_only=False))
+            stack.enter_context(mount_overlay(bases, state.root, state.root, read_only=False))
 
         yield
 
@@ -273,7 +273,7 @@ def mount_cache_overlay(state: MkosiState) -> Iterator[None]:
     d = state.workspace / "cache-overlay"
     d.mkdir(mode=0o755, exist_ok=True)
 
-    with mount_overlay([state.root], d, state.workdir, state.root, read_only=False):
+    with mount_overlay([state.root], d, state.root, read_only=False):
         yield
 
 
@@ -281,7 +281,7 @@ def mount_build_overlay(state: MkosiState, read_only: bool = False) -> ContextMa
     d = state.workspace / "build-overlay"
     if not d.is_symlink():
         d.mkdir(mode=0o755, exist_ok=True)
-    return mount_overlay([state.root], state.workspace.joinpath("build-overlay"), state.workdir, state.root, read_only)
+    return mount_overlay([state.root], state.workspace.joinpath("build-overlay"), state.root, read_only)
 
 
 def run_prepare_script(state: MkosiState, build: bool) -> None:

--- a/mkosi/state.py
+++ b/mkosi/state.py
@@ -39,7 +39,6 @@ class MkosiState:
         self.installer = instance
 
         btrfs_maybe_make_subvolume(self.config, self.root, mode=0o755)
-        self.workdir.mkdir()
         self.staging.mkdir()
         self.pkgmngr.mkdir()
         self.install_dir.mkdir(exist_ok=True)
@@ -53,10 +52,6 @@ class MkosiState:
     @property
     def root(self) -> Path:
         return self.workspace / "root"
-
-    @property
-    def workdir(self) -> Path:
-        return self.workspace / "workdir"
 
     @property
     def staging(self) -> Path:


### PR DESCRIPTION
- Use curl to download stage3 tarball so we get a progress bar
- Do not exclude dev, proc and sys directories when extracting tarball
  (only exclude their contents)
- Copy pkgmngr/ directory into stage3/ directory wholesale instead of
  individual files
- Various coding style fixes
- Stop using Repositories= to specify binary package repositories as it
  is not its intended purpose. Instead, pass configured environment
  variables to emerge so users can set PORTAGE_BINHOST instead.