### PR TITLE
Rework user/mount namespace handling and tools tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ when you are in the repository top level.
 
 To use your local mkosi checkout without being in the top level of the
 repository you can either call the shim `bin/mkosi` or make an editable install
-into a virtual environment.
+into a virtual environment. The `MKOSI_INTERPRETER` environment variable can be
+set when using the `bin/mkosi` shim to configure the python interpreter used to
+execute mkosi.
 
 The shim can be symlinked somewhere into your `PATH`. To make an editable
 install add `--editable` to either of the above examples using pip or pipx and

--- a/bin/mkosi
+++ b/bin/mkosi
@@ -3,4 +3,4 @@
 set -e
 PYTHONPATH="$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")"
 export PYTHONPATH
-exec python3 -B -m mkosi "$@"
+exec ${MKOSI_INTERPRETER:-python3} -B -m mkosi "$@"

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -45,7 +45,6 @@ from mkosi.run import (
     fork_and_wait,
     run,
     spawn,
-    which,
 )
 from mkosi.state import MkosiState
 from mkosi.types import PathString
@@ -439,7 +438,7 @@ def install_boot_loader(state: MkosiState) -> None:
     if not any(gen_kernel_images(state)) and state.config.bootable == ConfigFeature.auto:
         return
 
-    if not which("bootctl", tools=state.config.tools_tree):
+    if not shutil.which("bootctl"):
         if state.config.bootable == ConfigFeature.enabled:
             die("A bootable image was requested but bootctl was not found")
         return
