### PR TITLE
Stop using subdirectories of cache and build dirs automatically

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,14 @@
 - We now automatically configure the qemu firmware, kernel cmdline and
   initrd based on what type of kernel is passed by the user via
   `-kernel` or `QemuKernel=`
+- We don't create subdirectories beneath the configured cache or build
+  directories anymore. To get back the previous behavior, configure the
+  cache and build directories as follows:
+
+  ```conf
+  CacheDirectory=mkosi.cache/%d~%r~%a
+  BuildDirectory=mkosi.builddir/%d~%r~%a
+  ```
 
 ## v18
 

--- a/mkosi.conf.d/10-common.conf
+++ b/mkosi.conf.d/10-common.conf
@@ -4,8 +4,6 @@
 # These images are (among other things) used for running mkosi which means we need some disk space available so
 # default to directory output where disk space isn't a problem.
 @Format=directory
-@CacheDirectory=mkosi.cache
-@OutputDirectory=mkosi.output
 
 [Content]
 Autologin=yes

--- a/mkosi.conf.d/30-dirs.conf
+++ b/mkosi.conf.d/30-dirs.conf
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# These depend on the configured distribution, release and architecture
+# so we order this drop-in after all the other drop-ins.
+
+[Output]
+@CacheDirectory=mkosi.cache/%d~%r~%a
+@BuildDirectory=mkosi.builddir/%d~%r~%a

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2574,11 +2574,6 @@ def load_config(args: argparse.Namespace) -> MkosiConfig:
     if args.cmdline and not args.verb.supports_cmdline():
         die(f"Arguments after verb are not supported for {args.verb}.")
 
-    if args.cache_dir:
-        args.cache_dir = args.cache_dir / f"{args.distribution}~{args.release}~{args.architecture}"
-    if args.build_dir:
-        args.build_dir = args.build_dir / f"{args.distribution}~{args.release}~{args.architecture}"
-
     if args.sign:
         args.checksum = True
 


### PR DESCRIPTION
In some cases, for example mkosi-initrd running as a kernel-install script, we want to reuse the system package cache. Currently this is impossible as we unconditionally create a subdirectory beneath the provided cache directory. Let's stop doing that, as users can now explicitly configure this behavior themselves by specifying the cache directory or build directory as follows:

```
CacheDirectory=mkosi.cache/%d~%r~%a
BuildDirectory=mkosi.builddir/%d~%r~%a
```

Additionally, make sure the default tools tree only reuses the same cache as the preset it's used for when the distribution, release and architecture are the same as the preset's.