### PR TITLE
Add back BIOS support using grub

### DIFF
--- a/.github/mkosi.conf.d/10-common.conf
+++ b/.github/mkosi.conf.d/10-common.conf
@@ -7,6 +7,7 @@ KernelCommandLine=console=ttyS0
 
 [Content]
 Bootable=yes
+BiosBootloader=grub
 
 [Host]
 Autologin=yes

--- a/.github/mkosi.conf.d/20-arch.conf
+++ b/.github/mkosi.conf.d/20-arch.conf
@@ -4,3 +4,4 @@ Distribution=arch
 [Content]
 Packages=linux
          systemd
+         base

--- a/.github/mkosi.conf.d/20-arch.conf
+++ b/.github/mkosi.conf.d/20-arch.conf
@@ -5,3 +5,4 @@ Distribution=arch
 Packages=linux
          systemd
          base
+         grub

--- a/.github/mkosi.conf.d/20-centos.conf
+++ b/.github/mkosi.conf.d/20-centos.conf
@@ -8,8 +8,3 @@ Packages=kernel-core
          systemd
          systemd-boot
          udev
-         # Add extra packages to increase the size of the image a bit to make sure repart calculates a large
-         # enough minimal size for the XFS filesystem.
-         # TODO: Check if this is still needed when the next ubuntu LTS becomes available on Github Actions.
-         kernel-modules
-         llvm

--- a/.github/mkosi.conf.d/20-centos.conf
+++ b/.github/mkosi.conf.d/20-centos.conf
@@ -8,3 +8,4 @@ Packages=kernel-core
          systemd
          systemd-boot
          udev
+         grub2-pc

--- a/.github/mkosi.conf.d/20-debian.conf
+++ b/.github/mkosi.conf.d/20-debian.conf
@@ -9,3 +9,4 @@ Packages=linux-image-cloud-amd64
          udev
          dbus
          tzdata
+         grub-pc

--- a/.github/mkosi.conf.d/20-debian.conf
+++ b/.github/mkosi.conf.d/20-debian.conf
@@ -8,3 +8,4 @@ Packages=linux-image-cloud-amd64
          systemd-sysv
          udev
          dbus
+         tzdata

--- a/.github/mkosi.conf.d/20-fedora.conf
+++ b/.github/mkosi.conf.d/20-fedora.conf
@@ -7,3 +7,4 @@ Packages=kernel-core
          systemd-boot
          udev
          util-linux
+         grub2-pc

--- a/.github/mkosi.conf.d/20-opensuse.conf
+++ b/.github/mkosi.conf.d/20-opensuse.conf
@@ -6,3 +6,4 @@ Packages=kernel-kvmsmall
          systemd
          systemd-boot
          udev
+         grub2-i386-pc

--- a/.github/mkosi.conf.d/20-ubuntu.conf
+++ b/.github/mkosi.conf.d/20-ubuntu.conf
@@ -15,3 +15,4 @@ Packages=linux-kvm
          udev
          dbus
          tzdata
+         grub-pc

--- a/.github/mkosi.conf.d/20-ubuntu.conf
+++ b/.github/mkosi.conf.d/20-ubuntu.conf
@@ -14,3 +14,4 @@ Packages=linux-kvm
          systemd-sysv
          udev
          dbus
+         tzdata

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,3 +141,7 @@ jobs:
     - name: Boot ${{ matrix.distro }}/${{ matrix.format }} UEFI
       if: matrix.format == 'disk'
       run: timeout -k 30 10m mkosi --debug qemu
+
+    - name: Boot ${{ matrix.distro }}/${{ matrix.format }} BIOS
+      if: matrix.format == 'disk'
+      run: timeout -k 30 10m mkosi --debug --qemu-bios qemu

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -143,6 +143,11 @@ def install_distribution(state: MkosiState) -> None:
             with umask(~0o500):
                 (state.root / "efi").mkdir(exist_ok=True)
 
+            # Some distributions install EFI binaries directly to /boot/efi. Let's redirect them to /efi
+            # instead.
+            rmtree(state.root / "boot/efi")
+            (state.root / "boot/efi").symlink_to("../efi")
+
             if state.config.packages:
                 state.config.distribution.install_packages(state, state.config.packages)
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1374,14 +1374,10 @@ def make_image(state: MkosiState, skip: Sequence[str] = [], split: bool = False)
         definitions = state.workspace / "repart-definitions"
         if not definitions.exists():
             definitions.mkdir()
-            bootdir = state.root / "usr/lib/systemd/boot/efi"
+            bootloader = state.root / f"efi/EFI/BOOT/BOOT{state.config.architecture.to_efi()}.EFI"
 
