### PR TITLE
mkosi: implement --zero-mtime and sort some files

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -623,7 +623,7 @@ def make_cpio(root: Path, files: Iterator[Path], output: Path) -> None:
             #  https://github.com/python/mypy/issues/10583
             assert cpio.stdin is not None
 
-            for file in files:
+            for file in sorted(files):
                 cpio.stdin.write(os.fspath(file))
                 cpio.stdin.write("\0")
             cpio.stdin.close()

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -646,6 +646,7 @@ class MkosiConfig:
     hostname: Optional[str]
     root_password: Optional[tuple[str, bool]]
     root_shell: Optional[str]
+    zero_mtime: bool
 
     # QEMU-specific options
     qemu_gui: bool
@@ -868,6 +869,11 @@ class MkosiConfigParser:
             dest="use_subvolumes",
             section="Output",
             parse=config_parse_feature,
+        ),
+        MkosiConfigSetting(
+            dest="zero-mtime",
+            section="Output",
+            parse=config_parse_boolean,
         ),
         MkosiConfigSetting(
             dest="packages",
@@ -1552,6 +1558,13 @@ class MkosiConfigParser:
             "--use-subvolumes",
             metavar="FEATURE",
             help="Use btrfs subvolumes for faster directory operations where possible",
+            nargs="?",
+            action=action,
+        )
+        group.add_argument(
+            "--zero-mtime",
+            metavar="BOOL",
+            help="Zero mtime of the image",
             nargs="?",
             action=action,
         )


### PR DESCRIPTION
Sorts the files before we write the cpio, partially a reproducible builds issue but also just a good thing to do.

Implements --zero-mtime. See https://github.com/systemd/mkosi/issues/687

