### PR TITLE
skip passwd bind mounts if the path does not exist on the host

### DIFF
--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -344,6 +344,8 @@ def finalize_passwd_mounts(root: Path) -> list[PathString]:
     options: list[PathString] = []
 
     for f in ("passwd", "group", "shadow", "gshadow"):
+        if not (Path("etc") / f).exists():
+            continue
         p = root / "etc" / f
         if p.exists():
             options += ["--bind", p, f"/etc/{f}"]


### PR DESCRIPTION
Closes #1792.

If /etc/gshadow does not exist on the host, bubblewrap first needs to create it before bind mounting it. This fails, since we do not have permissions to write to /etc.
Instead, we now only bind mount over passwd related files if they exist on the host.