### PR TITLE
Add RHEL support

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -315,31 +315,6 @@ def config_default_release(namespace: argparse.Namespace) -> str:
     return cast(str, namespace.distribution.default_release())
 
 
-def config_default_mirror(namespace: argparse.Namespace) -> Optional[str]:
-    if namespace.distribution == Distribution.debian:
-        return "http://deb.debian.org/debian"
-    elif namespace.distribution == Distribution.ubuntu:
-        if namespace.architecture in (Architecture.x86, Architecture.x86_64):
-            return "http://archive.ubuntu.com/ubuntu"
-        else:
-            return "http://ports.ubuntu.com"
-    elif namespace.distribution == Distribution.arch:
-        if namespace.architecture == Architecture.arm64:
-            return "http://mirror.archlinuxarm.org"
-        else:
-            return "https://geo.mirror.pkgbuild.com"
-    elif namespace.distribution == Distribution.opensuse:
-        return "http://download.opensuse.org"
-    elif namespace.distribution == Distribution.fedora and namespace.release == "eln":
-        return "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose"
-    elif namespace.distribution == Distribution.gentoo:
-        return "https://distfiles.gentoo.org"
-    elif namespace.distribution == Distribution.rhel_ubi:
-        return "https://cdn-ubi.redhat.com/content/public/ubi/dist/"
-
-    return None
-
-
 def config_default_source_date_epoch(namespace: argparse.Namespace) -> Optional[int]:
     for env in namespace.environment:
         if env.startswith("SOURCE_DATE_EPOCH="):
