### PR TITLE
Only parse each path included with Include= once

### DIFF
--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -366,6 +366,9 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
   configuration is included after parsing all the other configuration
   files.
 
+: Note that each path containing extra configuration is only parsed
+  once, even if included more than once with `Include=`.
+
 ### [Preset] Section
 
 `Presets=`, `--preset=`

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -186,6 +186,7 @@ def test_parse_config(tmp_path: Path) -> None:
         """\
         [Content]
         Bootable=yes
+        BuildPackages=abc
         """
     )
     (tmp_path / "abc/mkosi.conf.d").mkdir()
@@ -202,9 +203,11 @@ def test_parse_config(tmp_path: Path) -> None:
         assert config.split_artifacts == False
 
         # Passing the directory should include both the main config file and the dropin.
-        _, [config] = parse_config(["--include", os.fspath(tmp_path / "abc")])
+        _, [config] = parse_config(["--include", os.fspath(tmp_path / "abc")] * 2)
         assert config.bootable == ConfigFeature.enabled
         assert config.split_artifacts == True
+        # The same extra config should not be parsed more than once.
+        assert config.build_packages == ["abc"]
 
         # Passing the main config file should not include the dropin.
         _, [config] = parse_config(["--include", os.fspath(tmp_path / "abc/mkosi.conf")])


### PR DESCRIPTION
Even if a path is included multiple times using Include=, let's make sure we only parse it once.