### PR TITLE
Use setpgid if available

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -46,7 +46,14 @@ from mkosi.mounts import mount, mount_overlay, mount_passwd, mount_usr
 from mkosi.pager import page
 from mkosi.partition import Partition, finalize_root, finalize_roothash
 from mkosi.qemu import copy_ephemeral, run_qemu, run_ssh
-from mkosi.run import become_root, bwrap, chroot_cmd, init_mount_namespace, run
+from mkosi.run import (
+    become_root,
+    bwrap,
+    chroot_cmd,
+    find_binary,
+    init_mount_namespace,
+    run,
+)
 from mkosi.state import MkosiState
 from mkosi.tree import copy_tree, install_tree, move_tree, rmtree
 from mkosi.types import _FILE, CompletedProcess, PathString
@@ -604,15 +611,8 @@ def find_grub_bios_directory(state: MkosiState) -> Optional[Path]:
 
 
 def find_grub_binary(state: MkosiState, binary: str) -> Optional[Path]:
-    path = ":".join(os.fspath(p) for p in [state.root / "usr/bin", state.root / "usr/sbin"])
-
     assert "grub" in binary and "grub2" not in binary
-
-    path = shutil.which(binary, path=path) or shutil.which(binary.replace("grub", "grub2"), path=path)
-    if not path:
-        return None
-
-    return Path("/") / Path(path).relative_to(state.root)
+    return find_binary(binary, state.root) or find_binary(binary.replace("grub", "grub2"), state.root)
 
 
 def find_grub_prefix(state: MkosiState) -> Optional[str]:

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -346,6 +346,9 @@ def bwrap(
             "sh", "-c", "chmod 1777 /dev/shm && exec $0 \"$@\"",
         ]
 
+        if setpgid := find_binary("setpgid"):
+            cmdline += [setpgid, "--foreground"]
+
         try:
             result = run([*cmdline, *cmd], env=env, log=False, stdin=stdin, stdout=stdout, input=input)
         except subprocess.CalledProcessError as e:
@@ -394,6 +397,9 @@ def apivfs_cmd(root: Path) -> list[PathString]:
         "--unsetenv", "TMPDIR",
     ]
 
+    if setpgid := find_binary("setpgid"):
+        cmdline += [setpgid, "--foreground"]
+
     if (root / "etc/machine-id").exists():
         # Make sure /etc/machine-id is not overwritten by any package manager post install scripts.
         cmdline += ["--ro-bind", root / "etc/machine-id", root / "etc/machine-id"]
@@ -434,6 +440,9 @@ def chroot_cmd(root: Path, *, options: Sequence[PathString] = ()) -> list[PathSt
         "--ro-bind", "/etc/resolv.conf", Path("/") / resolve,
         *options,
     ]
+
+    if setpgid := find_binary("setpgid", root):
+        cmdline += [setpgid, "--foreground"]
 
     return apivfs_cmd(root) + cmdline
 

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -11,6 +11,7 @@ import os
 import pwd
 import queue
 import shlex
+import shutil
 import signal
 import subprocess
 import sys
@@ -271,6 +272,11 @@ def have_effective_cap(capability: Capability) -> bool:
         return False
 
     return (int(hexcap, 16) & (1 << capability.value)) != 0
+
+
+def find_binary(name: str, root: Optional[Path] = None) -> Optional[Path]:
+    path = ":".join(os.fspath(p) for p in [root / "usr/bin", root / "usr/sbin"]) if root else os.environ["PATH"]
+    return Path("/") / Path(binary).relative_to(root or "/") if (binary := shutil.which(name, path=path)) else None
 
 
 def bwrap(


### PR DESCRIPTION
The next release of util-linux will include setpgid which has a
--foreground option that does exactly the same as our foreground()
function. This new utility allows us to make the processes executed
by bubblewrap the foreground process, which makes sure that SIGINT
isn't intercepted by bwrap.