### PR TITLE
Protect common system directories when running with bubblewrap

### DIFF
--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -306,10 +306,12 @@ def bwrap_cmd(
         "--dev-bind", "/", "/",
         "--chdir", Path.cwd(),
         "--die-with-parent",
+        "--ro-bind", (root or Path("/")) / "usr", "/usr",
     ]
 
-    if root:
-        cmdline += ["--bind", root / "usr", "/usr"]
+    for d in ("/etc", "/opt", "/srv", "/boot", "/efi"):
+        if Path(d).exists():
+            cmdline += ["--ro-bind", d, d]
 
     if apivfs:
         if not (apivfs / "etc/machine-id").exists():


### PR DESCRIPTION
Let's make sure that even when we run as root the tools we run can't brick the system by making core system directories read-only bind mounts when running tools with bubblewrap.

As an example of the stuff this protects again, let's say a package installs an absolute symlink to /usr and in the finalize script a user tries to remove everything under this symlink, they'll end up erasing /usr from their host system. By making /usr read-only, we prevent this from happening.