### PR TITLE
Enforce sections when parsing INI files

### DIFF
--- a/.github/mkosi.conf.d/10-common.conf
+++ b/.github/mkosi.conf.d/10-common.conf
@@ -1,13 +1,13 @@
 [Output]
 CacheDirectory=mkosi.cache
+
+[Content]
+Autologin=yes
+BiosBootloader=grub
 KernelCommandLine=console=ttyS0
                   systemd.unit=mkosi-check-and-shutdown.service
                   systemd.log_target=console
                   systemd.default_standard_output=journal+console
 
-[Content]
-BiosBootloader=grub
-
 [Host]
-Autologin=yes
 QemuVsock=yes

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1976,11 +1976,14 @@ def parse_config(argv: Sequence[str] = ()) -> tuple[MkosiArgs, tuple[MkosiConfig
         if path.exists():
             logging.debug(f"Including configuration file {Path.cwd() / path}")
 
-            for _, k, v in parse_ini(path, only_sections=["Distribution", "Output", "Content", "Validation", "Host", "Preset"]):
+            for section, k, v in parse_ini(path, only_sections=["Distribution", "Output", "Content", "Validation", "Host", "Preset"]):
                 ns = defaults if k.startswith("@") else namespace
 
                 if not (s := settings_lookup_by_name.get(k.removeprefix("@"))):
                     die(f"Unknown setting {k}")
+
+                if section != s.section:
+                    logging.warning(f"Setting {k} should be configured in [{s.section}], not [{section}].")
 
                 setattr(ns, s.dest, s.parse(v, getattr(ns, s.dest, None)))
 


### PR DESCRIPTION
Except for the `[Match]` section, a setting could be set in any of the valid sections because the actual section was ignored.