### PR TITLE
qemu: do not enable kvm when booting on non-native arch

### DIFF
--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -207,7 +207,7 @@ def copy_ephemeral(config: MkosiConfig, src: Path) -> Iterator[Path]:
 
 def run_qemu(args: MkosiArgs, config: MkosiConfig) -> None:
     accel = "tcg"
-    if config.qemu_kvm == ConfigFeature.enabled or (config.qemu_kvm == ConfigFeature.auto and qemu_check_kvm_support()):
+    if config.qemu_kvm == ConfigFeature.enabled or (config.qemu_kvm == ConfigFeature.auto and config.architecture.is_native() and qemu_check_kvm_support()):
         accel = "kvm"
 
     firmware, fw_supports_sb = find_qemu_firmware(config)


### PR DESCRIPTION
kvm is only supported on the native architecture, so skip it when booting a non-native one (eg: aarch64 on x86_64)