### PR TITLE
Stop tmpfiles from creating subvolumes

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1499,16 +1499,28 @@ def run_depmod(state: MkosiState) -> None:
 
 
 def run_sysusers(state: MkosiState) -> None:
+    if not shutil.which("systemd-sysusers"):
+        logging.info("systemd-sysusers is not installed, not generating system users")
+        return
+
     with complete_step("Generating system users"):
         run(["systemd-sysusers", "--root", state.root])
 
 
 def run_preset(state: MkosiState) -> None:
+    if not shutil.which("systemctl"):
+        logging.info("systemctl is not installed, not applying presets")
+        return
+
     with complete_step("Applying presets…"):
         run(["systemctl", "--root", state.root, "preset-all"])
 
 
 def run_hwdb(state: MkosiState) -> None:
+    if not shutil.which("systemd-hwdb"):
+        logging.info("systemd-hwdb is not installed, not generating hwdb")
+        return
+
     with complete_step("Generating hardware database"):
         run(["systemd-hwdb", "--root", state.root, "--usr", "--strict", "update"])
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -316,7 +316,7 @@ def run_prepare_script(state: MkosiState, build: bool) -> None:
                 ["chroot", "/work/prepare", "build"],
                 apivfs=state.root,
                 scripts=dict(chroot=chroot_cmd(state.root, options=options, network=True)),
-                env=dict(SRCDIR="/work/src") | state.environment,
+                env=dict(SRCDIR="/work/src") | state.config.environment,
             )
             shutil.rmtree(state.root / "work")
     else:
@@ -325,7 +325,7 @@ def run_prepare_script(state: MkosiState, build: bool) -> None:
                 ["chroot", "/work/prepare", "final"],
                 apivfs=state.root,
                 scripts=dict(chroot=chroot_cmd(state.root, options=options, network=True)),
-                env=dict(SRCDIR="/work/src") | state.environment,
+                env=dict(SRCDIR="/work/src") | state.config.environment,
             )
             shutil.rmtree(state.root / "work")
 
@@ -345,7 +345,7 @@ def run_postinst_script(state: MkosiState) -> None:
                     network=state.config.with_network,
                 ),
             ),
-            env=state.environment,
+            env=state.config.environment,
         )
 
         shutil.rmtree(state.root / "work")
@@ -357,7 +357,7 @@ def run_finalize_script(state: MkosiState) -> None:
 
     with complete_step("Running finalize script…"):
         run([state.config.finalize_script],
-            env={**state.environment, "BUILDROOT": str(state.root), "OUTPUTDIR": str(state.staging)})
+            env={**state.config.environment, "BUILDROOT": str(state.root), "OUTPUTDIR": str(state.staging)})
 
 
 def certificate_common_name(state: MkosiState, certificate: Path) -> str:
@@ -1578,7 +1578,7 @@ def run_selinux_relabel(state: MkosiState) -> None:
             cmd=["chroot", "sh", "-c", cmd],
             apivfs=state.root,
             scripts=dict(chroot=chroot_cmd(state.root)),
-            env=state.environment,
+            env=state.config.environment,
         )
 
 
@@ -1711,7 +1711,7 @@ def make_image(state: MkosiState, skip: Sequence[str] = [], split: bool = False)
     for fs, options in state.installer.filesystem_options(state).items():
         env[f"SYSTEMD_REPART_MKFS_OPTIONS_{fs.upper()}"] = " ".join(options)
 
-    for option, value in state.environment.items():
+    for option, value in state.config.environment.items():
         if option.startswith("SYSTEMD_REPART_MKFS_OPTIONS_"):
             env[option] = value
 
@@ -1873,7 +1873,7 @@ def run_build_script(state: MkosiState) -> None:
             ["chroot", "/work/build-script"],
             apivfs=state.root,
             scripts=dict(chroot=chroot_cmd(state.root, options=options, network=state.config.with_network)),
-            env=env | state.environment,
+            env=env | state.config.environment,
         )
 
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2043,7 +2043,9 @@ def load_kernel_command_line_extra(args: argparse.Namespace) -> list[str]:
 
 
 def load_environment(args: argparse.Namespace) -> dict[str, str]:
