### PR TITLE
Don't log exceptions from ssh/nspawn/qemu in --debug mode

### DIFF
--- a/mkosi/__main__.py
+++ b/mkosi/__main__.py
@@ -30,7 +30,8 @@ def propagate_failed_return() -> Iterator[None]:
 
         sys.exit(1)
     except subprocess.CalledProcessError as e:
-        if ARG_DEBUG.get():
+        # Failures from qemu, ssh and systemd-nspawn are expected and we won't log stacktraces for those.
+        if ARG_DEBUG.get() and e.cmd and e.cmd[0] not in ("qemu", "ssh", "systemd-nspawn"):
             sys.excepthook(*ensure_exc_info())
 
         # We always log when subprocess.CalledProcessError is raised, so we don't log again here.


### PR DESCRIPTION
While we generally want full stacktraces in debug mode from every exception, let's make an exception for ssh/systemd-nspawn/qemu, since these exceptions are expected.