@@ -1108,8 +1083,6 @@ SETTINGS = (
         dest="mirror",
         short="-m",
         section="Distribution",
-        default_factory=config_default_mirror,
-        default_factory_depends=("distribution", "release", "architecture"),
         help="Distribution mirror to use",
     ),
     MkosiConfigSetting(

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -81,6 +81,7 @@ class Distribution(StrEnum):
     opensuse     = enum.auto()
     mageia       = enum.auto()
     centos       = enum.auto()
+    rhel         = enum.auto()
     rhel_ubi     = enum.auto()
     openmandriva = enum.auto()
     rocky        = enum.auto()
@@ -96,6 +97,7 @@ class Distribution(StrEnum):
             Distribution.fedora,
             Distribution.mageia,
             Distribution.centos,
+            Distribution.rhel,
             Distribution.rhel_ubi,
             Distribution.openmandriva,
             Distribution.rocky,

--- a/mkosi/distributions/alma.py
+++ b/mkosi/distributions/alma.py
@@ -2,9 +2,9 @@
 
 from pathlib import Path
 
-from mkosi.config import MkosiConfig
 from mkosi.distributions import centos
 from mkosi.installer.dnf import Repo
+from mkosi.state import MkosiState
 
 
 class Installer(centos.Installer):
@@ -13,22 +13,22 @@ class Installer(centos.Installer):
         return "AlmaLinux"
 
     @staticmethod
-    def gpgurls(config: MkosiConfig) -> tuple[str, ...]:
-        gpgpath = Path(f"/usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-{config.release}")
+    def gpgurls(state: MkosiState) -> tuple[str, ...]:
+        gpgpath = Path(f"/usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-{state.config.release}")
         if gpgpath.exists():
             return (f"file://{gpgpath}",)
         else:
             return ("https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux-$releasever",)
 
     @classmethod
-    def repository_variants(cls, config: MkosiConfig, repo: str) -> list[Repo]:
-        if config.mirror:
-            url = f"baseurl={config.mirror}/almalinux/$releasever/{repo}/$basearch/os"
+    def repository_variants(cls, state: MkosiState, repo: str) -> list[Repo]:
+        if state.config.mirror:
+            url = f"baseurl={state.config.mirror}/almalinux/$releasever/{repo}/$basearch/os"
         else:
             url = f"mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/{repo.lower()}"
 
-        return [Repo(repo, url, cls.gpgurls(config))]
+        return [Repo(repo, url, cls.gpgurls(state))]
 
     @classmethod
-    def sig_repositories(cls, config: MkosiConfig) -> list[Repo]:
+    def sig_repositories(cls, state: MkosiState) -> list[Repo]:
         return []

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -7,7 +7,6 @@ from collections.abc import Iterable, Sequence
 from pathlib import Path
 
 from mkosi.architecture import Architecture
-from mkosi.config import MkosiConfig
 from mkosi.distributions import Distribution, DistributionInstaller, PackageType
 from mkosi.installer.dnf import Repo, invoke_dnf, setup_dnf
 from mkosi.log import complete_step, die
@@ -28,9 +27,8 @@ def move_rpm_db(root: Path) -> None:
             newdb.symlink_to(os.path.relpath(olddb, start=newdb.parent))
 
 
-def join_mirror(config: MkosiConfig, link: str) -> str:
-    assert config.mirror is not None
-    return urllib.parse.urljoin(config.mirror, link)
+def join_mirror(mirror: str, link: str) -> str:
+    return urllib.parse.urljoin(mirror, link)
 
 
 class Installer(DistributionInstaller):
@@ -102,7 +100,7 @@ class Installer(DistributionInstaller):
         if release <= 7:
             die(f"{cls.pretty_name()} 7 or earlier variants are not supported")
 
-        setup_dnf(state, cls.repositories(state.config, release))
+        setup_dnf(state, cls.repositories(state, release))
         (state.pkgmngr / "etc/dnf/vars/stream").write_text(f"{state.config.release}-stream\n")
 
     @classmethod
@@ -137,7 +135,7 @@ class Installer(DistributionInstaller):
         return a
 
     @staticmethod
-    def gpgurls(config: MkosiConfig) -> tuple[str, ...]:
+    def gpgurls(state: MkosiState) -> tuple[str, ...]:
         gpgurls = []
 
         for key in ("CentOS-Official", "CentOS-SIG-Extras"):
@@ -150,80 +148,80 @@ class Installer(DistributionInstaller):
         return tuple(gpgurls)
 
     @classmethod
-    def repository_variants(cls, config: MkosiConfig, repo: str) -> Iterable[Repo]:
-        if config.local_mirror:
-            yield Repo(repo, f"baseurl={config.local_mirror}", cls.gpgurls(config))
+    def repository_variants(cls, state: MkosiState, repo: str) -> Iterable[Repo]:
+        if state.config.local_mirror:
+            yield Repo(repo, f"baseurl={state.config.local_mirror}", cls.gpgurls(state))
 
-        elif config.mirror:
-            if int(config.release) <= 8:
+        elif state.config.mirror:
+            if int(state.config.release) <= 8:
                 yield Repo(
                     repo.lower(),
-                    f"baseurl={join_mirror(config, f'centos/$stream/{repo}/$basearch/os')}",
-                    cls.gpgurls(config),
+                    f"baseurl={join_mirror(state.config.mirror, f'centos/$stream/{repo}/$basearch/os')}",
+                    cls.gpgurls(state),
                 )
                 yield Repo(
                     f"{repo.lower()}-debuginfo",
-                    f"baseurl={join_mirror(config, 'centos-debuginfo/$stream/$basearch')}",
-                    cls.gpgurls(config),
+                    f"baseurl={join_mirror(state.config.mirror, 'centos-debuginfo/$stream/$basearch')}",
+                    cls.gpgurls(state),
                     enabled=False,
                 )
                 yield Repo(
                     f"{repo.lower()}-source",
-                    f"baseurl={join_mirror(config, f'centos/$stream/{repo}/Source')}",
-                    cls.gpgurls(config),
+                    f"baseurl={join_mirror(state.config.mirror, f'centos/$stream/{repo}/Source')}",
+                    cls.gpgurls(state),
                     enabled=False,
                 )
             else:
                 if repo == "extras":
                     yield Repo(
                         repo.lower(),
-                        f"baseurl={join_mirror(config, f'SIGs/$stream/{repo}/$basearch/extras-common')}",
-                        cls.gpgurls(config),
+                        f"baseurl={join_mirror(state.config.mirror, f'SIGs/$stream/{repo}/$basearch/extras-common')}",
+                        cls.gpgurls(state),
                     )
                     yield Repo(
                         f"{repo.lower()}-source",
-                        f"baseurl={join_mirror(config, f'SIGs/$stream/{repo}/source/extras-common')}",
-                        cls.gpgurls(config),
+                        f"baseurl={join_mirror(state.config.mirror, f'SIGs/$stream/{repo}/source/extras-common')}",
+                        cls.gpgurls(state),
                         enabled=False,
                     )
 
                 else:
                     yield Repo(
                         repo.lower(),
-                        f"baseurl={join_mirror(config, f'$stream/{repo}/$basearch/os')}",
-                        cls.gpgurls(config),
+                        f"baseurl={join_mirror(state.config.mirror, f'$stream/{repo}/$basearch/os')}",
+                        cls.gpgurls(state),
                     )
                     yield Repo(
                         f"{repo.lower()}-debuginfo",
-                        f"baseurl={join_mirror(config, f'$stream/{repo}/$basearch/debug/tree')}",
-                        cls.gpgurls(config),
+                        f"baseurl={join_mirror(state.config.mirror, f'$stream/{repo}/$basearch/debug/tree')}",
+                        cls.gpgurls(state),
                         enabled=False,
                     )
                     yield Repo(
                         f"{repo.lower()}-source",
-                        f"baseurl={join_mirror(config, f'$stream/{repo}/source/tree')}",
-                        cls.gpgurls(config),
+                        f"baseurl={join_mirror(state.config.mirror, f'$stream/{repo}/source/tree')}",
+                        cls.gpgurls(state),
                         enabled=False,
                     )
 
         else:
-            if int(config.release) <= 8:
+            if int(state.config.release) <= 8:
                 yield Repo(
                     repo.lower(),
                     f"mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo={repo}",
-                    cls.gpgurls(config),
+                    cls.gpgurls(state),
                 )
                 # These can't be retrieved from the mirrorlist.
                 yield Repo(
                     f"{repo.lower()}-debuginfo",
                     "baseurl=http://debuginfo.centos.org/$stream/$basearch",
-                    cls.gpgurls(config),
+                    cls.gpgurls(state),
                     enabled=False,
                 )
                 yield Repo(
                     f"{repo.lower()}-source",
                     f"baseurl=https://vault.centos.org/centos/$stream/{repo}/Source",
-                    cls.gpgurls(config),
+                    cls.gpgurls(state),
                     enabled=False,
                 )
             else:
@@ -233,62 +231,62 @@ class Installer(DistributionInstaller):
                     yield Repo(
                         repo.lower(),
                         f"{url}?arch=$basearch&repo=centos-extras-sig-extras-common-$stream",
-                        cls.gpgurls(config),
+                        cls.gpgurls(state),
                     )
                     yield Repo(
                         f"{repo.lower()}-source",
                         f"{url}?arch=source&repo=centos-extras-sig-extras-common-source-$stream",
-                        cls.gpgurls(config),
+                        cls.gpgurls(state),
                         enabled=False,
                     )
                 else:
                     yield Repo(
                         repo.lower(),
                         f"{url}?arch=$basearch&repo=centos-{repo.lower()}-$stream",
-                        cls.gpgurls(config),
+                        cls.gpgurls(state),
                     )
                     yield Repo(
                         f"{repo.lower()}-debuginfo",
                         f"{url}?arch=$basearch&repo=centos-{repo.lower()}-debug-$stream",
-                        cls.gpgurls(config),
+                        cls.gpgurls(state),
                         enabled=False,
                     )
                     yield Repo(
                         f"{repo.lower()}-source",
                         f"{url}?arch=source&repo=centos-{repo.lower()}-source-$stream",
-                        cls.gpgurls(config),
+                        cls.gpgurls(state),
                         enabled=False,
                     )
 
     @classmethod
-    def repositories(cls, config: MkosiConfig, release: int) -> Iterable[Repo]:
-        if config.local_mirror:
-            yield from cls.repository_variants(config, "AppStream")
+    def repositories(cls, state: MkosiState, release: int) -> Iterable[Repo]:
+        if state.config.local_mirror:
+            yield from cls.repository_variants(state, "AppStream")
         else:
-            yield from cls.repository_variants(config, "BaseOS")
-            yield from cls.repository_variants(config, "AppStream")
-            yield from cls.repository_variants(config, "extras")
+            yield from cls.repository_variants(state, "BaseOS")
+            yield from cls.repository_variants(state, "AppStream")
+            yield from cls.repository_variants(state, "extras")
 
         if release >= 9:
-            yield from cls.repository_variants(config, "CRB")
+            yield from cls.repository_variants(state, "CRB")
         else:
-            yield from cls.repository_variants(config, "PowerTools")
+            yield from cls.repository_variants(state, "PowerTools")
 
-        yield from cls.epel_repositories(config)
-        yield from cls.sig_repositories(config)
+        yield from cls.epel_repositories(state)
+        yield from cls.sig_repositories(state)
 
     @classmethod
-    def epel_repositories(cls, config: MkosiConfig) -> Iterable[Repo]:
-        gpgpath = Path(f"/usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-EPEL-{config.release}")
+    def epel_repositories(cls, state: MkosiState) -> Iterable[Repo]:
+        gpgpath = Path(f"/usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-EPEL-{state.config.release}")
         if gpgpath.exists():
             gpgurls = (f"file://{gpgpath}",)
         else:
-            gpgurls = (f"https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{config.release}",)
+            gpgurls = (f"https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{state.config.release}",)
 
-        if config.local_mirror:
+        if state.config.local_mirror:
             return
 
-        if config.mirror:
+        if state.config.mirror:
             for repo, dir in (
                 ("epel", "epel"),
                 ("epel-next", "epel/next"),
@@ -297,19 +295,19 @@ class Installer(DistributionInstaller):
             ):
                 yield Repo(
                     repo,
-                    f"baseurl={join_mirror(config, f'{dir}/$releasever/Everything/$basearch')}",
+                    f"baseurl={join_mirror(state.config.mirror, f'{dir}/$releasever/Everything/$basearch')}",
                     gpgurls,
                     enabled=False,
                 )
                 yield Repo(
                     f"{repo}-debuginfo",
-                    f"baseurl={join_mirror(config, f'{dir}/$releasever/Everything/$basearch/debug')}",
+                    f"baseurl={join_mirror(state.config.mirror, f'{dir}/$releasever/Everything/$basearch/debug')}",
                     gpgurls,
                     enabled=False,
                 )
                 yield Repo(
                     f"{repo}-source",
-                    f"baseurl={join_mirror(config, f'{dir}/$releasever/Everything/source/tree')}",
+                    f"baseurl={join_mirror(state.config.mirror, f'{dir}/$releasever/Everything/source/tree')}",
                     gpgurls,
                     enabled=False,
                 )
@@ -338,8 +336,8 @@ class Installer(DistributionInstaller):
             )
 
     @classmethod
