### PR TITLE
Follow up for 5462f5e31c4223a001c2ed5aa8d44177fb8454fc

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -247,9 +247,6 @@ def config_parse_feature(value: Optional[str], old: Optional[ConfigFeature]) -> 
 
 
 def config_match_feature(match: str, value: ConfigFeature) -> bool:
-    if not value:
-        return False
-
     return value == parse_feature(match)
 
 


### PR DESCRIPTION
The value can't be None anymore so remove redundant check.