@@ -461,7 +460,7 @@ def install_boot_loader(state: MkosiState) -> None:
 
                 if (state.config.secure_boot_sign_tool == SecureBootSignTool.sbsign or
                     state.config.secure_boot_sign_tool == SecureBootSignTool.auto and
-                    which("sbsign", state.config.tools_tree) is not None):
+                    shutil.which("sbsign") is not None):
                     bwrap(["sbsign",
                            "--key", state.config.secure_boot_key,
                            "--cert", state.config.secure_boot_certificate,
@@ -470,7 +469,7 @@ def install_boot_loader(state: MkosiState) -> None:
                           tools=state.config.tools_tree)
                 elif (state.config.secure_boot_sign_tool == SecureBootSignTool.pesign or
                       state.config.secure_boot_sign_tool == SecureBootSignTool.auto and
-                      which("pesign", tools=state.config.tools_tree) is not None):
+                      shutil.which("pesign") is not None):
                     pesign_prepare(state)
                     bwrap(["pesign",
                            "--certdir", state.workspace / "pesign",
@@ -601,11 +600,11 @@ def install_build_dest(state: MkosiState) -> None:
         copy_path(state.install_dir, state.root, tools=state.config.tools_tree)
 
 
-def gzip_binary(config: MkosiConfig) -> str:
-    return "pigz" if which("pigz", tools=config.tools_tree) else "gzip"
+def gzip_binary() -> str:
+    return "pigz" if shutil.which("pigz") else "gzip"
 
 
-def tar_binary(config: MkosiConfig) -> str:
+def tar_binary() -> str:
     # Some distros (Mandriva) install BSD tar as "tar", hence prefer
     # "gtar" if it exists, which should be GNU tar wherever it exists.
     # We are interested in exposing same behaviour everywhere hence
@@ -613,7 +612,7 @@ def tar_binary(config: MkosiConfig) -> str:
     # everywhere. In particular given the limited/different SELinux
     # support in BSD tar and the different command line syntax
     # compared to GNU tar.
-    return "gtar" if which("gtar", tools=config.tools_tree) else "tar"
+    return "gtar" if shutil.which("gtar") else "tar"
 
 
 def make_tar(state: MkosiState) -> None:
@@ -621,7 +620,7 @@ def make_tar(state: MkosiState) -> None:
         return
 
     cmd: list[PathString] = [
-        tar_binary(state.config),
+        tar_binary(),
         "-C", state.root,
         "-c", "--xattrs",
         "--xattrs-include=*",
@@ -953,7 +952,7 @@ def install_unified_kernel(state: MkosiState, roothash: Optional[str]) -> None:
                 die(f"sd-stub not found at /{stub.relative_to(state.root)} in the image")
 
             cmd: list[PathString] = [
-                which("ukify", tools=state.config.tools_tree) or "/usr/lib/systemd/ukify",
+                shutil.which("ukify") or "/usr/lib/systemd/ukify",
                 "--cmdline", f"@{state.workspace / 'cmdline'}",
                 "--os-release", f"@{state.root / 'usr/lib/os-release'}",
                 "--stub", stub,
@@ -990,7 +989,7 @@ def install_unified_kernel(state: MkosiState, roothash: Optional[str]) -> None:
 
                 sign_expected_pcr = (state.config.sign_expected_pcr == ConfigFeature.enabled or
                                     (state.config.sign_expected_pcr == ConfigFeature.auto and
-                                     which("systemd-measure", tools=state.config.tools_tree) is not None))
+                                     shutil.which("systemd-measure") is not None))
 
                 if sign_expected_pcr:
                     cmd += [
@@ -1014,11 +1013,11 @@ def install_unified_kernel(state: MkosiState, roothash: Optional[str]) -> None:
         die("A bootable image was requested but no kernel was found")
 
 
-def compressor_command(config: MkosiConfig, compression: Compression) -> list[PathString]:
+def compressor_command(compression: Compression) -> list[PathString]:
     """Returns a command suitable for compressing archives."""
 
     if compression == Compression.gz:
-        return [gzip_binary(config), "--fast", "--stdout", "-"]
+        return [gzip_binary(), "--fast", "--stdout", "-"]
     elif compression == Compression.xz:
         return ["xz", "--check=crc32", "--fast", "-T0", "--stdout", "-"]
     elif compression == Compression.zst:
@@ -1041,7 +1040,7 @@ def maybe_compress(state: MkosiState, compression: Compression, src: Path, dst: 
             src.unlink() # if src == dst, make sure dst doesn't truncate the src file but creates a new file.
 
             with dst.open("wb") as o:
-                bwrap(compressor_command(state.config, compression), stdin=i, stdout=o, tools=state.config.tools_tree)
+                bwrap(compressor_command(compression), stdin=i, stdout=o, tools=state.config.tools_tree)
                 os.chown(dst, uid=state.uid, gid=state.gid)
 
 

--- a/mkosi/__main__.py
+++ b/mkosi/__main__.py
@@ -10,13 +10,11 @@ from collections.abc import Iterator
 from mkosi import run_verb
 from mkosi.config import MkosiConfigParser
 from mkosi.log import ARG_DEBUG, log_setup
-from mkosi.run import ensure_exc_info, excepthook
+from mkosi.run import ensure_exc_info
 
 
 @contextlib.contextmanager
 def propagate_failed_return() -> Iterator[None]:
-    sys.excepthook = excepthook
-
     try:
         yield
     except SystemExit as e:

--- a/mkosi/btrfs.py
+++ b/mkosi/btrfs.py
@@ -8,19 +8,19 @@ from typing import cast
 from mkosi.config import ConfigFeature, MkosiConfig
 from mkosi.install import copy_path
 from mkosi.log import die
-from mkosi.run import bwrap
+from mkosi.run import run
 
 
-def statfs(config: MkosiConfig, path: Path) -> str:
-    return cast(str, bwrap(["stat", "--file-system", "--format", "%T", path.parent],
-                           root=config.tools_tree, stdout=subprocess.PIPE).stdout.strip())
+def statfs(path: Path) -> str:
+    return cast(str, run(["stat", "--file-system", "--format", "%T", path.parent],
+                         stdout=subprocess.PIPE).stdout.strip())
 
 
 def btrfs_maybe_make_subvolume(config: MkosiConfig, path: Path, mode: int) -> None:
     if config.use_subvolumes == ConfigFeature.enabled and not shutil.which("btrfs"):
         die("Subvolumes requested but the btrfs command was not found")
 
-    if statfs(config, path.parent) != "btrfs":
+    if statfs(path.parent) != "btrfs":
         if config.use_subvolumes == ConfigFeature.enabled:
             die(f"Subvolumes requested but {path} is not located on a btrfs filesystem")
 
@@ -28,9 +28,8 @@ def btrfs_maybe_make_subvolume(config: MkosiConfig, path: Path, mode: int) -> No
         return
 
     if config.use_subvolumes != ConfigFeature.disabled and shutil.which("btrfs") is not None:
-        result = bwrap(["btrfs", "subvolume", "create", path],
-                       check=config.use_subvolumes == ConfigFeature.enabled,
-                       root=config.tools_tree).returncode
+        result = run(["btrfs", "subvolume", "create", path],
+                       check=config.use_subvolumes == ConfigFeature.enabled).returncode
     else:
         result = 1
 
@@ -48,19 +47,18 @@ def btrfs_maybe_snapshot_subvolume(config: MkosiConfig, src: Path, dst: Path) ->
         die("Subvolumes requested but the btrfs command was not found")
 
     # Subvolumes always have inode 256 so we can use that to check if a directory is a subvolume.
-    if not subvolume or statfs(config, src) != "btrfs" or src.stat().st_ino != 256 or (dst.exists() and any(dst.iterdir())):
-        return copy_path(src, dst, root=config.tools_tree)
+    if not subvolume or statfs(src) != "btrfs" or src.stat().st_ino != 256 or (dst.exists() and any(dst.iterdir())):
+        return copy_path(src, dst)
 
     # btrfs can't snapshot to an existing directory so make sure the destination does not exist.
     if dst.exists():
         dst.rmdir()
 
     if shutil.which("btrfs"):
-        result = bwrap(["btrfs", "subvolume", "snapshot", src, dst],
-                       check=config.use_subvolumes == ConfigFeature.enabled,
-                       root=config.tools_tree).returncode
+        result = run(["btrfs", "subvolume", "snapshot", src, dst],
+                     check=config.use_subvolumes == ConfigFeature.enabled).returncode
     else:
         result = 1
 
     if result != 0:
-        copy_path(src, dst, root=config.tools_tree)
+        copy_path(src, dst)

--- a/mkosi/btrfs.py
+++ b/mkosi/btrfs.py
@@ -13,7 +13,7 @@ from mkosi.run import bwrap
 
 def statfs(config: MkosiConfig, path: Path) -> str:
     return cast(str, bwrap(["stat", "--file-system", "--format", "%T", path.parent],
-                           tools=config.tools_tree, stdout=subprocess.PIPE).stdout.strip())
+                           root=config.tools_tree, stdout=subprocess.PIPE).stdout.strip())
 
 
 def btrfs_maybe_make_subvolume(config: MkosiConfig, path: Path, mode: int) -> None:
@@ -30,7 +30,7 @@ def btrfs_maybe_make_subvolume(config: MkosiConfig, path: Path, mode: int) -> No
     if config.use_subvolumes != ConfigFeature.disabled and shutil.which("btrfs") is not None:
         result = bwrap(["btrfs", "subvolume", "create", path],
                        check=config.use_subvolumes == ConfigFeature.enabled,
-                       tools=config.tools_tree).returncode
+                       root=config.tools_tree).returncode
     else:
         result = 1
 
@@ -49,7 +49,7 @@ def btrfs_maybe_snapshot_subvolume(config: MkosiConfig, src: Path, dst: Path) ->
 
     # Subvolumes always have inode 256 so we can use that to check if a directory is a subvolume.
     if not subvolume or statfs(config, src) != "btrfs" or src.stat().st_ino != 256 or (dst.exists() and any(dst.iterdir())):
-        return copy_path(src, dst, tools=config.tools_tree)
+        return copy_path(src, dst, root=config.tools_tree)
 
     # btrfs can't snapshot to an existing directory so make sure the destination does not exist.
     if dst.exists():
@@ -58,9 +58,9 @@ def btrfs_maybe_snapshot_subvolume(config: MkosiConfig, src: Path, dst: Path) ->
     if shutil.which("btrfs"):
         result = bwrap(["btrfs", "subvolume", "snapshot", src, dst],
                        check=config.use_subvolumes == ConfigFeature.enabled,
-                       tools=config.tools_tree).returncode
+                       root=config.tools_tree).returncode
     else:
         result = 1
 
     if result != 0:
