### PR TITLE
Enable WithDocs= by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@
   the default tools tree
 - We now make sure git can be executed from mkosi scripts without
   running into permission errors
+- `WithDocs=` is now enabled by default.
 
 ## v18
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1287,6 +1287,7 @@ SETTINGS = (
         nargs="?",
         section="Content",
         parse=config_parse_boolean,
+        default=True,
         help="Install documentation",
     ),
     MkosiConfigSetting(

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -704,11 +704,11 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 `WithDocs=`, `--with-docs`
 
-: Include documentation in the image built. By default if the
-  underlying distribution package manager supports it documentation is
-  not included in the image built. The `$WITH_DOCS` environment
-  variable passed to the `mkosi.build` scripts indicates whether this
-  option was used or not.
+: Include documentation in the image. Enabled by default. When disabled,
+  if the underlying distribution package manager supports it
+  documentation is not included in the image. The `$WITH_DOCS`
+  environment variable passed to the `mkosi.build` scripts is set to `0`
+  or `1` depending on whether this option is enabled or disabled.
 
 `BaseTrees=`, `--base-tree=`
 


### PR DESCRIPTION
Let's include documentation by default so as to not confuse users.