### PR TITLE
Simplify become_root()

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -30,7 +30,7 @@ from mkosi.config import (
     MkosiConfigParser,
     SecureBootSignTool,
 )
-from mkosi.install import add_dropin_config_from_resource, copy_path, flock
+from mkosi.install import add_dropin_config_from_resource, copy_path
 from mkosi.log import Style, color_error, complete_step, die, log_step
 from mkosi.manifest import Manifest
 from mkosi.mounts import mount_overlay, mount_passwd, mount_tools, scandir_recursive
@@ -47,6 +47,7 @@ from mkosi.util import (
     OutputFormat,
     Verb,
     flatten,
+    flock,
     format_bytes,
     format_rlimit,
     is_apt_distribution,

--- a/mkosi/install.py
+++ b/mkosi/install.py
@@ -1,10 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
-import contextlib
-import fcntl
 import importlib.resources
-import os
-from collections.abc import Iterator
 from pathlib import Path
 from typing import Optional
 
@@ -29,17 +25,6 @@ def add_dropin_config_from_resource(
     dropin = root / f"usr/lib/systemd/system/{unit}.d/{name}.conf"
     dropin.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
     write_resource(dropin, resource, key, mode=0o644)
-
-
-@contextlib.contextmanager
-def flock(path: Path) -> Iterator[Path]:
-    fd = os.open(path, os.O_CLOEXEC|os.O_DIRECTORY|os.O_RDONLY)
-    try:
-        fcntl.fcntl(fd, fcntl.FD_CLOEXEC)
-        fcntl.flock(fd, fcntl.LOCK_EX)
-        yield Path(path)
-    finally:
-        os.close(fd)
 
 
 def copy_path(

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -4,6 +4,7 @@ import ast
 import contextlib
 import enum
 import errno
+import fcntl
 import functools
 import importlib
 import itertools
@@ -309,3 +310,14 @@ def try_import(module: str) -> None:
         importlib.import_module(module)
     except ModuleNotFoundError:
         pass
+
+
+@contextlib.contextmanager
+def flock(path: Path) -> Iterator[int]:
+    fd = os.open(path, os.O_CLOEXEC|os.O_RDONLY)
+    try:
+        fcntl.fcntl(fd, fcntl.FD_CLOEXEC)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield fd
+    finally:
+        os.close(fd)


### PR DESCRIPTION
- Instead of forking, use spawn() to start the newuidmap, newgidmap processes early
- Instead of multiprocessing.Event(), use flock to handle the necessary locking