### PR TITLE
CI: pin CentOS 9 kernel to workaround panic on shutdown

### DIFF
--- a/.github/mkosi.conf.d/20-alma-rocky.conf
+++ b/.github/mkosi.conf.d/20-alma-rocky.conf
@@ -1,5 +1,4 @@
 [Match]
-Distribution=|centos
 Distribution=|alma
 Distribution=|rocky
 

--- a/.github/mkosi.conf.d/20-centos9.conf
+++ b/.github/mkosi.conf.d/20-centos9.conf
@@ -1,0 +1,11 @@
+[Match]
+Distribution=centos
+Release=9
+
+[Content]
+Packages=
+         kernel-core-5.14.0-354.el9
+         systemd
+         systemd-boot
+         udev
+         grub2-pc


### PR DESCRIPTION
Newer kernels are affected by a regression that causes a kernel panic on shutdown, so pin them for now. Can be reverted once that problem is fixed.

https://bugzilla.redhat.com/show_bug.cgi?id=2234390