### PR TITLE
Ignore ssh configuration files when running ssh

### DIFF
--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -336,6 +336,7 @@ def run_qemu(args: MkosiArgs, config: MkosiConfig) -> None:
 def run_ssh(args: MkosiArgs, config: MkosiConfig) -> None:
     cmd = [
         "ssh",
+        "-F", "none",
         # Silence known hosts file errors/warnings.
         "-o", "UserKnownHostsFile=/dev/null",
         "-o", "StrictHostKeyChecking=no",


### PR DESCRIPTION
When in a user namespace, the ssh config files from /etc/ will be owned by nobody which makes ssh fail. Let's ignore these configuration files when running ssh to avoid such failures.

Fixes #1848