### PR TITLE
Allow using a default tools tree

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -35,7 +35,6 @@ runs:
         dnf \
         e2fsprogs \
         erofs-utils \
-        makepkg \
         mtools \
         ovmf \
         pacman-package-manager \

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2020,7 +2020,7 @@ def run_serve(config: MkosiConfig) -> None:
         os.chdir(config.output_dir)
 
     with http.server.HTTPServer(("", port), http.server.SimpleHTTPRequestHandler) as httpd:
-        print(f"Serving HTTP on port {port}: http://localhost:{port}/")
+        logging.info(f"Serving HTTP on port {port}: http://localhost:{port}/")
         httpd.serve_forever()
 
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1075,8 +1075,9 @@ def install_unified_kernel(state: MkosiState, partitions: Sequence[Partition]) -
                 "--efi-arch", state.config.architecture.to_efi(),
             ]
 
-            for p in state.config.extra_search_paths:
-                cmd += ["--tools", p]
+            if not state.config.tools_tree:
+                for p in state.config.extra_search_paths:
+                    cmd += ["--tools", p]
 
             uki_config = state.pkgmngr / "etc/kernel/uki.conf"
             if uki_config.exists():

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -946,8 +946,7 @@ def build_initrd(state: MkosiState) -> Path:
     ]
 
     with complete_step("Building initrd"):
-        args, presets = parse_config(cmdline)
-        config = presets[0]
+        args, [config] = parse_config(cmdline)
         unlink_output(args, config)
         build_image(args, config)
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -913,7 +913,6 @@ def build_initrd(state: MkosiState) -> Path:
         "--repository-key-check", str(state.config.repository_key_check),
         "--repositories", ",".join(state.config.repositories),
         "--package-manager-tree", ",".join(format_source_target(s, t) for s, t in state.config.package_manager_trees),
-        *(["--tools-tree", str(state.config.tools_tree)] if state.config.tools_tree else []),
         *(["--compress-output", str(state.config.compress_output)] if state.config.compress_output else []),
         "--with-network", str(state.config.with_network),
         "--cache-only", str(state.config.cache_only),

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -290,18 +290,7 @@ def config_default_release(namespace: argparse.Namespace) -> str:
     if namespace.distribution == hd and hr is not None:
         return hr
 
