### PR TITLE
Rework qemu device support checks

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2502,9 +2502,9 @@ def run_verb(args: MkosiArgs, presets: Sequence[MkosiConfig]) -> None:
     # file descriptors to qemu later. Note that we can't pass the kvm file descriptor to qemu until
     # https://gitlab.com/qemu-project/qemu/-/issues/1936 is resolved.
     qemu_device_fds = {
-        d: os.open(f"/dev/{d}", os.O_RDWR|os.O_CLOEXEC|os.O_NONBLOCK)
+        d: os.open(d.device(), os.O_RDWR|os.O_CLOEXEC|os.O_NONBLOCK)
         for d in QemuDeviceNode
-        if os.access(f"/dev/{d}", os.F_OK|os.R_OK|os.W_OK)
+        if d.available(log=True)
     }
 
     # Get the user UID/GID either on the host or in the user namespace running the build

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -33,14 +33,7 @@ from mkosi.log import ARG_DEBUG, ARG_DEBUG_SHELL, Style, die
 from mkosi.pager import page
 from mkosi.run import run
 from mkosi.types import PathString, SupportsRead
-from mkosi.util import (
-    INVOKING_USER,
-    StrEnum,
-    chdir,
-    flatten,
-    qemu_check_kvm_support,
-    qemu_check_vsock_support,
-)
+from mkosi.util import INVOKING_USER, StrEnum, chdir, flatten
 from mkosi.versioncomp import GenericVersion
 
 __version__ = "18"
@@ -2522,12 +2515,6 @@ def load_config(args: argparse.Namespace) -> MkosiConfig:
         if args.secure_boot_certificate is None:
             die("UEFI SecureBoot enabled, private key was found, but not the certificate.",
                 hint="Consider placing it in mkosi.crt")
-
-    if args.qemu_kvm == ConfigFeature.enabled and not qemu_check_kvm_support(log=False):
-        die("Sorry, the host machine does not support KVM acceleration.")
-
-    if args.qemu_vsock == ConfigFeature.enabled and not qemu_check_vsock_support(log=False):
-        die("Sorry, the host machine does not support vsock")
 
     if args.repositories and not (
         args.distribution.is_dnf_distribution() or

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -101,39 +101,6 @@ def chdir(directory: PathString) -> Iterator[None]:
         os.chdir(old)
 
 
-def qemu_check_kvm_support(log: bool) -> bool:
-    # some CI runners may present a non-working KVM device
-
-    if not os.access("/dev/kvm", os.F_OK):
-        if log:
-            logging.warning("/dev/kvm not found. Not using KVM acceleration.")
-        return False
-
-    if not os.access("/dev/kvm", os.R_OK|os.W_OK):
-        if log:
-            logging.warning("Permission denied to access /dev/kvm. Not using KVM acceleration")
-        return False
-
-    return True
-
-
-def qemu_check_vsock_support(log: bool) -> bool:
-    if not os.access("/dev/vhost-vsock", os.F_OK):
-        if log:
-            logging.warning("/dev/vhost-vsock not found. Not adding a vsock device to the virtual machine.")
-        return False
-
-    if not os.access("/dev/vhost-vsock", os.R_OK|os.W_OK):
-        if log:
-            logging.warning(
-                "Permission denied to access /dev/vhost-vsock. "
-                "Not adding a vsock device to the virtual machine."
-            )
-        return False
-
-    return True
-
-
 def make_executable(path: Path) -> None:
     st = path.stat()
     os.chmod(path, st.st_mode | stat.S_IEXEC)


### PR DESCRIPTION
Let's implement an available() method on the QemuDeviceNode enum and move the checks from load_config() to run_qemu() so they don't impede showing the summary or other verbs.

Let's also prefer using the file descriptor as a check whether the feature is available in run_qemu() instead of calling the available() method, as by the time we get to run_qemu() the available() method might return a different result.