### PR TITLE
Add support for RHEL UBI

### DIFF
--- a/.github/mkosi.conf.d/20-rhel-ubi.conf
+++ b/.github/mkosi.conf.d/20-rhel-ubi.conf
@@ -1,0 +1,6 @@
+[Match]
+Distribution=rhel-ubi
+
+[Content]
+Packages=systemd
+         systemd-udev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
         distro:
           - arch
           - centos
+          - rhel-ubi
           - debian
           - ubuntu
           - fedora
@@ -105,6 +106,9 @@ jobs:
           - cpio
           - disk
           - uki
+        exclude:
+          - distro: rhel-ubi
+            format: uki
 
     steps:
     - uses: actions/checkout@v3
@@ -140,9 +144,9 @@ jobs:
       run: sudo mkosi --debug boot
 
     - name: Boot ${{ matrix.distro }}/${{ matrix.format }} QEMU
-      if: matrix.format == 'disk' || matrix.format == 'uki' || matrix.format == 'cpio'
+      if: matrix.distro != 'rhel-ubi' && (matrix.format == 'disk' || matrix.format == 'uki' || matrix.format == 'cpio')
       run: timeout -k 30 10m mkosi --debug qemu
 
     - name: Boot ${{ matrix.distro }}/${{ matrix.format }} BIOS
-      if: matrix.format == 'disk'
+      if: matrix.distro != 'rhel-ubi' && matrix.format == 'disk'
       run: timeout -k 30 10m mkosi --debug --qemu-firmware bios qemu

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -325,6 +325,8 @@ def config_default_mirror(namespace: argparse.Namespace) -> Optional[str]:
         return "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose"
     elif namespace.distribution == Distribution.gentoo:
         return "https://distfiles.gentoo.org"
+    elif namespace.distribution == Distribution.rhel_ubi:
+        return "https://cdn-ubi.redhat.com/content/public/ubi/dist/"
 
     return None
 

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -75,6 +75,7 @@ class Distribution(StrEnum):
     opensuse     = enum.auto()
     mageia       = enum.auto()
     centos       = enum.auto()
+    rhel_ubi     = enum.auto()
     openmandriva = enum.auto()
     rocky        = enum.auto()
     alma         = enum.auto()
@@ -88,6 +89,7 @@ class Distribution(StrEnum):
             Distribution.fedora,
             Distribution.mageia,
             Distribution.centos,
+            Distribution.rhel_ubi,
             Distribution.openmandriva,
             Distribution.rocky,
             Distribution.alma,

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -23,6 +23,10 @@ class PackageType(StrEnum):
 
 class DistributionInstaller:
     @classmethod
+    def pretty_name(cls) -> str:
+        raise NotImplementedError
+
+    @classmethod
     def setup(cls, state: "MkosiState") -> None:
         raise NotImplementedError
 

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -24,19 +24,19 @@ class PackageType(StrEnum):
 class DistributionInstaller:
     @classmethod
     def setup(cls, state: "MkosiState") -> None:
-        raise NotImplementedError()
+        raise NotImplementedError
 
     @classmethod
     def install(cls, state: "MkosiState") -> None:
-        raise NotImplementedError()
+        raise NotImplementedError
 
     @classmethod
     def install_packages(cls, state: "MkosiState", packages: Sequence[str]) -> None:
-        raise NotImplementedError()
+        raise NotImplementedError
 
     @classmethod
     def remove_packages(cls, state: "MkosiState", packages: Sequence[str]) -> None:
-        raise NotImplementedError()
+        raise NotImplementedError
 
     @classmethod
     def filesystem(cls) -> str:

--- a/mkosi/distributions/alma.py
+++ b/mkosi/distributions/alma.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 from mkosi.config import MkosiConfig
-from mkosi.distributions.centos import CentosInstaller
+from mkosi.distributions import centos
 from mkosi.installer.dnf import Repo
 
 
-class AlmaInstaller(CentosInstaller):
+class Installer(centos.Installer):
     @staticmethod
     def gpgurls() -> tuple[str, ...]:
         return ("https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux-$releasever",)

--- a/mkosi/distributions/alma.py
+++ b/mkosi/distributions/alma.py
@@ -6,6 +6,10 @@ from mkosi.installer.dnf import Repo
 
 
 class Installer(centos.Installer):
+    @classmethod
+    def pretty_name(cls) -> str:
+        return "AlmaLinux"
+
     @staticmethod
     def gpgurls() -> tuple[str, ...]:
         return ("https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux-$releasever",)

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -11,6 +11,10 @@ from mkosi.state import MkosiState
 
 class Installer(DistributionInstaller):
     @classmethod
