### PR TITLE
make_tar: do not emit extended PAX headers for atime, ctime and mtime

### DIFF
--- a/mkosi/archive.py
+++ b/mkosi/archive.py
@@ -46,7 +46,11 @@ def make_tar(src: Path, dst: Path) -> None:
             "--directory", src,
             "--acls",
             "--selinux",
+            # --xattrs implies --format=pax
             "--xattrs",
+            # PAX format emits additional headers for atime, ctime and mtime
+            # that would make the archive non-reproducible.
+            "--pax-option=delete=atime,delete=ctime,delete=mtime",
             "--sparse",
             "--force-local",
             *tar_exclude_apivfs_tmp(),


### PR DESCRIPTION
The use of the `--xattrs` flag implies PAX headers (`--format=pax`).
In this mode, the tar will record atime, ctime and mtime as PAX headers (in addition to the usual USTAR header). 
Removing the headers makes the output reproducible.

See also: https://www.gnu.org/software/tar/manual/html_node/PAX-keywords.html