### PR TITLE
Pass through stdin when we call systemd-repart with --image=

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1571,7 +1571,8 @@ def run_shell(args: MkosiArgs, config: MkosiConfig) -> None:
                  "--no-pager",
                  "--dry-run=no",
                  "--offline=no",
-                 fname])
+                 fname],
+                 stdin=sys.stdin)
 
         if config.output_format == OutputFormat.directory:
             cmdline += ["--directory", fname]


### PR DESCRIPTION
When mounting an image, systemd's dissect logic might prompt for verity/encryption passphrases. Let's make sure the user can enter those if needed.