### PR TITLE
Add back support for bwrap 0.4

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1995,9 +1995,10 @@ def load_config(args: argparse.Namespace) -> MkosiConfig:
 
     if args.repositories and not (
         is_dnf_distribution(args.distribution) or
-        is_apt_distribution(args.distribution)
+        is_apt_distribution(args.distribution) or
+        args.distribution == Distribution.arch
     ):
-        die("Sorry, the --repositories option is only supported on dnf and apt based distributions")
+        die("Sorry, the --repositories option is only supported on pacman, dnf and apt based distributions")
 
     if args.initrds:
         args.initrds = [p.absolute() for p in args.initrds]

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -68,6 +68,14 @@ def setup_pacman(state: MkosiState) -> None:
 
     config.parent.mkdir(mode=0o755, exist_ok=True, parents=True)
 
+    repos = ["core"]
+    if not state.config.local_mirror:
+        repos += ["extra"]
+
+        for repo in ("core-testing", "extra-testing"):
+            if repo in state.config.repositories:
+                repos += [repo]
+
     with config.open("w") as f:
         f.write(
             dedent(
@@ -75,19 +83,16 @@ def setup_pacman(state: MkosiState) -> None:
                 [options]
                 SigLevel = {sig_level}
                 ParallelDownloads = 5
-
-                [core]
-                {server}
                 """
             )
         )
 
-        if not state.config.local_mirror:
+        for repo in repos:
             f.write(
                 dedent(
                     f"""\
 
-                    [extra]
+                    [{repo}]
                     {server}
                     """
                 )

--- a/mkosi/state.py
+++ b/mkosi/state.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 import importlib
+import os
 import tempfile
 from pathlib import Path
 
@@ -23,9 +24,13 @@ class MkosiState:
 
         self.environment = self.config.environment.copy()
         if self.config.image_id is not None:
-            self.environment['IMAGE_ID'] = self.config.image_id
+            self.environment["IMAGE_ID"] = self.config.image_id
         if self.config.image_version is not None:
-            self.environment['IMAGE_VERSION'] = self.config.image_version
+            self.environment["IMAGE_VERSION"] = self.config.image_version
+        if (proxy := os.environ.get("http_proxy")):
+            self.environment["http_proxy"] = proxy
+        if (proxy := os.environ.get("https_proxy")):
+            self.environment["https_proxy"] = proxy
 
         try:
             distro = str(self.config.distribution)


### PR DESCRIPTION
CentOS Stream 9 is still on bwrap 0.4 which is unfortunately still important so let's add back support for bwrap 0.4. Luckily, instead of doing awkward template formatting, shells pass extra arguments received when "-c" is used as arguments to the invoked command, so we can make use of that to keep the same API for bwrap_cmd().