### PR TITLE
Drop "mkosi" from UKI names

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1018,7 +1018,7 @@ def install_unified_kernel(state: MkosiState, partitions: Sequence[Partition]) -
 
     for kver, kimg in gen_kernel_images(state):
         with complete_step(f"Generating unified kernel image for {kimg}"):
-            image_id = state.config.image_id or f"mkosi-{state.config.distribution}"
+            image_id = state.config.image_id or state.config.distribution.name
 
             # See https://systemd.io/AUTOMATIC_BOOT_ASSESSMENT/#boot-counting
             boot_count = ""

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -298,7 +298,6 @@ def run_qemu(args: MkosiArgs, config: MkosiConfig) -> None:
                  "--offline=yes",
                  fname])
 
-        # Debian images fail to boot with virtio-scsi, see: https://github.com/systemd/mkosi/issues/725
         if config.output_format == OutputFormat.cpio:
             kernel = config.output_dir / config.output_split_kernel
             if not kernel.exists() and "-kernel" not in args.cmdline:


### PR DESCRIPTION
Let's not leak that the image was generated by mkosi into the image via the UKI name.