### PR TITLE
Add ruff config to `pyprojects.toml` and address its warnings

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -19,7 +19,7 @@ import textwrap
 import uuid
 from collections.abc import Iterator, Sequence
 from pathlib import Path
-from typing import ContextManager, Optional, TextIO, Union
+from typing import Optional, TextIO, Union
 
 from mkosi.archive import extract_tar, make_cpio, make_tar
 from mkosi.config import (
@@ -151,7 +151,9 @@ def install_build_packages(state: MkosiState) -> None:
     if not need_build_packages(state.config):
         return
 
-    with complete_step(f"Installing build packages for {str(state.config.distribution).capitalize()}"), mount_build_overlay(state):
+    # TODO: move to parenthesised context managers once on 3.10
+    pd = str(state.config.distribution).capitalize()
+    with complete_step(f"Installing build packages for {pd}"), mount_build_overlay(state):
         state.config.distribution.install_packages(state, state.config.build_packages)
 
 
@@ -196,7 +198,7 @@ def mount_cache_overlay(state: MkosiState) -> Iterator[None]:
         yield
 
 
-def mount_build_overlay(state: MkosiState, read_only: bool = False) -> ContextManager[Path]:
+def mount_build_overlay(state: MkosiState, read_only: bool = False) -> contextlib.AbstractContextManager[Path]:
     d = state.workspace / "build-overlay"
     if not d.is_symlink():
         with umask(~0o755):
@@ -559,7 +561,7 @@ def find_grub_bios_directory(state: MkosiState) -> Optional[Path]:
 def find_grub_binary(state: MkosiState, binary: str) -> Optional[Path]:
     path = ":".join(os.fspath(p) for p in [state.root / "usr/bin", state.root / "usr/sbin"])
 
-    assert "grub" in binary and not "grub2" in binary
+    assert "grub" in binary and "grub2" not in binary
 
     path = shutil.which(binary, path=path) or shutil.which(binary.replace("grub", "grub2"), path=path)
     if not path:
@@ -716,12 +718,18 @@ def prepare_grub_bios(state: MkosiState, partitions: Sequence[Partition]) -> Non
                 kimg = Path(shutil.copy2(state.root / kimg, kdst / "vmlinuz"))
                 kmods = Path(shutil.copy2(kmods, kdst / "kmods"))
 
+                distribution = state.config.distribution
+                image = kimg.relative_to(state.root / "efi")
+                cmdline = " ".join(state.config.kernel_command_line)
+                initrd = initrd.relative_to(state.root / "efi")
+                kmods = kmods.relative_to(state.root / "efi")
+
                 f.write(
                     textwrap.dedent(
                         f"""\
-                        menuentry "{state.config.distribution}-{kver}" {{
-                            linux /{kimg.relative_to(state.root / "efi")} {root} {" ".join(state.config.kernel_command_line)}
-                            initrd /{initrd.relative_to(state.root / "efi")} /{kmods.relative_to(state.root / "efi")}
+                        menuentry "{distribution}-{kver}" {{
+                            linux /{image} {root} {cmdline}
+                            initrd /{initrd} /{kmods}
                         }}
                         """
                     )
@@ -914,7 +922,11 @@ def build_initrd(state: MkosiState) -> Path:
         "--make-initrd", "yes",
         "--bootable", "no",
         "--manifest-format", "",
-        *(["--source-date-epoch", str(state.config.source_date_epoch)] if state.config.source_date_epoch is not None else []),
+        *(
+            ["--source-date-epoch", str(state.config.source_date_epoch)]
+            if state.config.source_date_epoch is not None else
+            []
+        ),
         *(["--locale", state.config.locale] if state.config.locale else []),
         *(["--locale-messages", state.config.locale_messages] if state.config.locale_messages else []),
         *(["--keymap", state.config.keymap] if state.config.keymap else []),
@@ -1084,7 +1096,10 @@ def install_uki(state: MkosiState, partitions: Sequence[Partition]) -> None:
         shutil.copy(state.root / kimg, state.staging / state.config.output_split_kernel)
         break
 
-    if state.config.output_format in (OutputFormat.cpio, OutputFormat.uki) and state.config.bootable == ConfigFeature.auto:
+    if (
+        state.config.output_format in (OutputFormat.cpio, OutputFormat.uki) and
+        state.config.bootable == ConfigFeature.auto
+    ):
         return
 
     if state.config.architecture.to_efi() is None and state.config.bootable == ConfigFeature.auto:
@@ -1110,7 +1125,9 @@ def install_uki(state: MkosiState, partitions: Sequence[Partition]) -> None:
             if state.config.bootloader == Bootloader.uki:
                 boot_binary = state.root / "efi/EFI/BOOT/BOOTX64.EFI"
             elif state.config.image_version:
-                boot_binary = state.root / f"efi/EFI/Linux/{image_id}_{state.config.image_version}-{kver}{boot_count}.efi"
+                boot_binary = (
+                    state.root / f"efi/EFI/Linux/{image_id}_{state.config.image_version}-{kver}{boot_count}.efi"
+                )
             elif roothash:
                 _, _, h = roothash.partition("=")
                 boot_binary = state.root / f"efi/EFI/Linux/{image_id}-{kver}-{h}{boot_count}.efi"
@@ -1245,7 +1262,7 @@ def calculate_signature(state: MkosiState) -> None:
         # Set the path of the keyring to use based on the environment if possible and fallback to the default
         # path. Without this the keyring for the root user will instead be used which will fail for a
         # non-root build.
-        env = dict(GNUPGHOME=os.environ.get("GNUPGHOME", os.fspath(((Path(os.environ["HOME"]) / ".gnupg")))))
+        env = dict(GNUPGHOME=os.environ.get("GNUPGHOME", os.fspath(Path(os.environ["HOME"]) / ".gnupg")))
         if sys.stderr.isatty():
             env |= dict(GPGTTY=os.ttyname(sys.stderr.fileno()))
 
@@ -2079,7 +2096,8 @@ def bump_image_version(uid: int = -1, gid: int = -1) -> None:
     except ValueError:
         new_version = version + ".2"
         logging.info(
-            f"Last component of current version is not a decimal integer, appending '.2', bumping '{version}' → '{new_version}'."
+            "Last component of current version is not a decimal integer, "
+            f"appending '.2', bumping '{version}' → '{new_version}'."
         )
     else:
         new_version = ".".join(v[:-1] + [str(m + 1)])
@@ -2130,7 +2148,10 @@ def expand_specifier(s: str) -> str:
 
 
 def needs_build(args: MkosiArgs, config: MkosiConfig) -> bool:
-    return args.verb.needs_build() and (args.force > 0 or not (config.output_dir / config.output_with_compression).exists())
+    return (
+        args.verb.needs_build() and
+        (args.force > 0 or not (config.output_dir / config.output_with_compression).exists())
+    )
 
 
 @contextlib.contextmanager
@@ -2179,7 +2200,10 @@ def finalize_tools(args: MkosiArgs, presets: Sequence[MkosiConfig]) -> Sequence[
             "--incremental", str(p.incremental),
             "--acl", str(p.acl),
             "--format", "directory",
-            *flatten(["--package", package] for package in itertools.chain(distribution.tools_tree_packages(), p.tools_tree_packages)),
+            *flatten(
+                ["--package", package]
+                for package in itertools.chain(distribution.tools_tree_packages(), p.tools_tree_packages))
+            ,
             "--output", f"{distribution}-tools",
             "--bootable", "no",
             "--manifest-format", "",
@@ -2223,7 +2247,9 @@ def mount_tools(tree: Optional[Path]) -> Iterator[None]:
                 continue
 
             (Path("/") / subdir).mkdir(parents=True, exist_ok=True)
-            stack.enter_context(mount(what=tree / subdir, where=Path("/") / subdir, operation="--bind", read_only=True))
+            stack.enter_context(
+                mount(what=tree / subdir, where=Path("/") / subdir, operation="--bind", read_only=True)
+            )
 
         yield
 

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -4,7 +4,7 @@ import enum
 import importlib
 import re
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Optional, Type, cast
+from typing import TYPE_CHECKING, Optional, cast
 
 from mkosi.architecture import Architecture
 from mkosi.log import die
@@ -122,13 +122,13 @@ class Distribution(StrEnum):
     def tools_tree_packages(self) -> list[str]:
         return self.installer().tools_tree_packages()
 
-    def installer(self) -> Type[DistributionInstaller]:
+    def installer(self) -> type[DistributionInstaller]:
         try:
             mod = importlib.import_module(f"mkosi.distributions.{self}")
             installer = getattr(mod, f"{str(self).title().replace('_','')}Installer")
             if not issubclass(installer, DistributionInstaller):
                 die(f"Distribution installer for {self} is not a subclass of DistributionInstaller")
-            return cast(Type[DistributionInstaller], installer)
+            return cast(type[DistributionInstaller], installer)
         except (ImportError, AttributeError):
             die("No installer for this distribution.")
 

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -110,7 +110,12 @@ class FedoraInstaller(DistributionInstaller):
             if state.config.release != "rawhide":
                 repos += [
                     Repo("updates", f"{url}&repo=updates-released-f$releasever", gpgurls),
-                    Repo("updates-debuginfo", f"{url}&repo=updates-released-debug-f$releasever", gpgurls, enabled=False),
+                    Repo(
+                        "updates-debuginfo",
+                        f"{url}&repo=updates-released-debug-f$releasever",
+                        gpgurls,
+                        enabled=False,
+                    ),
                     Repo("updates-source", f"{url}&repo=updates-released-source-f$releasever", gpgurls, enabled=False),
                 ]
 

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -95,7 +95,9 @@ class OpensuseInstaller(DistributionInstaller):
         else:
             repos = [Repo("repo-oss", f"baseurl={release_url}", fetch_gpgurls(release_url) if not zypper else ())]
             if updates_url is not None:
-                repos += [Repo("repo-update", f"baseurl={updates_url}", fetch_gpgurls(updates_url) if not zypper else ())]
+                repos += [
+                    Repo("repo-update", f"baseurl={updates_url}", fetch_gpgurls(updates_url) if not zypper else ())
+                ]
 
         if zypper:
             setup_zypper(state, repos)

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -60,7 +60,9 @@ def apt_cmd(state: MkosiState, command: str) -> list[PathString]:
     debarch = state.config.distribution.architecture(state.config.architecture)
 
     trustedkeys = state.pkgmngr / "etc/apt/trusted.gpg"
-    trustedkeys = trustedkeys if trustedkeys.exists() else f"/usr/share/keyrings/{state.config.distribution}-archive-keyring.gpg"
+    trustedkeys = (
+        trustedkeys if trustedkeys.exists() else f"/usr/share/keyrings/{state.config.distribution}-archive-keyring.gpg"
+    )
     trustedkeys_dir = state.pkgmngr / "etc/apt/trusted.gpg.d"
     trustedkeys_dir = trustedkeys_dir if trustedkeys_dir.exists() else "/usr/share/keyrings"
 

--- a/mkosi/log.py
+++ b/mkosi/log.py
@@ -5,7 +5,8 @@ import contextvars
 import logging
 import os
 import sys
-from typing import Any, Iterator, NoReturn, Optional
+from collections.abc import Iterator
+from typing import Any, NoReturn, Optional
 
 # This global should be initialized after parsing arguments
 ARG_DEBUG = contextvars.ContextVar("debug", default=False)

--- a/mkosi/mounts.py
+++ b/mkosi/mounts.py
@@ -124,7 +124,13 @@ def mount_usr(tree: Optional[Path], umount: bool = True) -> Iterator[None]:
         # If we mounted over /usr, trying to use umount will fail with "target is busy", because umount is
         # being called from /usr, which we're trying to unmount. To work around this issue, we do a lazy
         # unmount.
-        with mount(what=tree / "usr", where=Path("/usr"), operation="--bind", read_only=True, umount=umount, lazy=True):
+        with mount(
+            what=tree / "usr",
+            where=Path("/usr"),
+            operation="--bind",
+            read_only=True,
+            umount=umount, lazy=True
+        ):
             yield
     finally:
         os.environ["PATH"] = old

--- a/mkosi/partition.py
+++ b/mkosi/partition.py
@@ -1,9 +1,9 @@
 import dataclasses
 import json
 import subprocess
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any, Mapping, Optional
+from typing import Any, Optional
 
 from mkosi.log import die
 from mkosi.run import run

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -17,9 +17,10 @@ import sys
 import tempfile
 import textwrap
 import threading
+from collections.abc import Awaitable, Mapping, Sequence
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Awaitable, Mapping, Optional, Sequence, Tuple, Type
+from typing import Any, Optional
 
 from mkosi.log import ARG_DEBUG, ARG_DEBUG_SHELL, die
 from mkosi.types import _FILE, CompletedProcess, PathString, Popen
@@ -58,7 +59,10 @@ def read_subrange(path: Path) -> int:
         die(f"No mapping found for {user or uid} in {path}")
 
     if int(count) < SUBRANGE:
-        die(f"subuid/subgid range length must be at least {SUBRANGE}, got {count} for {user or uid} from line '{line}'")
+        die(
+            f"subuid/subgid range length must be at least {SUBRANGE}, "
+            f"got {count} for {user or uid} from line '{line}'"
+        )
 
     return int(start)
 
@@ -142,7 +146,7 @@ def foreground(*, new_process_group: bool = True) -> None:
         signal.signal(signal.SIGTTOU, old)
 
 
-def ensure_exc_info() -> Tuple[Type[BaseException], BaseException, TracebackType]:
+def ensure_exc_info() -> tuple[type[BaseException], BaseException, TracebackType]:
     exctype, exc, tb = sys.exc_info()
     assert exctype
     assert exc
@@ -339,7 +343,8 @@ def bwrap(
             result = run([*cmdline, *cmd], env=env, log=False, stdin=stdin, stdout=stdout, input=input)
         except subprocess.CalledProcessError as e:
             if log:
-                logging.error(f"\"{shlex.join(os.fspath(s) for s in cmd)}\" returned non-zero exit code {e.returncode}.")
+                c = shlex.join(os.fspath(s) for s in cmd)
+                logging.error(f"\"{c}\" returned non-zero exit code {e.returncode}.")
             if ARG_DEBUG_SHELL.get():
                 run([*cmdline, "sh"], stdin=sys.stdin, check=False, env=env, log=False)
             raise e
@@ -465,7 +470,7 @@ class MkosiAsyncioThread(threading.Thread):
 
     def __exit__(
         self,
-        type: Optional[Type[BaseException]],
+        type: Optional[type[BaseException]],
         value: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> None:

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -67,8 +67,7 @@ def sort_packages(packages: Iterable[str]) -> list[str]:
     """Sorts packages: normal first, paths second, conditional third"""
 
     m = {"(": 2, "/": 1}
-    sort = lambda name: (m.get(name[0], 0), name)
-    return sorted(packages, key=sort)
+    return sorted(packages, key=lambda name: (m.get(name[0], 0), name))
 
 
 def flatten(lists: Iterable[Iterable[T]]) -> list[T]:
@@ -150,7 +149,10 @@ def qemu_check_vsock_support(log: bool) -> bool:
             return False
         elif e.errno in (errno.EPERM, errno.EACCES):
             if log:
-                logging.warning("Permission denied to access /dev/vhost-vsock. Not adding a vsock device to the virtual machine.")
+                logging.warning(
+                    "Permission denied to access /dev/vhost-vsock. "
+                    "Not adding a vsock device to the virtual machine."
+                )
             return False
 
         raise e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,8 @@ strict_equality = true
 [[tool.mypy.overrides]]
 module = ["argcomplete"]
 ignore_missing_imports = true
+
+[tool.ruff]
+target-version = "py39"
+line-length = 119
+select = ["E", "F", "I", "UP"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,13 +26,13 @@ def test_compression_enum_creation() -> None:
 
 
 def test_compression_enum_bool() -> None:
-    assert bool(Compression.none) == False
-    assert bool(Compression.zst)  == True
-    assert bool(Compression.xz)   == True
-    assert bool(Compression.bz2)  == True
-    assert bool(Compression.gz)   == True
-    assert bool(Compression.lz4)  == True
-    assert bool(Compression.lzma) == True
+    assert not bool(Compression.none)
+    assert bool(Compression.zst)
+    assert bool(Compression.xz)
+    assert bool(Compression.bz2)
+    assert bool(Compression.gz)
+    assert bool(Compression.lz4)
+    assert bool(Compression.lzma)
 
 
 def test_compression_enum_str() -> None:

--- a/tests/test_versioncomp.py
+++ b/tests/test_versioncomp.py
@@ -67,8 +67,14 @@ def test_generic_version_spec() -> None:
         2
     )
 )
-def test_generic_version_strverscmp_improved_doc(s1: tuple[int, GenericVersion], s2: tuple[int, GenericVersion]) -> None:
-    """Example from the doc string of strverscmp_improved in systemd/src/fundamental/string-util-fundamental.c"""
+def test_generic_version_strverscmp_improved_doc(
+    s1: tuple[int, GenericVersion],
+    s2: tuple[int, GenericVersion],
+) -> None:
+    """Example from the doc string of strverscmp_improved.
+
+    strverscmp_improved can be found in systemd/src/fundamental/string-util-fundamental.c
+    """
     i1, v1 = s1
     i2, v2 = s2
     assert (v1 == v2) == (i1 == i2)


### PR DESCRIPTION
This also add the pyupgrade and pycodestyle rules in addition and fixes their warnings. These are mostly long line warnings and are fixed by reintroducing the 119 character line limit that we had in the past, but which got lost when we moved away from black, but existed before that as well.