### PR TITLE
gentoo: add gnu-efi USE flag to build systemd-boot

### DIFF
--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -71,7 +71,8 @@ def invoke_emerge(
             # boot: for systemd
             # minimal: because we like minimals
             # initramfs, symlink for kernel
-            USE="boot initramfs minimal symlink",
+            # gnu-efi: https://wiki.gentoo.org/wiki/Systemd/systemd-boot#Installation
+            USE="boot initramfs minimal symlink gnu-efi",
         ) | env | state.environment,
     )
 


### PR DESCRIPTION
Not sure this is the right flag, but the first thing that a minute of googling turned up, since the CI failures for Gentoo have been bugging me.

/cc @257 