### PR TITLE
Do not remount build root as ro in build chroot

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -424,7 +424,6 @@ def run_build_scripts(state: MkosiState) -> None:
                     "--setenv", "OUTPUTDIR", "/work/out",
                     "--setenv", "BUILDROOT", "/",
                     *(["--setenv", "BUILDDIR", "/work/build"] if state.config.build_dir else []),
-                    "--remount-ro", "/",
                 ],
             )
 


### PR DESCRIPTION
  The PR #1970 added an additional volatile overlay to the buildroot, which
  currently can only be used from the host, i.e. without mkosi-chroot.
  Once mkosi-chroot is run, the build overlay is readonly again.
  Fixes https://github.com/systemd/mkosi/issues/1974.