-        copy_path(src, dst, tools=config.tools_tree)
+        copy_path(src, dst, root=config.tools_tree)

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1974,7 +1974,7 @@ def load_credentials(args: argparse.Namespace) -> dict[str, str]:
     if args.directory != "" and d.is_dir():
         for e in d.iterdir():
             if os.access(e, os.X_OK):
-                creds[e.name] = run([e], text=True, stdout=subprocess.PIPE, env=os.environ).stdout
+                creds[e.name] = run([e], stdout=subprocess.PIPE, env=os.environ).stdout
             else:
                 creds[e.name] = e.read_text()
 
@@ -1985,7 +1985,6 @@ def load_credentials(args: argparse.Namespace) -> dict[str, str]:
     if "firstboot.timezone" not in creds:
         tz = run(
             ["timedatectl", "show", "-p", "Timezone", "--value"],
-            text=True,
             stdout=subprocess.PIPE,
             check=False,
         ).stdout.strip()
@@ -1998,7 +1997,6 @@ def load_credentials(args: argparse.Namespace) -> dict[str, str]:
     if args.ssh and "ssh.authorized_keys.root" not in creds and "SSH_AUTH_SOCK" in os.environ:
         key = run(
             ["ssh-add", "-L"],
-            text=True,
             stdout=subprocess.PIPE,
             env=os.environ,
             check=False,

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -136,4 +136,4 @@ def invoke_pacman(state: MkosiState, packages: Sequence[str], apivfs: bool = Tru
     bwrap(cmdline,
           apivfs=state.root if apivfs else None,
           env=dict(KERNEL_INSTALL_BYPASS="1") | state.environment,
-          tools=state.config.tools_tree)
+          root=state.config.tools_tree)

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -135,5 +135,4 @@ def invoke_pacman(state: MkosiState, packages: Sequence[str], apivfs: bool = Tru
 
     bwrap(cmdline,
           apivfs=state.root if apivfs else None,
-          env=dict(KERNEL_INSTALL_BYPASS="1") | state.environment,
-          root=state.config.tools_tree)
+          env=dict(KERNEL_INSTALL_BYPASS="1") | state.environment)

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -93,9 +93,9 @@ class DebianInstaller(DistributionInstaller):
 
         for deb in essential:
             with tempfile.NamedTemporaryFile(dir=state.workspace) as f:
-                bwrap(["dpkg-deb", "--fsys-tarfile", deb], stdout=f, tools=state.config.tools_tree)
+                bwrap(["dpkg-deb", "--fsys-tarfile", deb], stdout=f, root=state.config.tools_tree)
                 bwrap(["tar", "-C", state.root, "--keep-directory-symlink", "--extract", "--file", f.name],
-                      tools=state.config.tools_tree)
+                      root=state.config.tools_tree)
 
         # Finally, run apt to properly install packages in the chroot without having to worry that maintainer
         # scripts won't find basic tools that they depend on.
