### PR TITLE
Always set distribution in tests 

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -292,6 +292,15 @@ def config_default_compression(namespace: argparse.Namespace) -> Compression:
         return Compression.none
 
 
+def config_default_distribution(namespace: argparse.Namespace) -> Distribution:
+    detected = detect_distribution()[0]
+
+    if not detected:
+        die("Distribution of your host can't be detected or isn't a supported target. Please set Distribution= in your config.")
+
+    return detected
+
+
 def config_default_release(namespace: argparse.Namespace) -> str:
     # If the configured distribution matches the host distribution, use the same release as the host.
     hd, hr = detect_distribution()
@@ -896,7 +905,7 @@ SETTINGS = (
         section="Distribution",
         parse=config_make_enum_parser(Distribution),
         match=config_make_enum_matcher(Distribution),
-        default=detect_distribution()[0],
+        default_factory=config_default_distribution,
         choices=Distribution.values(),
         help="Distribution to install",
     ),


### PR DESCRIPTION
This enables executing the tests on distributions that aren't targeted by mkosi. Before, the tests would fail as the detected distribution was None.