### PR TITLE
opensuse: Install systemd-boot package

### DIFF
--- a/.github/mkosi.conf.d/20-opensuse.conf
+++ b/.github/mkosi.conf.d/20-opensuse.conf
@@ -4,4 +4,5 @@ Distribution=opensuse
 [Content]
 Packages=kernel-kvmsmall
          systemd
+         systemd-boot
          udev


### PR DESCRIPTION
systemd-boot package was split from systemd in Tumbleweed, so let's make sure we install it in CI.