+    def pretty_name(cls) -> str:
+        return "Arch Linux"
+
+    @classmethod
     def filesystem(cls) -> str:
         return "ext4"
 

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -9,7 +9,7 @@ from mkosi.log import die
 from mkosi.state import MkosiState
 
 
-class ArchInstaller(DistributionInstaller):
+class Installer(DistributionInstaller):
     @classmethod
     def filesystem(cls) -> str:
         return "ext4"

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -33,7 +33,7 @@ def join_mirror(config: MkosiConfig, link: str) -> str:
     return urllib.parse.urljoin(config.mirror, link)
 
 
-class CentosInstaller(DistributionInstaller):
+class Installer(DistributionInstaller):
     @classmethod
     def filesystem(cls) -> str:
         return "xfs"

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -36,6 +36,10 @@ def join_mirror(config: MkosiConfig, link: str) -> str:
 
 class Installer(DistributionInstaller):
     @classmethod
+    def pretty_name(cls) -> str:
+        return "CentOS"
+
+    @classmethod
     def filesystem(cls) -> str:
         return "xfs"
 

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -93,7 +93,7 @@ class Installer(DistributionInstaller):
         release = int(state.config.release)
 
         if release <= 7:
-            die("CentOS 7 or earlier variants are not supported")
+            die(f"{cls.pretty_name()} 7 or earlier variants are not supported")
 
         setup_dnf(state, cls.repositories(state.config, release))
         (state.pkgmngr / "etc/dnf/vars/stream").write_text(f"{state.config.release}-stream\n")
@@ -103,8 +103,8 @@ class Installer(DistributionInstaller):
         # Make sure glibc-minimal-langpack is installed instead of glibc-all-langpacks.
         cls.install_packages(state, ["filesystem", "glibc-minimal-langpack"], apivfs=False)
 
-        # On Fedora, the default rpmdb has moved to /usr/lib/sysimage/rpm so if that's the case we need to
-        # move it back to /var/lib/rpm on CentOS.
+        # On Fedora, the default rpmdb has moved to /usr/lib/sysimage/rpm so if that's the case we
+        # need to move it back to /var/lib/rpm on CentOS.
         move_rpm_db(state.root)
 
     @classmethod
@@ -115,8 +115,8 @@ class Installer(DistributionInstaller):
     def remove_packages(cls, state: MkosiState, packages: Sequence[str]) -> None:
         invoke_dnf(state, "remove", packages)
 
-    @staticmethod
-    def architecture(arch: Architecture) -> str:
+    @classmethod
+    def architecture(cls, arch: Architecture) -> str:
         a = {
             Architecture.x86_64   : "x86_64",
             Architecture.ppc64_le : "ppc64le",
@@ -125,7 +125,7 @@ class Installer(DistributionInstaller):
         }.get(arch)
 
         if not a:
-            die(f"Architecture {a} is not supported by CentOS")
+            die(f"Architecture {a} is not supported by {cls.pretty_name()}")
 
         return a
 

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -15,7 +15,7 @@ from mkosi.state import MkosiState
 from mkosi.util import umask
 
 
-class DebianInstaller(DistributionInstaller):
+class Installer(DistributionInstaller):
     @classmethod
     def filesystem(cls) -> str:
         return "ext4"

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -17,6 +17,10 @@ from mkosi.util import umask
 
 class Installer(DistributionInstaller):
     @classmethod
+    def pretty_name(cls) -> str:
+        return "Debian"
+
+    @classmethod
     def filesystem(cls) -> str:
         return "ext4"
 

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -10,7 +10,7 @@ from mkosi.log import die
 from mkosi.state import MkosiState
 
 
-class FedoraInstaller(DistributionInstaller):
+class Installer(DistributionInstaller):
     @classmethod
     def filesystem(cls) -> str:
         return "btrfs"

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -12,6 +12,10 @@ from mkosi.state import MkosiState
 
 class Installer(DistributionInstaller):
     @classmethod
+    def pretty_name(cls) -> str:
+        return "Fedora Linux"
+
+    @classmethod
     def filesystem(cls) -> str:
         return "btrfs"
 