-    def sig_repositories(cls, config: MkosiConfig) -> Iterable[Repo]:
-        if config.local_mirror:
+    def sig_repositories(cls, state: MkosiState) -> Iterable[Repo]:
+        if state.config.local_mirror:
             return
 
         sigs = (
@@ -362,47 +360,47 @@ class Installer(DistributionInstaller):
             gpgurls = tuple(gpgurls)
 
             for c in components:
-                if config.mirror:
-                    if int(config.release) <= 8:
+                if state.config.mirror:
+                    if int(state.config.release) <= 8:
                         yield Repo(
                             f"{sig}-{c}",
-                            f"baseurl={join_mirror(config, f'centos/$stream/{sig}/$basearch/{c}')}",
+                            f"baseurl={join_mirror(state.config.mirror, f'centos/$stream/{sig}/$basearch/{c}')}",
                             gpgurls,
                             enabled=False,
                         )
                         yield Repo(
                             f"{sig}-{c}-debuginfo",
-                            f"baseurl={join_mirror(config, f'$stream/{sig}/$basearch')}",
+                            f"baseurl={join_mirror(state.config.mirror, f'$stream/{sig}/$basearch')}",
                             gpgurls,
                             enabled=False,
                         )
                         yield Repo(
                             f"{sig}-{c}-source",
-                            f"baseurl={join_mirror(config, f'centos/$stream/{sig}/Source')}",
+                            f"baseurl={join_mirror(state.config.mirror, f'centos/$stream/{sig}/Source')}",
                             gpgurls,
                             enabled=False,
                         )
                     else:
                         yield Repo(
                             f"{sig}-{c}",
-                            f"baseurl={join_mirror(config, f'SIGs/$stream/{sig}/$basearch/{c}')}",
+                            f"baseurl={join_mirror(state.config.mirror, f'SIGs/$stream/{sig}/$basearch/{c}')}",
                             gpgurls,
                             enabled=False,
                         )
                         yield Repo(
                             f"{sig}-{c}-debuginfo",
-                            f"baseurl={join_mirror(config, f'SIGs/$stream/{sig}/$basearch/{c}/debug')}",
+                            f"baseurl={join_mirror(state.config.mirror, f'SIGs/$stream/{sig}/$basearch/{c}/debug')}",
                             gpgurls,
                             enabled=False,
                         )
                         yield Repo(
                             f"{sig}-{c}-source",
-                            f"baseurl={join_mirror(config, f'SIGs/$stream/{sig}/source/{c}')}",
+                            f"baseurl={join_mirror(state.config.mirror, f'SIGs/$stream/{sig}/source/{c}')}",
                             gpgurls,
                             enabled=False,
                         )
                 else:
-                    if int(config.release) <= 8:
+                    if int(state.config.release) <= 8:
                         yield Repo(
                             f"{sig}-{c}",
                             f"mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo={sig}-{c}",
@@ -450,7 +448,7 @@ class Installer(DistributionInstaller):
                         enabled=False,
                     )
 
-                    if int(config.release) >= 9:
+                    if int(state.config.release) >= 9:
                         yield Repo(
                             f"{sig}-{c}-testing-debuginfo",
                             f"baseurl=https://buildlogs.centos.org/centos/$stream/{sig}/$basearch/{c}",

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -80,16 +80,16 @@ class Installer(DistributionInstaller):
 
     @staticmethod
     def repositories(state: MkosiState, local: bool = True) -> list[str]:
-        assert state.config.mirror
-
         archives = ("deb", "deb-src")
         components = ' '.join(("main", *state.config.repositories))
 
         if state.config.local_mirror and local:
             return [f"deb [trusted=yes] {state.config.local_mirror} {state.config.release} {components}"]
 
+        mirror = state.config.mirror or "http://deb.debian.org/debian"
+
         repos = [
-            f"{archive} {state.config.mirror} {state.config.release} {components}"
+            f"{archive} {mirror} {state.config.release} {components}"
             for archive in archives
         ]
 
@@ -100,7 +100,7 @@ class Installer(DistributionInstaller):
             return repos
 
         repos += [
-            f"{archive} {state.config.mirror} {state.config.release}-updates {components}"
+            f"{archive} {mirror} {state.config.release}-updates {components}"
             for archive in archives
         ]
 

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -89,9 +89,9 @@ class Installer(DistributionInstaller):
         if state.config.local_mirror:
             repos += [Repo("fedora", f"baseurl={state.config.mirror}", gpgurls)]
         elif state.config.release == "eln":
-            assert state.config.mirror
+            mirror = state.config.mirror or "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose"
             for repo in ("Appstream", "BaseOS", "Extras", "CRB"):
-                url = f"baseurl={urllib.parse.urljoin(state.config.mirror, repo)}"
+                url = f"baseurl={urllib.parse.urljoin(mirror, repo)}"
                 repos += [
                     Repo(repo.lower(), f"{url}/$basearch/os", gpgurls),
                     Repo(repo.lower(), f"{url}/$basearch/debug/tree", gpgurls, enabled=False),

--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -86,10 +86,10 @@ class Installer(DistributionInstaller):
     def install(cls, state: MkosiState) -> None:
         arch = state.config.distribution.architecture(state.config.architecture)
 
-        assert state.config.mirror
+        mirror = state.config.mirror or "https://distfiles.gentoo.org"
         # http://distfiles.gentoo.org/releases/amd64/autobuilds/latest-stage3.txt
         stage3tsf_path_url = urllib.parse.urljoin(
-            state.config.mirror.partition(" ")[0],
+            mirror.partition(" ")[0],
             f"releases/{arch}/autobuilds/latest-stage3.txt",
         )
 
@@ -104,7 +104,7 @@ class Installer(DistributionInstaller):
             else:
                 die("profile names changed upstream?")
 
-        stage3_url = urllib.parse.urljoin(state.config.mirror, f"releases/{arch}/autobuilds/{stage3_latest}")
+        stage3_url = urllib.parse.urljoin(mirror, f"releases/{arch}/autobuilds/{stage3_latest}")
         stage3_tar = state.cache_dir / "stage3.tar"
         stage3 = state.cache_dir / "stage3"
 

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -80,20 +80,22 @@ class Installer(DistributionInstaller):
         if release == "leap":
             release = "stable"
 
+        mirror = state.config.mirror or "http://download.opensuse.org"
+
         # If the release looks like a timestamp, it's Tumbleweed. 13.x is legacy
         # (14.x won't ever appear). For anything else, let's default to Leap.
         if state.config.local_mirror:
             release_url = f"{state.config.local_mirror}"
             updates_url = None
         if release.isdigit() or release == "tumbleweed":
-            release_url = f"{state.config.mirror}/tumbleweed/repo/oss/"
-            updates_url = f"{state.config.mirror}/update/tumbleweed/"
+            release_url = f"{mirror}/tumbleweed/repo/oss/"
+            updates_url = f"{mirror}/update/tumbleweed/"
         elif release in ("current", "stable"):
-            release_url = f"{state.config.mirror}/distribution/openSUSE-{release}/repo/oss/"
-            updates_url = f"{state.config.mirror}/update/openSUSE-{release}/"
+            release_url = f"{mirror}/distribution/openSUSE-{release}/repo/oss/"
+            updates_url = f"{mirror}/update/openSUSE-{release}/"
         else:
-            release_url = f"{state.config.mirror}/distribution/leap/{release}/repo/oss/"
-            updates_url = f"{state.config.mirror}/update/leap/{release}/oss/"
+            release_url = f"{mirror}/distribution/leap/{release}/repo/oss/"
+            updates_url = f"{mirror}/update/leap/{release}/oss/"
 
         zypper = shutil.which("zypper")
 

--- a/mkosi/distributions/rhel.py
+++ b/mkosi/distributions/rhel.py
@@ -100,7 +100,7 @@ class Installer(centos.Installer):
             )
 
     @classmethod
-    def repositories(cls, state: MkosiState, release: int) -> Iterable[Repo]:
+    def repositories(cls, state: MkosiState) -> Iterable[Repo]:
         yield from cls.repository_variants(state, "baseos")
         yield from cls.repository_variants(state, "appstream")
         yield from cls.repository_variants(state, "codeready-builder")

--- a/mkosi/distributions/rhel.py
+++ b/mkosi/distributions/rhel.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any, Optional
+
+from mkosi.distributions import centos
+from mkosi.installer.dnf import Repo
+from mkosi.log import die
+from mkosi.state import MkosiState
+
+
+class Installer(centos.Installer):
+    @classmethod
+    def pretty_name(cls) -> str:
+        return "RHEL"
+
+    @staticmethod
+    def gpgurls(state: MkosiState) -> tuple[str, ...]:
+        return ("https://access.redhat.com/security/data/fd431d51.txt",)
+
+    @staticmethod
+    def sslcacert(state: MkosiState) -> Optional[Path]:
+        if state.config.mirror:
+            return None
+
+        p = Path("etc/rhsm/ca/redhat-uep.pem")
+        if (state.pkgmngr / p).exists():
+            p = state.pkgmngr / p
+        elif (Path("/") / p).exists():
+            p = Path("/") / p
+        else:
+            die("redhat-uep.pem certificate not found in host system or package manager tree")
+
+        return p
+
+    @staticmethod
+    def sslclientkey(state: MkosiState) -> Optional[Path]:
+        if state.config.mirror:
+            return None
+
+        pattern = "etc/pki/entitlement/*-key.pem"
+
+        p = next((p for p in sorted(state.pkgmngr.glob(pattern))), None)
+        if not p:
+            p = next((p for p in Path("/").glob(pattern)), None)
+        if not p:
+            die("Entitlement key not found in host system or package manager tree")
+
+        return p
+
+    @staticmethod
+    def sslclientcert(state: MkosiState) -> Optional[Path]:
+        if state.config.mirror:
+            return None
+
+        pattern = "etc/pki/entitlement/*.pem"
+
+        p = next((p for p in sorted(state.pkgmngr.glob(pattern)) if "key" not in p.name), None)
+        if not p:
+            p = next((p for p in sorted(Path("/").glob(pattern)) if "key" not in p.name), None)
+        if not p:
+            die("Entitlement certificate not found in host system or package manager tree")
+
+        return p
+
+    @classmethod
+    def repository_variants(cls, state: MkosiState, repo: str) -> Iterable[Repo]:
+        if state.config.local_mirror:
+            yield Repo(repo, f"baseurl={state.config.local_mirror}", cls.gpgurls(state))
+        else:
+            mirror = state.config.mirror or "https://cdn.redhat.com/content/dist/"
+
+            common: dict[str, Any] = dict(
+                gpgurls=cls.gpgurls(state),
+                sslcacert=cls.sslcacert(state),
+                sslclientcert=cls.sslclientcert(state),
+                sslclientkey=cls.sslclientkey(state),
+            )
+
+            v = state.config.release
+            major = int(float(v))
+            yield Repo(
+                f"rhel-{v}-{repo}-rpms",
+                f"baseurl={centos.join_mirror(mirror, f'rhel{major}/{v}/$basearch/{repo}/os')}",
+                enabled=True,
+                **common,
+            )
+            yield Repo(
+                f"rhel-{v}-{repo}-debug-rpms",
+                f"baseurl={centos.join_mirror(mirror, f'rhel{major}/{v}/$basearch/{repo}/debug')}",
+                enabled=False,
+                **common,
+            )
+            yield Repo(
+                f"rhel-{v}-{repo}-source",
+                f"baseurl={centos.join_mirror(mirror, f'rhel{major}/{v}/$basearch/{repo}/source')}",
+                enabled=False,
+                **common,
+            )
+
+    @classmethod
+    def repositories(cls, state: MkosiState, release: int) -> Iterable[Repo]:
+        yield from cls.repository_variants(state, "baseos")
+        yield from cls.repository_variants(state, "appstream")
+        yield from cls.repository_variants(state, "codeready-builder")
+        yield from cls.epel_repositories(state)

--- a/mkosi/distributions/rhel_ubi.py
+++ b/mkosi/distributions/rhel_ubi.py
@@ -41,13 +41,6 @@ class Installer(centos.Installer):
                 cls.gpgurls(state),
                 enabled=False,
             )
-            if repo == "codeready-builder":
-                yield Repo(
-                    f"ubi-{v}-{repo}",
-                    f"baseurl={centos.join_mirror(mirror, f'ubi{v}/{v}/$basearch/{repo}/os')}",
-                    cls.gpgurls(state),
-                    enabled=False,
-                )
 
     @classmethod
     def repositories(cls, state: MkosiState, release: int) -> Iterable[Repo]:

--- a/mkosi/distributions/rhel_ubi.py
+++ b/mkosi/distributions/rhel_ubi.py
@@ -2,9 +2,9 @@
 
 from collections.abc import Iterable
 
-from mkosi.config import MkosiConfig
 from mkosi.distributions import centos
 from mkosi.installer.dnf import Repo
+from mkosi.state import MkosiState
 
 
 class Installer(centos.Installer):
@@ -13,42 +13,44 @@ class Installer(centos.Installer):
         return "RHEL UBI"
 
     @staticmethod
-    def gpgurls(config: MkosiConfig) -> tuple[str, ...]:
+    def gpgurls(state: MkosiState) -> tuple[str, ...]:
         return ("https://access.redhat.com/security/data/fd431d51.txt",)
 
     @classmethod
-    def repository_variants(cls, config: MkosiConfig, repo: str) -> Iterable[Repo]:
-        if config.local_mirror:
-            yield Repo(repo, f"baseurl={config.local_mirror}", cls.gpgurls(config))
+    def repository_variants(cls, state: MkosiState, repo: str) -> Iterable[Repo]:
+        if state.config.local_mirror:
+            yield Repo(repo, f"baseurl={state.config.local_mirror}", cls.gpgurls(state))
         else:
-            v = config.release
+            assert state.config.mirror
+
+            v = state.config.release
             yield Repo(
                 f"ubi-{v}-{repo}-rpms",
-                f"baseurl={centos.join_mirror(config, f'ubi{v}/{v}/$basearch/{repo}/os')}",
-                cls.gpgurls(config),
+                f"baseurl={centos.join_mirror(state.config.mirror, f'ubi{v}/{v}/$basearch/{repo}/os')}",
+                cls.gpgurls(state),
             )
             yield Repo(
                 f"ubi-{v}-{repo}-debug-rpms",
-                f"baseurl={centos.join_mirror(config, f'ubi{v}/{v}/$basearch/{repo}/debug')}",
-                cls.gpgurls(config),
+                f"baseurl={centos.join_mirror(state.config.mirror, f'ubi{v}/{v}/$basearch/{repo}/debug')}",
+                cls.gpgurls(state),
                 enabled=False,
             )
             yield Repo(
                 f"ubi-{v}-{repo}-source",
-                f"baseurl={centos.join_mirror(config, f'ubi{v}/{v}/$basearch/{repo}/source')}",
-                cls.gpgurls(config),
+                f"baseurl={centos.join_mirror(state.config.mirror, f'ubi{v}/{v}/$basearch/{repo}/source')}",
+                cls.gpgurls(state),
                 enabled=False,
             )
             if repo == "codeready-builder":
                 yield Repo(
                     f"ubi-{v}-{repo}",
-                    f"baseurl={centos.join_mirror(config, f'ubi{v}/{v}/$basearch/{repo}/os')}",
-                    cls.gpgurls(config),
+                    f"baseurl={centos.join_mirror(state.config.mirror, f'ubi{v}/{v}/$basearch/{repo}/os')}",
+                    cls.gpgurls(state),
                     enabled=False,
                 )
 
     @classmethod
-    def repositories(cls, config: MkosiConfig, release: int) -> Iterable[Repo]:
-        yield from cls.repository_variants(config, "baseos")
-        yield from cls.repository_variants(config, "appstream")
-        yield from cls.repository_variants(config, "codeready-builder")
+    def repositories(cls, state: MkosiState, release: int) -> Iterable[Repo]:
+        yield from cls.repository_variants(state, "baseos")
+        yield from cls.repository_variants(state, "appstream")
+        yield from cls.repository_variants(state, "codeready-builder")

--- a/mkosi/distributions/rhel_ubi.py
+++ b/mkosi/distributions/rhel_ubi.py
@@ -47,3 +47,4 @@ class Installer(centos.Installer):
         yield from cls.repository_variants(state, "baseos")
         yield from cls.repository_variants(state, "appstream")
         yield from cls.repository_variants(state, "codeready-builder")
+        yield from cls.epel_repositories(state)

--- a/mkosi/distributions/rhel_ubi.py
+++ b/mkosi/distributions/rhel_ubi.py
@@ -43,7 +43,7 @@ class Installer(centos.Installer):
             )
 
     @classmethod
