### PR TITLE
Rework tar archive handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -103,6 +103,9 @@
       exec mkosi-chroot "$SCRIPT" "$@"
   fi
   ```
+- Removed `--tar-strip-selinux-context=` option. We now label all files
+  properly if selinux is enabled and if users don't want the labels,
+  they can simply exclude them when extracting the archive.
 
 ## v14
 

--- a/mkosi.md
+++ b/mkosi.md
@@ -517,15 +517,6 @@ they should be specified with a boolean argument: either "1", "yes", or "true" t
   https://uapi-group.org/specifications/specs/extension_image for more
   information.
 
-`TarStripSELinuxContext=`, `--tar-strip-selinux-context`
-
-: If running on a SELinux-enabled system (Fedora Linux, CentOS, Rocky Linux,
-  Alma Linux), files
-  inside the container are tagged with SELinux context extended
-  attributes (`xattrs`), which may interfere with host SELinux rules
-  in building or further container import stages.  This option strips
-  SELinux context attributes from the resulting tar archive.
-
 ### [Content] Section
 
 `Packages=`, `--package=`, `-p`

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -618,7 +618,6 @@ def make_tar(state: MkosiState) -> None:
         "-c", "--xattrs",
         "--xattrs-include=*",
         "--file", state.staging / state.config.output_with_format,
-        *(["--xattrs-exclude=security.selinux"] if state.config.tar_strip_selinux_context else []),
         ".",
     ]
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -644,7 +644,6 @@ class MkosiConfig:
     compress_output: Compression
     image_version: Optional[str]
     image_id: Optional[str]
-    tar_strip_selinux_context: bool
     incremental: bool
     packages: list[str]
     remove_packages: list[str]
@@ -932,14 +931,6 @@ class MkosiConfigParser:
             match=config_make_string_matcher(allow_globs=True),
             section="Output",
             help="Set ID for image",
-        ),
-        MkosiConfigSetting(
-            dest="tar_strip_selinux_context",
-            metavar="BOOL",
-            nargs="?",
-            section="Output",
-            parse=config_parse_boolean,
-            help="Do not include SELinux file context information in tar. Not compatible with bsdtar.",
         ),
         MkosiConfigSetting(
             dest="split_artifacts",
@@ -2112,9 +2103,6 @@ def load_config(args: argparse.Namespace) -> MkosiConfig:
 
     if args.cmdline and not args.verb.supports_cmdline():
         die(f"Arguments after verb are not supported for {args.verb}.")
-
-    if shutil.which("bsdtar") and args.distribution == Distribution.openmandriva and args.tar_strip_selinux_context:
-        die("Sorry, bsdtar on OpenMandriva is incompatible with --tar-strip-selinux-context")
 
     if args.cache_dir:
         args.cache_dir = args.cache_dir / f"{args.distribution}~{args.release}"

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -11,6 +11,7 @@ from mkosi.installer.apt import invoke_apt, setup_apt
 from mkosi.log import die
 from mkosi.run import run
 from mkosi.state import MkosiState
+from mkosi.tree import extract_tree
 
 
 class DebianInstaller(DistributionInstaller):
@@ -112,7 +113,7 @@ class DebianInstaller(DistributionInstaller):
         for deb in essential:
             with tempfile.NamedTemporaryFile() as f:
                 run(["dpkg-deb", "--fsys-tarfile", deb], stdout=f)
-                run(["tar", "-C", state.root, "--keep-directory-symlink", "--extract", "--file", f.name])
+                extract_tree(Path(f.name), state.root)
 
         # Finally, run apt to properly install packages in the chroot without having to worry that maintainer
         # scripts won't find basic tools that they depend on.

--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -12,7 +12,7 @@ from mkosi.distributions import DistributionInstaller, PackageType
 from mkosi.log import ARG_DEBUG, complete_step, die
 from mkosi.run import apivfs_cmd, bwrap, chroot_cmd, run
 from mkosi.state import MkosiState
-from mkosi.tree import copy_tree, rmtree
+from mkosi.tree import copy_tree, extract_tree, rmtree
 from mkosi.types import PathString
 from mkosi.util import flatten, sort_packages
 
@@ -111,14 +111,7 @@ class GentooInstaller(DistributionInstaller):
 
         if not any(stage3.iterdir()):
             with complete_step(f"Extracting {stage3_tar.name} to {stage3}"):
-                run(["tar",
-                     "--numeric-owner",
-                     "-C", stage3,
-                     "--extract",
-                     "--file", stage3_tar,
-                     "--exclude", "./dev/*",
-                     "--exclude", "./proc/*",
-                     "--exclude", "./sys/*"])
+                extract_tree(stage3_tar, stage3)
 
         for d in ("binpkgs", "distfiles", "repos/gentoo"):
             (state.cache_dir / d).mkdir(parents=True, exist_ok=True)

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -14,6 +14,7 @@ import os
 import pwd
 import re
 import resource
+import shutil
 import stat
 import sys
 import tempfile
@@ -213,3 +214,14 @@ class StrEnum(enum.Enum):
     @classmethod
     def values(cls) -> list[str]:
         return list(map(str, cls))
+
+
+def tar_binary() -> str:
+    # Some distros (Mandriva) install BSD tar as "tar", hence prefer
+    # "gtar" if it exists, which should be GNU tar wherever it exists.
+    # We are interested in exposing same behaviour everywhere hence
+    # it's preferable to use the same implementation of tar
+    # everywhere. In particular given the limited/different SELinux
+    # support in BSD tar and the different command line syntax
+    # compared to GNU tar.
+    return "gtar" if shutil.which("gtar") else "tar"


### PR DESCRIPTION
- Instead of relying on shutil.unpack_archive(), let's always use tar
- Introduce archive_tree() and extract_tree() to abstract tar archives
- Make sure tar always uses the user/group information from the root dir
- Enable all features
- Make sure tar doesn't overwrite directory permissions