### PR TITLE
Drop "first assignment wins" logic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - `mkosi.version` is now picked up from preset and dropin directories as
   well following the usual config precedence logic
+- The "first assignment wins" logic was dropped from configuration
+  parsing. Settings parsed later will now override earlier values and
+  the `!` exclusion logic for lists was removed. Assigning the empty
+  string to a list can be used to clear previously assigned values.
 
 ## v15.1
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -10,6 +10,7 @@ import fnmatch
 import functools
 import graphlib
 import inspect
+import logging
 import operator
 import os.path
 import platform
@@ -1852,15 +1853,15 @@ class MkosiConfigParser:
         # is no longer needed in build infrastructure (e.g.: OBS).
         if getattr(namespace, "nspawn_keep_unit", None):
             delattr(namespace, "nspawn_keep_unit")
-            print("Warning: --nspawn-keep-unit is no longer supported")
+            logging.warning("--nspawn-keep-unit is no longer supported")
 
         if getattr(namespace, "default", None):
             delattr(namespace, "default")
-            print("Warning: --default is no longer supported")
+            logging.warning("--default is no longer supported")
 
         if getattr(namespace, "cache", None):
             delattr(namespace, "cache")
-            print("Warning: --cache is no longer supported")
+            logging.warning("--cache is no longer supported")
 
     def resolve_deps(self, args: MkosiArgs, presets: Sequence[MkosiConfig]) -> list[MkosiConfig]:
         graph = {p.preset: p.dependencies for p in presets}

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -266,28 +266,28 @@ Configuration is parsed in the following order:
 * Any default paths (depending on the option) are configured if the
   corresponding path exists.
 
-If a setting is specified multiple times across the different sources
-of configuration, the first assignment that is found is used. For example,
-a setting specified on the command line will always take precedence over
-the same setting configured in a config file. To override settings in a
-dropin file, make sure your dropin file is alphanumerically ordered
-before the config file that you're trying to override.
+Settings that take a list of values are merged by appending the new
+values to the previously configured values. If a list setting is set to
+the empty list, all previously assigned values are cleared.
 
-Settings that take a list of values are merged by prepending each value
-to the previously configured values. If a value of a list setting is
-prefixed with `!`, if any later assignment of that setting tries to add
-the same value, that value is ignored. Values prefixed with `!` can be
-globs to ignore more than one value.
+To conditionally include configuration files, the `[Match]` section can
+be used. Matches can use a pipe symbol ("|") after the equals sign
+("…=|…"), which causes the match to become a triggering match. The
+config file will be included if the logical AND of all non-triggering
+matches and the logical OR of all triggering matches is satisfied. To
+negate the result of a match, prefix the argument with an exclamation
+mark. If an argument is prefixed with the pipe symbol and an exclamation
+mark, the pipe symbol must be passed first, and the exclamation second.
 
-To conditionally include configuration files, the `[Match]` section can be used. Matches can use a pipe
-symbol ("|") after the equals sign ("…=|…"), which causes the match to become a triggering match. The config
-file will be included if the logical AND of all non-triggering matches and the logical OR of all triggering
-matches is satisfied. To negate the result of a match, prefix the argument with an exclamation mark. If an
-argument is prefixed with the pipe symbol and an exclamation mark, the pipe symbol must be passed first, and
-the exclamation second.
+Note that `[Match]` settings match against the current values of
+specific settings, and do not take into account changes made to the
+setting in configuration files that have not been parsed yet. Also note
+that matching against a setting and then changing its value afterwards
+in a different config file may lead to unexpected results.
 
-Command line options that take no argument are shown without "=" in their long version. In the config files,
-they should be specified with a boolean argument: either "1", "yes", or "true" to enable, or "0", "no",
+Command line options that take no argument are shown without "=" in
+their long version. In the config files, they should be specified with a
+boolean argument: either "1", "yes", or "true" to enable, or "0", "no",
 "false" to disable.
 
 ### [Match] Section.
@@ -543,12 +543,13 @@ they should be specified with a boolean argument: either "1", "yes", or "true" t
 
 `RepartDirectories=`, `--repart-dir=`
 
