### PR TITLE
gentoo: Only support binary package repositories

### DIFF
--- a/.github/mkosi.conf.d/20-gentoo.conf
+++ b/.github/mkosi.conf.d/20-gentoo.conf
@@ -1,15 +1,12 @@
 [Match]
 Distribution=gentoo
 
+[Distribution]
+Mirror=https://raw.githubusercontent.com/257/binpkgs/master
+
 [Content]
-Environment=PORTAGE_BINHOST=https://raw.githubusercontent.com/257/binpkgs/master
-# needed for system-9999
-PackageManagerTrees=mkosi.pkgmngr/gentoo
-Packages=sys-kernel/gentoo-kernel-bin[initramfs]
-         =sys-apps/systemd-9999[boot]
-         # Failed to execute /usr/lib/systemd/system-environment-generators/10-gentoo-path: No such file or directory
-         # Failed to execute /usr/lib/systemd/system-generators/gentoo-local-generator: No such file or directory
-         sys-apps/gentoo-systemd-integration
+Packages=sys-kernel/gentoo-kernel-bin
+         sys-apps/systemd
          app-shells/bash
          # mkosi-check-and-shutdown.sh[46]: /usr/lib/systemd/mkosi-check-and-shutdown.sh: line 5: tee: command not found
          sys-apps/coreutils

--- a/.github/mkosi.pkgmngr/gentoo/etc/portage/package.accept_keywords/9999
+++ b/.github/mkosi.pkgmngr/gentoo/etc/portage/package.accept_keywords/9999
@@ -1,1 +1,0 @@
-=sys-apps/systemd-9999 **

--- a/.github/mkosi.pkgmngr/gentoo/etc/portage/package.use/systemd
+++ b/.github/mkosi.pkgmngr/gentoo/etc/portage/package.use/systemd
@@ -1,1 +1,0 @@
-sys-apps/systemd boot

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -307,8 +307,6 @@ def config_default_mirror(namespace: argparse.Namespace) -> Optional[str]:
         return "http://download.opensuse.org"
     elif d == Distribution.fedora and r == "eln":
         return "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose"
-    elif d == Distribution.gentoo:
-        return "https://distfiles.gentoo.org"
 
     return None
 


### PR DESCRIPTION
Supporting only binary packages will allow us to greatly simplify
our gentoo implementation:

- Won't need to make a distinction between sysroot and root anymore
- No more need for a stage 3 tarball once we get portage packaged in
fedora and other distributions
- No more messing around with profiles and use flags

The main change is that users are required to configure a binary package
repository to be able to build gentoo images. They have to either configure
a binary package repository mirror using --mirror or use a local binary
package directory by setting "Environment=PKGDIR=...".

Also contains the following changes:

- Make sure emerge shows the dep tree before installing
- Drop --quiet flags from emerge to get more info by default
- Set PORTAGE_USERNAME=root and PORTAGE_GRPNAME=root since we're in
a user namespace anyway so it doesn't matter to run as root