### PR TITLE
Rename "direct" firmware option to "linux"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,9 @@
   distribution and release to use can be configured with
   `ToolsTreeDistribution=` and `ToolsTreeRelease=` or are determined
   automatically based on the image being built.
+- Added `uki` output format. This is similar to `cpio`, except the cpio
+  is packaged up as a UKI with a kernel image and stub picked up from
+  the rootfs.
 
 ## v15.1
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -130,7 +130,7 @@ class BiosBootloader(StrEnum):
 
 class QemuFirmware(StrEnum):
     auto   = enum.auto()
-    direct = enum.auto()
+    linux  = enum.auto()
     uefi   = enum.auto()
     bios   = enum.auto()
 

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -222,7 +222,7 @@ def run_qemu(args: MkosiArgs, config: MkosiConfig) -> None:
     if config.output_format == OutputFormat.uki and config.qemu_firmware not in (QemuFirmware.auto, QemuFirmware.uefi):
         die(f"uki images cannot be booted with the '{config.qemu_firmware}' firmware")
 
-    if config.output_format == OutputFormat.cpio and config.qemu_firmware not in (QemuFirmware.auto, QemuFirmware.direct, QemuFirmware.uefi):
+    if config.output_format == OutputFormat.cpio and config.qemu_firmware not in (QemuFirmware.auto, QemuFirmware.linux, QemuFirmware.uefi):
         die(f"cpio images cannot be booted with the '{config.qemu_firmware}' firmware")
 
     accel = "tcg"
@@ -231,7 +231,7 @@ def run_qemu(args: MkosiArgs, config: MkosiConfig) -> None:
         accel = "kvm"
 
     if config.qemu_firmware == QemuFirmware.auto:
-        firmware = QemuFirmware.direct if config.output_format == OutputFormat.cpio else QemuFirmware.uefi
+        firmware = QemuFirmware.linux if config.output_format == OutputFormat.cpio else QemuFirmware.uefi
     else:
         firmware = config.qemu_firmware
 
@@ -321,7 +321,7 @@ def run_qemu(args: MkosiArgs, config: MkosiConfig) -> None:
                  "--offline=yes",
                  fname])
 
-        if firmware == QemuFirmware.direct or config.output_format in (OutputFormat.cpio, OutputFormat.uki):
+        if firmware == QemuFirmware.linux or config.output_format in (OutputFormat.cpio, OutputFormat.uki):
             if config.output_format == OutputFormat.uki:
                 kernel = fname
             elif config.qemu_kernel:
@@ -350,7 +350,7 @@ def run_qemu(args: MkosiArgs, config: MkosiConfig) -> None:
         if config.output_format == OutputFormat.cpio:
             cmdline += ["-initrd", fname]
         elif config.output_format == OutputFormat.disk:
-            if firmware == QemuFirmware.direct:
+            if firmware == QemuFirmware.linux:
                 cmdline += ["-initrd", config.output_dir / config.output_split_initrd]
 
             cmdline += ["-drive", f"if=none,id=mkosi,file={fname},format=raw",

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -1050,12 +1050,12 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 `QemuFirmware=`, `--qemu-firmware=`
 
 : When used with the `qemu` verb, this option which firmware to use.
-  Takes one of `uefi`, `bios`, `direct`, or `auto`. Defaults to `auto`.
+  Takes one of `uefi`, `bios`, `linux`, or `auto`. Defaults to `auto`.
   When set to `uefi`, the OVMF firmware is used. When set to `bios`, the
-  default SeaBIOS firmware is used. When set to `direct`, direct kernel
+  default SeaBIOS firmware is used. When set to `linux`, direct kernel
   boot is used. See the `QemuKernel=` option for more details on which
   kernel image is used with direct kernel boot. When set to `auto`,
-  `direct` is used if a cpio image is being booted, `uefi` otherwise.
+  `linux` is used if a cpio image is being booted, `uefi` otherwise.
 
 `QemuKernel=`, `--qemu-kernel=`
 


### PR DESCRIPTION
"linux" seems like a better name rather than "direct" since we're
using Linux itself as the firmware here in a sense.