-: Paths to directories containing systemd-repart partition definition files that
-  are used when mkosi invokes systemd-repart when building a disk image. If not
-  specified and `mkosi.repart/` exists in the local directory, it will be used
-  instead. Note that mkosi invokes repart with `--root=` set to the root of the
-  image root, so any `CopyFiles=` source paths in partition definition files will
-  be relative to the image root directory.
+: Paths to directories containing systemd-repart partition definition
+  files that are used when mkosi invokes systemd-repart when building a
+  disk image. If `mkosi.repart/` exists in the local directory, it will
+  be used for this purpose as well. Note that mkosi invokes repart with
+  `--root=` set to the root of the image root, so any `CopyFiles=`
+  source paths in partition definition files will be relative to the
+  image root directory.
 
 `SectorSize=`, `--sector-size=`
 
@@ -658,10 +659,9 @@ they should be specified with a boolean argument: either "1", "yes", or "true" t
   image. If the second path is not provided, the directory is copied
   on top of the root directory of the image. Use this to insert files
   and directories into the OS tree before the package manager installs
-  any packages. If this option is not used, but the `mkosi.skeleton/`
-  directory is found in the local directory it is automatically used
-  for this purpose with the root directory as target (also see the
-  "Files" section below).
+  any packages. If the `mkosi.skeleton/` directory is found in the local
+  directory it is also used for this purpose with the root directory as
+  target (also see the "Files" section below).
 
 : As with the base tree logic above, instead of a directory, a tar
   file may be provided too. `mkosi.skeleton.tar` will be automatically
@@ -687,10 +687,9 @@ they should be specified with a boolean argument: either "1", "yes", or "true" t
   to the target directory inside the image. If the second path is not
   provided, the directory is copied on top of the root directory of the
   image. Use this to override any default configuration files shipped
-  with the distribution. If this option is not used, but the
-  `mkosi.extra/` directory is found in the local directory it is
-  automatically used for this purpose with the root directory as target.
-  (also see the "Files" section below).
+  with the distribution. If the `mkosi.extra/` directory is found in the
+  local directory it is also used for this purpose with the root
+  directory as target. (also see the "Files" section below).
 
 : As with the base tree logic above, instead of a directory, a tar
   file may be provided too. `mkosi.extra.tar` will be automatically


### PR DESCRIPTION
From experience in the systemd repository's usage of presets, we've
learned that we want to have fixed values for certain settings for
presets that cannot be overridden by either the CLI options or by
global config. Good examples are that the Format= of a base image
should always be "directory" and the Format= of an initrd image
should always be "cpio" or that Bootable= should always be "no" for
both the base image and the initrd image and their list of packages
should not be affected by any packages specified on the CLI.

The issue is that with "first assignment wins" logic, we need to add
an explicit "override" mechanism which almost all settings in these
presets would then use to make sure they can't be changed by CLI
options. This seems rather backwards, and is a good indication that
any settings configured in config should not be overridden by settings
set on the CLI.

Even disregarding usage of presets, any existing mkosi config will almost
certainly not be written to expect arbitrary changes in the config due
to options set on the CLI.

Also, it's currently not entirely trivial to set default values for
presets from the global config, because any values set in the global
config cannot be overridden anymore by presets. By not doing "first
assignment wins" logic, this becomes trivial as the global config can
simply set a default value and it can be overridden by presets.

Of course by removing "first assignment wins" logic, we do introduce
the issue again that "first assignment wins" solves in the first place,
which is that it becomes possible to assign a value to a setting, match
on that value and then change the setting later. We acknowledge this by
documenting it in the manual. Also, in some cases, this is exactly what
you want. For example, if you want to use a Fedora rawhide tools tree to
build CentOS 8 images, you have to first match on distribution == centos
and then set Distribution=fedora afterwards for the tools tree preset, so
this actually makes perfect sense in some cases.

While this is technically a compat break, it will only be noticed by users
doing advanced stuff with mkosi, which AFAIK does not exist yet outside of
the systemd repo. In fact even the systemd repo was not broken by this change,
so we should be OK with making it, given the large benefits we get out of it.

This commit also simplifies the interfaces of the parser and matching callbacks
to not take the namespace as an argument anymore, but to simply take the existing
value as an argument instead.