### PR TITLE
propagate SOURCE_DATE_EPOCH when calling systemd-repart

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1721,6 +1721,8 @@ def make_image(state: MkosiState, skip: Sequence[str] = [], split: bool = False)
     for option, value in state.config.environment.items():
         if option.startswith("SYSTEMD_REPART_MKFS_OPTIONS_"):
             env[option] = value
+        if option == "SOURCE_DATE_EPOCH":
+            env[option] = value
 
     with complete_step("Generating disk image"):
         output = json.loads(run(cmdline, stdout=subprocess.PIPE, env=env).stdout)


### PR DESCRIPTION
With this change, setting `Environment=SOURCE_DATE_EPOCH=0` in the mkosi config, mkosi will propagate the variable to systemd-repart.
systemd-repart calls mksquashfs and other mkfs tools.
Some mkfs tools already respect SOURCE_DATE_EPOCH, resulting in predictable timestamps in squashfs partitions (and maybe others).