### PR TITLE
tooltrees: add curl to default packages

### DIFF
--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -37,6 +37,7 @@ class ArchInstaller(DistributionInstaller):
             "ca-certificates",
             "coreutils",
             "cpio",
+            "curl",
             "debian-archive-keyring",
             "dnf",
             "dosfstools",

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -58,6 +58,7 @@ class CentosInstaller(DistributionInstaller):
             "ca-certificates",
             "coreutils",
             "cpio",
+            "curl",
             "dnf",
             "dosfstools",
             "e2fsprogs",

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -42,6 +42,7 @@ class DebianInstaller(DistributionInstaller):
             "ca-certificates",
             "coreutils",
             "cpio",
+            "curl",
             "debian-archive-keyring",
             "dnf",
             "dosfstools",

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -38,6 +38,7 @@ class FedoraInstaller(DistributionInstaller):
             "ca-certificates",
             "coreutils",
             "cpio",
+            "curl-minimal",
             "debian-keyring",
             "dnf5",
             "dosfstools",

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -39,6 +39,7 @@ class OpensuseInstaller(DistributionInstaller):
             "ca-certificates",
             "coreutils",
             "cpio",
+            "curl",
             "dnf",
             "dosfstools",
             "e2fsprogs",


### PR DESCRIPTION
This makes it easy to download a file from a prepare script when using a default tool tree.

I went with `curl` instead of `curl-minimal` for Centos since `curl-minimal` is only available in Centos 9.