### PR TITLE
Make the empty string reset settings to their default value

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -148,14 +148,16 @@ def test_parse_config(tmp_path: Path) -> None:
         """\
         [Content]
         Packages=
+        ImageId=
         """
     )
 
     with chdir(tmp_path):
         _, [config] = parse_config()
 
-    # Test that empty string resets the list.
+    # Test that empty assignment resets settings.
     assert config.packages == []
+    assert config.image_id is None
     # mkosi.version should only be used if no version is set explicitly.
     assert config.image_version == "0"
 


### PR DESCRIPTION
If the empty string is assigned, we should make sure the setting is assigned its default value so let's make sure we return None in that case after all