### PR TITLE
Make tools= argument for bwrap() required

### DIFF
--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -274,7 +274,10 @@ def run_qemu(args: MkosiArgs, config: MkosiConfig) -> None:
             fname = config.output_dir / config.output
 
         if config.output_format == OutputFormat.disk:
-            bwrap(["systemd-repart", "--definitions", "", "--no-pager", "--size", "8G", "--pretty", "no", fname])
+            bwrap(
+                ["systemd-repart", "--definitions", "", "--no-pager", "--size", "8G", "--pretty", "no", fname],
+                tools=config.tools_tree,
+            )
 
         # Debian images fail to boot with virtio-scsi, see: https://github.com/systemd/mkosi/issues/725
         if config.output_format == OutputFormat.cpio:

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -413,7 +413,7 @@ def bwrap_cmd(
 def bwrap(
     cmd: Sequence[PathString],
     *,
-    tools: Optional[Path] = None,
+    tools: Optional[Path],
     apivfs: Optional[Path] = None,
     log: bool = True,
     scripts: Mapping[str, Sequence[PathString]] = {},


### PR DESCRIPTION
We generally always want this to be used, so let's make it required. Also, add tools= to the one invocation of bwrap() that wasn't forwarding it yet.