### PR TITLE
ubuntu: Enable universe repository by default on kinetic and later

### DIFF
--- a/mkosi/distributions/ubuntu.py
+++ b/mkosi/distributions/ubuntu.py
@@ -8,7 +8,13 @@ from mkosi.state import MkosiState
 class UbuntuInstaller(DebianInstaller):
     @staticmethod
     def repositories(state: MkosiState, local: bool = True) -> list[str]:
-        repos = ' '.join(("main", *state.config.repositories))
+        repos = ["main"]
+        if state.config.release not in ("focal", "jammy"):
+            # From kinetic onwards, the usr-is-merged package is available in universe and is required by
+            # mkosi to set up a proper usr-merged system so we add the universe repository unconditionally.
+            repos += ["universe"]
+
+        repos = ' '.join((*repos, *state.config.repositories))
 
         if state.config.local_mirror and local:
             return [f"deb [trusted=yes] {state.config.local_mirror} {state.config.release} {repos}"]


### PR DESCRIPTION
From kinetic onwards, the usr-is-merged package is available and has to be installed to get a proper usrmerge system but for some reason it's in the universe repository so we enable the universe repository by default from kinetic onwards so we can install the usrmerge package.