### PR TITLE
Rename "none" distribution to "custom"

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -986,8 +986,8 @@ def build_initrd(state: MkosiState) -> Path:
     if symlink.exists():
         return symlink.resolve()
 
-    if state.config.distribution == Distribution.none:
-        die(f"Building a default initrd is not supported with distribution {state.config.distribution}")
+    if state.config.distribution == Distribution.custom:
+        die("Building a default initrd is not supported for custom distributions")
 
     # Default values are assigned via the parser so we go via the argument parser to construct
     # the config for the initrd.

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -298,9 +298,9 @@ def config_default_distribution(namespace: argparse.Namespace) -> Distribution:
     if not detected:
         logging.info(
             "Distribution of your host can't be detected or isn't a supported target. "
-            "Defaulting to Distribution=none."
+            "Defaulting to Distribution=custom."
         )
-        return Distribution.none
+        return Distribution.custom
 
     return detected
 

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -72,7 +72,6 @@ class DistributionInstaller:
 
 
 class Distribution(StrEnum):
-    none         = enum.auto()
     fedora       = enum.auto()
     debian       = enum.auto()
     ubuntu       = enum.auto()
@@ -85,6 +84,7 @@ class Distribution(StrEnum):
     rocky        = enum.auto()
     alma         = enum.auto()
     gentoo       = enum.auto()
+    custom       = enum.auto()
 
     def is_centos_variant(self) -> bool:
         return self in (Distribution.centos, Distribution.alma, Distribution.rocky)

--- a/mkosi/distributions/custom.py
+++ b/mkosi/distributions/custom.py
@@ -19,9 +19,9 @@ class Installer(DistributionInstaller):
     @classmethod
     def install_packages(cls, state: MkosiState, packages: Sequence[str]) -> None:
         if packages:
-            die("Installing packages is not supported with distribution 'none'")
+            die("Installing packages is not supported for custom distributions'")
 
     @classmethod
     def remove_packages(cls, state: MkosiState, packages: Sequence[str]) -> None:
         if packages:
-            die("Removing packages is not supported with distribution 'none'")
+            die("Removing packages is not supported for custom distributions")

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -395,8 +395,9 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 : The distribution to install in the image. Takes one of the following
   arguments: `fedora`, `debian`, `ubuntu`, `arch`, `opensuse`, `mageia`,
-  `centos`, `rhel-ubi`, `openmandriva`, `rocky`, `alma`, `none`.
-  If not specified, defaults to the distribution of the host.
+  `centos`, `rhel-ubi`, `openmandriva`, `rocky`, `alma`, `custom`.
+  If not specified, defaults to the distribution of the host or `custom`
+  if the distribution of the host is not a supported distribution.
 
 `Release=`, `--release=`, `-r`
 
@@ -1294,7 +1295,10 @@ any distribution that packages `apt` may be used to build *Debian* or *Ubuntu* i
 Any distribution that packages `dnf` may be used to build images for any of the rpm-based distributions.
 Any distro that packages `pacman` may be used to build *Arch Linux* images.
 Any distribution that packages `zypper` may be used to build *openSUSE* images.
-Other distributions and build automation tools for embedded Linux systems such as Buildroot, OpenEmbedded and Yocto Project may be used by selecting the `none` distribution, and populating the rootfs via a combination of base trees, skeleton trees, and prepare scripts.
+Other distributions and build automation tools for embedded Linux
+systems such as Buildroot, OpenEmbedded and Yocto Project may be used by
+selecting the `custom` distribution, and populating the rootfs via a
+combination of base trees, skeleton trees, and prepare scripts.
 
 Currently, *Fedora Linux* packages all relevant tools as of Fedora 28.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -216,7 +216,6 @@ def test_parse_config(tmp_path: Path) -> None:
 
 
 def test_parse_load_verb(tmp_path: Path) -> None:
-    (tmp_path / "mkosi.conf").write_text("[Distribution]\nDistribution=fedora")
     with chdir(tmp_path):
         assert parse_config(["build"])[0].verb == Verb.build
         assert parse_config(["clean"])[0].verb == Verb.clean
@@ -255,24 +254,8 @@ def test_parse_config_files_filter(tmp_path: Path) -> None:
         confd = Path("mkosi.conf.d")
         confd.mkdir()
 
-        (confd / "10-file.conf").write_text(
-            """\
-            [Distribution]
-            Distribution=fedora
-
-            [Content]
-            Packages=yes
-            """
-        )
-        (confd / "20-file.noconf").write_text(
-            """\
-            [Distribution]
-            Distribution=fedora
-
-            [Content]
-            Packages=yes
-            """
-        )
+        (confd / "10-file.conf").write_text("[Content]\nPackages=yes")
+        (confd / "20-file.noconf").write_text("[Content]\nPackages=nope")
 
         _, [config] = parse_config()
         assert config.packages == ["yes"]
@@ -280,7 +263,7 @@ def test_parse_config_files_filter(tmp_path: Path) -> None:
 
 def test_compression(tmp_path: Path) -> None:
     with chdir(tmp_path):
-        _, [config] = parse_config(["--format", "disk", "--compress-output", "False", "--distribution", "fedora"])
+        _, [config] = parse_config(["--format", "disk", "--compress-output", "False"])
         assert config.compress_output == Compression.none
 
 
@@ -487,9 +470,6 @@ def test_match_imageversion(tmp_path: Path, op: str, version: str) -> None:
         parent = Path("mkosi.conf")
         parent.write_text(
             """\
-            [Distribution]
-            Distribution=fedora
-
             [Output]
             ImageId=testimage
             ImageVersion=123
@@ -546,24 +526,11 @@ def test_package_manager_tree(tmp_path: Path, skel: Optional[Path], pkgmngr: Opt
     with chdir(tmp_path):
         config = Path("mkosi.conf")
         with config.open("w") as f:
-            f.write(
-                """
-                [Distribution]
-                Distribution=fedora
-
-                [Content]
-                """
-            )
+            f.write("[Content]\n")
             if skel is not None:
-                f.write(f"""
-                SkeletonTrees={skel}
-                """
-            )
+                f.write(f"SkeletonTrees={skel}\n")
             if pkgmngr is not None:
-                f.write(f"""
-                PackageManagerTrees={pkgmngr}
-                """
-            )
+                f.write(f"PackageManagerTrees={pkgmngr}\n")
 
         _, [conf] = parse_config()
 
@@ -598,9 +565,6 @@ def test_wrong_section_warning(
         Path("mkosi.conf").write_text(
             "\n".join(
                 f"""\
-                [Distribution]
-                Distribution=fedora
-
                 [{section}]
                 ImageId=testimage
                 """


### PR DESCRIPTION
"custom" seems a better fit than "none" since there likely still
is a distribution, we just don't support it.