### PR TITLE
Drop Arch workaround

### DIFF
--- a/.github/mkosi.conf.d/20-arch.conf
+++ b/.github/mkosi.conf.d/20-arch.conf
@@ -1,10 +1,6 @@
 [Match]
 Distribution=arch
 
-[Distribution]
-# TODO: Remove once archlinux-keyring is updated in ppa:michel-slm/kernel-utils.
-RepositoryKeyCheck=no
-
 [Content]
 Packages=linux
          systemd


### PR DESCRIPTION
archlinux-keyring should have been updated so this issue should be fixed now.