### PR TITLE
Add support for using OverlayFS instead of copying

### DIFF
--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -118,7 +118,7 @@ class GentooInstaller(DistributionInstaller):
         for d in ("binpkgs", "distfiles", "repos/gentoo"):
             (state.cache_dir / d).mkdir(parents=True, exist_ok=True)
 
-        copy_tree(state.config, state.pkgmngr, stage3, preserve_owner=False)
+        copy_tree(state, state.pkgmngr, stage3, preserve_owner=False)
 
         features = " ".join([
             # Disable sandboxing in emerge because we already do it in mkosi.

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -19,6 +19,7 @@ from mkosi.architecture import Architecture
 from mkosi.config import ConfigFeature, MkosiArgs, MkosiConfig, OutputFormat
 from mkosi.log import die
 from mkosi.run import MkosiAsyncioThread, run, spawn
+from mkosi.state import MkosiBasicState
 from mkosi.tree import copy_tree, rmtree
 from mkosi.types import PathString
 from mkosi.util import format_bytes, qemu_check_kvm_support, qemu_check_vsock_support
@@ -199,7 +200,7 @@ def copy_ephemeral(config: MkosiConfig, src: Path) -> Iterator[Path]:
     tmp = src.parent / f"{src.name}-{uuid.uuid4().hex}"
 
     try:
-        copy_tree(config, src, tmp)
+        copy_tree(MkosiBasicState(config), src, tmp)
         yield tmp
     finally:
         rmtree(tmp)

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -554,7 +554,8 @@ they should be specified with a boolean argument: either "1", "yes", or "true" t
   changes to the specified base trees. Each base tree is attached as a lower
   layer in an overlayfs structure, and the output becomes the upper layer,
   initially empty. Thus files that are not modified compared to the base trees
-  will not be present in the final output.
+  will not be present in the final output. This option enables
+  `--overlay-as-copy` automatically.
 
 : This option may be used to create systemd "system extensions" or
   portable services. See
@@ -626,6 +627,13 @@ they should be specified with a boolean argument: either "1", "yes", or "true" t
   not included in the image built. The `$WITH_DOCS` environment
   variable passed to the `mkosi.build` script indicates whether this
   option was used or not.
+
+`OverlayAsCopy=`, `--overlay-as-copy`
+
+: Use an overlay file system instead of copying files. This is useful
+  where the workspace is on a different file system or the workspace file
+  system does not support reflinks. Note that this option is implied when
+  `Overlay=` is used.
 
 `BaseTrees=`, `--base-tree=`
 

--- a/mkosi/state.py
+++ b/mkosi/state.py
@@ -1,10 +1,37 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
+import shutil
+import subprocess
 from pathlib import Path
 
-from mkosi.config import MkosiArgs, MkosiConfig
-from mkosi.tree import make_tree
+from mkosi.config import ConfigFeature, MkosiArgs, MkosiConfig
+from mkosi.log import die
 from mkosi.util import umask
+
+
+# This function bares resemblance to the one in mkosi/tree.py because there
+# would be a circular import otherwise.
+def make_tree(config: MkosiConfig, path: Path) -> None:
+    on_btrfs = subprocess.run(
+        ["stat", "--file-system", "--format", "%T", path.parent],
+        stdout=subprocess.PIPE
+    ).stdout.strip() == b"btrfs"
+
+    if not on_btrfs:
+        if config.use_subvolumes == ConfigFeature.enabled:
+            die(f"Subvolumes requested but {path} is not located on a btrfs filesystem")
+
+        path.mkdir()
+        return
+
+    if config.use_subvolumes != ConfigFeature.disabled and shutil.which("btrfs") is not None:
+        result = subprocess.run(["btrfs", "subvolume", "create", path],
+                     check=config.use_subvolumes == ConfigFeature.enabled).returncode
+    else:
+        result = 1
+
+    if result != 0:
+        path.mkdir()
 
 
 class MkosiState:
@@ -21,6 +48,10 @@ class MkosiState:
         self.pkgmngr.mkdir()
         self.install_dir.mkdir(exist_ok=True)
         self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+        # This is the list of directories to mount as overlay base directories
+        # when config.overlay_as_copy is used
+        self.overlay_as_copy_dirs : list[Path] = list()
 
     @property
     def root(self) -> Path:
@@ -41,3 +72,18 @@ class MkosiState:
     @property
     def install_dir(self) -> Path:
         return self.workspace / "dest"
+
+
+class MkosiBasicState:
+    """Used when an MkosiState object is required but there is no workspace."""
+
+    def __init__(self, config: MkosiConfig) -> None:
+        self.config = config
+
+    @property
+    def overlay_as_copy_dirs(self) -> list[Path]:
+        return list()
+
+    @property
+    def root(self) -> Path:
+        return Path("/")


### PR DESCRIPTION
This PR is reasonably sized and makes use of overlay mounts instead of copying. This list of base directories is stored as part of `MkosiState`. The function `mount_image()` is no longer needed because we enable the `--overlay-as-copy` option whenever `--overlay` is set to prevent overlay stacking issues.

Unfortunately the `copy_tree()` function now needs access to the state which has meant a bit of code churn.

I also found that `mount_overlay()` was not properly setting up multiple lower directories, so if nothing else that change should be applied.

I successfully tested the following combinations with an `mkosi.extra` directory and `BaseTrees=` set:

* A normal build
* Cache mode of a normal build
* A build with `--overlay-as-copy`
* Cache mode of a build with `--overlay-as-copy`