### PR TITLE
Get rid of final uses of joinpath()

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1565,8 +1565,8 @@ class MkosiConfigParser:
         if extras:
             # Dropin configuration has priority over any default paths.
 
-            if path.parent.joinpath("mkosi.conf.d").exists():
-                for p in sorted(path.parent.joinpath("mkosi.conf.d").iterdir()):
+            if (path.parent / "mkosi.conf.d").exists():
+                for p in sorted((path.parent / "mkosi.conf.d").iterdir()):
                     if p.is_dir() or p.suffix == ".conf":
                         with chdir(p if p.is_dir() else Path.cwd()):
                             self.parse_config(p if p.is_file() else Path("."), namespace)

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -176,7 +176,7 @@ class DebianInstaller(DistributionInstaller):
 
 
 def install_apt_sources(state: MkosiState, repos: Sequence[str]) -> None:
-    if not state.root.joinpath("usr/bin/apt").exists():
+    if not (state.root / "usr/bin/apt").exists():
         return
 
     sources = state.root / "etc/apt/sources.list"

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -10,12 +10,12 @@ from mkosi.util import flatten, sort_packages, umask
 
 
 def setup_apt(state: MkosiState, repos: Sequence[str]) -> None:
-    state.pkgmngr.joinpath("etc/apt").mkdir(exist_ok=True, parents=True)
-    state.pkgmngr.joinpath("etc/apt/apt.conf.d").mkdir(exist_ok=True, parents=True)
-    state.pkgmngr.joinpath("etc/apt/preferences.d").mkdir(exist_ok=True, parents=True)
-    state.pkgmngr.joinpath("etc/apt/sources.list.d").mkdir(exist_ok=True, parents=True)
-    state.pkgmngr.joinpath("var/log/apt").mkdir(exist_ok=True, parents=True)
-    state.pkgmngr.joinpath("var/lib/apt").mkdir(exist_ok=True, parents=True)
+    (state.pkgmngr / "etc/apt").mkdir(exist_ok=True, parents=True)
+    (state.pkgmngr / "etc/apt/apt.conf.d").mkdir(exist_ok=True, parents=True)
+    (state.pkgmngr / "etc/apt/preferences.d").mkdir(exist_ok=True, parents=True)
+    (state.pkgmngr / "etc/apt/sources.list.d").mkdir(exist_ok=True, parents=True)
+    (state.pkgmngr / "var/log/apt").mkdir(exist_ok=True, parents=True)
+    (state.pkgmngr / "var/lib/apt").mkdir(exist_ok=True, parents=True)
 
     # TODO: Drop once apt 2.5.4 is widely available.
     with umask(~0o755):

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -28,9 +28,9 @@ def dnf_executable(state: MkosiState) -> str:
 
 
 def setup_dnf(state: MkosiState, repos: Sequence[Repo], filelists: bool = True) -> None:
-    state.pkgmngr.joinpath("etc/dnf/vars").mkdir(exist_ok=True, parents=True)
-    state.pkgmngr.joinpath("etc/yum.repos.d").mkdir(exist_ok=True, parents=True)
-    state.pkgmngr.joinpath("var/lib/dnf").mkdir(exist_ok=True, parents=True)
+    (state.pkgmngr / "etc/dnf/vars").mkdir(exist_ok=True, parents=True)
+    (state.pkgmngr / "etc/yum.repos.d").mkdir(exist_ok=True, parents=True)
+    (state.pkgmngr / "var/lib/dnf").mkdir(exist_ok=True, parents=True)
 
     config = state.pkgmngr / "etc/dnf/dnf.conf"
 

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -31,7 +31,7 @@ def setup_pacman(state: MkosiState) -> None:
 
     # Create base layout for pacman and pacman-key
     with umask(~0o755):
-        state.root.joinpath("var/lib/pacman").mkdir(exist_ok=True, parents=True)
+        (state.root / "var/lib/pacman").mkdir(exist_ok=True, parents=True)
 
     config = state.pkgmngr / "etc/pacman.conf"
     if config.exists():
@@ -73,7 +73,7 @@ def setup_pacman(state: MkosiState) -> None:
                 )
             )
 
-        if any(state.pkgmngr.joinpath("etc/pacman.d/").glob("*.conf")):
+        if any((state.pkgmngr / "etc/pacman.d/").glob("*.conf")):
             f.write(
                 textwrap.dedent(
                     f"""\

--- a/mkosi/manifest.py
+++ b/mkosi/manifest.py
@@ -231,7 +231,7 @@ class Manifest:
             source_package.add(package)
 
     def record_pkg_packages(self, root: Path) -> None:
-        packages = sorted(root.joinpath("var/lib/pacman/local").glob("*/desc"))
+        packages = sorted((root / "var/lib/pacman/local").glob("*/desc"))
 
         for desc in packages:
             name, version, source, arch = parse_pkg_desc(desc)


### PR DESCRIPTION
We prefer using parentheses instead of joinpath() these days. This commit gets rid of the remaining places where we're still using joinpath().