### PR TITLE
Use with in spawn()

### DIFF
--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -193,11 +193,11 @@ def start_swtpm() -> Iterator[Path]:
 
             cmdline += ["--ctrl", f"type=unixio,fd={sock.fileno()}"]
 
-            with spawn(\
-                cmdline,\
-                user=INVOKING_USER.uid,\
-                group=INVOKING_USER.gid,\
-                pass_fds=(sock.fileno(),)\
+            with spawn(
+                cmdline,
+                user=INVOKING_USER.uid,
+                group=INVOKING_USER.gid,
+                pass_fds=(sock.fileno(),)
             ) as proc:
                 try:
                     yield path
@@ -254,11 +254,11 @@ def start_virtiofsd(directory: Path, *, uidmap: bool) -> Iterator[Path]:
 
         # virtiofsd has to run unprivileged to use the --uid-map and --gid-map options, so run it as the given
         # user/group if those are provided.
-        with spawn(\
-            cmdline,\
-            user=INVOKING_USER.uid if uidmap else None,\
-            group=INVOKING_USER.gid if uidmap else None,\
-            pass_fds=(sock.fileno(),)\
+        with spawn(
+            cmdline,
+            user=INVOKING_USER.uid if uidmap else None,
+            group=INVOKING_USER.gid if uidmap else None,
+            pass_fds=(sock.fileno(),)
         ) as proc:
             try:
                 yield path

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -250,7 +250,7 @@ def spawn(
         stdout = sys.stderr
 
     try:
-        yield subprocess.Popen(
+        with subprocess.Popen(
             cmdline,
             stdin=stdin,
             stdout=stdout,
@@ -261,7 +261,8 @@ def spawn(
             pass_fds=pass_fds,
             env=env,
             preexec_fn=make_foreground_process if foreground else None,
-        )
+        ) as proc:
+            yield proc
     except FileNotFoundError:
         die(f"{cmdline[0]} not found in PATH.")
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
If we yield the Popen, we yield a context manager from a context
manager, which becomes hard to follow, since we'll only enter the
outer context manager, and not the inner Popen context manager. To
make things simpler, let's enter the Popen context manager in
spawn() itself.