### PR TITLE
Set agetty autologin credentials by default

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1855,7 +1855,10 @@ class MkosiConfigParser:
 
 
 def load_credentials(args: argparse.Namespace) -> dict[str, str]:
-    creds = {}
+    creds = {
+        "agetty.autologin": "root",
+        "login.noauth": "yes",
+    }
 
     d = Path("mkosi.credentials")
     if args.directory != "" and d.is_dir():


### PR DESCRIPTION
Eventually we'll replace --autologin with these but for now let's set both.