### PR TITLE
Add --extra-config-options

### DIFF
--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -219,6 +219,13 @@ Those settings cannot be configured in the configuration files.
 
 : Show the summary output as JSON-SEQ.
 
+`--extra-config-options=`
+
+: Extra CLI config options to parse. This option is useful when
+  integrate with mkosi and want to allow users to specify extra config
+  options as CLI arguments. `--config-options=` will fail if any options
+  are passed that do not modify configuration.
+
 ## Supported output formats
 
 The following output formats are supported:

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -166,3 +166,7 @@ def umask(mask: int) -> Iterator[None]:
         yield
     finally:
         os.umask(old)
+
+
+def identity(s: Any) -> Any:
+    return s


### PR DESCRIPTION
This allows passing extra CLI config options to apply. The difference between passing options via this option or passing the directly as extra CLI options is that --extra-config-options= will fail if any non-config option is specified (A verb, --json, --no-pager, --directory, ...).