### PR TITLE
Make sure util-linux is installed in the initrd

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -880,6 +880,7 @@ def install_unified_kernel(state: MkosiState, roothash: Optional[str]) -> None:
                 "--acl", yes_no(state.config.acl),
                 "--format", "cpio",
                 "--package", "systemd",
+                "--package", "util-linux",
                 *(["--package", "udev"] if not is_portage_distribution(state.config.distribution) else []),
                 "--package", "kmod",
                 *(["--package", "dmsetup"] if is_apt_distribution(state.config.distribution) else []),


### PR DESCRIPTION
systemd on Fedora prefers to install util-linux-core instead of util-linux which doesn't ship sulogin which makes starting emergency.service enter an infinite loop. Let's make sure util-linux is installed so sulogin is available in the initrd.