### PR TITLE
Install ca-certificates in tools tree and make sure it's used

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -43,7 +43,7 @@ from mkosi.installer import clean_package_manager_metadata, package_manager_scri
 from mkosi.kmod import gen_required_kernel_modules, process_kernel_modules
 from mkosi.log import ARG_DEBUG, complete_step, die, log_step
 from mkosi.manifest import Manifest
-from mkosi.mounts import mount_overlay, mount_passwd, mount_usr
+from mkosi.mounts import mount, mount_overlay, mount_passwd, mount_usr
 from mkosi.pager import page
 from mkosi.qemu import copy_ephemeral, run_qemu, run_ssh
 from mkosi.run import become_root, bwrap, chroot_cmd, init_mount_namespace, run
@@ -2193,6 +2193,34 @@ def finalize_tools(args: MkosiArgs, presets: Sequence[MkosiConfig]) -> Sequence[
     return new
 
 
+@contextlib.contextmanager
+def mount_tools(tree: Optional[Path]) -> Iterator[None]:
+    if not tree:
+        yield
+        return
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(mount_usr(tree))
+
+        # On recent Fedora versions, rpm has started doing very strict checks on GPG certificate validity. To
+        # make these checks pass, we need to make sure a few directories from /etc in the tools tree are
+        # mounted into the host as well. Because the directories might not exist on the host, we mount a
+        # writable directory on top of /etc in an overlay so we can create these mountpoints without running
+        # into permission errors.
+
+        tmp = stack.enter_context(tempfile.TemporaryDirectory(dir="/var/tmp"))
+        stack.enter_context(mount_overlay([Path("/etc")], Path(tmp), Path("/etc"), read_only=False))
+
+        for subdir in ("etc/pki", "etc/ssl", "etc/crypto-policies", "etc/ca-certificates"):
+            if not (tree / subdir).exists():
+                continue
+
+            (Path("/") / subdir).mkdir(parents=True, exist_ok=True)
+            stack.enter_context(mount(what=tree / subdir, where=Path("/") / subdir, operation="--bind", read_only=True))
+
+        yield
+
+
 def run_verb(args: MkosiArgs, presets: Sequence[MkosiConfig]) -> None:
     if args.verb.needs_root() and os.getuid() != 0:
         die(f"Must be root to run the {args.verb} command")
@@ -2277,7 +2305,7 @@ def run_verb(args: MkosiArgs, presets: Sequence[MkosiConfig]) -> None:
             continue
 
         with complete_step(f"Building {config.preset or 'default'} image"),\
-            mount_usr(config.tools_tree),\
+            mount_tools(config.tools_tree),\
             prepend_to_environ_path(config):
 
             # Create these as the invoking user to make sure they're owned by the user running mkosi.

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -943,6 +943,7 @@ def build_initrd(state: MkosiState) -> Path:
         *(["--timezone", state.config.timezone] if state.config.timezone else []),
         *(["--hostname", state.config.hostname] if state.config.hostname else []),
         *(["--root-password", rootpwopt] if rootpwopt else []),
+        *([f"--environment={k}='{v}'" for k, v in state.config.environment.items()]),
         *(["-f"] * state.args.force),
         "build",
     ]
@@ -2176,6 +2177,7 @@ def finalize_tools(args: MkosiArgs, presets: Sequence[MkosiConfig]) -> Sequence[
             "--bootable", "no",
             "--manifest-format", "",
             *(["--source-date-epoch", str(p.source_date_epoch)] if p.source_date_epoch is not None else []),
+            *([f"--environment={k}='{v}'" for k, v in p.environment.items()]),
             *(["-f"] * args.force),
             "build",
         ]

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -34,6 +34,7 @@ class ArchInstaller(DistributionInstaller):
             "bash",
             "btrfs-progs",
             "bubblewrap",
+            "ca-certificates",
             "coreutils",
             "cpio",
             "debian-archive-keyring",

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -51,6 +51,7 @@ class CentosInstaller(DistributionInstaller):
         return [
             "bash",
             "bubblewrap",
+            "ca-certificates",
             "coreutils",
             "cpio",
             "dnf",
@@ -60,9 +61,9 @@ class CentosInstaller(DistributionInstaller):
             "mtools",
             "openssh-clients",
             "openssl",
+            "pesign",
             "python3-cryptography",
             "qemu-kvm-core",
-            "pesign",
             "socat",
             "squashfs-tools",
             "strace",

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -39,6 +39,7 @@ class DebianInstaller(DistributionInstaller):
             "bash",
             "btrfs-progs",
             "bubblewrap",
+            "ca-certificates",
             "coreutils",
             "cpio",
             "debian-archive-keyring",

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -35,6 +35,7 @@ class FedoraInstaller(DistributionInstaller):
             "bash",
             "btrfs-progs",
             "bubblewrap",
+            "ca-certificates",
             "coreutils",
             "cpio",
             "debian-keyring",

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -36,6 +36,7 @@ class OpensuseInstaller(DistributionInstaller):
             "bash",
             "btrfs-progs",
             "bubblewrap",
+            "ca-certificates",
             "coreutils",
             "cpio",
             "dnf",


### PR DESCRIPTION
Too old ca-certificates on the host can cause package manager failures when using a tools tree, so let's install ca-certificates into the tools tree and make sure it is used.