-    def repositories(cls, state: MkosiState, release: int) -> Iterable[Repo]:
+    def repositories(cls, state: MkosiState) -> Iterable[Repo]:
         yield from cls.repository_variants(state, "baseos")
         yield from cls.repository_variants(state, "appstream")
         yield from cls.repository_variants(state, "codeready-builder")

--- a/mkosi/distributions/rhel_ubi.py
+++ b/mkosi/distributions/rhel_ubi.py
@@ -21,30 +21,30 @@ class Installer(centos.Installer):
         if state.config.local_mirror:
             yield Repo(repo, f"baseurl={state.config.local_mirror}", cls.gpgurls(state))
         else:
-            assert state.config.mirror
+            mirror = state.config.mirror or "https://cdn-ubi.redhat.com/content/public/ubi/dist/"
 
             v = state.config.release
             yield Repo(
                 f"ubi-{v}-{repo}-rpms",
-                f"baseurl={centos.join_mirror(state.config.mirror, f'ubi{v}/{v}/$basearch/{repo}/os')}",
+                f"baseurl={centos.join_mirror(mirror, f'ubi{v}/{v}/$basearch/{repo}/os')}",
                 cls.gpgurls(state),
             )
             yield Repo(
                 f"ubi-{v}-{repo}-debug-rpms",
-                f"baseurl={centos.join_mirror(state.config.mirror, f'ubi{v}/{v}/$basearch/{repo}/debug')}",
+                f"baseurl={centos.join_mirror(mirror, f'ubi{v}/{v}/$basearch/{repo}/debug')}",
                 cls.gpgurls(state),
                 enabled=False,
             )
             yield Repo(
                 f"ubi-{v}-{repo}-source",
-                f"baseurl={centos.join_mirror(state.config.mirror, f'ubi{v}/{v}/$basearch/{repo}/source')}",
+                f"baseurl={centos.join_mirror(mirror, f'ubi{v}/{v}/$basearch/{repo}/source')}",
                 cls.gpgurls(state),
                 enabled=False,
             )
             if repo == "codeready-builder":
                 yield Repo(
                     f"ubi-{v}-{repo}",
-                    f"baseurl={centos.join_mirror(state.config.mirror, f'ubi{v}/{v}/$basearch/{repo}/os')}",
+                    f"baseurl={centos.join_mirror(mirror, f'ubi{v}/{v}/$basearch/{repo}/os')}",
                     cls.gpgurls(state),
                     enabled=False,
                 )

