### PR TITLE
Make sure package managers are always configured

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1770,6 +1770,8 @@ def build_image(args: MkosiArgs, config: MkosiConfig) -> None:
             install_skeleton_trees(state)
             cached = reuse_cache(state)
 
+            state.config.distribution.setup(state)
+
             if not cached:
                 with mount_cache_overlay(state):
                     install_distribution(state)

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -23,6 +23,10 @@ class PackageType(StrEnum):
 
 class DistributionInstaller:
     @classmethod
+    def setup(cls, state: "MkosiState") -> None:
+        raise NotImplementedError()
+
+    @classmethod
     def install(cls, state: "MkosiState") -> None:
         raise NotImplementedError()
 
@@ -78,6 +82,9 @@ class Distribution(StrEnum):
 
     def is_portage_distribution(self) -> bool:
         return self in (Distribution.gentoo,)
+
+    def setup(self, state: "MkosiState") -> None:
+        return self.installer().setup(state)
 
     def install(self, state: "MkosiState") -> None:
         return self.installer().install(state)

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -19,12 +19,15 @@ class ArchInstaller(DistributionInstaller):
         return PackageType.pkg
 
     @classmethod
+    def setup(cls, state: MkosiState) -> None:
+        setup_pacman(state)
+
+    @classmethod
     def install(cls, state: MkosiState) -> None:
         cls.install_packages(state, ["filesystem"], apivfs=False)
 
     @classmethod
     def install_packages(cls, state: MkosiState, packages: Sequence[str], apivfs: bool = True) -> None:
-        setup_pacman(state)
         invoke_pacman(state, packages, apivfs=apivfs)
 
     @staticmethod

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -57,6 +57,10 @@ class DebianInstaller(DistributionInstaller):
         return repos
 
     @classmethod
+    def setup(cls, state: MkosiState) -> None:
+        setup_apt(state, cls.repositories(state))
+
+    @classmethod
     def install(cls, state: MkosiState) -> None:
         # Instead of using debootstrap, we replicate its core functionality here. Because dpkg does not have
         # an option to delay running pre-install maintainer scripts when it installs a package, it's
@@ -126,7 +130,6 @@ class DebianInstaller(DistributionInstaller):
         policyrcd.write_text("#!/bin/sh\nexit 101\n")
         policyrcd.chmod(0o755)
 
-        setup_apt(state, cls.repositories(state))
         invoke_apt(state, "apt-get", "update", apivfs=False)
         invoke_apt(state, "apt-get", "install", packages, apivfs=apivfs)
         install_apt_sources(state, cls.repositories(state, local=False))

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -20,11 +20,7 @@ class FedoraInstaller(DistributionInstaller):
         return PackageType.rpm
 
     @classmethod
-    def install(cls, state: MkosiState) -> None:
-        cls.install_packages(state, ["filesystem"], apivfs=False)
-
-    @classmethod
-    def install_packages(cls, state: MkosiState, packages: Sequence[str], apivfs: bool = True) -> None:
+    def setup(cls, state: MkosiState) -> None:
         # See: https://fedoraproject.org/security/
         gpgurls = ("https://fedoraproject.org/fedora.gpg",)
         repos = []
@@ -73,6 +69,13 @@ class FedoraInstaller(DistributionInstaller):
 
         # TODO: Use `filelists=True` when F37 goes EOL.
         setup_dnf(state, repos, filelists=fedora_release_at_most(state.config.release, "37"))
+
+    @classmethod
+    def install(cls, state: MkosiState) -> None:
+        cls.install_packages(state, ["filesystem"], apivfs=False)
+
+    @classmethod
+    def install_packages(cls, state: MkosiState, packages: Sequence[str], apivfs: bool = True) -> None:
         invoke_dnf(state, "install", packages, apivfs=apivfs)
 
     @classmethod

--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -65,6 +65,10 @@ class GentooInstaller(DistributionInstaller):
         return PackageType.ebuild
 
     @classmethod
+    def setup(cls, state: MkosiState) -> None:
+        pass
+
+    @classmethod
     def install(cls, state: MkosiState) -> None:
         arch = state.config.distribution.architecture(state.config.architecture)
 