@@ -247,7 +247,7 @@ def invoke_apt(
     return bwrap(["apt-get", *options, operation, *packages],
                  apivfs=state.root if apivfs else None,
                  env=env | state.environment,
-                 tools=state.config.tools_tree)
+                 root=state.config.tools_tree)
 
 
 def install_apt_sources(state: MkosiState, repos: Sequence[str]) -> None:

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
+import shutil
 import tempfile
 from collections.abc import Sequence
 from pathlib import Path
@@ -8,7 +9,7 @@ from textwrap import dedent
 from mkosi.architecture import Architecture
 from mkosi.distributions import DistributionInstaller
 from mkosi.log import die
-from mkosi.run import bwrap, which
+from mkosi.run import bwrap
 from mkosi.state import MkosiState
 from mkosi.types import CompletedProcess, PathString
 
@@ -231,7 +232,7 @@ def invoke_apt(
         "-o", f"Dir::Etc::trusted={trustedkeys}",
         "-o", f"Dir::Etc::trustedparts={trustedkeys_dir}",
         "-o", f"Dir::Log={state.pkgmngr / 'var/log/apt'}",
-        "-o", f"Dir::Bin::dpkg={which('dpkg', tools=state.config.tools_tree)}",
+        "-o", f"Dir::Bin::dpkg={shutil.which('dpkg')}",
         "-o", "Debug::NoLocking=true",
         "-o", f"DPkg::Options::=--root={state.root}",
         "-o", f"DPkg::Options::=--log={state.pkgmngr / 'var/log/apt/dpkg.log'}",

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -221,7 +221,7 @@ def invoke_dnf(
     bwrap(cmdline,
           apivfs=state.root if apivfs else None,
           env=dict(KERNEL_INSTALL_BYPASS="1") | env | state.environment,
-          tools=state.config.tools_tree)
+          root=state.config.tools_tree)
 
     fixup_rpmdb_location(state.root)
 

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -12,7 +12,7 @@ from mkosi.architecture import Architecture
 from mkosi.distributions import DistributionInstaller
 from mkosi.log import die
 from mkosi.remove import unlink_try_hard
-from mkosi.run import bwrap, which
+from mkosi.run import bwrap
 from mkosi.state import MkosiState
 from mkosi.util import Distribution, detect_distribution, sort_packages
 
@@ -173,8 +173,8 @@ def invoke_dnf(
     state.pkgmngr.joinpath("var/lib/dnf").mkdir(exist_ok=True, parents=True)
 
     # dnf5 does not support building for foreign architectures yet (missing --forcearch)
-    dnf = which("dnf5", tools=state.config.tools_tree) if state.config.architecture.is_native() else None
-    dnf = dnf or which("dnf", tools=state.config.tools_tree) or "yum"
+    dnf = shutil.which("dnf5") if state.config.architecture.is_native() else None
+    dnf = dnf or shutil.which("dnf") or "yum"
 
     cmdline = [
         dnf,

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -220,8 +220,7 @@ def invoke_dnf(
 
     bwrap(cmdline,
           apivfs=state.root if apivfs else None,
-          env=dict(KERNEL_INSTALL_BYPASS="1") | env | state.environment,
-          root=state.config.tools_tree)
+          env=dict(KERNEL_INSTALL_BYPASS="1") | env | state.environment)
 
     fixup_rpmdb_location(state.root)
 

--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -124,7 +124,7 @@ class GentooInstaller(DistributionInstaller):
             if stage3_tar.exists():
                 cmd += ["--time-cond", stage3_tar]
 
-            bwrap(cmd, tools=state.config.tools_tree)
+            bwrap(cmd, root=state.config.tools_tree)
 
             if stage3_tar.stat().st_mtime > old:
                 unlink_try_hard(stage3)
@@ -141,12 +141,12 @@ class GentooInstaller(DistributionInstaller):
                        "--exclude", "./dev/*",
                        "--exclude", "./proc/*",
                        "--exclude", "./sys/*"],
-                      tools=state.config.tools_tree)
+                      root=state.config.tools_tree)
 
         for d in ("binpkgs", "distfiles", "repos/gentoo"):
             (state.cache_dir / d).mkdir(parents=True, exist_ok=True)
 