--- a/mkosi/distributions/rocky.py
+++ b/mkosi/distributions/rocky.py
@@ -2,9 +2,9 @@
 
 from pathlib import Path
 
-from mkosi.config import MkosiConfig
 from mkosi.distributions import centos
 from mkosi.installer.dnf import Repo
+from mkosi.state import MkosiState
 
 
 class Installer(centos.Installer):
@@ -13,22 +13,22 @@ class Installer(centos.Installer):
         return "Rocky Linux"
 
     @staticmethod
-    def gpgurls(config: MkosiConfig) -> tuple[str, ...]:
-        gpgpath = Path(f"/usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-{config.release}")
+    def gpgurls(state: MkosiState) -> tuple[str, ...]:
+        gpgpath = Path(f"/usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-{state.config.release}")
         if gpgpath.exists():
             return (f"file://{gpgpath}",)
         else:
             return ("https://download.rockylinux.org/pub/rocky/RPM-GPG-KEY-Rocky-$releasever",)
 
     @classmethod
-    def repository_variants(cls, config: MkosiConfig, repo: str) -> list[Repo]:
-        if config.mirror:
-            url = f"baseurl={config.mirror}/rocky/$releasever/{repo}/$basearch/os"
+    def repository_variants(cls, state: MkosiState, repo: str) -> list[Repo]:
+        if state.config.mirror:
+            url = f"baseurl={state.config.mirror}/rocky/$releasever/{repo}/$basearch/os"
         else:
             url = f"mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo={repo}-$releasever"
 
