### PR TITLE
Add "none" distribution

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -294,7 +294,8 @@ def config_default_distribution(namespace: argparse.Namespace) -> Distribution:
     detected = detect_distribution()[0]
 
     if not detected:
-        die("Distribution of your host can't be detected or isn't a supported target. Please set Distribution= in your config.")
+        logging.info("Distribution of your host can't be detected or isn't a supported target. Defaulting to Distribution=none.")
+        return Distribution.none
 
     return detected
 

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -72,6 +72,7 @@ class DistributionInstaller:
 
 
 class Distribution(StrEnum):
+    none         = enum.auto()
     fedora       = enum.auto()
     debian       = enum.auto()
     ubuntu       = enum.auto()

--- a/mkosi/distributions/none.py
+++ b/mkosi/distributions/none.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
+from collections.abc import Sequence
+
+from mkosi.distributions import DistributionInstaller
+from mkosi.log import die
+from mkosi.state import MkosiState
+
+
+class Installer(DistributionInstaller):
+    @classmethod
+    def setup(cls, state: MkosiState) -> None:
+        pass
+
+    @classmethod
+    def install(cls, state: MkosiState) -> None:
+        pass
+
+    @classmethod
+    def install_packages(cls, state: MkosiState, packages: Sequence[str]) -> None:
+        if packages:
+            die("Installing packages is not supported with distribution 'none'")
+
+    @classmethod
+    def remove_packages(cls, state: MkosiState, packages: Sequence[str]) -> None:
+        if packages:
+            die("Removing packages is not supported with distribution 'none'")

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -395,8 +395,8 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 : The distribution to install in the image. Takes one of the following
   arguments: `fedora`, `debian`, `ubuntu`, `arch`, `opensuse`, `mageia`,
-  `centos`, `rhel-ubi`, `openmandriva`, `rocky`, `alma`. If not
-  specified, defaults to the distribution of the host.
+  `centos`, `rhel-ubi`, `openmandriva`, `rocky`, `alma`, `none`.
+  If not specified, defaults to the distribution of the host.
 
 `Release=`, `--release=`, `-r`
 
@@ -1283,6 +1283,8 @@ distributions:
   guarantee that it will work at all and the core maintainers will
   generally not fix gentoo specific issues**)
 
+* *None* (**Requires the user to provide a pre-built rootfs**)
+
 In theory, any distribution may be used on the host for building images
 containing any other distribution, as long as the necessary tools are
 available.
@@ -1291,6 +1293,7 @@ any distribution that packages `apt` may be used to build *Debian* or *Ubuntu* i
 Any distribution that packages `dnf` may be used to build images for any of the rpm-based distributions.
 Any distro that packages `pacman` may be used to build *Arch Linux* images.
 Any distribution that packages `zypper` may be used to build *openSUSE* images.
+Other distributions and build automation tools for embedded Linux systems such as Buildroot, OpenEmbedded and Yocto Project may be used by selecting the `none` distribution, and populating the rootfs via a combination of base trees, skeleton trees, and prepare scripts.
 
 Currently, *Fedora Linux* packages all relevant tools as of Fedora 28.
 


### PR DESCRIPTION
So here's a first stab.
I had to make the efi symlink conditional because my testing skeleton tree is for an arm system without EFI.
Also I just took the architecture list from Fedora for now, is there a way to say "all of them / don't care"?