### PR TITLE
Add RuntimeSize= setting

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -34,6 +34,7 @@ from mkosi.config import (
     OutputFormat,
     SecureBootSignTool,
     Verb,
+    format_bytes,
     format_source_target,
     parse_config,
     summary,
@@ -60,7 +61,6 @@ from mkosi.types import _FILE, CompletedProcess, PathString
 from mkosi.util import (
     InvokingUser,
     flatten,
-    format_bytes,
     format_rlimit,
     one_zero,
     scopedenv,
@@ -2125,7 +2125,7 @@ def run_shell(args: MkosiArgs, config: MkosiConfig) -> None:
         if config.output_format == OutputFormat.disk and args.verb == Verb.boot:
             run(["systemd-repart",
                  "--image", fname,
-                 "--size", "8G",
+                 *([f"--size={config.runtime_size}"] if config.runtime_size else []),
                  "--no-pager",
                  "--dry-run=no",
                  "--offline=no",

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -23,13 +23,14 @@ from mkosi.config import (
     MkosiConfig,
     OutputFormat,
     QemuFirmware,
+    format_bytes,
 )
 from mkosi.log import die
 from mkosi.partition import finalize_root, find_partitions
 from mkosi.run import MkosiAsyncioThread, run, spawn
 from mkosi.tree import copy_tree, rmtree
 from mkosi.types import PathString
-from mkosi.util import format_bytes, qemu_check_kvm_support, qemu_check_vsock_support
+from mkosi.util import qemu_check_kvm_support, qemu_check_vsock_support
 
 
 def machine_cid(config: MkosiConfig) -> int:
@@ -399,11 +400,11 @@ def run_qemu(args: MkosiArgs, config: MkosiConfig, uid: int, gid: int) -> None:
         else:
             fname = config.output_dir / config.output
 
-        if config.output_format == OutputFormat.disk and not config.qemu_cdrom:
+        if config.output_format == OutputFormat.disk and config.runtime_size:
             run(["systemd-repart",
                  "--definitions", "",
                  "--no-pager",
-                 "--size=8G",
+                 f"--size={config.runtime_size}",
                  "--pretty=no",
                  "--offline=yes",
                  fname])

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -1242,6 +1242,13 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
   machine in these directories will be owned by the user running mkosi
   on the host.
 
+`RuntimeSize=`, `--runtime-size`
+
+: If specified, disk images are grown to the specified size before
+  they're booted with systemd-nspawn or qemu. Takes a size in bytes.
+  Additionally, the suffixes `K`, `M` and `G` can be used to specify a
+  size in kilobytes, megabytes and gigabytes respectively.
+
 ## Supported distributions
 
 Images may be created containing installations of the following

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -160,17 +160,6 @@ def qemu_check_vsock_support(log: bool) -> bool:
     return True
 
 
-def format_bytes(num_bytes: int) -> str:
-    if num_bytes >= 1024**3:
-        return f"{num_bytes/1024**3 :0.1f}G"
-    if num_bytes >= 1024**2:
-        return f"{num_bytes/1024**2 :0.1f}M"
-    if num_bytes >= 1024:
-        return f"{num_bytes/1024 :0.1f}K"
-
-    return f"{num_bytes}B"
-
-
 def make_executable(path: Path) -> None:
     st = path.stat()
     os.chmod(path, st.st_mode | stat.S_IEXEC)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,6 +16,7 @@ from mkosi.config import (
     ConfigFeature,
     OutputFormat,
     Verb,
+    config_parse_bytes,
     parse_config,
     parse_ini,
 )
@@ -609,3 +610,24 @@ def test_wrong_section_warning(
             parse_config(args)
 
         assert len(caplog.records) == warning_count
+
+
+def test_config_parse_bytes() -> None:
+    assert config_parse_bytes(None) is None
+    assert config_parse_bytes("1") == 4096
+    assert config_parse_bytes("8000") == 8192
+    assert config_parse_bytes("8K") == 8192
+    assert config_parse_bytes("4097") == 8192
+    assert config_parse_bytes("1M") == 1024**2
+    assert config_parse_bytes("1.9M") == 1994752
+    assert config_parse_bytes("1G") == 1024**3
+    assert config_parse_bytes("7.3G") == 7838318592
+
+    with pytest.raises(SystemExit):
+        config_parse_bytes("-1")
+    with pytest.raises(SystemExit):
+        config_parse_bytes("-2K")
+    with pytest.raises(SystemExit):
+        config_parse_bytes("-3M")
+    with pytest.raises(SystemExit):
+        config_parse_bytes("-4G")


### PR DESCRIPTION
Currently we unconditionally grow disk images to 8G before booting
them in systemd-nspawn or qemu. Let's do better here by making the
size configurable and not growing the disk images by default.

We also move format_bytes() to config.py as most other formatting
functions are located there.