### PR TITLE
Beef up --kernel-command-line-extra= defaults a little bit

### DIFF
--- a/.github/mkosi.conf.d/20-ubuntu.conf
+++ b/.github/mkosi.conf.d/20-ubuntu.conf
@@ -2,11 +2,15 @@
 Distribution=ubuntu
 
 [Distribution]
+Release=lunar
+
+[Distribution]
 Repositories=main,universe
 
 [Content]
 Packages=linux-kvm
          systemd
+         systemd-boot
          systemd-sysv
          udev
          dbus

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1393,6 +1393,7 @@ def summary(args: MkosiArgs, config: MkosiConfig) -> str:
                NSpawn Settings: {none_to_none(config.nspawn_settings)}
             Extra search paths: {line_join_list(config.extra_search_paths)}
           QEMU Extra Arguments: {line_join_list(config.qemu_args)}
+     Extra Kernel Command Line: {line_join_list(config.kernel_command_line_extra)}
 """
 
     if config.output_format == OutputFormat.disk:

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -227,7 +227,7 @@ def config_default_release(namespace: argparse.Namespace) -> str:
         Distribution.alma: "9",
         Distribution.mageia: "cauldron",
         Distribution.debian: "testing",
-        Distribution.ubuntu: "jammy",
+        Distribution.ubuntu: "lunar",
         Distribution.opensuse: "tumbleweed",
         Distribution.openmandriva: "cooker",
         Distribution.gentoo: "17.1",

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2021,10 +2021,20 @@ def load_kernel_command_line_extra(args: argparse.Namespace) -> list[str]:
         f"systemd.tty.columns.ttyS0={columns}",
         f"systemd.tty.rows.ttyS0={lines}",
         "console=ttyS0",
+        # Make sure we set up networking in the VM/container.
+        "systemd.wants=network-online.target",
+        # Make sure we don't load vmw_vmci which messes with virtio vsock.
+        "module_blacklist=vmw_vmci",
     ]
 
-    if args.output_format == OutputFormat.cpio:
-        cmdline += ["rd.systemd.unit=default.target"]
+    if not any(s.startswith("ip=") for s in args.kernel_command_line_extra):
+        cmdline += ["ip=enp0s1:any", "ip=host0:any"]
+
+    if not any(s.startswith("loglevel=") for s in args.kernel_command_line_extra):
+        cmdline += ["loglevel=4"]
+
+    if not any(s.startswith("SYSTEMD_SULOGIN_FORCE=") for s in args.kernel_command_line_extra):
+        cmdline += ["SYSTEMD_SULOGIN_FORCE=1"]
 
     for s in args.kernel_command_line_extra:
         key, sep, value = s.partition("=")


### PR DESCRIPTION
Let's provide a better experience out of the box when booting an image:
- Always blacklist vmw_vmci so it can't interfere with vsock
- Always pull in network-online.target
- Configure systemd-network-generator for enp0s1 and host0 if not
  configured explicitly
- Use a default loglevel where only warnings or higher are logged to
  the serial console by the kernel
- Set SYSTEMD_SULOGIN_FORCE=1 unless configured explicitly so users
  get a shell in the initrd if something goes wrong, even if no root
  password is configured