### PR TITLE
Use a dash in the workspace directory prefix

### DIFF
--- a/mkosi/state.py
+++ b/mkosi/state.py
@@ -17,7 +17,7 @@ class MkosiState:
         self.config = config
 
     def __enter__(self) -> "MkosiState":
-        self._workspace = tempfile.TemporaryDirectory(dir=self.config.workspace_dir or Path.cwd(), prefix=".mkosi.tmp")
+        self._workspace = tempfile.TemporaryDirectory(dir=self.config.workspace_dir or Path.cwd(), prefix=".mkosi-tmp")
         make_tree(self.config, self.root, mode=0o755)
         self.staging.mkdir()
         self.pkgmngr.mkdir()


### PR DESCRIPTION
We used to use a dash here as well so let's keep existing gitignore's working by keeping that in place.