-    return {
-        Distribution.fedora: "38",
-        Distribution.centos: "9",
-        Distribution.rocky: "9",
-        Distribution.alma: "9",
-        Distribution.mageia: "cauldron",
-        Distribution.debian: "testing",
-        Distribution.ubuntu: "lunar",
-        Distribution.opensuse: "tumbleweed",
-        Distribution.openmandriva: "cooker",
-        Distribution.gentoo: "17.1",
-    }.get(namespace.distribution, "rolling")
+    return cast(str, namespace.distribution.default_release())
 
 
 def config_default_mirror(namespace: argparse.Namespace) -> Optional[str]:

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -148,7 +148,6 @@ def parse_boolean(s: str) -> bool:
 def parse_path(value: str,
                *,
                required: bool = True,
-               absolute: bool = True,
                resolve: bool = True,
                expanduser: bool = True,
                expandvars: bool = True,
@@ -165,9 +164,6 @@ def parse_path(value: str,
 
     if required and not path.exists():
         die(f"{value} does not exist")
-
-    if absolute:
-        path = path.absolute()
 
     if resolve:
         path = path.resolve()
@@ -188,7 +184,7 @@ def make_source_target_paths_parser(absolute: bool = True) -> Callable[[str], tu
         src, sep, target = value.partition(':')
         src_path = parse_path(src, required=False)
         if sep:
-            target_path = parse_path(target, required=False, absolute=False, resolve=False, expanduser=False)
+            target_path = parse_path(target, required=False, resolve=False, expanduser=False)
             if absolute and not target_path.is_absolute():
                 die("Target path must be absolute")
         else:
@@ -408,14 +404,14 @@ def config_match_image_version(match: str, value: Optional[str]) -> bool:
 
 def make_path_parser(*,
                      required: bool = True,
-                     absolute: bool = True,
+                     resolve: bool = True,
                      expanduser: bool = True,
                      expandvars: bool = True,
                      secret: bool = False) -> Callable[[str], Path]:
     return functools.partial(
         parse_path,
         required=required,
-        absolute=absolute,
+        resolve=resolve,
         expanduser=expanduser,
         expandvars=expandvars,
         secret=secret,
@@ -424,7 +420,6 @@ def make_path_parser(*,
 
 def config_make_path_parser(*,
                             required: bool = True,
-                            absolute: bool = True,
                             resolve: bool = True,
                             expanduser: bool = True,
                             expandvars: bool = True,
@@ -434,7 +429,6 @@ def config_make_path_parser(*,
             return parse_path(
                 value,
                 required=required,
-                absolute=absolute,
                 resolve=resolve,
                 expanduser=expanduser,
                 expandvars=expandvars,
@@ -1623,7 +1617,7 @@ SETTINGS = (
         dest="tools_tree",
         metavar="PATH",
         section="Host",
-        parse=config_make_path_parser(required=False, absolute=False),
+        parse=config_make_path_parser(required=False, resolve=False),
         paths=("mkosi.tools",),
         help="Look up programs to execute inside the given tree",
     ),
@@ -1941,7 +1935,6 @@ def parse_config(argv: Sequence[str] = ()) -> tuple[MkosiArgs, tuple[MkosiConfig
                         f,
                         secret=s.path_secret,
                         required=False,
-                        absolute=False,
                         resolve=False,
                         expanduser=False,
                         expandvars=False,

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1621,7 +1621,6 @@ SETTINGS = (
     ),
     MkosiConfigSetting(
         dest="tools_tree",
-        long="--tools-tree",
         metavar="PATH",
         section="Host",
         parse=config_make_path_parser(required=False, absolute=False),

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -704,6 +704,8 @@ class MkosiConfig:
     kernel_command_line_extra: list[str]
     acl: bool
     tools_tree: Optional[Path]
+    tools_tree_distribution: Optional[Distribution]
+    tools_tree_release: Optional[str]
 
     # QEMU-specific options
     qemu_gui: bool
@@ -1617,9 +1619,23 @@ SETTINGS = (
         dest="tools_tree",
         metavar="PATH",
         section="Host",
-        parse=config_make_path_parser(required=False, resolve=False),
+        parse=config_make_path_parser(required=False),
         paths=("mkosi.tools",),
         help="Look up programs to execute inside the given tree",
+    ),
+    MkosiConfigSetting(
+        dest="tools_tree_distribution",
+        metavar="DISTRIBUTION",
+        section="Host",
+        parse=config_make_enum_parser(Distribution),
+        help="Set the distribution to use for the default tools tree",
+    ),
+    MkosiConfigSetting(
+        dest="tools_tree_release",
+        metavar="RELEASE",
+        section="Host",
+        parse=config_parse_string,
+        help="Set the release to use for the default tools tree",
     ),
 )
 
@@ -2373,6 +2389,8 @@ Clean Package Manager Metadata: {yes_no_auto(config.clean_package_metadata)}
      Extra Kernel Command Line: {line_join_list(config.kernel_command_line_extra)}
                       Use ACLs: {config.acl}
                     Tools Tree: {config.tools_tree}
+       Tools Tree Distribution: {none_to_none(config.tools_tree_distribution)}
+            Tools Tree Release: {none_to_none(config.tools_tree_release)}
 
                       QEMU GUI: {yes_no(config.qemu_gui)}
                 QEMU CPU Cores: {config.qemu_smp}

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -54,6 +54,14 @@ class DistributionInstaller:
     def default_release(cls) -> str:
         raise NotImplementedError()
 
+    @classmethod
+    def default_tools_tree_distribution(cls) -> "Distribution":
+        raise NotImplementedError()
+
+    @classmethod
+    def tools_tree_packages(cls) -> list[str]:
+        raise NotImplementedError()
+
 
 class Distribution(StrEnum):
     fedora       = enum.auto()
@@ -107,6 +115,12 @@ class Distribution(StrEnum):
 
     def default_release(self) -> str:
         return self.installer().default_release()
+
+    def default_tools_tree_distribution(self) -> "Distribution":
+        return self.installer().default_tools_tree_distribution()
+
+    def tools_tree_packages(self) -> list[str]:
+        return self.installer().tools_tree_packages()
 
     def installer(self) -> Type[DistributionInstaller]:
         try:

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -50,6 +50,10 @@ class DistributionInstaller:
     def package_type(cls) -> PackageType:
         raise NotImplementedError()
 
+    @classmethod
+    def default_release(cls) -> str:
+        raise NotImplementedError()
+
 
 class Distribution(StrEnum):
     fedora       = enum.auto()
@@ -100,6 +104,9 @@ class Distribution(StrEnum):
 
     def package_type(self) -> PackageType:
         return self.installer().package_type()
+
+    def default_release(self) -> str:
+        return self.installer().default_release()
 
     def installer(self) -> Type[DistributionInstaller]:
         try:

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -3,7 +3,7 @@
 from collections.abc import Sequence
 
 from mkosi.architecture import Architecture
-from mkosi.distributions import DistributionInstaller, PackageType
+from mkosi.distributions import Distribution, DistributionInstaller, PackageType
 from mkosi.installer.pacman import invoke_pacman, setup_pacman
 from mkosi.log import die
 from mkosi.state import MkosiState
@@ -21,6 +21,45 @@ class ArchInstaller(DistributionInstaller):
     @classmethod
     def default_release(cls) -> str:
         return "rolling"
+
+    @classmethod
+    def default_tools_tree_distribution(cls) -> Distribution:
+        return Distribution.arch
+
+    @classmethod
+    def tools_tree_packages(cls) -> list[str]:
+        return [
+            "archlinux-keyring",
+            "base",
+            "bash",
+            "btrfs-progs",
+            "bubblewrap",
+            "coreutils",
+            "cpio",
+            "debian-archive-keyring",
+            "dnf",
+            "dosfstools",
+            "e2fsprogs",
+            "edk2-ovmf",
+            "erofs-utils",
+            "mtools",
+            "openssh",
+            "openssl",
+            "pacman",
+            "python-cryptography",
+            "qemu-base",
+            "sbsigntools",
+            "socat",
+            "squashfs-tools",
+            "strace",
+            "swtpm",
+            "systemd-ukify",
+            "systemd",
+            "tar",
+            "xfsprogs",
+            "xz",
+            "zstd",
+        ]
 
     @classmethod
     def setup(cls, state: MkosiState) -> None:

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -19,6 +19,10 @@ class ArchInstaller(DistributionInstaller):
         return PackageType.pkg
 
     @classmethod
+    def default_release(cls) -> str:
+        return "rolling"
+
+    @classmethod
     def setup(cls, state: MkosiState) -> None:
         setup_pacman(state)
 

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from mkosi.architecture import Architecture
 from mkosi.config import MkosiConfig
-from mkosi.distributions import DistributionInstaller, PackageType
+from mkosi.distributions import Distribution, DistributionInstaller, PackageType
 from mkosi.installer.dnf import Repo, invoke_dnf, setup_dnf
 from mkosi.log import complete_step, die
 from mkosi.state import MkosiState
@@ -41,6 +41,40 @@ class CentosInstaller(DistributionInstaller):
     @classmethod
     def default_release(cls) -> str:
         return "9"
+
+    @classmethod
+    def default_tools_tree_distribution(cls) -> Distribution:
+        return Distribution.fedora
+
+    @classmethod
+    def tools_tree_packages(cls) -> list[str]:
+        return [
+            "bash",
+            "bubblewrap",
+            "coreutils",
+            "cpio",
+            "dnf",
+            "dosfstools",
+            "e2fsprogs",
+            "edk2-ovmf",
+            "mtools",
+            "openssh-clients",
+            "openssl",
+            "python3-cryptography",
+            "qemu-kvm-core",
+            "pesign",
+            "socat",
+            "squashfs-tools",
+            "strace",
+            "swtpm",
+            "systemd-container",
+            "systemd-udev",
+            "systemd",
+            "tar",
+            "xfsprogs",
+            "xz",
+            "zstd",
+        ]
 
     @classmethod
     def setup(cls, state: MkosiState) -> None:

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -39,6 +39,10 @@ class CentosInstaller(DistributionInstaller):
         return PackageType.rpm
 
     @classmethod
+    def default_release(cls) -> str:
+        return "9"
+
+    @classmethod
     def setup(cls, state: MkosiState) -> None:
         release = int(state.config.release)
 

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from mkosi.architecture import Architecture
 from mkosi.archive import extract_tar
-from mkosi.distributions import DistributionInstaller, PackageType
+from mkosi.distributions import Distribution, DistributionInstaller, PackageType
 from mkosi.installer.apt import invoke_apt, setup_apt
 from mkosi.log import die
 from mkosi.run import run
@@ -27,6 +27,48 @@ class DebianInstaller(DistributionInstaller):
     @classmethod
     def default_release(cls) -> str:
         return "testing"
+
+    @classmethod
+    def default_tools_tree_distribution(cls) -> Distribution:
+        return Distribution.debian
+
+    @classmethod
+    def tools_tree_packages(cls) -> list[str]:
+        return [
+            "apt",
+            "bash",
+            "btrfs-progs",
+            "bubblewrap",
+            "coreutils",
+            "cpio",
+            "debian-archive-keyring",
+            "dnf",
+            "dosfstools",
+            "e2fsprogs",
+            "erofs-utils",
+            "libtss2-dev",
+            "mtools",
+            "openssh-client",
+            "openssl",
+            "ovmf",
+            "pacman-package-manager",
+            "python3-cryptography",
+            "python3-pefile",
+            "qemu-system",
+            "sbsigntool",
+            "socat",
+            "squashfs-tools",
+            "strace",
+            "swtpm",
+            "systemd-boot",
+            "systemd-container",
+            "systemd",
+            "tar",
+            "xfsprogs",
+            "xz-utils",
+            "zstd",
+            "zypper",
+        ]
 
     @staticmethod
     def repositories(state: MkosiState, local: bool = True) -> list[str]:

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -24,6 +24,10 @@ class DebianInstaller(DistributionInstaller):
     def package_type(cls) -> PackageType:
         return PackageType.deb
 
+    @classmethod
+    def default_release(cls) -> str:
+        return "testing"
+
     @staticmethod
     def repositories(state: MkosiState, local: bool = True) -> list[str]:
         assert state.config.mirror

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -20,6 +20,10 @@ class FedoraInstaller(DistributionInstaller):
         return PackageType.rpm
 
     @classmethod
+    def default_release(cls) -> str:
+        return "38"
+
+    @classmethod
     def setup(cls, state: MkosiState) -> None:
         # See: https://fedoraproject.org/security/
         gpgurls = ("https://fedoraproject.org/fedora.gpg",)

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -4,7 +4,7 @@ import urllib.parse
 from collections.abc import Sequence
 
 from mkosi.architecture import Architecture
-from mkosi.distributions import DistributionInstaller, PackageType
+from mkosi.distributions import Distribution, DistributionInstaller, PackageType
 from mkosi.installer.dnf import Repo, invoke_dnf, setup_dnf
 from mkosi.log import die
 from mkosi.state import MkosiState
@@ -22,6 +22,48 @@ class FedoraInstaller(DistributionInstaller):
     @classmethod
     def default_release(cls) -> str:
         return "39"
+
+    @classmethod
+    def default_tools_tree_distribution(cls) -> Distribution:
+        return Distribution.fedora
+
+    @classmethod
+    def tools_tree_packages(cls) -> list[str]:
+        return [
+            "apt",
+            "archlinux-keyring",
+            "bash",
+            "btrfs-progs",
+            "bubblewrap",
+            "coreutils",
+            "cpio",
+            "debian-keyring",
+            "dnf5",
+            "dosfstools",
+            "e2fsprogs",
+            "edk2-ovmf",
+            "erofs-utils",
+            "mtools",
+            "openssh-clients",
+            "openssl",
+            "pacman",
+            "python3-cryptography",
+            "qemu-kvm-core",
+            "sbsigntools",
+            "socat",
+            "squashfs-tools",
+            "strace",
+            "swtpm",
+            "systemd-container",
+            "systemd-udev",
+            "systemd-ukify",
+            "systemd",
+            "tar",
+            "xfsprogs",
+            "xz",
+            "zstd",
+            "zypper",
+        ]
 
     @classmethod
     def setup(cls, state: MkosiState) -> None:

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -21,7 +21,7 @@ class FedoraInstaller(DistributionInstaller):
 
     @classmethod
     def default_release(cls) -> str:
-        return "38"
+        return "39"
 
     @classmethod
     def setup(cls, state: MkosiState) -> None:

--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from mkosi.architecture import Architecture
 from mkosi.archive import extract_tar
-from mkosi.distributions import DistributionInstaller, PackageType
+from mkosi.distributions import Distribution, DistributionInstaller, PackageType
 from mkosi.log import ARG_DEBUG, complete_step, die
 from mkosi.run import apivfs_cmd, bwrap, chroot_cmd, run
 from mkosi.state import MkosiState
@@ -69,6 +69,10 @@ class GentooInstaller(DistributionInstaller):
     @classmethod
     def default_release(cls) -> str:
         return "17.1"
+
+    @classmethod
+    def default_tools_tree_distribution(cls) -> Distribution:
+        return Distribution.gentoo
 
     @classmethod
     def setup(cls, state: MkosiState) -> None:

--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -67,6 +67,10 @@ class GentooInstaller(DistributionInstaller):
         return PackageType.ebuild
 
     @classmethod
+    def default_release(cls) -> str:
+        return "17.1"
+
+    @classmethod
     def setup(cls, state: MkosiState) -> None:
         pass
 

--- a/mkosi/distributions/mageia.py
+++ b/mkosi/distributions/mageia.py
@@ -3,7 +3,7 @@
 from collections.abc import Sequence
 
 from mkosi.architecture import Architecture
-from mkosi.distributions import DistributionInstaller, PackageType
+from mkosi.distributions import Distribution, DistributionInstaller, PackageType
 from mkosi.installer.dnf import Repo, invoke_dnf, setup_dnf
 from mkosi.log import die
 from mkosi.state import MkosiState
@@ -21,6 +21,10 @@ class MageiaInstaller(DistributionInstaller):
     @classmethod
     def default_release(cls) -> str:
         return "cauldron"
+
+    @classmethod
+    def default_tools_tree_distribution(cls) -> Distribution:
+        return Distribution.mageia
 
     @classmethod
     def setup(cls, state: MkosiState) -> None:

--- a/mkosi/distributions/mageia.py
+++ b/mkosi/distributions/mageia.py
@@ -19,6 +19,10 @@ class MageiaInstaller(DistributionInstaller):
         return PackageType.rpm
 
     @classmethod
+    def default_release(cls) -> str:
+        return "cauldron"
+
+    @classmethod
     def setup(cls, state: MkosiState) -> None:
         release = state.config.release.strip("'")
         arch = state.config.distribution.architecture(state.config.architecture)

--- a/mkosi/distributions/openmandriva.py
+++ b/mkosi/distributions/openmandriva.py
@@ -19,6 +19,10 @@ class OpenmandrivaInstaller(DistributionInstaller):
         return PackageType.rpm
 
     @classmethod
+    def default_release(cls) -> str:
+        return "cooker"
+
+    @classmethod
     def setup(cls, state: MkosiState) -> None:
         release = state.config.release.strip("'")
         arch = state.config.distribution.architecture(state.config.architecture)

--- a/mkosi/distributions/openmandriva.py
+++ b/mkosi/distributions/openmandriva.py
@@ -3,7 +3,7 @@
 from collections.abc import Sequence
 
 from mkosi.architecture import Architecture
-from mkosi.distributions import DistributionInstaller, PackageType
+from mkosi.distributions import Distribution, DistributionInstaller, PackageType
 from mkosi.installer.dnf import Repo, invoke_dnf, setup_dnf
 from mkosi.log import die
 from mkosi.state import MkosiState
@@ -21,6 +21,10 @@ class OpenmandrivaInstaller(DistributionInstaller):
     @classmethod
     def default_release(cls) -> str:
         return "cooker"
+
+    @classmethod
+    def default_tools_tree_distribution(cls) -> Distribution:
+        return Distribution.openmandriva
 
     @classmethod
     def setup(cls, state: MkosiState) -> None:

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -6,7 +6,7 @@ import xml.etree.ElementTree as ElementTree
 from collections.abc import Sequence
 
 from mkosi.architecture import Architecture
-from mkosi.distributions import DistributionInstaller, PackageType
+from mkosi.distributions import Distribution, DistributionInstaller, PackageType
 from mkosi.installer.dnf import Repo, invoke_dnf, setup_dnf
 from mkosi.installer.zypper import invoke_zypper, setup_zypper
 from mkosi.log import die
@@ -25,6 +25,44 @@ class OpensuseInstaller(DistributionInstaller):
     @classmethod
     def default_release(cls) -> str:
         return "tumbleweed"
+
+    @classmethod
+    def default_tools_tree_distribution(cls) -> Distribution:
+        return Distribution.opensuse
+
+    @classmethod
+    def tools_tree_packages(cls) -> list[str]:
+        return [
+            "bash",
+            "btrfs-progs",
+            "bubblewrap",
+            "coreutils",
+            "cpio",
+            "dnf",
+            "dosfstools",
+            "e2fsprogs",
+            "erofs-utils",
+            "grep",
+            "mtools",
+            "openssh-clients",
+            "openssl",
+            "ovmf",
+            "qemu-headless",
+            "sbsigntools",
+            "socat",
+            "squashfs",
+            "strace",
+            "swtpm",
+            "systemd-boot",
+            "systemd-container",
+            "systemd-experimental",
+            "systemd",
+            "tar",
+            "xfsprogs",
+            "xz",
+            "zstd",
+            "zypper",
+        ]
 
     @classmethod
     def setup(cls, state: MkosiState) -> None:

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -23,6 +23,10 @@ class OpensuseInstaller(DistributionInstaller):
         return PackageType.rpm
 
     @classmethod
+    def default_release(cls) -> str:
+        return "tumbleweed"
+
+    @classmethod
     def setup(cls, state: MkosiState) -> None:
         release = state.config.release
         if release == "leap":

--- a/mkosi/distributions/ubuntu.py
+++ b/mkosi/distributions/ubuntu.py
@@ -6,6 +6,10 @@ from mkosi.state import MkosiState
 
 
 class UbuntuInstaller(DebianInstaller):
+    @classmethod
+    def default_release(cls) -> str:
+        return "lunar"
+
     @staticmethod
     def repositories(state: MkosiState, local: bool = True) -> list[str]:
         if state.config.local_mirror and local:

--- a/mkosi/manifest.py
+++ b/mkosi/manifest.py
@@ -3,6 +3,7 @@
 import dataclasses
 import datetime
 import json
+import logging
 import subprocess
 import textwrap
 from pathlib import Path
@@ -279,9 +280,9 @@ class Manifest:
         packages, and includes the changelogs. A diff between two such
         reports shows what changed *in* the packages quite nicely.
         """
-        print(f"Packages: {len(self.packages)}", file=out)
-        print(f"Size:     {sum(p.size for p in self.packages)}", file=out)
+        logging.info(f"Packages: {len(self.packages)}")
+        logging.info(f"Size:     {sum(p.size for p in self.packages)}")
 
         for package in self.source_packages.values():
-            print(f"\n{80*'-'}\n", file=out)
+            logging.info(f"\n{80*'-'}\n")
             out.write(package.report())

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -1114,6 +1114,22 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
   `--extra-search-path=` are ignored when looking up binaries in the
   given tools tree.
 
+: If set to `default`, mkosi will automatically add an extra tools tree
+  preset and use it as the tools tree.
+
+`ToolsTreeDistribution=`, `--tools-tree-distribution=`
+
+: Set the distribution to use for the default tools tree. By default,
+  the same distribution as the image that's being built is used, except
+  for CentOS and Ubuntu images, in which case Fedora and Debian are used
+  respectively.
+
+`ToolsTreeRelease=`, `--tools-tree-release=`
+
+: Set the distribution release to use for the default tools tree. By
+  default, the hardcoded default release in mkosi for the distribution
+  is used.
+
 ## Supported distributions
 
 Images may be created containing installations of the following

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -15,7 +15,6 @@ import pwd
 import re
 import resource
 import stat
-import sys
 import tempfile
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from pathlib import Path
@@ -54,7 +53,7 @@ def read_os_release() -> Iterator[tuple[str, str]]:
                     val = ast.literal_eval(val)
                 yield name, val
             else:
-                print(f"{filename}:{line_number}: bad line {line!r}", file=sys.stderr)
+                logging.info(f"{filename}:{line_number}: bad line {line!r}")
 
 
 def format_rlimit(rlimit: int) -> str:


### PR DESCRIPTION
Instead of requiring users to always set up a tools tree preset, let's
allow specifying "default" as the tools tree to have mkosi build a default
tools tree itself. This default tools tree includes all the software that
might be necessary to build an image (excluding software that might be
required by various user scripts).

For distributions that do not have a rolling release variant, we use the
closest matching distribution. e.g. for CentOS, we use Fedora and for
Ubuntu we use Debian.
