### PR TITLE
Rework ini file parsing

### DIFF
--- a/mkosi/__main__.py
+++ b/mkosi/__main__.py
@@ -44,9 +44,6 @@ def main() -> None:
     log_setup()
     args, presets = MkosiConfigParser().parse()
 
-    if ARG_DEBUG.get():
-        logging.getLogger().setLevel(logging.DEBUG)
-
     try:
         run_verb(args, presets)
     finally:


### PR DESCRIPTION
Python's configparser module is rather inadequate for our purposes.
Specifically, it's built around every setting only being specified once
in a config file and even though we got it to kind of parse more than
one of the same setting with our own custom dict type, there's a lot of
limitations involved. Specifically, assigning the empty value is
impossible with the current approach. To avoid all these issues, let's
introduce our own ini parser.

This also splits off the matching logic into a new method match_config()
and moves setting the debugging level just after we've parsed CLI options
so we get debug messages from the parser as well.