### PR TITLE
gentoo: stop passing USE environment to emerge

### DIFF
--- a/.github/mkosi.conf.d/20-gentoo.conf
+++ b/.github/mkosi.conf.d/20-gentoo.conf
@@ -3,8 +3,10 @@ Distribution=gentoo
 
 [Content]
 Environment=PORTAGE_BINHOST=https://raw.githubusercontent.com/257/binpkgs/master
-Packages=sys-kernel/gentoo-kernel-bin
-         sys-apps/systemd
+# needed for system-9999
+PackageManagerTrees=mkosi.pkgmngr/gentoo
+Packages=sys-kernel/gentoo-kernel-bin[initramfs]
+         =sys-apps/systemd-9999[boot]
          # Failed to execute /usr/lib/systemd/system-environment-generators/10-gentoo-path: No such file or directory
          # Failed to execute /usr/lib/systemd/system-generators/gentoo-local-generator: No such file or directory
          sys-apps/gentoo-systemd-integration

--- a/.github/mkosi.pkgmngr/gentoo/etc/portage/package.accept_keywords/9999
+++ b/.github/mkosi.pkgmngr/gentoo/etc/portage/package.accept_keywords/9999
@@ -1,0 +1,1 @@
+=sys-apps/systemd-9999 **

--- a/.github/mkosi.pkgmngr/gentoo/etc/portage/package.use/systemd
+++ b/.github/mkosi.pkgmngr/gentoo/etc/portage/package.use/systemd
@@ -1,0 +1,1 @@
+sys-apps/systemd boot

--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -68,10 +68,6 @@ def invoke_emerge(
                 "parallel-install",
                 *(["noman", "nodoc", "noinfo"] if state.config.with_docs else []),
             ]),
-            # boot: for systemd
-            # minimal: because we like minimals
-            # initramfs, symlink for kernel
-            USE="boot initramfs minimal symlink",
         ) | env | state.environment,
     )
 


### PR DESCRIPTION
also make sure we stay with systemd-9999 (version built from git) in order keep up with changes in systemd