### PR TITLE
Install udev instead of systemd-udev

### DIFF
--- a/.github/mkosi.conf.d/20-centos.conf
+++ b/.github/mkosi.conf.d/20-centos.conf
@@ -8,3 +8,8 @@ Packages=kernel-core
          systemd
          systemd-boot
          udev
+         # Add extra packages to increase the size of the image a bit to make sure repart calculates a large
+         # enough minimal size for the XFS filesystem.
+         # TODO: Check if this is still needed when the next ubuntu LTS becomes available on Github Actions.
+         kernel-modules
+         llvm

--- a/.github/mkosi.conf.d/20-centos.conf
+++ b/.github/mkosi.conf.d/20-centos.conf
@@ -7,4 +7,4 @@ Distribution=|rocky
 Packages=kernel-core
          systemd
          systemd-boot
-         systemd-udev
+         udev

--- a/.github/mkosi.conf.d/20-fedora.conf
+++ b/.github/mkosi.conf.d/20-fedora.conf
@@ -5,5 +5,5 @@ Distribution=fedora
 Packages=kernel-core
          systemd
          systemd-boot
-         systemd-udev
+         udev
          util-linux

--- a/docs/bootable.md
+++ b/docs/bootable.md
@@ -19,7 +19,7 @@ Packages=linux
 Packages=kernel
          systemd
          systemd-boot
-         systemd-udev
+         udev
          util-linux
 ```
 
@@ -30,7 +30,7 @@ Packages=kernel
 Packages=kernel
          systemd
          systemd-boot
-         systemd-udev
+         udev
 ```
 
 ## Debian

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -631,6 +631,7 @@ def install_unified_kernel(state: MkosiState, roothash: Optional[str]) -> None:
                 "--acl", str(state.config.acl),
                 "--format", "cpio",
                 "--package", "systemd",
+                "--package", "udev",
                 "--package", "util-linux",
                 "--package", "kmod",
                 *(["--package", "dmsetup"] if state.config.distribution.is_apt_distribution() else []),


### PR DESCRIPTION
Installing systemd-udev means running into
https://bugzilla.redhat.com/show_bug.cgi?id=2183279 so let's install udev which avoids that issue.