### PR TITLE
Open qemu device nodes before unsharing user namespace

### DIFF
--- a/mkosi/__main__.py
+++ b/mkosi/__main__.py
@@ -2,6 +2,7 @@
 # PYTHON_ARGCOMPLETE_OK
 
 import contextlib
+import faulthandler
 import logging
 import shutil
 import subprocess
@@ -43,6 +44,9 @@ def propagate_failed_return() -> Iterator[None]:
 def main() -> None:
     log_setup()
     args, presets = parse_config(sys.argv[1:])
+
+    if args.debug:
+        faulthandler.enable()
 
     try:
         run_verb(args, presets)

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -34,7 +34,7 @@ from mkosi.pager import page
 from mkosi.run import run
 from mkosi.types import PathString, SupportsRead
 from mkosi.util import (
-    InvokingUser,
+    INVOKING_USER,
     StrEnum,
     chdir,
     flatten,
@@ -166,8 +166,8 @@ def parse_path(value: str,
     path = Path(value)
 
     if expanduser:
-        if path.is_relative_to("~") and not InvokingUser.is_running_user():
-            path = InvokingUser.home / path.relative_to("~")
+        if path.is_relative_to("~") and not INVOKING_USER.is_running_user():
+            path = INVOKING_USER.home / path.relative_to("~")
         path = path.expanduser()
 
     if required and not path.exists():

--- a/mkosi/mounts.py
+++ b/mkosi/mounts.py
@@ -12,7 +12,7 @@ from typing import Optional
 from mkosi.log import complete_step
 from mkosi.run import run
 from mkosi.types import PathString
-from mkosi.util import InvokingUser, umask
+from mkosi.util import INVOKING_USER, umask
 from mkosi.versioncomp import GenericVersion
 
 
@@ -137,11 +137,11 @@ def mount_passwd(root: Path = Path("/")) -> Iterator[None]:
     """
     with tempfile.NamedTemporaryFile(prefix="mkosi.passwd", mode="w") as passwd:
         passwd.write("root:x:0:0:root:/root:/bin/sh\n")
-        if InvokingUser.uid != 0:
-            name = InvokingUser.name
-            passwd.write(f"{name}:x:{InvokingUser.uid}:{InvokingUser.gid}:{name}:/home/{name}:/bin/sh\n")
+        if INVOKING_USER.uid != 0:
+            name = INVOKING_USER.name
+            passwd.write(f"{name}:x:{INVOKING_USER.uid}:{INVOKING_USER.gid}:{name}:/home/{name}:/bin/sh\n")
         passwd.flush()
-        os.fchown(passwd.file.fileno(), InvokingUser.uid, InvokingUser.gid)
+        os.fchown(passwd.file.fileno(), INVOKING_USER.uid, INVOKING_USER.gid)
 
         with mount(passwd.name, root / "etc/passwd", operation="--bind"):
             yield

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -25,7 +25,7 @@ from typing import Any, Optional
 
 from mkosi.log import ARG_DEBUG, ARG_DEBUG_SHELL, die
 from mkosi.types import _FILE, CompletedProcess, PathString, Popen
-from mkosi.util import InvokingUser, flock, make_executable, one_zero
+from mkosi.util import INVOKING_USER, flock, make_executable, one_zero
 
 CLONE_NEWNS = 0x00020000
 CLONE_NEWUSER = 0x10000000
@@ -75,7 +75,7 @@ def become_root() -> None:
     The current user will be mapped to root and 65436 will be mapped to the UID/GID of the invoking user.
     The other IDs will be mapped through.
 
-    The function modifies the uid, gid of the InvokingUser object to the uid, gid of the invoking user in the user
+    The function modifies the uid, gid of the INVOKING_USER object to the uid, gid of the invoking user in the user
     namespace.
     """
     if os.getuid() == 0:
@@ -126,8 +126,8 @@ def become_root() -> None:
     os.setresgid(0, 0, 0)
     os.setgroups([0])
 
-    InvokingUser.uid = SUBRANGE - 100
-    InvokingUser.gid = SUBRANGE - 100
+    INVOKING_USER.uid = SUBRANGE - 100
+    INVOKING_USER.gid = SUBRANGE - 100
 
 
 def init_mount_namespace() -> None:

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -74,7 +74,7 @@ def flatten(lists: Iterable[Iterable[T]]) -> list[T]:
     return list(itertools.chain.from_iterable(lists))
 
 
-class InvokingUser:
+class INVOKING_USER:
     uid = int(os.getenv("SUDO_UID") or os.getenv("PKEXEC_UID") or os.getuid())
     gid = int(os.getenv("SUDO_GID") or os.getgid())
     name = pwd.getpwuid(uid).pw_name

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -4,7 +4,6 @@ import ast
 import contextlib
 import copy
 import enum
-import errno
 import fcntl
 import functools
 import importlib
@@ -104,40 +103,33 @@ def chdir(directory: PathString) -> Iterator[None]:
 
 def qemu_check_kvm_support(log: bool) -> bool:
     # some CI runners may present a non-working KVM device
-    try:
-        os.close(os.open("/dev/kvm", os.O_RDWR|os.O_CLOEXEC))
-    except OSError as e:
-        if e.errno == errno.ENOENT:
-            if log:
-                logging.warning("/dev/kvm not found. Not using KVM acceleration.")
-            return False
-        elif e.errno in (errno.EPERM, errno.EACCES):
-            if log:
-                logging.warning("Permission denied to access /dev/kvm. Not using KVM acceleration")
-            return False
 
-        raise e
+    if not os.access("/dev/kvm", os.F_OK):
+        if log:
+            logging.warning("/dev/kvm not found. Not using KVM acceleration.")
+        return False
+
+    if not os.access("/dev/kvm", os.R_OK|os.W_OK):
+        if log:
+            logging.warning("Permission denied to access /dev/kvm. Not using KVM acceleration")
+        return False
 
     return True
 
 
 def qemu_check_vsock_support(log: bool) -> bool:
-    try:
-        os.close(os.open("/dev/vhost-vsock", os.O_RDWR|os.O_CLOEXEC))
-    except OSError as e:
-        if e.errno == errno.ENOENT:
-            if log:
-                logging.warning("/dev/vhost-vsock not found. Not adding a vsock device to the virtual machine.")
-            return False
-        elif e.errno in (errno.EPERM, errno.EACCES):
-            if log:
-                logging.warning(
-                    "Permission denied to access /dev/vhost-vsock. "
-                    "Not adding a vsock device to the virtual machine."
-                )
-            return False
+    if not os.access("/dev/vhost-vsock", os.F_OK):
+        if log:
+            logging.warning("/dev/vhost-vsock not found. Not adding a vsock device to the virtual machine.")
+        return False
 
-        raise e
+    if not os.access("/dev/vhost-vsock", os.R_OK|os.W_OK):
+        if log:
+            logging.warning(
+                "Permission denied to access /dev/vhost-vsock. "
+                "Not adding a vsock device to the virtual machine."
+            )
+        return False
 
     return True
 


### PR DESCRIPTION
Where possible, we should open the qemu device nodes before we unshare
the user namespace as this might not be possible anymore after unsharing
the user namespace because we might lose access to the kvm group.

Currently this is only possible for /dev/vhost-vsock. I've opened
https://gitlab.com/qemu-project/qemu/-/issues/1936 to hopefully make
it work for /dev/kvm as well.