### PR TITLE
Machine name fixes

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1766,7 +1766,8 @@ def run_shell(args: MkosiArgs, config: MkosiConfig) -> None:
             "--console=autopipe",
         ]
 
-    cmdline += ["--machine", config.output]
+    # Underscores are not allowed in machine names so replace them with hyphens.
+    cmdline += ["--machine", (config.image_id or config.preset or config.output).replace("_", "-")]
 
     for k, v in config.credentials.items():
         cmdline += [f"--set-credential={k}:{v}"]


### PR DESCRIPTION
- Prefer the image id or preset name over the output name
- Make sure the machine name doesn't contain underscores as those are not allowed.