### PR TITLE
config: Add support for default options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
   parsing. Settings parsed later will now override earlier values and
   the `!` exclusion logic for lists was removed. Assigning the empty
   string to a list can be used to clear previously assigned values.
+- Configuration files now accept a `DefaultSetting=value` that can override
+  the default value specified in the documentation.
 
 ## v15.1
 

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -253,6 +253,9 @@ single-letter shortcut is also allowed. In the configuration files,
 the setting must be in the appropriate section, so the settings are
 grouped by section below.
 
+Settings also support `DefaultSetting=default-value` to override the default
+that is specified in the documentation below.
+
 Configuration is parsed in the following order:
 
 * The command line arguments are parsed


### PR DESCRIPTION
Support allowing a user to specify an option to override the chosen default. For example, the user can set `DefaultDistribution=` or `--default-distribution` and the configuration will automatically resolve `state.config.distribution`. The user can also still specify `Distribution=` in a preset or configuration file and override the default.

This change covers setting a default if the configuration parser automatically sets a default. This means that `DefaultPackages=` is not a valid option since there is no default for `Packages=` set by the configuration parser.

This should fix #1761.