--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -59,6 +59,10 @@ def invoke_emerge(state: MkosiState, packages: Sequence[str] = (), apivfs: bool 
 
 class Installer(DistributionInstaller):
     @classmethod
+    def pretty_name(cls) -> str:
+        return "Gentoo"
+
+    @classmethod
     def filesystem(cls) -> str:
         return "btrfs"
 

--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -57,7 +57,7 @@ def invoke_emerge(state: MkosiState, packages: Sequence[str] = (), apivfs: bool 
     )
 
 
-class GentooInstaller(DistributionInstaller):
+class Installer(DistributionInstaller):
     @classmethod
     def filesystem(cls) -> str:
         return "btrfs"

--- a/mkosi/distributions/mageia.py
+++ b/mkosi/distributions/mageia.py
@@ -9,7 +9,7 @@ from mkosi.log import die
 from mkosi.state import MkosiState
 
 
-class MageiaInstaller(DistributionInstaller):
+class Installer(DistributionInstaller):
     @classmethod
     def filesystem(cls) -> str:
         return "ext4"

--- a/mkosi/distributions/mageia.py
+++ b/mkosi/distributions/mageia.py
@@ -11,6 +11,10 @@ from mkosi.state import MkosiState
 
 class Installer(DistributionInstaller):
     @classmethod
+    def pretty_name(cls) -> str:
+        return "Mageia"
+
+    @classmethod
     def filesystem(cls) -> str:
         return "ext4"
 

--- a/mkosi/distributions/openmandriva.py
+++ b/mkosi/distributions/openmandriva.py
@@ -11,6 +11,10 @@ from mkosi.state import MkosiState
 
 class Installer(DistributionInstaller):
     @classmethod
+    def pretty_name(cls) -> str:
+        return "OpenMandriva"
+
+    @classmethod
     def filesystem(cls) -> str:
         return "ext4"
 

--- a/mkosi/distributions/openmandriva.py
+++ b/mkosi/distributions/openmandriva.py
@@ -9,7 +9,7 @@ from mkosi.log import die
 from mkosi.state import MkosiState
 
 
-class OpenmandrivaInstaller(DistributionInstaller):
+class Installer(DistributionInstaller):
     @classmethod
     def filesystem(cls) -> str:
         return "ext4"

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -13,7 +13,7 @@ from mkosi.log import die
 from mkosi.state import MkosiState
 
 
-class OpensuseInstaller(DistributionInstaller):
+class Installer(DistributionInstaller):
     @classmethod
     def filesystem(cls) -> str:
         return "btrfs"

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -15,6 +15,10 @@ from mkosi.state import MkosiState
 
 class Installer(DistributionInstaller):
     @classmethod
+    def pretty_name(cls) -> str:
+        return "openSUSE"
+
+    @classmethod
     def filesystem(cls) -> str:
         return "btrfs"
 

--- a/mkosi/distributions/rhel_ubi.py
+++ b/mkosi/distributions/rhel_ubi.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
+from typing import Iterable
+
+from mkosi.config import MkosiConfig
+from mkosi.distributions import centos
+from mkosi.installer.dnf import Repo
+
+
+class Installer(centos.Installer):
+    @classmethod
+    def pretty_name(cls) -> str:
+        return "RHEL UBI"
+
+    @staticmethod
+    def gpgurls() -> tuple[str, ...]:
+        return ("https://access.redhat.com/security/data/fd431d51.txt",)
+
+    @classmethod
+    def repository_variants(cls, config: MkosiConfig, repo: str) -> Iterable[Repo]:
+        if config.local_mirror:
+            yield Repo(repo, f"baseurl={config.local_mirror}", cls.gpgurls())
+        else:
+            v = config.release
+            yield Repo(
+                f"ubi-{v}-{repo}-rpms",
+                f"baseurl={centos.join_mirror(config, f'ubi{v}/{v}/$basearch/{repo}/os')}",
+                cls.gpgurls(),
+            )
+            yield Repo(
+                f"ubi-{v}-{repo}-debug-rpms",
+                f"baseurl={centos.join_mirror(config, f'ubi{v}/{v}/$basearch/{repo}/debug')}",
+                cls.gpgurls(),
+                enabled=False,
+            )
+            yield Repo(
+                f"ubi-{v}-{repo}-source",
+                f"baseurl={centos.join_mirror(config, f'ubi{v}/{v}/$basearch/{repo}/source')}",
+                cls.gpgurls(),
+                enabled=False,
+            )
+            if repo == "codeready-builder":
+                yield Repo(
+                    f"ubi-{v}-{repo}",
+                    f"baseurl={centos.join_mirror(config, f'ubi{v}/{v}/$basearch/{repo}/os')}",
+                    cls.gpgurls(),
+                    enabled=False,
+                )
+
+    @classmethod
+    def repositories(cls, config: MkosiConfig, release: int) -> Iterable[Repo]:
+        yield from cls.repository_variants(config, "baseos")
+        yield from cls.repository_variants(config, "appstream")
+        yield from cls.repository_variants(config, "codeready-builder")

--- a/mkosi/distributions/rocky.py
+++ b/mkosi/distributions/rocky.py
@@ -6,6 +6,10 @@ from mkosi.installer.dnf import Repo
 
 
 class Installer(centos.Installer):
+    @classmethod
+    def pretty_name(cls) -> str:
+        return "Rocky Linux"
+
     @staticmethod
     def gpgurls() -> tuple[str, ...]:
         return ("https://download.rockylinux.org/pub/rocky/RPM-GPG-KEY-Rocky-$releasever",)

--- a/mkosi/distributions/rocky.py
+++ b/mkosi/distributions/rocky.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 from mkosi.config import MkosiConfig
-from mkosi.distributions.centos import CentosInstaller
+from mkosi.distributions import centos
 from mkosi.installer.dnf import Repo
 
 
-class RockyInstaller(CentosInstaller):
+class Installer(centos.Installer):
     @staticmethod
     def gpgurls() -> tuple[str, ...]:
         return ("https://download.rockylinux.org/pub/rocky/RPM-GPG-KEY-Rocky-$releasever",)

--- a/mkosi/distributions/ubuntu.py
+++ b/mkosi/distributions/ubuntu.py
@@ -7,6 +7,10 @@ from mkosi.state import MkosiState
 
 class Installer(debian.Installer):
     @classmethod
+    def pretty_name(cls) -> str:
+        return "Ubuntu"
+
+    @classmethod
     def default_release(cls) -> str:
         return "lunar"
 

--- a/mkosi/distributions/ubuntu.py
+++ b/mkosi/distributions/ubuntu.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 from mkosi.architecture import Architecture
-from mkosi.distributions.debian import DebianInstaller
+from mkosi.distributions import debian
 from mkosi.state import MkosiState
 
 
-class UbuntuInstaller(DebianInstaller):
+class Installer(debian.Installer):
     @classmethod
     def default_release(cls) -> str:
         return "lunar"

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -2,7 +2,7 @@
 import os
 import shutil
 import textwrap
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from pathlib import Path
 from typing import NamedTuple
 
@@ -27,7 +27,7 @@ def dnf_executable(state: MkosiState) -> str:
     return dnf
 
 
-def setup_dnf(state: MkosiState, repos: Sequence[Repo], filelists: bool = True) -> None:
+def setup_dnf(state: MkosiState, repos: Iterable[Repo], filelists: bool = True) -> None:
     (state.pkgmngr / "etc/dnf/vars").mkdir(exist_ok=True, parents=True)
     (state.pkgmngr / "etc/yum.repos.d").mkdir(exist_ok=True, parents=True)
     (state.pkgmngr / "var/lib/dnf").mkdir(exist_ok=True, parents=True)

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -382,7 +382,7 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 : The distribution to install in the image. Takes one of the following
   arguments: `fedora`, `debian`, `ubuntu`, `arch`, `opensuse`, `mageia`,
-  `centos`, `openmandriva`, `rocky`, `alma`. If not
+  `centos`, `rhel-ubi`, `openmandriva`, `rocky`, `alma`. If not
   specified, defaults to the distribution of the host.
 
 `Release=`, `--release=`, `-r`
@@ -1204,6 +1204,8 @@ distributions:
 
 * *CentOS*
 
+* *RHEL UBI*
+
 * *OpenMandriva*
 
 * *Rocky Linux*
@@ -1216,13 +1218,12 @@ distributions:
 
 In theory, any distribution may be used on the host for building images
 containing any other distribution, as long as the necessary tools are
-available. Specifically, any distribution that packages `apt` may be
-used to build *Debian* or *Ubuntu* images. Any distribution that
-packages `dnf` may be used to build *CentOS*, *Alma Linux*, *Rocky
-Linux*, *Fedora Linux*, *OpenSUSE*, *Mageia* or *OpenMandriva* images.
-Any distro that packages `pacman` may be used to build *Arch Linux*
-images. Any distribution that packages `zypper` may be used to build
-*openSUSE* images.
+available.
+Specifically,
+any distribution that packages `apt` may be used to build *Debian* or *Ubuntu* images.
+Any distribution that packages `dnf` may be used to build images for any of the rpm-based distributions.
+Any distro that packages `pacman` may be used to build *Arch Linux* images.
+Any distribution that packages `zypper` may be used to build *openSUSE* images.
 
 Currently, *Fedora Linux* packages all relevant tools as of Fedora 28.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -194,7 +194,7 @@ def test_parse_load_verb(tmp_path: Path) -> None:
 def test_os_distribution(tmp_path: Path) -> None:
     with chdir(tmp_path):
         for dist in Distribution:
-            _, [config] = parse_config(["-d", dist.name])
+            _, [config] = parse_config(["-d", dist.value])
             assert config.distribution == dist
 
         with pytest.raises(tuple((argparse.ArgumentError, SystemExit))):


### PR DESCRIPTION
The repository naming matches what is visible in the standard ubi container image (registry.access.redhat.com/ubi8/ubi).

This is the first time that I'm doing anything more complicated wit UBIs, but I hope this is a sensible beginning.

In Distribution.installer(), try..except is replaced by assert. If the installer class for a distro is missing, then it's a programming error and not somthing we should suppress.