### PR TITLE
build/cache dir name: append architecture

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2274,9 +2274,9 @@ def load_config(args: argparse.Namespace) -> MkosiConfig:
         die(f"Arguments after verb are not supported for {args.verb}.")
 
     if args.cache_dir:
-        args.cache_dir = args.cache_dir / f"{args.distribution}~{args.release}"
+        args.cache_dir = args.cache_dir / f"{args.distribution}~{args.release}~{args.architecture}"
     if args.build_dir:
-        args.build_dir = args.build_dir / f"{args.distribution}~{args.release}"
+        args.build_dir = args.build_dir / f"{args.distribution}~{args.release}~{args.architecture}"
 
     if args.sign:
         args.checksum = True

--- a/mkosi/state.py
+++ b/mkosi/state.py
@@ -45,7 +45,7 @@ class MkosiState:
 
     @property
     def cache_dir(self) -> Path:
-        return self.config.cache_dir or self.workspace / f"cache/{self.config.distribution}~{self.config.release}"
+        return self.config.cache_dir or self.workspace / f"cache/{self.config.distribution}~{self.config.release}~{self.config.architecture}"
 
     @property
     def install_dir(self) -> Path:


### PR DESCRIPTION
The builds and caches are architecture specific, so name them accordingly