-        copy_path(state.pkgmngr, stage3, preserve_owner=False, tools=state.config.tools_tree)
+        copy_path(state.pkgmngr, stage3, preserve_owner=False, root=state.config.tools_tree)
 
         bwrap(
             cmd=["chroot", "emerge-webrsync"],

--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -12,7 +12,7 @@ from mkosi.distributions import DistributionInstaller
 from mkosi.install import copy_path
 from mkosi.log import ARG_DEBUG, complete_step, die
 from mkosi.remove import unlink_try_hard
-from mkosi.run import bwrap, chroot_cmd
+from mkosi.run import bwrap, chroot_cmd, run
 from mkosi.state import MkosiState
 from mkosi.types import PathString
 
@@ -47,7 +47,6 @@ def invoke_emerge(
             *(["--verbose", "--quiet=n", "--quiet-fail=n"] if ARG_DEBUG.get() else ["--quiet-build", "--quiet"]),
             *options,
         ],
-        tools=state.config.tools_tree,
         apivfs=state.cache_dir / "stage3",
         scripts=dict(
             chroot=chroot_cmd(
@@ -124,7 +123,7 @@ class GentooInstaller(DistributionInstaller):
             if stage3_tar.exists():
                 cmd += ["--time-cond", stage3_tar]
 
-            bwrap(cmd, root=state.config.tools_tree)
+            run(cmd)
 
             if stage3_tar.stat().st_mtime > old:
                 unlink_try_hard(stage3)
@@ -133,24 +132,22 @@ class GentooInstaller(DistributionInstaller):
 
         if not any(stage3.iterdir()):
             with complete_step(f"Extracting {stage3_tar.name} to {stage3}"):
-                bwrap(["tar",
-                       "--numeric-owner",
-                       "-C", stage3,
-                       "--extract",
-                       "--file", stage3_tar,
-                       "--exclude", "./dev/*",
-                       "--exclude", "./proc/*",
-                       "--exclude", "./sys/*"],
-                      root=state.config.tools_tree)
+                run(["tar",
+                     "--numeric-owner",
+                     "-C", stage3,
+                     "--extract",
+                     "--file", stage3_tar,
+                     "--exclude", "./dev/*",
+                     "--exclude", "./proc/*",
+                     "--exclude", "./sys/*"])
 
         for d in ("binpkgs", "distfiles", "repos/gentoo"):
             (state.cache_dir / d).mkdir(parents=True, exist_ok=True)
 
-        copy_path(state.pkgmngr, stage3, preserve_owner=False, root=state.config.tools_tree)
+        copy_path(state.pkgmngr, stage3, preserve_owner=False)
 
         bwrap(
             cmd=["chroot", "emerge-webrsync"],
-            tools=state.config.tools_tree,
             apivfs=stage3,
             scripts=dict(
                 chroot=chroot_cmd(

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
+import shutil
 import textwrap
 import urllib.request
 import xml.etree.ElementTree as ElementTree
@@ -9,7 +10,7 @@ from mkosi.architecture import Architecture
 from mkosi.distributions import DistributionInstaller
 from mkosi.distributions.fedora import Repo, fixup_rpmdb_location, invoke_dnf, setup_dnf
 from mkosi.log import die
-from mkosi.run import bwrap, which
+from mkosi.run import bwrap
 from mkosi.state import MkosiState
 
 
@@ -43,7 +44,7 @@ class OpensuseInstaller(DistributionInstaller):
             release_url = f"{state.config.mirror}/distribution/leap/{release}/repo/oss/"
             updates_url = f"{state.config.mirror}/update/leap/{release}/oss/"
 
-        zypper = which("zypper", tools=state.config.tools_tree)
+        zypper = shutil.which("zypper")
 
         # If we need to use a local mirror, create a temporary repository definition
         # that doesn't get in the image, as it is valid only at image build time.
@@ -63,7 +64,7 @@ class OpensuseInstaller(DistributionInstaller):
 
     @classmethod
     def remove_packages(cls, state: MkosiState, packages: Sequence[str]) -> None:
-        if which("zypper", tools=state.config.tools_tree):
+        if shutil.which("zypper"):
             invoke_zypper(state, "remove", packages, ["--clean-deps"])
         else:
             invoke_dnf(state, "remove", packages)

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -142,7 +142,7 @@ def invoke_zypper(
     bwrap(cmdline,
           apivfs=state.root if apivfs else None,
           env=dict(ZYPP_CONF=str(state.pkgmngr / "etc/zypp/zypp.conf"), KERNEL_INSTALL_BYPASS="1") | state.environment,
-          tools=state.config.tools_tree)
+          root=state.config.tools_tree)
 
     fixup_rpmdb_location(state.root)
 

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -141,8 +141,7 @@ def invoke_zypper(
 
     bwrap(cmdline,
           apivfs=state.root if apivfs else None,
-          env=dict(ZYPP_CONF=str(state.pkgmngr / "etc/zypp/zypp.conf"), KERNEL_INSTALL_BYPASS="1") | state.environment,
-          root=state.config.tools_tree)
+          env=dict(ZYPP_CONF=str(state.pkgmngr / "etc/zypp/zypp.conf"), KERNEL_INSTALL_BYPASS="1") | state.environment)
 
     fixup_rpmdb_location(state.root)
 

--- a/mkosi/install.py
+++ b/mkosi/install.py
@@ -48,7 +48,7 @@ def copy_path(
     *,
     dereference: bool = False,
     preserve_owner: bool = True,
-    tools: Optional[Path] = None,
+    root: Optional[Path] = None,
 ) -> None:
     bwrap([
         "cp",
@@ -58,4 +58,4 @@ def copy_path(
         "--no-target-directory",
         "--reflink=auto",
         src, dst,
-    ], tools=tools)
+    ], root=root)

--- a/mkosi/install.py
+++ b/mkosi/install.py
@@ -8,7 +8,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Optional
 
-from mkosi.run import bwrap
+from mkosi.run import run
 from mkosi.util import make_executable
 
 
@@ -48,9 +48,8 @@ def copy_path(
     *,
     dereference: bool = False,
     preserve_owner: bool = True,
-    root: Optional[Path] = None,
 ) -> None:
-    bwrap([
+    run([
         "cp",
         "--recursive",
         f"--{'' if dereference else 'no-'}dereference",
@@ -58,4 +57,4 @@ def copy_path(
         "--no-target-directory",
         "--reflink=auto",
         src, dst,
-    ], root=root)
+    ])

--- a/mkosi/manifest.py
+++ b/mkosi/manifest.py
@@ -111,7 +111,7 @@ class Manifest:
                    "-qa",
                    "--qf", r"%{NEVRA}\t%{SOURCERPM}\t%{NAME}\t%{ARCH}\t%{LONGSIZE}\t%{INSTALLTIME}\n"],
                   stdout=PIPE,
-                  tools=self.config.tools_tree)
+                  root=self.config.tools_tree)
 
         packages = sorted(c.stdout.splitlines())
 
@@ -154,7 +154,7 @@ class Manifest:
                            nevra],
                           stdout=PIPE,
                           stderr=DEVNULL,
-                          tools=self.config.tools_tree)
+                          root=self.config.tools_tree)
                 changelog = c.stdout.strip()
                 source = SourcePackageManifest(srpm, changelog)
                 self.source_packages[srpm] = source
