### PR TITLE
prepare for more cache modes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - `mkosi.version` is now picked up from preset and dropin directories as
   well following the usual config precedence logic
+- The option `--incremental` is now deprecated. It will be removed in a
+  future version. Use `--cache-mode=prepare` instead.
+- A new option `--cache-mode` is now available which supports more caching
+  between build runs. See the documentation for further details.
 
 ## v15.1
 

--- a/mkosi/log.py
+++ b/mkosi/log.py
@@ -30,6 +30,10 @@ def die(message: str,
     sys.exit(1)
 
 
+def warn(message: str) -> None:
+    logging.warning(f"{message}")
+
+
 def log_step(text: str) -> None:
     prefix = " " * LEVEL
 


### PR DESCRIPTION
This change doesn't really add much more than some documentation updates and a caching enum type, but it does pave the way for more caching options to be made available. The intent is to get consensus on how other caching modes will be handled, document the current mode with a view to extending and make sure we can easily extend caching modes.