### PR TITLE
Drop list reset on empty value

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,8 +6,8 @@
   well following the usual config precedence logic
 - The "first assignment wins" logic was dropped from configuration
   parsing. Settings parsed later will now override earlier values and
-  the `!` exclusion logic for lists was removed. Assigning the empty
-  string to a list can be used to clear previously assigned values.
+  the `!` operator for lists will now remove values already in the list
+  instead of preventing specific values from being added.
 
 ## v15.1
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -358,8 +358,11 @@ def config_make_list_parser(delimiter: str,
 
         for v in values:
             if not v:
-                new = []
                 continue
+
+            if v.startswith("!"):
+                v = v[1:]
+                new = [n for n in new if not fnmatch.fnmatchcase(v, n)]
 
             new.append(parse(v))
 

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -272,8 +272,10 @@ setting. Also note that before v16, we used to do the opposite, where
 the earlier assignment would be used instead of later assignments.
 
 Settings that take a list of values are merged by appending the new
-values to the previously configured values. If a list setting is set to
-the empty list, all previously assigned values are cleared.
+values to the previously configured values. If a value of a list setting
+is prefixed with `!`, all existing instances of that value in the list
+are removed. Values prefixed with `!` can be globs to remove more than
+one value.
 
 To conditionally include configuration files, the `[Match]` section can
 be used. Matches can use a pipe symbol ("|") after the equals sign


### PR DESCRIPTION
This does not work properly with python's configparser, which will insert empty lines when doing something like the following:

```
Packages=
       abc
```