### PR TITLE
Don't fail if tput commands fail

### DIFF
--- a/mkosi/__main__.py
+++ b/mkosi/__main__.py
@@ -51,8 +51,8 @@ def main() -> None:
         run_verb(args, presets)
     finally:
         if sys.stderr.isatty() and shutil.which("tput"):
-            run(["tput", "cnorm"])
-            run(["tput", "smam"])
+            run(["tput", "cnorm"], check=False)
+            run(["tput", "smam"], check=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Let's consider these best effort, no need to fail mkosi if we can't fix the terminal.

Fixes #1846