### PR TITLE
Use systemd-repart's new --offline argument

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1609,6 +1609,7 @@ def make_image(state: MkosiState, skip: Sequence[str] = [], split: bool = False)
         "--dry-run=no",
         "--json=pretty",
         "--no-pager",
+        "--offline=yes",
         "--root", state.root,
         state.staging / state.config.output_with_format,
     ]
@@ -1924,7 +1925,7 @@ def nspawn_knows_arg(arg: str) -> bool:
 
 
 def finalize_image(image: Path, *, size: str) -> None:
-    run(["systemd-repart", "--image", image, "--size", size, "--no-pager", "--dry-run=no", image])
+    run(["systemd-repart", "--image", image, "--size", size, "--no-pager", "--dry-run=no", "--offline=no", image])
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
When building images, we never want to use loop devices, so use --offline=yes in that case. When booting images, we know that systemd-nspawn requires loop devices, so require them for systemd-repart as well using --offline=no.