@@ -168,7 +168,7 @@ class Manifest:
                    "--showformat",
                        r'${Package}\t${source:Package}\t${Version}\t${Architecture}\t${Installed-Size}\t${db-fsys:Last-Modified}\n'],
                   stdout=PIPE,
-                  tools=self.config.tools_tree)
+                  root=self.config.tools_tree)
 
         packages = sorted(c.stdout.splitlines())
 
@@ -227,7 +227,7 @@ class Manifest:
                 # We have to run from the root, because if we use the RootDir option to make
                 # apt from the host look at the repositories in the image, it will also pick
                 # the 'methods' executables from there, but the ABI might not be compatible.
-                result = bwrap(cmd, stdout=PIPE, tools=self.config.tools_tree)
+                result = bwrap(cmd, stdout=PIPE, root=self.config.tools_tree)
                 source_package = SourcePackageManifest(source, result.stdout.strip())
                 self.source_packages[source] = source_package
 

--- a/mkosi/manifest.py
+++ b/mkosi/manifest.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 from typing import IO, Any, Optional
 
 from mkosi.config import MkosiConfig
-from mkosi.run import bwrap
+from mkosi.run import run
 from mkosi.util import Distribution, ManifestFormat, PackageType
 
 
@@ -105,13 +105,12 @@ class Manifest:
         if not (root / dbpath).exists():
             dbpath = "/var/lib/rpm"
 
-        c = bwrap(["rpm",
-                   f"--root={root}",
-                   f"--dbpath={dbpath}",
-                   "-qa",
-                   "--qf", r"%{NEVRA}\t%{SOURCERPM}\t%{NAME}\t%{ARCH}\t%{LONGSIZE}\t%{INSTALLTIME}\n"],
-                  stdout=PIPE,
-                  root=self.config.tools_tree)
+        c = run(["rpm",
+                 f"--root={root}",
+                 f"--dbpath={dbpath}",
+                 "-qa",
+                 "--qf", r"%{NEVRA}\t%{SOURCERPM}\t%{NAME}\t%{ARCH}\t%{LONGSIZE}\t%{INSTALLTIME}\n"],
+                stdout=PIPE)
 
         packages = sorted(c.stdout.splitlines())
 
@@ -146,15 +145,14 @@ class Manifest:
 
             source = self.source_packages.get(srpm)
             if source is None:
-                c = bwrap(["rpm",
-                           f"--root={root}",
-                           f"--dbpath={dbpath}",
-                           "-q",
-                           "--changelog",
-                           nevra],
-                          stdout=PIPE,
-                          stderr=DEVNULL,
-                          root=self.config.tools_tree)
+                c = run(["rpm",
+                         f"--root={root}",
+                         f"--dbpath={dbpath}",
+                         "-q",
+                         "--changelog",
+                         nevra],
+                        stdout=PIPE,
+                        stderr=DEVNULL)
                 changelog = c.stdout.strip()
                 source = SourcePackageManifest(srpm, changelog)
                 self.source_packages[srpm] = source
