### PR TITLE
Remove package manager generated hwdb from /etc

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1513,6 +1513,9 @@ def run_hwdb(state: MkosiState) -> None:
     with complete_step("Generating hardware database"):
         run(["systemd-hwdb", "--root", state.root, "--usr", "--strict", "update"])
 
+    # Remove any existing hwdb in /etc in favor of the one we just put in /usr.
+    (state.root / "etc/udev/hwdb.bin").unlink(missing_ok=True)
+
 
 def run_firstboot(state: MkosiState) -> None:
     password, hashed = state.config.root_password or (None, False)


### PR DESCRIPTION
We generate the hwdb in /usr, so remove any existing one that is leftover in /etc.