### PR TITLE
opensuse: Add back support for zypper

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -46,7 +46,8 @@ runs:
         squashfs-tools \
         swtpm \
         systemd-container \
-        xfsprogs
+        xfsprogs \
+        zypper
 
       sudo pacman-key --init
       sudo pacman-key --populate archlinux


### PR DESCRIPTION
Let's add back support for zypper to build opensuse images. If both zypper and dnf are installed, let's prefer using zypper.