### PR TITLE
Move network argument from chroot_cmd() to bwrap()

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -225,13 +225,13 @@ def run_prepare_script(state: MkosiState, build: bool) -> None:
             "--setenv", "SRCDIR", "/work/src",
             "--setenv", "BUILDROOT", "/",
         ],
-        network=True,
     )
 
     if build:
         with complete_step("Running prepare script in build overlay…"), mount_build_overlay(state):
             bwrap(
                 [state.config.prepare_script, "build"],
+                network=True,
                 options=finalize_mounts(state.config),
                 scripts={"mkosi-chroot": chroot} | package_manager_scripts(state),
                 env=env | state.config.environment,
@@ -241,6 +241,7 @@ def run_prepare_script(state: MkosiState, build: bool) -> None:
         with complete_step("Running prepare script…"):
             bwrap(
                 [state.config.prepare_script, "final"],
+                network=True,
                 options=finalize_mounts(state.config),
                 scripts={"mkosi-chroot": chroot} | package_manager_scripts(state),
                 env=env | state.config.environment,
@@ -288,12 +289,12 @@ def run_build_script(state: MkosiState) -> None:
             *(["--setenv", "BUILDDIR", "/work/build"] if state.config.build_dir else []),
             "--remount-ro", "/",
         ],
-        network=state.config.with_network,
     )
 
     with complete_step("Running build script…"), mount_build_overlay(state):
         bwrap(
             [state.config.build_script],
+            network=state.config.with_network,
             options=finalize_mounts(state.config),
             scripts={"mkosi-chroot": chroot} | package_manager_scripts(state),
             env=env | state.config.environment,
@@ -325,12 +326,12 @@ def run_postinst_script(state: MkosiState) -> None:
             "--setenv", "OUTPUTDIR", "/work/out",
             "--setenv", "BUILDROOT", "/",
         ],
-        network=state.config.with_network,
     )
 
     with complete_step("Running postinstall script…"):
         bwrap(
             [state.config.postinst_script, "final"],
+            network=state.config.with_network,
             options=finalize_mounts(state.config),
             scripts={"mkosi-chroot": chroot} | package_manager_scripts(state),
             env=env | state.config.environment,
@@ -362,12 +363,12 @@ def run_finalize_script(state: MkosiState) -> None:
             "--setenv", "OUTPUTDIR", "/work/out",
             "--setenv", "BUILDROOT", "/",
         ],
-        network=state.config.with_network,
     )
 
     with complete_step("Running finalize script…"):
         bwrap(
             [state.config.finalize_script],
+            network=state.config.with_network,
             options=finalize_mounts(state.config),
             scripts={"mkosi-chroot": chroot} | package_manager_scripts(state),
             env=env | state.config.environment,

--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -42,6 +42,7 @@ def invoke_emerge(state: MkosiState, packages: Sequence[str] = (), apivfs: bool 
             f"--root={state.root}",
             *sort_packages(packages),
         ],
+        network=True,
         options=[
             # TODO: Get rid of as many of these as possible.
             "--bind", state.cache_dir / "stage3/etc", "/etc",
@@ -142,10 +143,9 @@ class GentooInstaller(DistributionInstaller):
         chroot = chroot_cmd(
             stage3,
             options=["--bind", state.cache_dir / "repos", "/var/db/repos"],
-            network=True,
         )
 
-        bwrap(cmd=chroot + ["emerge-webrsync"],
+        bwrap(cmd=chroot + ["emerge-webrsync"], network=True,
               options=flatten(["--bind", d, d] for d in (state.config.workspace_dir, state.config.cache_dir) if d))
 
         invoke_emerge(state, packages=["sys-apps/baselayout"], apivfs=False)

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -106,4 +106,4 @@ def invoke_apt(
     cmd = apivfs_cmd(state.root) if apivfs else []
     bwrap(cmd + apt_cmd(state, command) + [operation, *sort_packages(packages)],
           options=flatten(["--bind", d, d] for d in (state.config.workspace_dir, state.config.cache_dir) if d),
-          env=state.config.environment)
+          network=True, env=state.config.environment)

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -117,7 +117,7 @@ def invoke_dnf(state: MkosiState, command: str, packages: Iterable[str], apivfs:
     cmd = apivfs_cmd(state.root) if apivfs else []
     bwrap(cmd + dnf_cmd(state) + [command, *sort_packages(packages)],
           options=flatten(["--bind", d, d] for d in (state.config.workspace_dir, state.config.cache_dir) if d),
-          env=state.config.environment)
+          network=True, env=state.config.environment)
 
     fixup_rpmdb_location(state.root)
 

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -114,4 +114,4 @@ def invoke_pacman(state: MkosiState, packages: Sequence[str], apivfs: bool = Tru
     cmd = apivfs_cmd(state.root) if apivfs else []
     bwrap(cmd + pacman_cmd(state) + ["-Sy", *sort_packages(packages)],
           options=flatten(["--bind", d, d] for d in (state.config.workspace_dir, state.config.cache_dir) if d),
-          env=state.config.environment)
+          network=True, env=state.config.environment)

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -71,6 +71,6 @@ def invoke_zypper(
     cmd = apivfs_cmd(state.root) if apivfs else []
     bwrap(cmd + zypper_cmd(state) + [verb, *sort_packages(packages), *options],
           options=flatten(["--bind", d, d] for d in (state.config.workspace_dir, state.config.cache_dir) if d),
-          env=state.config.environment)
+          network=True, env=state.config.environment)
 
     fixup_rpmdb_location(state.root)


### PR DESCRIPTION
If we're not supposed to use the network, that should apply to the script running on the host as well, so move the network argument from chroot_cmd() to bwrap().

We just always mount resolv.conf into the image now. If the network namespace is unshared, there's not much that can be done with the info in there anyway.