### PR TITLE
Use local GPG keys from distribution-gpg-keys if available

### DIFF
--- a/mkosi/distributions/alma.py
+++ b/mkosi/distributions/alma.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
+from pathlib import Path
+
 from mkosi.config import MkosiConfig
 from mkosi.distributions import centos
 from mkosi.installer.dnf import Repo
@@ -11,8 +13,12 @@ class Installer(centos.Installer):
         return "AlmaLinux"
 
     @staticmethod
-    def gpgurls() -> tuple[str, ...]:
-        return ("https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux-$releasever",)
+    def gpgurls(config: MkosiConfig) -> tuple[str, ...]:
+        gpgpath = Path(f"/usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-{config.release}")
+        if gpgpath.exists():
+            return (f"file://{gpgpath}",)
+        else:
+            return ("https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux-$releasever",)
 
     @classmethod
     def repository_variants(cls, config: MkosiConfig, repo: str) -> list[Repo]:
@@ -21,7 +27,7 @@ class Installer(centos.Installer):
         else:
             url = f"mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/{repo.lower()}"
 
-        return [Repo(repo, url, cls.gpgurls())]
+        return [Repo(repo, url, cls.gpgurls(config))]
 
     @classmethod
     def sig_repositories(cls, config: MkosiConfig) -> list[Repo]:

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -2,6 +2,7 @@
 
 import urllib.parse
 from collections.abc import Sequence
+from pathlib import Path
 
 from mkosi.architecture import Architecture
 from mkosi.distributions import Distribution, DistributionInstaller, PackageType
@@ -44,6 +45,7 @@ class Installer(DistributionInstaller):
             "cpio",
             "curl-minimal",
             "debian-keyring",
+            "distribution-gpg-keys",
             "dnf5",
             "dosfstools",
             "e2fsprogs",
@@ -76,8 +78,12 @@ class Installer(DistributionInstaller):
 
     @classmethod
     def setup(cls, state: MkosiState) -> None:
-        # See: https://fedoraproject.org/security/
-        gpgurls = ("https://fedoraproject.org/fedora.gpg",)
+        gpgpath = Path(f"/usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-{state.config.release}-primary")
+        if gpgpath.exists():
+            gpgurls = (f"file://{gpgpath}",)
+        else:
+            # See: https://fedoraproject.org/security/
+            gpgurls = ("https://fedoraproject.org/fedora.gpg",)
         repos = []
 
         if state.config.local_mirror:

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -44,6 +44,7 @@ class Installer(DistributionInstaller):
             "coreutils",
             "cpio",
             "curl",
+            "distribution-gpg-keys",
             "dnf",
             "dosfstools",
             "e2fsprogs",

--- a/mkosi/distributions/rhel_ubi.py
+++ b/mkosi/distributions/rhel_ubi.py
@@ -13,37 +13,37 @@ class Installer(centos.Installer):
         return "RHEL UBI"
 
     @staticmethod
-    def gpgurls() -> tuple[str, ...]:
+    def gpgurls(config: MkosiConfig) -> tuple[str, ...]:
         return ("https://access.redhat.com/security/data/fd431d51.txt",)
 
     @classmethod
     def repository_variants(cls, config: MkosiConfig, repo: str) -> Iterable[Repo]:
         if config.local_mirror:
-            yield Repo(repo, f"baseurl={config.local_mirror}", cls.gpgurls())
+            yield Repo(repo, f"baseurl={config.local_mirror}", cls.gpgurls(config))
         else:
             v = config.release
             yield Repo(
                 f"ubi-{v}-{repo}-rpms",
                 f"baseurl={centos.join_mirror(config, f'ubi{v}/{v}/$basearch/{repo}/os')}",
-                cls.gpgurls(),
+                cls.gpgurls(config),
             )
             yield Repo(
                 f"ubi-{v}-{repo}-debug-rpms",
                 f"baseurl={centos.join_mirror(config, f'ubi{v}/{v}/$basearch/{repo}/debug')}",
-                cls.gpgurls(),
+                cls.gpgurls(config),
                 enabled=False,
             )
             yield Repo(
                 f"ubi-{v}-{repo}-source",
                 f"baseurl={centos.join_mirror(config, f'ubi{v}/{v}/$basearch/{repo}/source')}",
-                cls.gpgurls(),
+                cls.gpgurls(config),
                 enabled=False,
             )
             if repo == "codeready-builder":
                 yield Repo(
                     f"ubi-{v}-{repo}",
                     f"baseurl={centos.join_mirror(config, f'ubi{v}/{v}/$basearch/{repo}/os')}",
-                    cls.gpgurls(),
+                    cls.gpgurls(config),
                     enabled=False,
                 )
 

--- a/mkosi/distributions/rocky.py
+++ b/mkosi/distributions/rocky.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
+from pathlib import Path
+
 from mkosi.config import MkosiConfig
 from mkosi.distributions import centos
 from mkosi.installer.dnf import Repo
@@ -11,8 +13,12 @@ class Installer(centos.Installer):
         return "Rocky Linux"
 
     @staticmethod
-    def gpgurls() -> tuple[str, ...]:
-        return ("https://download.rockylinux.org/pub/rocky/RPM-GPG-KEY-Rocky-$releasever",)
+    def gpgurls(config: MkosiConfig) -> tuple[str, ...]:
+        gpgpath = Path(f"/usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-{config.release}")
+        if gpgpath.exists():
+            return (f"file://{gpgpath}",)
+        else:
+            return ("https://download.rockylinux.org/pub/rocky/RPM-GPG-KEY-Rocky-$releasever",)
 
     @classmethod
     def repository_variants(cls, config: MkosiConfig, repo: str) -> list[Repo]:
