### PR TITLE
Do not require signatures for local packages

### DIFF
--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -55,6 +55,7 @@ def setup_pacman(state: MkosiState) -> None:
                 f"""\
                 [options]
                 SigLevel = {sig_level}
+                LocalFileSigLevel = Optional
                 ParallelDownloads = 5
                 """
             )


### PR DESCRIPTION
This is the default in the pacman.conf arch ships (https://gitlab.archlinux.org/archlinux/packaging/packages/pacman/-/blob/main/pacman.conf?ref_type=heads#L42) and allows to build AUR packages in build scripts and installing them in the final image.