### PR TITLE
Make sure options are always applied last in bwrap() and chroot_cmd()

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1909,7 +1909,7 @@ def load_kernel_command_line_extra(args: argparse.Namespace) -> list[str]:
     ]
 
     if not any(s.startswith("ip=") for s in args.kernel_command_line_extra):
-        cmdline += ["ip=enp0s1:any", "ip=host0:any"]
+        cmdline += ["ip=enp0s1:any", "ip=enp0s2:any", "ip=host0:any"]
 
     if not any(s.startswith("loglevel=") for s in args.kernel_command_line_extra):
         cmdline += ["loglevel=4"]


### PR DESCRIPTION
That way, if the options remount anything read-only, we can be sure it doesn't affect any of the operations set up in bwrap() and chroot_cmd() themselves.