### PR TITLE
Do not run modinfo on builtin modules

### DIFF
--- a/mkosi/kmod.py
+++ b/mkosi/kmod.py
@@ -58,7 +58,7 @@ def resolve_module_dependencies(root: Path, kver: str, modules: Sequence[str]) -
     # We could run modinfo once for each module but that's slow. Luckily we can pass multiple modules to
     # modinfo and it'll process them all in a single go. We get the modinfo for all modules to build two maps
     # that map the path of the module to its module dependencies and its firmware dependencies respectively.
-    info = bwrap(chroot_cmd(root) + ["modinfo", "--set-version", kver, "--null", *nametofile.keys(), *builtin],
+    info = bwrap(chroot_cmd(root) + ["modinfo", "--set-version", kver, "--null", *nametofile.keys()],
                  stdout=subprocess.PIPE).stdout
 
     log_step("Calculating required kernel modules and firmware")


### PR DESCRIPTION
This causes issues on CentOS Stream 8 with errors about not being able to find builtin modules.

Aside from the issues, running modinfo on builtin modules also does not make a lot of sense. We run modinfo to fetch module and firmware dependencies, but a builtin module that has non-builtin module dependencies is not really valuable because the dependent module has to be loaded from disk then. The same goes for firmware dependencies.