### PR TITLE
config: Support override options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 - `mkosi.version` is now picked up from preset and dropin directories as
   well following the usual config precedence logic
+- Options specified in configuration files can now be overridden using
+  `OverrideOption=`. For example, `OverrideFormat=disk` can be used in a preset
+  with `Format=directory` set in the main configuration file.
 
 ## v15.1
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1654,8 +1654,11 @@ class MkosiConfigParser:
 
         for section in parser.sections():
             for k, v in parser.items(section):
-                if not (s := self.settings_lookup.get(k)):
+                if not (s := self.settings_lookup.get(k.removeprefix("Override"))):
                     die(f"Unknown setting {k}")
+
+                if k.startswith("Override") and s.dest in namespace:
+                    delattr(namespace, s.dest)
 
                 setattr(namespace, s.dest, s.parse(s.dest, v, namespace))
 

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -253,6 +253,10 @@ single-letter shortcut is also allowed. In the configuration files,
 the setting must be in the appropriate section, so the settings are
 grouped by section below.
 
+All configuration settings additionally support `OverrideSomeSetting=new-value`
+when used in drop-in files or presets. This allows settings to be overridden
+from the default when using presets.
+
 Configuration is parsed in the following order:
 
 * The command line arguments are parsed

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
-from mkosi.config import Compression
+import argparse
+import tempfile
+from pathlib import Path
+
+from mkosi.config import Compression, MkosiConfigParser
 
 
 def test_compression_enum_creation() -> None:
@@ -31,3 +35,16 @@ def test_compression_enum_str() -> None:
     assert str(Compression.gz)   == "gz"
     assert str(Compression.lz4)  == "lz4"
     assert str(Compression.lzma) == "lzma"
+
+
+def test_config_override() -> None:
+    with tempfile.NamedTemporaryFile('w') as f:
+        f.write("[Contents]\n")
+        f.write("Packages = foo\n")
+        f.write("OverridePackages = bar\n")
+        f.flush()
+        f.seek(0)
+
+        ns = argparse.Namespace()
+        assert MkosiConfigParser().parse_config(Path(f.name), ns)
+        assert getattr(ns, "packages") == ["bar"]


### PR DESCRIPTION
This change allows options specified as `OverrideXXX=` to take precedence over any prior options specified as `XXX=` including those that have been set by default. This only affects configuration file parsing.

Likely to resolve #1761 and #1825.