@@ -162,13 +160,12 @@ class Manifest:
             source.add(package)
 
     def record_deb_packages(self, root: Path) -> None:
-        c = bwrap(["dpkg-query",
-                   f"--admindir={root}/var/lib/dpkg",
-                   "--show",
-                   "--showformat",
-                       r'${Package}\t${source:Package}\t${Version}\t${Architecture}\t${Installed-Size}\t${db-fsys:Last-Modified}\n'],
-                  stdout=PIPE,
-                  root=self.config.tools_tree)
+        c = run(["dpkg-query",
+                 f"--admindir={root}/var/lib/dpkg",
+                 "--show",
+                 "--showformat",
+                     r'${Package}\t${source:Package}\t${Version}\t${Architecture}\t${Installed-Size}\t${db-fsys:Last-Modified}\n'],
+                 stdout=PIPE)
 
         packages = sorted(c.stdout.splitlines())
 
@@ -227,7 +224,7 @@ class Manifest:
                 # We have to run from the root, because if we use the RootDir option to make
                 # apt from the host look at the repositories in the image, it will also pick
                 # the 'methods' executables from there, but the ABI might not be compatible.
-                result = bwrap(cmd, stdout=PIPE, root=self.config.tools_tree)
+                result = run(cmd, stdout=PIPE)
                 source_package = SourcePackageManifest(source, result.stdout.strip())
                 self.source_packages[source] = source_package
 

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -274,10 +274,7 @@ def run_qemu(args: MkosiArgs, config: MkosiConfig) -> None:
             fname = config.output_dir / config.output
 
         if config.output_format == OutputFormat.disk:
-            bwrap(
-                ["systemd-repart", "--definitions", "", "--no-pager", "--size", "8G", "--pretty", "no", fname],
-                tools=config.tools_tree,
-            )
+            bwrap(["systemd-repart", "--definitions", "", "--no-pager", "--size", "8G", "--pretty", "no", fname])
 
         # Debian images fail to boot with virtio-scsi, see: https://github.com/systemd/mkosi/issues/725
         if config.output_format == OutputFormat.cpio:

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -20,7 +20,7 @@ from mkosi.btrfs import btrfs_maybe_snapshot_subvolume
 from mkosi.config import ConfigFeature, MkosiArgs, MkosiConfig
 from mkosi.log import die
 from mkosi.remove import unlink_try_hard
-from mkosi.run import MkosiAsyncioThread, bwrap, bwrap_cmd, spawn, which
+from mkosi.run import MkosiAsyncioThread, bwrap, bwrap_cmd, spawn
 from mkosi.types import PathString
 from mkosi.util import (
     Distribution,
@@ -41,7 +41,7 @@ def machine_cid(config: MkosiConfig) -> int:
 def find_qemu_binary(config: MkosiConfig) -> str:
     binaries = ["qemu", "qemu-kvm", f"qemu-system-{config.architecture.to_qemu()}"]
     for binary in binaries:
-        if which(binary, tools=config.tools_tree) is not None:
+        if shutil.which(binary) is not None:
             return binary
 
     die("Couldn't find QEMU/KVM binary")
@@ -294,7 +294,7 @@ def run_qemu(args: MkosiArgs, config: MkosiConfig) -> None:
                         "-device", "virtio-scsi-pci,id=scsi",
                         "-device", "scsi-hd,drive=hd,bootindex=1"]
 
-        if config.qemu_swtpm != ConfigFeature.disabled and which("swtpm", tools=config.tools_tree) is not None:
+        if config.qemu_swtpm != ConfigFeature.disabled and shutil.which("swtpm") is not None:
             sock = stack.enter_context(start_swtpm(config))
             cmdline += ["-chardev", f"socket,id=chrtpm,path={sock}",
                         "-tpmdev", "emulator,id=tpm0,chardev=chrtpm"]

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -138,7 +138,7 @@ def find_ovmf_vars(config: MkosiConfig) -> Path:
 
 @contextlib.contextmanager
 def start_swtpm(config: MkosiConfig) -> Iterator[Optional[Path]]:
-    with tempfile.TemporaryDirectory() as state, bwrap_cmd(tools=config.tools_tree) as bwrap:
+    with tempfile.TemporaryDirectory() as state, bwrap_cmd(root=config.tools_tree) as bwrap:
         sock = Path(state) / Path("sock")
         proc = spawn([*bwrap, "swtpm", "socket", "--tpm2", "--tpmstate", f"dir={state}", "--ctrl", f"type=unixio,path={sock}"])
 
@@ -313,7 +313,7 @@ def run_qemu(args: MkosiArgs, config: MkosiConfig) -> None:
               stdout=sys.stdout,
               env=os.environ,
               log=False,