@@ -21,7 +27,7 @@ class Installer(centos.Installer):
         else:
             url = f"mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo={repo}-$releasever"
 
-        return [Repo(repo, url, cls.gpgurls())]
+        return [Repo(repo, url, cls.gpgurls(config))]
 
     @classmethod
     def sig_repositories(cls, config: MkosiConfig) -> list[Repo]:

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -1173,43 +1173,44 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
   which distributions default tools tree packages are defined and which
   packages are included in those default tools trees:
 
-  |                     | Fedora | CentOS | Debian | Arch | openSUSE |
-  |---------------------|--------|--------|--------|------|----------|
-  | `apt`               | X      | X      | X      | X    |          |
-  | `archlinux-keyring` | X      |        | X      | X    |          |
-  | `bash`              | X      | X      | X      | X    | X        |
-  | `btrfs-progs`       | X      |        | X      | X    | X        |
-  | `bubblewrap`        | X      | X      | X      | X    | X        |
-  | `ca-certificates`   | X      | X      | X      | X    | X        |
-  | `coreutils`         | X      | X      | X      | X    | X        |
-  | `cpio`              | X      | X      | X      | X    | X        |
-  | `curl`              | X      | X      | X      | X    | X        |
-  | `debian-keyring`    | X      | X      | X      | X    |          |
-  | `dnf`               | X      | X      | X      | X    | X        |
-  | `dosfstools`        | X      | X      | X      | X    | X        |
-  | `e2fsprogs`         | X      | X      | X      | X    | X        |
-  | `edk2-ovmf`         | X      | X      | X      | X    | X        |
-  | `erofs-utils`       | X      |        | X      | X    | X        |
-  | `mtools`            | X      | X      | X      | X    | X        |
-  | `openssh`           | X      | X      | X      | X    | X        |
-  | `openssl`           | X      | X      | X      | X    | X        |
-  | `pacman`            | X      |        | X      | X    |          |
-  | `pesign`            | X      | X      | X      | X    | X        |
-  | `qemu`              | X      | X      | X      | X    | X        |
-  | `sbsigntools`       | X      |        | X      | X    | X        |
-  | `socat`             | X      | X      | X      | X    | X        |
-  | `squashfs-tools`    | X      | X      | X      | X    | X        |
-  | `strace`            | X      | X      | X      | X    | X        |
-  | `swtpm`             | X      | X      | X      | X    | X        |
-  | `systemd`           | X      | X      | X      | X    | X        |
-  | `ukify`             | X      |        | X      | X    | X        |
-  | `tar`               | X      | X      | X      | X    | X        |
-  | `util-linux`        | X      | X      | X      | X    | X        |
-  | `virtiofsd`         | X      | X      |        | X    | X        |
-  | `xfsprogs`          | X      | X      | X      | X    | X        |
-  | `xz`                | X      | X      | X      | X    | X        |
-  | `zstd`              | X      | X      | X      | X    | X        |
-  | `zypper`            | X      |        | X      | X    |          |
+  |                         | Fedora | CentOS | Debian | Arch | openSUSE |
+  |-------------------------|--------|--------|--------|------|----------|
+  | `apt`                   | X      | X      | X      | X    |          |
+  | `archlinux-keyring`     | X      |        | X      | X    |          |
+  | `bash`                  | X      | X      | X      | X    | X        |
+  | `btrfs-progs`           | X      |        | X      | X    | X        |
+  | `bubblewrap`            | X      | X      | X      | X    | X        |
+  | `ca-certificates`       | X      | X      | X      | X    | X        |
+  | `coreutils`             | X      | X      | X      | X    | X        |
+  | `cpio`                  | X      | X      | X      | X    | X        |
+  | `curl`                  | X      | X      | X      | X    | X        |
+  | `debian-keyring`        | X      | X      | X      | X    |          |
+  | `distribution-gpg-keys` | X      | X      |        |      | X        |
+  | `dnf`                   | X      | X      | X      | X    | X        |
+  | `dosfstools`            | X      | X      | X      | X    | X        |
+  | `e2fsprogs`             | X      | X      | X      | X    | X        |
+  | `edk2-ovmf`             | X      | X      | X      | X    | X        |
+  | `erofs-utils`           | X      |        | X      | X    | X        |
+  | `mtools`                | X      | X      | X      | X    | X        |
+  | `openssh`               | X      | X      | X      | X    | X        |
+  | `openssl`               | X      | X      | X      | X    | X        |
+  | `pacman`                | X      |        | X      | X    |          |
+  | `pesign`                | X      | X      | X      | X    | X        |
+  | `qemu`                  | X      | X      | X      | X    | X        |
+  | `sbsigntools`           | X      |        | X      | X    | X        |
+  | `socat`                 | X      | X      | X      | X    | X        |
+  | `squashfs-tools`        | X      | X      | X      | X    | X        |
+  | `strace`                | X      | X      | X      | X    | X        |
+  | `swtpm`                 | X      | X      | X      | X    | X        |
+  | `systemd`               | X      | X      | X      | X    | X        |
+  | `ukify`                 | X      |        | X      | X    | X        |
+  | `tar`                   | X      | X      | X      | X    | X        |
+  | `util-linux`            | X      | X      | X      | X    | X        |
+  | `virtiofsd`             | X      | X      |        | X    | X        |
+  | `xfsprogs`              | X      | X      | X      | X    | X        |
+  | `xz`                    | X      | X      | X      | X    | X        |
+  | `zstd`                  | X      | X      | X      | X    | X        |
+  | `zypper`                | X      |        | X      | X    |          |
 
 `ToolsTreeDistribution=`, `--tools-tree-distribution=`
 


### PR DESCRIPTION
Let's prefer using local keys from the distribution-gpg-keys package if available.