### PR TITLE
Revert "ci: enable jammy-proposed-updates to test new libzypp"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,10 +108,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Enable proposed-updates
-      run: |
-        sudo mkdir -p /etc/apt/sources.list.d/
-        echo 'deb http://azure.archive.ubuntu.com/ubuntu jammy-proposed restricted main universe' | sudo tee /etc/apt/sources.list.d/proposed.list
     - uses: ./
 
     # Make sure the latest changes from the pull request are used.


### PR DESCRIPTION
libzypp is now released in the updates repo, so no need to use proposed-updates anymore

This reverts commit b6167c2047facda41aa73bd37907ba012e5c5e8a.