-    env = {}
+    env = {
+        "SYSTEMD_TMPFILES_FORCE_SUBVOL": "0",
+    }
 
     if args.image_id is not None:
         env["IMAGE_ID"] = args.image_id

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2042,6 +2042,22 @@ def load_kernel_command_line_extra(args: argparse.Namespace) -> list[str]:
     return cmdline
 
 
+def load_environment(args: argparse.Namespace) -> dict[str, str]:
+    env = {}
+
+    if args.image_id is not None:
+        env["IMAGE_ID"] = args.image_id
+    if args.image_version is not None:
+        env["IMAGE_VERSION"] = args.image_version
+    if (proxy := os.environ.get("http_proxy")):
+        env["http_proxy"] = proxy
+    if (proxy := os.environ.get("https_proxy")):
+        env["https_proxy"] = proxy
+
+    # Mypy doesn't like | here.
+    return {**env, **args.environment}
+
+
 def load_args(args: argparse.Namespace) -> MkosiArgs:
     if args.debug:
         ARG_DEBUG.set(args.debug)
@@ -2089,6 +2105,7 @@ def load_config(args: argparse.Namespace) -> MkosiConfig:
 
     args.credentials = load_credentials(args)
     args.kernel_command_line_extra = load_kernel_command_line_extra(args)
+    args.environment = load_environment(args)
 
     if args.secure_boot and args.verb != Verb.genkey:
         if args.secure_boot_key is None:

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -135,4 +135,4 @@ def invoke_pacman(state: MkosiState, packages: Sequence[str], apivfs: bool = Tru
 
     bwrap(cmdline,
           apivfs=state.root if apivfs else None,
-          env=dict(KERNEL_INSTALL_BYPASS="1") | state.environment)
+          env=dict(KERNEL_INSTALL_BYPASS="1") | state.config.environment)

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -245,7 +245,7 @@ def invoke_apt(
 
     bwrap(["apt-get", *options, operation, *packages],
           apivfs=state.root if apivfs else None,
-          env=env | state.environment)
+          env=env | state.config.environment)
 
 
 def install_apt_sources(state: MkosiState, repos: Sequence[str]) -> None:

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -220,7 +220,7 @@ def invoke_dnf(
 
     bwrap(cmdline,
           apivfs=state.root if apivfs else None,
-          env=dict(KERNEL_INSTALL_BYPASS="1") | env | state.environment)
+          env=dict(KERNEL_INSTALL_BYPASS="1") | env | state.config.environment)
 
     fixup_rpmdb_location(state.root)
 

--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -67,7 +67,7 @@ def invoke_emerge(
                 "parallel-install",
                 *(["noman", "nodoc", "noinfo"] if state.config.with_docs else []),
             ]),
-        ) | env | state.environment,
+        ) | env | state.config.environment,
     )
 
 

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -141,7 +141,7 @@ def invoke_zypper(
 
     bwrap(cmdline,
           apivfs=state.root if apivfs else None,
-          env=dict(ZYPP_CONF=str(state.pkgmngr / "etc/zypp/zypp.conf"), KERNEL_INSTALL_BYPASS="1") | state.environment)
+          env=dict(ZYPP_CONF=str(state.pkgmngr / "etc/zypp/zypp.conf"), KERNEL_INSTALL_BYPASS="1") | state.config.environment)
 
     fixup_rpmdb_location(state.root)
 

--- a/mkosi/state.py
+++ b/mkosi/state.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 import importlib
-import os
 import tempfile
 from pathlib import Path
 
@@ -19,16 +18,6 @@ class MkosiState:
         self.config = config
 
         self._workspace = tempfile.TemporaryDirectory(dir=config.workspace_dir or Path.cwd(), prefix=".mkosi.tmp")
-
-        self.environment = self.config.environment.copy()
-        if self.config.image_id is not None:
-            self.environment["IMAGE_ID"] = self.config.image_id
-        if self.config.image_version is not None:
-            self.environment["IMAGE_VERSION"] = self.config.image_version
-        if (proxy := os.environ.get("http_proxy")):
-            self.environment["http_proxy"] = proxy
-        if (proxy := os.environ.get("https_proxy")):
-            self.environment["https_proxy"] = proxy
 
         try:
             distro = str(self.config.distribution)


### PR DESCRIPTION
Generally when building an image there's no point in creating nested
subvolumes in these directories so let's disable that.