-              tools=config.tools_tree)
+              root=config.tools_tree)
 
     if status := int(notifications.get("EXIT_STATUS", 0)):
         raise subprocess.CalledProcessError(status, cmdline)

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -412,7 +412,7 @@ def bwrap_cmd(
 def bwrap(
     cmd: Sequence[PathString],
     *,
-    tools: Optional[Path],
+    tools: Optional[Path] = None,
     apivfs: Optional[Path] = None,
     log: bool = True,
     scripts: Mapping[str, Sequence[PathString]] = {},

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -11,7 +11,6 @@ import os
 import pwd
 import queue
 import shlex
-import shutil
 import signal
 import subprocess
 import sys
@@ -485,10 +484,6 @@ def chroot_cmd(root: Path, *, options: Sequence[PathString] = (), network: bool 
         cmdline += ["--unshare-net"]
 
     return cmdline
-
-
-def which(program: str, tools: Optional[Path]) -> Optional[str]:
-    return shutil.which(program, path=f"{tools}/usr/bin:{tools}/usr/sbin" if tools else None)
 
 
 class MkosiAsyncioThread(threading.Thread):

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -312,7 +312,7 @@ def spawn(
 @contextlib.contextmanager
 def bwrap_cmd(
     *,
-    tools: Optional[Path] = None,
+    root: Optional[Path] = None,
     apivfs: Optional[Path] = None,
     scripts: Mapping[str, Sequence[PathString]] = {},
 ) -> Iterator[list[PathString]]:
@@ -321,7 +321,7 @@ def bwrap_cmd(
         "--dev-bind", "/", "/",
         "--chdir", Path.cwd(),
         "--die-with-parent",
-        "--ro-bind", (tools or Path("/")) / "usr", "/usr",
+        "--ro-bind", (root or Path("/")) / "usr", "/usr",
     ]
 
     for d in ("/etc", "/opt", "/srv", "/boot", "/efi"):
@@ -378,7 +378,7 @@ def bwrap_cmd(
             make_executable(Path(d) / name)
 
         # We modify the PATH via --setenv so that bwrap itself is looked up in PATH before we change it.
-        if tools:
+        if root:
             # If a tools tree is specified, we should ignore any local modifications made to PATH as any of
             # those binaries might not work anymore when /usr is replaced wholesale. We also make sure that
             # both /usr/bin and /usr/sbin/ are searched so that e.g. if the host is Arch and the root is
@@ -412,7 +412,7 @@ def bwrap_cmd(
 def bwrap(
     cmd: Sequence[PathString],
     *,
-    tools: Optional[Path] = None,
+    root: Optional[Path] = None,
     apivfs: Optional[Path] = None,
     log: bool = True,
     scripts: Mapping[str, Sequence[PathString]] = {},
@@ -424,7 +424,7 @@ def bwrap(
     check: bool = True,
     env: Mapping[str, PathString] = {},
 ) -> CompletedProcess:
-    with bwrap_cmd(tools=tools, apivfs=apivfs, scripts=scripts) as bwrap:
+    with bwrap_cmd(root=root, apivfs=apivfs, scripts=scripts) as bwrap:
         try:
             result = run(
                 [*bwrap, *cmd],

--- a/mkosi/state.py
+++ b/mkosi/state.py
@@ -14,11 +14,9 @@ from mkosi.log import die
 class MkosiState:
     """State related properties."""
 
-    def __init__(self, args: MkosiArgs, config: MkosiConfig, uid: int, gid: int) -> None:
+    def __init__(self, args: MkosiArgs, config: MkosiConfig) -> None:
         self.args = args
         self.config = config
-        self.uid = uid
-        self.gid = gid
 
         self._workspace = tempfile.TemporaryDirectory(dir=config.workspace_dir or Path.cwd(), prefix=".mkosi.tmp")
 


### PR DESCRIPTION
The biggest change is that instead of making bwrap() responsible
for mounting the tools tree, we do it ourselves before we build/boot
each image. We do the same for remounting the top level directories
read-only, instead of leaving it to bwrap(), we do it once at the
start of run_verb(). Because we now mess with the host system mounts
ourselves again, we also go back to unconditionally unsharing a mount
namespace, even when running as root.

With the above out of the way, there's no real reason left to run
regular executables with bwrap(), so those are moved back to be
executed using run(). The above changes also remove the need for
bwrap_cmd(), so it is merged back with bwrap() again.

One nasty caveat of overmounting /usr ourselves at the start of
execution is that some python modules are loaded dynamically and we
need to make sure this has happened before we start overmounting /usr.
This is done in a new function load_dynamic_modules().

Finally, this commit also gets rid of running the image build in a
subprocess. Instead, after doing the build and doing the final tools
tree mount for the image we're going to boot/qemu/ssh into, if we're
going to do an unprivleged operation, we change uid/gid to the invoking
user. This is more or less the same as running these operations unprivileged
outside of the user namespace.

For boot/shell, these only run privileged, so we check beforehand
that we're running as root, and this doesn't change after become_root(),
so since we're just root all the time, there's no need to run the image
build in a subprocess.

We also unify more of the uid/gid handling in run_verb() in general.