### PR TITLE
gentoo: don't excluse sys from stage3

### DIFF
--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -132,9 +132,9 @@ class GentooInstaller(DistributionInstaller):
                        "--extract",
                        "--file", stage3_tar,
                        "--exclude", "./dev/*",
-                       "--exclude", "./proc/*",
-                       "--exclude", "./sys/*"],
+                       "--exclude", "./proc/*",],
                       root=state.config.tools_tree)
+                unlink_try_hard((stage3 / "sys"))
 
         for d in ("binpkgs", "distfiles", "repos/gentoo"):
             (state.cache_dir / d).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
we missed this in fad6ca1 CI only test with binaries whereas actual builds from source fail.

this is stopgap, real solution is to figure out why builds fail. a good place to start would to check permissions under /sys shipped with stage3 and adapt that in our mount-opts.