### PR TITLE
Make sure shadow-utils is installed in tools trees

### DIFF
--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -57,6 +57,7 @@ class Installer(DistributionInstaller):
             "python-cryptography",
             "qemu-base",
             "sbsigntools",
+            "shadow",
             "socat",
             "squashfs-tools",
             "strace",

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -79,6 +79,7 @@ class Installer(DistributionInstaller):
             "pesign",
             "python3-cryptography",
             "qemu-kvm-core",
+            "shadow-utils",
             "socat",
             "squashfs-tools",
             "strace",

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -71,6 +71,7 @@ class Installer(DistributionInstaller):
             "systemd-container",
             "systemd",
             "tar",
+            "uidmap",
             "util-linux",
             "xfsprogs",
             "xz-utils",

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -58,6 +58,7 @@ class Installer(DistributionInstaller):
             "python3-cryptography",
             "qemu-kvm-core",
             "sbsigntools",
+            "shadow-utils",
             "socat",
             "squashfs-tools",
             "strace",

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -57,6 +57,7 @@ class Installer(DistributionInstaller):
             "pesign",
             "qemu-headless",
             "sbsigntools",
+            "shadow",
             "socat",
             "squashfs",
             "strace",


### PR DESCRIPTION
This provides newuidmap/newgidmap which are used by virtiofsd, so let's make sure these are available.