### PR TITLE
ci: enable jammy-proposed-updates to test new libzypp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Enable proposed-updates
+      run: |
+        sudo mkdir -p /etc/apt/sources.list.d/
+        echo 'deb http://azure.archive.ubuntu.com/ubuntu jammy-proposed restricted main universe' | sudo tee /etc/apt/sources.list.d/proposed.list
     - uses: ./
 
     # Make sure the latest changes from the pull request are used.


### PR DESCRIPTION
I got some patches backported to jammy to try and fix https issues, enable proposed-updates so that it can be tested before moving to the release stage

As mentioned on https://bugs.launchpad.net/ubuntu/+source/libzypp/+bug/2025400 I need to show that the patched libzypp works fine, so let's enable proposed-updates on jammy for a while