-            # If Bootable=auto and we have at least one UKI and a bootloader, let's generate an ESP partition.
             add = (state.config.bootable == ConfigFeature.enabled or
-                  (state.config.bootable == ConfigFeature.auto and
-                   bootdir.exists() and
-                   any(bootdir.iterdir()) and
-                   any(gen_kernel_images(state))))
+                  (state.config.bootable == ConfigFeature.auto and bootloader.exists()))
 
             if add:
                 (definitions / "00-esp.conf").write_text(

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -471,13 +471,13 @@ def install_systemd_boot(state: MkosiState) -> None:
 
     if not shutil.which("bootctl"):
         if state.config.bootable == ConfigFeature.enabled:
-            die("A bootable image was requested but bootctl was not found")
+            die("An EFI bootable image with systemd-boot was requested but bootctl was not found")
         return
 
     directory = state.root / "usr/lib/systemd/boot/efi"
     if not directory.exists() or not any(directory.iterdir()):
         if state.config.bootable == ConfigFeature.enabled:
-            die("A bootable image was requested but systemd-boot was not found at "
+            die("A EFI bootable image with systemd-boot was requested but systemd-boot was not found at "
                 f"{directory.relative_to(state.root)}")
         return
 
@@ -725,7 +725,7 @@ def install_unified_kernel(state: MkosiState, partitions: Sequence[Partition]) -
     if state.config.bootable == ConfigFeature.disabled:
         return
 
-    if state.config.bootloader not in (Bootloader.systemd_boot, Bootloader.uki):
+    if state.config.bootloader == Bootloader.none:
         return
 
     for kver, kimg in gen_kernel_images(state):

--- a/mkosi/__main__.py
+++ b/mkosi/__main__.py
@@ -52,6 +52,7 @@ def main() -> None:
     finally:
         if sys.stderr.isatty() and shutil.which("tput"):
             run(["tput", "cnorm"])
+            run(["tput", "smam"])
 
 
 if __name__ == "__main__":

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -116,6 +116,7 @@ class DocFormat(StrEnum):
 
 
 class Bootloader(StrEnum):
+    none         = enum.auto()
     uki          = enum.auto()
     systemd_boot = enum.auto()
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -121,6 +121,11 @@ class Bootloader(StrEnum):
     systemd_boot = enum.auto()
 
 
+class BiosBootloader(StrEnum):
+    none = enum.auto()
+    grub = enum.auto()
+
+
 def parse_boolean(s: str) -> bool:
     "Parse 1/true/yes/y/t/on as true and 0/false/no/n/f/off/None as false"
     s_l = s.lower()
@@ -695,6 +700,7 @@ class MkosiConfig:
 
     bootable: ConfigFeature
     bootloader: Bootloader
+    bios_bootloader: BiosBootloader
     initrds: list[Path]
     kernel_command_line: list[str]
     kernel_modules_include: list[str]
@@ -1195,7 +1201,16 @@ class MkosiConfigParser:
             parse=config_make_enum_parser(Bootloader),
             choices=Bootloader.values(),
             default=Bootloader.systemd_boot,
-            help="Specify which bootloader to use",
+            help="Specify which UEFI bootloader to use",
+        ),
+        MkosiConfigSetting(
+            dest="bios_bootloader",
+            metavar="BOOTLOADER",
+            section="Content",
+            parse=config_make_enum_parser(BiosBootloader),
+            choices=BiosBootloader.values(),
+            default=BiosBootloader.none,
+            help="Specify which BIOS bootloader to use",
         ),
         MkosiConfigSetting(
             dest="initrds",
@@ -2253,6 +2268,7 @@ Clean Package Manager Metadata: {yes_no_auto(config.clean_package_metadata)}
 
                       Bootable: {yes_no_auto(config.bootable)}
                     Bootloader: {config.bootloader}
+               BIOS Bootloader: {config.bios_bootloader}
                        Initrds: {line_join_list(config.initrds)}
            Kernel Command Line: {line_join_list(config.kernel_command_line)}
         Kernel Modules Include: {line_join_list(config.kernel_modules_include)}

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -745,6 +745,7 @@ class MkosiConfig:
     qemu_vsock: ConfigFeature
     qemu_swtpm: ConfigFeature
     qemu_cdrom: bool
+    qemu_bios: bool
     qemu_args: Sequence[str]
 
     preset: Optional[str]
@@ -1491,6 +1492,14 @@ class MkosiConfigParser:
             section="Host",
             parse=config_parse_boolean,
             help="Attach the image as a CD-ROM to the virtual machine",
+        ),
+        MkosiConfigSetting(
+            dest="qemu_bios",
+            metavar="BOOLEAN",
+            nargs="?",
+            section="Host",
+            parse=config_parse_boolean,
+            help="Boot QEMU with SeaBIOS instead of EDK2",
         ),
         MkosiConfigSetting(
             dest="qemu_args",
@@ -2302,6 +2311,7 @@ Clean Package Manager Metadata: {yes_no_auto(config.clean_package_metadata)}
                 QEMU Use VSock: {config.qemu_vsock}
                 QEMU Use Swtpm: {config.qemu_swtpm}
                QEMU Use CD-ROM: {yes_no(config.qemu_cdrom)}
+                     QEMU BIOS: {yes_no(config.qemu_bios)}
           QEMU Extra Arguments: {line_join_list(config.qemu_args)}
 """
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -119,6 +119,7 @@ class Bootloader(StrEnum):
     none         = enum.auto()
     uki          = enum.auto()
     systemd_boot = enum.auto()
+    grub         = enum.auto()
 
 
 class BiosBootloader(StrEnum):

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -107,6 +107,5 @@ def invoke_apt(
 ) -> None:
     cmd = apivfs_cmd(state.root) if apivfs else []
     bwrap(cmd + apt_cmd(state, command) + [operation, *sort_packages(packages)],
-          # dpkg doesn't seem to unset TMPDIR when chrooting so we unset it for dpkg.
-          options=["--unsetenv", "TMPDIR"] + flatten(["--bind", d, d] for d in (state.config.workspace_dir, state.config.cache_dir) if d),
+          options=flatten(["--bind", d, d] for d in (state.config.workspace_dir, state.config.cache_dir) if d),
           network=True, env=state.config.environment)

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -791,6 +791,25 @@ they should be specified with a boolean argument: either "1", "yes", or "true" t
   be generated for the latest installed kernel (the one with the highest
   version) which is installed to `EFI/BOOT/BOOTX64.EFI` in the ESP.
 
+`BiosBootloader=`, `--bios-bootloader=`
+
+: Takes one of `none` or `grub`. Defaults to `none`. If set to `none`,
+  no BIOS bootloader will be installed. If set to `grub`, grub is
+  installed as the BIOS boot loader if a bootable image is requested
+  with the `Bootable=` option. If no repart partition definition files
+  are configured, mkosi will add a grub BIOS boot partition and an EFI
+  system partition to the default partition definition files.
+
+: Note that this option is not mutually exclusive with `Bootloader=`. It
+  is possible to have an image that is both bootable on UEFI and BIOS by
+  configuring both `Bootloader=` and `BiosBootloader=`.
+
+: The grub BIOS boot partition should have UUID
+  `21686148-6449-6e6f-744e-656564454649` and should be at least 1MB.
+
+: Even if no EFI bootloader is installed, we still need an ESP for BIOS
+  boot as that's where we store the kernel, initrd and grub modules.
+
 `Initrds=`, `--initrd`
 
 : Use user-provided initrd(s). Takes a comma separated list of paths to

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -783,13 +783,29 @@ they should be specified with a boolean argument: either "1", "yes", or "true" t
 
 `Bootloader=`, `--bootloader=`
 
-: Takes one of `none`, `systemd-boot` or `uki`. Defaults to
+: Takes one of `none`, `systemd-boot`, `uki` or `grub`. Defaults to
   `systemd-boot`. If set to `none`, no EFI bootloader will be installed
   into the image. If set to `systemd-boot`, systemd-boot will be
   installed and for each installed kernel, a UKI will be generated and
   stored in `EFI/Linux` in the ESP. If set to `uki`, a single UKI will
   be generated for the latest installed kernel (the one with the highest
-  version) which is installed to `EFI/BOOT/BOOTX64.EFI` in the ESP.
+  version) which is installed to `EFI/BOOT/BOOTX64.EFI` in the ESP. If
+  set to `grub`, for each installed kernel, a UKI will be generated and
+  stored in `EFI/Linux` in the ESP. For each generated UKI, a menu entry
+  is appended to the grub configuration in `grub/grub.cfg` in the ESP
+  which chainloads into the UKI. A shim grub.cfg is also written to
+  `EFI/<distribution>/grub.cfg` in the ESP which loads `grub/grub.cfg`
+  in the ESP for compatibility with signed versions of grub which load
+  the grub configuration from this location.
+
+: Note that we do not yet install grub to the ESP when `Bootloader=` is
+  set to `grub`. This has to be done manually in a postinst or finalize
+  script. The grub EFI binary should be installed to
+  `/efi/EFI/BOOT/BOOTX64.EFI` (or similar depending on the architecture)
+  and should be configured to load its configuration from
+  `EFI/<distribution>/grub.cfg` in the ESP. Signed versions of grub
+  shipped by distributions will load their configuration from this
+  location by default.
 
 `BiosBootloader=`, `--bios-bootloader=`
 

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -1004,6 +1004,12 @@ they should be specified with a boolean argument: either "1", "yes", or "true" t
   attach the image to the virtual machine as a CD-ROM device. Takes a
   boolean. Defaults to `no`.
 
+`QemuBios=`, `--qemu-bios=`
+
+: When used with the `qemu` verb, this option specifies whether to use
+  the BIOS firmware instead of the UEFI firmware. Takes a boolean.
+  Defaults to `no`.
+
 `QemuArgs=`
 
 : Space-delimited list of additional arguments to pass when invoking

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -771,24 +771,25 @@ they should be specified with a boolean argument: either "1", "yes", or "true" t
 `Bootable=`, `--bootable=`
 
 : Takes a boolean or `auto`. Enables or disables generation of a
-  bootable image. If enabled, mkosi will install systemd-boot, and add
-  an ESP partition when the disk image output is used. If systemd-boot
-  is not installed or no kernel images can be found, the build will
-  fail. `auto` behaves as if the option was enabled, but the build won't
-  fail if either no kernel images or systemd-boot can't be found. If
-  disabled, systemd-boot won't be installed even if found inside the
-  image, no unified kernel images will be generated and no ESP partition
-  will be added to the image if the disk output format is used.
+  bootable image. If enabled, mkosi will install an EFI bootloader, and
+  add an ESP partition when the disk image output is used. If the
+  selected EFI bootloader (See `Bootloader=`) is not installed or no
+  kernel images can be found, the build will fail. `auto` behaves as if
+  the option was enabled, but the build won't fail if either no kernel
+  images or the selected EFI bootloader can't be found. If disabled, no
+  bootloader will be installed even if found inside the image, no
+  unified kernel images will be generated and no ESP partition will be
+  added to the image if the disk output format is used.
 
 `Bootloader=`, `--bootloader=`
 
-: Takes one of `systemd-boot` or `uki`. Defaults to `systemd-boot`. If
-  set to `systemd-boot`, systemd-boot will be installed and for each
-  installed kernel, a UKI will be generated and stored in `EFI/Linux` in
-  the ESP partition. If set to `uki`, systemd-boot will not be installed
-  and a single UKI will be generated for the latest installed kernel
-  (the one with the highest version) and stored in
-  `EFI/BOOT/BOOTX64.EFI`.
+: Takes one of `none`, `systemd-boot` or `uki`. Defaults to
+  `systemd-boot`. If set to `none`, no EFI bootloader will be installed
+  into the image. If set to `systemd-boot`, systemd-boot will be
+  installed and for each installed kernel, a UKI will be generated and
+  stored in `EFI/Linux` in the ESP. If set to `uki`, a single UKI will
+  be generated for the latest installed kernel (the one with the highest
+  version) which is installed to `EFI/BOOT/BOOTX64.EFI` in the ESP.
 
 `Initrds=`, `--initrd`
 

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -369,6 +369,8 @@ def apivfs_cmd(root: Path) -> list[PathString]:
         "--proc", root / "proc",
         "--dev", root / "dev",
         "--ro-bind", "/sys", root / "sys",
+        # APIVFS generally means chrooting is going to happen so unset TMPDIR just to be safe.
+        "--unsetenv", "TMPDIR",
     ]
 
     if (root / "etc/machine-id").exists():
@@ -394,7 +396,6 @@ def chroot_cmd(root: Path, *, options: Sequence[PathString] = ()) -> list[PathSt
         "--setenv", "container", "mkosi",
         "--setenv", "HOME", "/",
         "--setenv", "PATH", "/usr/bin:/usr/sbin",
-        "--unsetenv", "TMPDIR",
     ]
 
     resolve = Path("etc/resolv.conf")


### PR DESCRIPTION
Add back BIOS support using grub
Let's add back support for booting on BIOS using grub. This comes
with the following limitations:

- grub does not support UKIs on BIOS, so we set up the individual
components instead
- grub cannot search partitions by PARTUUID, so we're forced to have
it find the ESP by partition number instead.

We opt to generate grub.cfg ourselves instead of relying on grub-mkconfig.
grub-mkconfig is basically like kernel-install but for grub configuration,
it has a ton of distro specific cruft that we want to ignore, so we simply
don't use it and generate the grub configuration ourselves.

To allow for unprivileged installation of grub, we can't use grub-install
as it insists on opening the root device and probing its filesystem, which
isn't possible unprivileged. Instead, we run grub-mkimage and grub-bios-setup
ourselves, and manually copy the required files to the ESP.

We use the ESP to store the kernels, initrds and grub config. In the event
that grub adds support for UKIs on BIOS in the future, we can simply modify
the generated grub configuration to use our generated UKIs instead.