-        return [Repo(repo, url, cls.gpgurls(config))]
+        return [Repo(repo, url, cls.gpgurls(state))]
 
     @classmethod
-    def sig_repositories(cls, config: MkosiConfig) -> list[Repo]:
+    def sig_repositories(cls, state: MkosiState) -> list[Repo]:
         return []

--- a/mkosi/distributions/ubuntu.py
+++ b/mkosi/distributions/ubuntu.py
@@ -21,29 +21,34 @@ class Installer(debian.Installer):
 
         archives = ("deb", "deb-src")
 
+        if state.config.architecture in (Architecture.x86, Architecture.x86_64):
+            mirror = state.config.mirror or "http://archive.ubuntu.com/ubuntu"
+        else:
+            mirror = state.config.mirror or "http://ports.ubuntu.com"
+
         # From kinetic onwards, the usr-is-merged package is available in universe and is required by
         # mkosi to set up a proper usr-merged system so we add the universe repository unconditionally.
         components = ["main"] + (["universe"] if state.config.release not in ("focal", "jammy") else [])
         components = ' '.join((*components, *state.config.repositories))
 
         repos = [
-            f"{archive} {state.config.mirror} {state.config.release} {components}"
+            f"{archive} {mirror} {state.config.release} {components}"
             for archive in archives
         ]
 
         repos += [
-            f"{archive} {state.config.mirror} {state.config.release}-updates {components}"
+            f"{archive} {mirror} {state.config.release}-updates {components}"
             for archive in archives
         ]
 
         # Security updates repos are never mirrored. But !x86 are on the ports server.
         if state.config.architecture in [Architecture.x86, Architecture.x86_64]:
-            url = "http://security.ubuntu.com/ubuntu/"
+            mirror = "http://security.ubuntu.com/ubuntu/"
         else:
-            url = "http://ports.ubuntu.com/"
+            mirror = "http://ports.ubuntu.com/"
 
         repos += [
-            f"{archive} {url} {state.config.release}-security {components}"
+            f"{archive} {mirror} {state.config.release}-security {components}"
             for archive in archives
         ]
 

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -72,6 +72,8 @@ def setup_dnf(state: MkosiState, repos: Iterable[Repo], filelists: bool = True) 
                     f.write("gpgkey=" if i == 0 else len("gpgkey=") * " ")
                     f.write(f"{url}\n")
 
+                f.write("\n")
+
 
 def dnf_cmd(state: MkosiState) -> list[PathString]:
     dnf = dnf_executable(state)

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -4,7 +4,7 @@ import shutil
 import textwrap
 from collections.abc import Iterable
 from pathlib import Path
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
 from mkosi.run import apivfs_cmd, bwrap
 from mkosi.state import MkosiState
@@ -18,6 +18,9 @@ class Repo(NamedTuple):
     url: str
     gpgurls: tuple[str, ...]
     enabled: bool = True
+    sslcacert: Optional[Path] = None
+    sslclientkey: Optional[Path] = None
+    sslclientcert: Optional[Path] = None
 
 
 def dnf_executable(state: MkosiState) -> str:
