### PR TITLE
Allow build script to install extra stuff in the build overlay

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -298,6 +298,15 @@ def mount_build_overlay(state: MkosiState) -> contextlib.AbstractContextManager[
     return mount_overlay([state.root], state.workspace / "build-overlay", state.root)
 
 
+@contextlib.contextmanager
+def mount_volatile_overlay(state: MkosiState) -> Iterator[Path]:
+    with tempfile.TemporaryDirectory() as d:
+        Path(d).chmod(0o755)
+
+        with mount_overlay([state.root], Path(d), state.root) as p:
+            yield p
+
+
 def finalize_mounts(config: MkosiConfig) -> list[PathString]:
     sources = [
         (src, Path.cwd() / (str(target).lstrip("/") if target else "."))
@@ -391,7 +400,11 @@ def run_build_scripts(state: MkosiState) -> None:
             CHROOT_BUILDDIR="/work/build",
         )
 
-    with mount_build_overlay(state), mount_passwd(state.name, state.uid, state.gid, state.root):
+    with (
+        mount_build_overlay(state),\
+        mount_passwd(state.name, state.uid, state.gid, state.root),\
+        mount_volatile_overlay(state)\
+    ):
         for script in state.config.build_scripts:
             chroot = chroot_cmd(
                 state.root,


### PR DESCRIPTION
If we're building multiple things within a build script and one of those depends on headers from a previous build, the headers have to be installed into / so they can be picked up by the next build. Let's make this possible by allowing to install to /. However, we make sure all these changes are ephemeral by mounting a temporary directory on top of / before we run any build scripts. In effect, this means the headers are thrown away after each build.