### PR TITLE
Do not try to copy vmlinuz for non-bootable images

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1353,6 +1353,9 @@ def copy_nspawn_settings(state: MkosiState) -> None:
 
 
 def copy_vmlinuz(state: MkosiState) -> None:
+    if state.config.bootable == ConfigFeature.disabled:
+        return
+
     if (state.staging / state.config.output_split_kernel).exists():
         return
 


### PR DESCRIPTION
When building an initrd, copy_vmlinuz() would fail because there is no vmlinuz file to copy.