### PR TITLE
apt: Make invoke_apt() and apt_cmd() slightly more generic

### DIFF
--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -108,8 +108,8 @@ class DebianInstaller(DistributionInstaller):
         policyrcd.chmod(0o755)
 
         setup_apt(state, cls.repositories(state))
-        invoke_apt(state, "update", apivfs=False)
-        invoke_apt(state, "install", packages, apivfs=apivfs)
+        invoke_apt(state, "apt-get", "update", apivfs=False)
+        invoke_apt(state, "apt-get", "install", packages, apivfs=apivfs)
         install_apt_sources(state, cls.repositories(state, local=False))
 
         policyrcd.unlink()
@@ -123,7 +123,7 @@ class DebianInstaller(DistributionInstaller):
 
     @classmethod
     def remove_packages(cls, state: MkosiState, packages: Sequence[str]) -> None:
-        invoke_apt(state, "purge", packages)
+        invoke_apt(state, "apt-get", "purge", packages)
 
     @staticmethod
     def architecture(arch: Architecture) -> str:

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -53,7 +53,7 @@ def setup_apt(state: MkosiState, repos: Sequence[str]) -> None:
                 f.write(f"{repo}\n")
 
 
-def apt_cmd(state: MkosiState) -> list[str]:
+def apt_cmd(state: MkosiState, command: str) -> list[str]:
     debarch = state.installer.architecture(state.config.architecture)
 
     trustedkeys = state.pkgmngr / "etc/apt/trusted.gpg"
@@ -67,7 +67,7 @@ def apt_cmd(state: MkosiState) -> list[str]:
         "DEBIAN_FRONTEND=noninteractive",
         "DEBCONF_INTERACTIVE_SEEN=true",
         "INITRD=No",
-        "apt-get",
+        command,
         "-o", f"APT::Architecture={debarch}",
         "-o", f"APT::Architectures={debarch}",
         "-o", "APT::Immediate-Configure=off",
@@ -97,10 +97,11 @@ def apt_cmd(state: MkosiState) -> list[str]:
 
 def invoke_apt(
     state: MkosiState,
+    command: str,
     operation: str,
     packages: Sequence[str] = (),
     apivfs: bool = True,
 ) -> None:
-    bwrap(apt_cmd(state) + [operation, *packages],
+    bwrap(apt_cmd(state, command) + [operation, *packages],
           apivfs=state.root if apivfs else None,
           env=state.config.environment)


### PR DESCRIPTION
Let's allow passing in the apt command we want to execute.

Split out of #1701 