### PR TITLE
Gentoo fixes

### DIFF
--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -21,24 +21,19 @@ def invoke_emerge(state: MkosiState, packages: Sequence[str] = (), apivfs: bool 
     bwrap(
         cmd=[
             "emerge",
-            *packages,
-            "--update",
-            "--deep",
             "--buildpkg=y",
             "--usepkg=y",
+            "--getbinpkg=y",
+            "--binpkg-respect-use=y",
             "--jobs",
             "--load-average",
-            "--nospinner",
             "--root-deps=rdeps",
             "--with-bdeps=n",
-            "--complete-graph-if-new-use=y",
             "--verbose-conflicts",
-            "--changed-use",
-            "--newuse",
             "--noreplace",
-            f"--root={state.root}",
-            "--binpkg-respect-use",
             *(["--verbose", "--quiet=n", "--quiet-fail=n"] if ARG_DEBUG.get() else ["--quiet-build", "--quiet"]),
+            f"--root={state.root}",
+            *packages,
         ],
         apivfs=state.root if apivfs else None,
         options=[
@@ -118,10 +113,11 @@ class GentooInstaller(DistributionInstaller):
         copy_tree(state.config, state.pkgmngr, stage3, preserve_owner=False)
 
         features = " ".join([
-            "getbinpkg",
-            "-candy",
             # Disable sandboxing in emerge because we already do it in mkosi.
             "-sandbox",
+            "-pid-sandbox",
+            "-ipc-sandbox",
+            "-network-sandbox",
             "-userfetch",
             "-userpriv",
             "-usersandbox",


### PR DESCRIPTION
- Drop --update, we never want to update packages, only install new ones
- Drop --changed-use and --new-use, these apply to updating an existing system, we're always installing a new one
- Drop --deep and --complete-graph-if-new-use, these don't seem to have any noticeable effect
- Move getbinpkg from FEATURE to emerge CLI option --getbinpkg
- Do not disable spinner and candy option
- Explicitly disable all sandboxing features