### PR TITLE
Run qemu as the invoking user again

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -8,7 +8,6 @@ runs:
   - name: Permit unprivileged access to kvm, vhost-vsock and vhost-net devices
     shell: bash
     run: |
-      sudo adduser $(id -un) kvm
       sudo sed -i '/kvm/s/0660/0666/g'   /usr/lib/tmpfiles.d/static-nodes-permissions.conf
       sudo sed -i '/vhost/s/0660/0666/g' /usr/lib/tmpfiles.d/static-nodes-permissions.conf
       sudo modprobe kvm

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -167,7 +167,7 @@ def parse_path(value: str,
 
     if expanduser:
         if path.is_relative_to("~") and not InvokingUser.is_running_user():
-            path = InvokingUser.home() / path.relative_to("~")
+            path = InvokingUser.home / path.relative_to("~")
         path = path.expanduser()
 
     if required and not path.exists():

--- a/mkosi/state.py
+++ b/mkosi/state.py
@@ -10,13 +10,10 @@ from mkosi.util import umask
 class MkosiState:
     """State related properties."""
 
-    def __init__(self, args: MkosiArgs, config: MkosiConfig, workspace: Path, name: str, uid: int, gid: int) -> None:
+    def __init__(self, args: MkosiArgs, config: MkosiConfig, workspace: Path) -> None:
         self.args = args
         self.config = config
         self.workspace = workspace
-        self.name = name
-        self.uid = uid
-        self.gid = gid
 
         with umask(~0o755):
             # Using a btrfs subvolume as the upperdir in an overlayfs results in EXDEV so make sure we create


### PR DESCRIPTION
This commit also reworks InvokingUser to calculate all its members on module import (when we haven't yet unshared the user namespace). become_root() is also changed to modify the InvokingUser object instead of returning the new uid, gid. Finally, we stop passing around uid, gid everywhere and just use the InvokingUser object directly as a singleton.

We also stop dropping privileges in mkosi itself. Instead, we prefer running ssh, qemu and the embedded web server unprivileged. This allows us to get rid of the logic to not unmount the last tools tree as we will now always still have enough privileges to do so.