@@ -67,6 +70,13 @@ def setup_dnf(state: MkosiState, repos: Iterable[Repo], filelists: bool = True) 
                         """
                     )
                 )
+
+                if repo.sslcacert:
+                    f.write(f"sslcacert={repo.sslcacert}\n")
+                if repo.sslclientcert:
+                    f.write(f"sslclientcert={repo.sslclientcert}\n")
+                if repo.sslclientkey:
+                    f.write(f"sslclientkey={repo.sslclientkey}\n")
 
                 for i, url in enumerate(repo.gpgurls):
                     f.write("gpgkey=" if i == 0 else len("gpgkey=") * " ")

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -12,15 +12,13 @@ from mkosi.util import sort_packages, umask
 
 
 def setup_pacman(state: MkosiState) -> None:
-    assert state.config.mirror
-
     if state.config.local_mirror:
         server = f"Server = {state.config.local_mirror}"
     else:
         if state.config.architecture == Architecture.arm64:
-            server = f"Server = {state.config.mirror}/$arch/$repo"
+            server = f"Server = {state.config.mirror or 'http://mirror.archlinuxarm.org'}/$arch/$repo"
         else:
-            server = f"Server = {state.config.mirror}/$repo/os/$arch"
+            server = f"Server = {state.config.mirror or 'https://geo.mirror.pkgbuild.com'}/$repo/os/$arch"
 
     if state.config.repository_key_check:
         sig_level = "Required DatabaseOptional"

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -395,9 +395,10 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 : The distribution to install in the image. Takes one of the following
   arguments: `fedora`, `debian`, `ubuntu`, `arch`, `opensuse`, `mageia`,
-  `centos`, `rhel-ubi`, `openmandriva`, `rocky`, `alma`, `custom`.
-  If not specified, defaults to the distribution of the host or `custom`
-  if the distribution of the host is not a supported distribution.
+  `centos`, `rhel`, `rhel-ubi`, `openmandriva`, `rocky`, `alma`,
+  `custom`. If not specified, defaults to the distribution of the host
+  or `custom` if the distribution of the host is not a supported
+  distribution.
 
 `Release=`, `--release=`, `-r`
 
@@ -1321,6 +1322,8 @@ distributions:
 
 * *CentOS*
 
+* *RHEL*
+
 * *RHEL UBI*
 
 * *OpenMandriva*
@@ -1349,6 +1352,10 @@ selecting the `custom` distribution, and populating the rootfs via a
 combination of base trees, skeleton trees, and prepare scripts.
 
 Currently, *Fedora Linux* packages all relevant tools as of Fedora 28.
+
+Note that when not using a custom mirror, `RHEL` images can only be
+built from a host system with a `RHEL` subscription (established using
+e.g. `subscription-manager`).
 
 # Execution Flow
 

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -425,7 +425,25 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 `Mirror=`, `--mirror=`, `-m`
 
 : The mirror to use for downloading the distribution packages. Expects
-  a mirror URL as argument.
+  a mirror URL as argument. If not provided, the default mirror for the
+  distribution is used.
+
+: The default mirrors for each distribution are as follows (unless
+  specified, the same mirror is used for all architectures):
+
+  |                | x86-64                            | aarch64                        |
+  |----------------|--------------------------------------------------------------------|
+  | `debian`       | http://deb.debian.org/debian      |                                |
+  | `arch`         | https://geo.mirror.pkgbuild.com   | http://mirror.archlinuxarm.org |
+  | `opensuse`     | http://download.opensuse.org      |                                |
+  | `ubuntu`       | http://archive.ubuntu.com         | http://ports.ubuntu.com        |
+  | `centos`       | https://mirrors.centos.org        |                                |
+  | `rocky`        | https://mirrors.rockylinux.org    |                                |
+  | `alma`         | https://mirrors.almalinux.org     |                                |
+  | `fedora`       | https://mirrors.fedoraproject.org |                                |
+  | `rhel-ubi`     | https://cdn-ubi.redhat.com        |                                |
+  | `mageia`       | https://www.mageia.org            |                                |
+  | `openmandriva` | http://mirrors.openmandriva.org   |                                |
 
 `LocalMirror=`, `--local-mirror=`
 

--- a/mkosi/versioncomp.py
+++ b/mkosi/versioncomp.py
@@ -139,32 +139,44 @@ class GenericVersion:
             v2 = v2.removeprefix(v2_letter_prefix)
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, GenericVersion):
+        if isinstance(other, (str, int)):
+            other = GenericVersion(str(other))
+        elif not isinstance(other, GenericVersion):
             return False
         return self.compare_versions(self._version, other._version) == self._EQUAL
 
     def __ne__(self, other: object) -> bool:
-        if not isinstance(other, GenericVersion):
+        if isinstance(other, (str, int)):
+            other = GenericVersion(str(other))
+        elif not isinstance(other, GenericVersion):
             return False
         return self.compare_versions(self._version, other._version) != self._EQUAL
 
     def __lt__(self, other: object) -> bool:
-        if not isinstance(other, GenericVersion):
+        if isinstance(other, (str, int)):
+            other = GenericVersion(str(other))
+        elif not isinstance(other, GenericVersion):
             return False
         return self.compare_versions(self._version, other._version) == self._LEFT_SMALLER
 
     def __le__(self, other: object) -> bool:
-        if not isinstance(other, GenericVersion):
+        if isinstance(other, (str, int)):
+            other = GenericVersion(str(other))
+        elif not isinstance(other, GenericVersion):
             return False
         return self.compare_versions(self._version, other._version) in (self._EQUAL, self._LEFT_SMALLER)
 
     def __gt__(self, other: object) -> bool:
-        if not isinstance(other, GenericVersion):
+        if isinstance(other, (str, int)):
+            other = GenericVersion(str(other))
+        elif not isinstance(other, GenericVersion):
             return False
         return self.compare_versions(self._version, other._version) == self._RIGHT_SMALLER
 
     def __ge__(self, other: object) -> bool:
-        if not isinstance(other, GenericVersion):
+        if isinstance(other, (str, int)):
+            other = GenericVersion(str(other))
+        elif not isinstance(other, GenericVersion):
             return False
         return self.compare_versions(self._version, other._version) in (self._EQUAL, self._RIGHT_SMALLER)
 

--- a/tests/test_versioncomp.py
+++ b/tests/test_versioncomp.py
@@ -6,6 +6,14 @@ import pytest
 from mkosi.versioncomp import GenericVersion
 
 
+def test_conversion() -> None:
+    assert GenericVersion("1") < 2
+    assert GenericVersion("1") < "2"
+    assert GenericVersion("2") > 1
+    assert GenericVersion("2") > "1"
+    assert GenericVersion("1") == "1"
+
+
 def test_generic_version_systemd() -> None:
     """Same as the first block of systemd/test/test-compare-versions.sh"""
     assert GenericVersion("1") < GenericVersion("2")


### PR DESCRIPTION
To make RHEL work, we have to look up the necessary certificates and
add them to the generated repo files. This requires the image build to
be done from a system with a RHEL subscription.