### PR TITLE
Drop leftover gentoo config file for CI

### DIFF
--- a/.github/mkosi.pkgmngr/gentoo/etc/portage/package.accept_keywords/9999
+++ b/.github/mkosi.pkgmngr/gentoo/etc/portage/package.accept_keywords/9999
@@ -1,1 +1,0 @@
-=sys-apps/systemd-9999 **

--- a/.github/mkosi.pkgmngr/gentoo/etc/portage/package.use/systemd
+++ b/.github/mkosi.pkgmngr/gentoo/etc/portage/package.use/systemd
@@ -1,1 +1,0 @@
-sys-apps/systemd boot


### PR DESCRIPTION
We don't run gentoo in CI anymore, so drop the leftover config file for it.