### PR TITLE
gentoo: Use bwrap() instead of run_workspace_command() to run emerge

### DIFF
--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -32,7 +32,6 @@ def invoke_emerge(
             "--deep",
             "--buildpkg=y",
             "--usepkg=y",
-            "--keep-going=y",
             "--jobs",
             "--load-average",
             "--nospinner",

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -252,6 +252,7 @@ def bwrap(
     cmd: Sequence[PathString],
     *,
     apivfs: Optional[Path] = None,
+    options: Sequence[PathString] = (),
     log: bool = True,
     scripts: Mapping[str, Sequence[PathString]] = {},
     env: Mapping[str, PathString] = {},
@@ -261,6 +262,7 @@ def bwrap(
         "--dev-bind", "/", "/",
         "--chdir", Path.cwd(),
         "--die-with-parent",
+        *options,
     ]
 
     if apivfs:


### PR DESCRIPTION
Similar to the other distros, run the package manager with bwrap()
instead of run_workspace_command(). Also disable the sandboxing of
emerge as we do it in mkosi already.