### PR TITLE
Don't store default initrd artifacts in output directory

### DIFF
--- a/mkosi.conf.d/20-fedora.conf
+++ b/mkosi.conf.d/20-fedora.conf
@@ -7,6 +7,7 @@ Distribution=fedora
 @Release=39
 
 [Content]
+KernelCommandLine=enforcing=0
 Packages=
         apt
         archlinux-keyring
@@ -60,6 +61,3 @@ Packages=
         xz
         zstd
         zypper
-
-[Host]
-KernelCommandLine=enforcing=0

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -215,8 +215,8 @@ def run(
             cwd=cwd,
             preexec_fn=make_foreground_process,
         )
-    except FileNotFoundError:
-        die(f"{cmdline[0]} not found in PATH.")
+    except FileNotFoundError as e:
+        die(f"{e.filename} not found.")
     except subprocess.CalledProcessError as e:
         if log:
             logging.error(f"\"{shlex.join(cmdline)}\" returned non-zero exit code {e.returncode}.")
@@ -263,8 +263,8 @@ def spawn(
             preexec_fn=make_foreground_process if foreground else None,
         ) as proc:
             yield proc
-    except FileNotFoundError:
-        die(f"{cmdline[0]} not found in PATH.")
+    except FileNotFoundError as e:
+        die(f"{e.filename} not found.")
     except subprocess.CalledProcessError as e:
         if log:
             logging.error(f"\"{shlex.join(cmdline)}\" returned non-zero exit code {e.returncode}.")


### PR DESCRIPTION
We don't use these for anything and the initrd can already be
accessed using the split initrd, so let's not store the default
initrd artifacts in the output directory.
