### PR TITLE
Remove git blame section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,6 @@ when not installed as a zipapp.
 Please note, that the python module exists solely for the usage of the mkosi
 binary and is not to be considered a public API.
 
-## git blame
-
-When using git blame, be sure to add `--ignore-revs-file .git-blame-ignore-revs` to the arguments to ignore
-irrelevant code formatting commits. This can be set permanently via the `blame.ignoreRevsFile` git option.
-
 # References
 
 * [Primary mkosi git repository on GitHub](https://github.com/systemd/mkosi/)


### PR DESCRIPTION
The paragraph introduced in #585 became stale after #1777 was merged.