### PR TITLE
set Dir::Etc option on apt based distros

### DIFF
--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -22,16 +22,18 @@ def setup_apt(state: MkosiState, repos: Sequence[str]) -> None:
         (state.root / "var/lib/dpkg").mkdir(parents=True, exist_ok=True)
         (state.root / "var/lib/dpkg/status").touch()
 
-    # We have a special apt.conf outside of pkgmngr dir that only configures "Dir" that we pass to
-    # APT_CONFIG to tell apt it should read config files in pkgmngr instead of in its usual locations. This
-    # is required because apt parses CLI configuration options after parsing its configuration files and as
-    # such we can't use CLI options to tell apt where to look for configuration files.
+    # We have a special apt.conf outside of pkgmngr dir that only configures "Dir" and "Dir::Etc"
+    # that we pass to APT_CONFIG to tell apt it should read config files in pkgmngr instead of
+    # in its usual locations. This is required because apt parses CLI configuration options after
+    # parsing its configuration files and as such we can't use CLI options to tell apt where to
+    # look for configuration files.
     config = state.workspace / "apt.conf"
     if not config.exists():
         config.write_text(
             textwrap.dedent(
                 f"""\
                 Dir "{state.pkgmngr}";
+                Dir::Etc "etc/apt";
                 """
             )
         )


### PR DESCRIPTION
Some distros (namely nix / nixpkgs) ship apt with a non-standard setting for `Dir::Etc` (defaults to `etc/apt` on Ubuntu).

On nix:
```shell-session
$ apt-config dump | grep "Dir::Etc"
Dir::Etc "nix/store/yj93sx10c2zrrza3lbxhhxjrzd51y1z1-apt-2.7.2/etc/apt";
Dir::Etc::sourcelist "sources.list";
Dir::Etc::sourceparts "sources.list.d";
Dir::Etc::main "apt.conf";
Dir::Etc::netrc "auth.conf";
Dir::Etc::netrcparts "auth.conf.d";
Dir::Etc::parts "apt.conf.d";
Dir::Etc::preferences "preferences";
Dir::Etc::preferencesparts "preferences.d";
Dir::Etc::trusted "trusted.gpg";
Dir::Etc::trustedparts "trusted.gpg.d";
```

In order to get a working apt, mkosi should set `Dir::Etc` to ensure relative paths under `etc/apt` are resolved correctly.
I think non-default settings may also be set on other distros where apt is not the primary package manger, so I believe setting a sane value here is a good idea in general.

Technically, mkosi could also set the remaining options under `Dir::Etc::` to be relative to `Dir::Etc` but I don't know if we want to do this for now.