### PR TITLE
Make BuildSources more flexible

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -725,8 +725,10 @@ they should be specified with a boolean argument: either "1", "yes", or "true" t
 
 `BuildSources=`, `--build-sources=`
 
-: Takes a path to a source tree to mount into the development image, if
-  the build script is used.
+: Takes a list of colon-separated pairs of paths to source trees and where to mount them in the development
+  image, if the build script is used. Every target path is prefixed with `/work/src` and all build sources
+  are sorted lexicographically by mount target before mounting so that top level paths are mounted first. By
+  default, the current working directory is mounted to `/work/src`.
 
 `BuildPackages=`, `--build-package=`
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1977,7 +1977,6 @@ def run_shell(args: MkosiArgs, config: MkosiConfig) -> None:
         ]
 
     cmdline += ["--machine", config.output]
-    cmdline += [f"--bind={config.build_sources}:/root/src", "--chdir=/root/src"]
 
     for k, v in config.credentials.items():
         cmdline += [f"--set-credential={k}:{v}"]


### PR DESCRIPTION
Currently, when you want to build multiple projects together, you
have to make the other projects subdirectories of the one with the
mkosi config, which is inconvenient. To make this more flexible, let's
allow specifying multiple source trees and where to mount them under
/work/src so that multiple projects can be mounted in a fixed location
regardless of their location on the host.