--- a/mkosi/distributions/mageia.py
+++ b/mkosi/distributions/mageia.py
@@ -19,11 +19,7 @@ class MageiaInstaller(DistributionInstaller):
         return PackageType.rpm
 
     @classmethod
-    def install(cls, state: MkosiState) -> None:
-        cls.install_packages(state, ["filesystem"], apivfs=False)
-
-    @classmethod
-    def install_packages(cls, state: MkosiState, packages: Sequence[str], apivfs: bool = True) -> None:
+    def setup(cls, state: MkosiState) -> None:
         release = state.config.release.strip("'")
         arch = state.config.distribution.architecture(state.config.architecture)
 
@@ -52,6 +48,13 @@ class MageiaInstaller(DistributionInstaller):
             repos += [Repo(f"mageia-{release}-updates", updates_url, (gpgurl,))]
 
         setup_dnf(state, repos)
+
+    @classmethod
+    def install(cls, state: MkosiState) -> None:
+        cls.install_packages(state, ["filesystem"], apivfs=False)
+
+    @classmethod
+    def install_packages(cls, state: MkosiState, packages: Sequence[str], apivfs: bool = True) -> None:
         invoke_dnf(state, "install", packages, apivfs=apivfs)
 
     @classmethod

--- a/mkosi/distributions/openmandriva.py
+++ b/mkosi/distributions/openmandriva.py
@@ -19,11 +19,7 @@ class OpenmandrivaInstaller(DistributionInstaller):
         return PackageType.rpm
 
     @classmethod
-    def install(cls, state: MkosiState) -> None:
-        cls.install_packages(state, ["filesystem"])
-
-    @classmethod
-    def install_packages(cls, state: MkosiState, packages: Sequence[str], apivfs: bool = True) -> None:
+    def setup(cls, state: MkosiState) -> None:
         release = state.config.release.strip("'")
         arch = state.config.distribution.architecture(state.config.architecture)
 
@@ -53,6 +49,13 @@ class OpenmandrivaInstaller(DistributionInstaller):
             repos += [Repo("updates", updates_url, (gpgurl,))]
 
         setup_dnf(state, repos)
+
+    @classmethod
+    def install(cls, state: MkosiState) -> None:
+        cls.install_packages(state, ["filesystem"])
+
+    @classmethod
+    def install_packages(cls, state: MkosiState, packages: Sequence[str], apivfs: bool = True) -> None:
         invoke_dnf(state, "install", packages, apivfs=apivfs)
 
     @classmethod

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -23,11 +23,7 @@ class OpensuseInstaller(DistributionInstaller):
         return PackageType.rpm
 
     @classmethod
-    def install(cls, state: MkosiState) -> None:
-        cls.install_packages(state, ["filesystem"], apivfs=False)
-
-    @classmethod
-    def install_packages(cls, state: MkosiState, packages: Sequence[str], apivfs: bool = True) -> None:
+    def setup(cls, state: MkosiState) -> None:
         release = state.config.release
         if release == "leap":
             release = "stable"
@@ -60,9 +56,18 @@ class OpensuseInstaller(DistributionInstaller):
 
         if zypper:
             setup_zypper(state, repos)
-            invoke_zypper(state, "install", packages, apivfs=apivfs)
         else:
             setup_dnf(state, repos)
+
+    @classmethod
+    def install(cls, state: MkosiState) -> None:
+        cls.install_packages(state, ["filesystem"], apivfs=False)
+
+    @classmethod
+    def install_packages(cls, state: MkosiState, packages: Sequence[str], apivfs: bool = True) -> None:
+        if shutil.which("zypper"):
+            invoke_zypper(state, "install", packages, apivfs=apivfs)
+        else:
             invoke_dnf(state, "install", packages, apivfs=apivfs)
 
     @classmethod


### PR DESCRIPTION
Currently, when using cached images, setup_dnf() and friends won't be called when a cached image is used. Yet it's now entirely possible that dnf might be called to install extra packages in the postinstall script, so we always need the package managers to be configured properly. Let's make sure we do that by introducing a new setup() method that is always called.