### PR TITLE
Get rid of check_root() function

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1736,11 +1736,6 @@ def acl_toggle_build(config: MkosiConfig, uid: int) -> Iterator[None]:
         yield
 
 
-def check_root() -> None:
-    if os.getuid() != 0:
-        die("Must be invoked as root.")
-
-
 @contextlib.contextmanager
 def acl_toggle_boot(config: MkosiConfig, uid: int) -> Iterator[None]:
     if not config.acl or config.output_format != OutputFormat.directory:
@@ -1927,8 +1922,8 @@ def prepend_to_environ_path(config: MkosiConfig) -> Iterator[None]:
 
 
 def run_verb(args: MkosiArgs, presets: Sequence[MkosiConfig]) -> None:
-    if args.verb.needs_sudo():
-        check_root()
+    if args.verb.needs_root() and os.getuid() != 0:
+        die(f"Must be root to run the {args.verb} command")
 
     if args.verb == Verb.genkey:
         return generate_key_cert_pair(args)

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -50,6 +50,7 @@ from mkosi.util import (
     flatten,
     format_bytes,
     format_rlimit,
+    one_zero,
     scopedenv,
     try_import,
 )
@@ -1665,10 +1666,6 @@ def build_image(args: MkosiArgs, config: MkosiConfig) -> None:
             output_base.symlink_to(state.config.output_with_compression)
 
     print_output_size(config.output_dir / config.output)
-
-
-def one_zero(b: bool) -> str:
-    return "1" if b else "0"
 
 
 def setfacl(root: Path, uid: int, allow: bool) -> None:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -374,7 +374,7 @@ def run_finalize_script(state: MkosiState) -> None:
         )
 
 
-def certificate_common_name(state: MkosiState, certificate: Path) -> str:
+def certificate_common_name(certificate: Path) -> str:
     output = run([
         "openssl",
         "x509",
@@ -472,7 +472,7 @@ def install_boot_loader(state: MkosiState) -> None:
                     pesign_prepare(state)
                     run(["pesign",
                          "--certdir", state.workspace / "pesign",
-                         "--certificate", certificate_common_name(state, state.config.secure_boot_certificate),
+                         "--certificate", certificate_common_name(state.config.secure_boot_certificate),
                          "--sign",
                          "--force",
                          "--in", input,
@@ -946,7 +946,7 @@ def install_unified_kernel(state: MkosiState, roothash: Optional[str]) -> None:
                     cmd += [
                         "--signtool", "pesign",
                         "--secureboot-certificate-dir", state.workspace / "pesign",
-                        "--secureboot-certificate-name", certificate_common_name(state, state.config.secure_boot_certificate),
+                        "--secureboot-certificate-name", certificate_common_name(state.config.secure_boot_certificate),
                     ]
 
                 sign_expected_pcr = (state.config.sign_expected_pcr == ConfigFeature.enabled or

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -64,7 +64,7 @@ class Verb(StrEnum):
     def needs_build(self) -> bool:
         return self in (Verb.build, Verb.shell, Verb.boot, Verb.qemu, Verb.serve)
 
-    def needs_sudo(self) -> bool:
+    def needs_root(self) -> bool:
         return self in (Verb.shell, Verb.boot)
 
 

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -225,3 +225,7 @@ def tar_binary() -> str:
     # support in BSD tar and the different command line syntax
     # compared to GNU tar.
     return "gtar" if shutil.which("gtar") else "tar"
+
+
+def one_zero(b: bool) -> str:
+    return "1" if b else "0"


### PR DESCRIPTION
Only has one call site so let's just inline it.