### PR TITLE
add config setting seed to set systemd-repart `--seed`

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1633,6 +1633,7 @@ def make_image(state: MkosiState, skip: Sequence[str] = [], split: bool = False)
         "--no-pager",
         "--offline=yes",
         "--root", state.root,
+        "--seed", str(state.config.seed) if state.config.seed else "random",
         state.staging / state.config.output_with_format,
     ]
 

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -586,6 +586,14 @@ boolean argument: either "1", "yes", or "true" to enable, or "0", "no",
   created, an error is raised. If `auto`, missing `btrfs` or failures to
   create subvolumes are ignored.
 
+`Seed=`, `--seed=`
+
+: Takes a UUID as argument or the special value `random`.
+  Overrides the seed that [`systemd-repart(8)`](https://www.freedesktop.org/software/systemd/man/systemd-repart.service.html)
+  uses when building a disk image. This is useful to achieve reproducible
+  builds, where deterministic UUIDs and other partition metadata should be
+  derived on each build.
+
 ### [Content] Section
 
 `Packages=`, `--package=`, `-p`


### PR DESCRIPTION
Seed takes a UUID as argument or the special value **random**.
Overrides the seed that [`systemd-repart(8)`](https://www.freedesktop.org/software/systemd/man/systemd-repart.service.html) uses when building a disk image. This is useful to achieve reproducible builds, where deterministic UUIDs and other partition metadata should be derived on each build.

In particular, this makes GPT UUIDs deterministic as well as the dm-verity UUID and salt.