### PR TITLE
Run finalize script after selinux relabel

### DIFF
--- a/mkosi.md
+++ b/mkosi.md
@@ -1081,8 +1081,8 @@ Then, for each preset, we execute the following steps:
 * Run `systemd-firstboot`
 * Run `systemd-hwdb`
 * Remove packages and files (`RemovePackages=`, `RemoveFiles=`)
-* Run finalize script (`mkosi.finalize`)
 * Run SELinux relabel is a SELinux policy is installed
+* Run finalize script (`mkosi.finalize`)
 * Generate unified kernel image if configured to do so
 * Generate final output format
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1397,8 +1397,8 @@ def build_image(args: MkosiArgs, config: MkosiConfig) -> None:
 
             clean_package_manager_metadata(state)
             remove_files(state)
-            run_finalize_script(state)
             run_selinux_relabel(state)
+            run_finalize_script(state)
 
         roothash, _ = make_image(state, skip=("esp", "xbootldr"))
         install_unified_kernel(state, roothash)


### PR DESCRIPTION
Let's make the finalize script true to its name and run it as the final operation before we start packaging things up.