### PR TITLE
Give scripts access to sys.stdin

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -195,6 +195,7 @@ def run_prepare_script(state: MkosiState, build: bool) -> None:
                 apivfs=state.root,
                 scripts=dict(chroot=chroot_cmd(state.root, options=options, network=True)),
                 env=dict(SRCDIR="/work/src") | state.config.environment,
+                stdin=sys.stdin,
             )
             shutil.rmtree(state.root / "work")
     else:
@@ -204,6 +205,7 @@ def run_prepare_script(state: MkosiState, build: bool) -> None:
                 apivfs=state.root,
                 scripts=dict(chroot=chroot_cmd(state.root, options=options, network=True)),
                 env=dict(SRCDIR="/work/src") | state.config.environment,
+                stdin=sys.stdin,
             )
             shutil.rmtree(state.root / "work")
 
@@ -253,6 +255,7 @@ def run_build_script(state: MkosiState) -> None:
             apivfs=state.root,
             scripts=dict(chroot=chroot_cmd(state.root, options=options, network=state.config.with_network)),
             env=env | state.config.environment,
+            stdin=sys.stdin,
         )
 
 
@@ -272,6 +275,7 @@ def run_postinst_script(state: MkosiState) -> None:
                 ),
             ),
             env=state.config.environment,
+            stdin=sys.stdin,
         )
 
         shutil.rmtree(state.root / "work")

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -121,7 +121,7 @@ class CentosInstaller(DistributionInstaller):
                 if repo == "extras":
                     return [
                         Repo(repo.lower(), f"{url}?arch=$basearch&repo=centos-extras-sig-extras-common-$stream", cls.gpgurls()),
-                        Repo(repo.lower(), f"{url}?arch=source&repo=centos-extras-sig-extras-common-source-$stream", cls.gpgurls(), enabled=False),
+                        Repo(f"{repo.lower()}-source", f"{url}?arch=source&repo=centos-extras-sig-extras-common-source-$stream", cls.gpgurls(), enabled=False),
                     ]
 
                 return [

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -257,6 +257,7 @@ def bwrap(
     log: bool = True,
     scripts: Mapping[str, Sequence[PathString]] = {},
     env: Mapping[str, str] = {},
+    stdin: _FILE = None,
 ) -> CompletedProcess:
     cmdline: list[PathString] = [
         "bwrap",
@@ -336,7 +337,7 @@ def bwrap(
         cmdline += ["sh", "-c", f"{chmod} && {container} && exec $0 \"$@\" || exit $?"]
 
         try:
-            result = run([*cmdline, *cmd], env=env, log=False)
+            result = run([*cmdline, *cmd], env=env, log=False, stdin=stdin)
         except subprocess.CalledProcessError as e:
             if log:
                 logging.error(f"\"{' '.join(str(s) for s in cmd)}\" returned non-zero exit code {e.returncode}.")


### PR DESCRIPTION
It's very useful to be able to put "bash" in a script to get a shell, so let's support that.