### PR TITLE
Temporarily disable keyring checking for Arch

### DIFF
--- a/.github/mkosi.conf.d/20-arch.conf
+++ b/.github/mkosi.conf.d/20-arch.conf
@@ -1,6 +1,10 @@
 [Match]
 Distribution=arch
 
+[Distribution]
+# TODO: Remove once archlinux-keyring is updated in ppa:michel-slm/kernel-utils.
+RepositoryKeyCheck=no
+
 [Content]
 Packages=linux
          systemd


### PR DESCRIPTION
Until the archlinux-keyring package is updated, let's disable keyring checking for Arch.