### PR TITLE
Support booting directory images in qemu

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2178,13 +2178,13 @@ def load_kernel_command_line_extra(args: argparse.Namespace) -> list[str]:
         f"systemd.tty.rows.ttyS0={lines}",
         "console=ttyS0",
         # Make sure we set up networking in the VM/container.
-        "systemd.wants=network-online.target",
+        "systemd.wants=network.target",
         # Make sure we don't load vmw_vmci which messes with virtio vsock.
         "module_blacklist=vmw_vmci",
     ]
 
     if not any(s.startswith("ip=") for s in args.kernel_command_line_extra):
-        cmdline += ["ip=enp0s1:any", "ip=enp0s2:any", "ip=host0:any"]
+        cmdline += ["ip=enp0s1:any", "ip=enp0s2:any", "ip=host0:any", "ip=none"]
 
     if not any(s.startswith("loglevel=") for s in args.kernel_command_line_extra):
         cmdline += ["loglevel=4"]

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -168,7 +168,9 @@ def start_virtiofsd(directory: Path) -> Iterator[Path]:
         # Make sure virtiofsd is allowed to create its socket in this temporary directory.
         os.chown(state, uid, gid)
 
-        sock = Path(state) / Path("sock")
+        # Make sure we can use the socket name as a unique identifier for the fs as well but make sure it's not too
+        # long as virtiofs tag names are limited to 36 bytes.
+        sock = Path(state) / f"sock-{uuid.uuid4().hex}"[:35]
 
         virtiofsd = shutil.which("virtiofsd")
         if virtiofsd is None:

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -437,9 +437,9 @@ def run_qemu(args: MkosiArgs, config: MkosiConfig, uid: int, gid: int) -> None:
                 sock = stack.enter_context(start_virtiofsd(fname))
                 cmdline += [
                     "-chardev", f"socket,id={sock.name},path={sock}",
-                    "-device", f"vhost-user-fs-pci,queue-size=1024,chardev={sock.name},tag=/dev/root",
+                    "-device", f"vhost-user-fs-pci,queue-size=1024,chardev={sock.name},tag=root",
                 ]
-                root = "root=/dev/root rootfstype=virtiofs rw"
+                root = "root=root rootfstype=virtiofs rw"
             else:
                 root = ""
 

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -414,10 +414,13 @@ def run_qemu(args: MkosiArgs, config: MkosiConfig, uid: int, gid: int) -> None:
             elif config.qemu_kernel:
                 kernel = config.qemu_kernel
             elif "-kernel" not in args.cmdline:
-                kernel = config.output_dir / config.output_split_kernel
+                if firmware == QemuFirmware.uefi:
+                    kernel = config.output_dir / config.output_split_uki
+                else:
+                    kernel = config.output_dir / config.output_split_kernel
                 if not kernel.exists():
                     die(
-                        "No kernel found, please install a kernel in the image "
+                        f"Kernel or UKI not found at {kernel}, please install a kernel in the image "
                         "or provide a -kernel argument to mkosi qemu"
                     )
             else:

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -292,9 +292,10 @@ def run_qemu(args: MkosiArgs, config: MkosiConfig) -> None:
 
     ovmf, ovmf_supports_sb = find_ovmf_firmware(config) if firmware == QemuFirmware.uefi else (None, False)
 
+    # A shared memory backend might increase ram usage so only add one if actually necessary for virtiofsd.
     shm = []
-    if config.runtime_trees:
-        shm = ["-object", "memory-backend-memfd,id=mem,size=2G,share=on"]
+    if config.runtime_trees or config.output_format == OutputFormat.directory:
+        shm = ["-object", f"memory-backend-memfd,id=mem,size={config.qemu_mem},share=on"]
 
     if config.architecture == Architecture.arm64:
         machine = f"type=virt,accel={accel}"

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -450,12 +450,14 @@ def run_qemu(args: MkosiArgs, config: MkosiConfig, uid: int, gid: int) -> None:
 
         if config.output_format == OutputFormat.cpio:
             cmdline += ["-initrd", fname]
-        elif config.output_format == OutputFormat.uki and firmware == QemuFirmware.linux:
+        elif (
+            firmware == QemuFirmware.linux and
+            config.output_format in (OutputFormat.uki, OutputFormat.directory, OutputFormat.disk) and
+            (config.output_dir / config.output_split_initrd).exists()
+        ):
             cmdline += ["-initrd", config.output_dir / config.output_split_initrd]
-        elif config.output_format == OutputFormat.disk:
-            if firmware == QemuFirmware.linux:
-                cmdline += ["-initrd", config.output_dir / config.output_split_initrd]
 
+        if config.output_format == OutputFormat.disk:
             cmdline += ["-drive", f"if=none,id=mkosi,file={fname},format=raw",
                         "-device", "virtio-scsi-pci,id=scsi",
                         "-device", f"scsi-{'cd' if config.qemu_cdrom else 'hd'},drive=mkosi,bootindex=1"]


### PR DESCRIPTION
Using virtiofsd, we can boot straight into a virtiofs instance of
a directory image. This does require the virtiofsd instance to run
as (fake) root so we can't switch to the user running mkosi anymore
when running unprivleged but that shouldn't be a problem.

This also only works with kernels that have the virtiofs driver
builtin which I don't think is the case in any major distros yet.