### PR TITLE
ci: use https for OpenSUSE again

### DIFF
--- a/.github/mkosi.conf.d/20-opensuse.conf
+++ b/.github/mkosi.conf.d/20-opensuse.conf
@@ -1,6 +1,9 @@
 [Match]
 Distribution=opensuse
 
+[Distribution]
+Mirror=https://download.opensuse.org
+
 [Content]
 Packages=kernel-kvmsmall
          systemd


### PR DESCRIPTION
The CI is now running a version of libzypp that should improve the https situation, let's test it for a while