### PR TITLE
Move PackageManagerTrees= to the Distribution section

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -8,11 +8,22 @@ runs:
   - name: Permit unprivileged access to kvm, vhost-vsock and vhost-net devices
     shell: bash
     run: |
-      sudo sed -i '/kvm/s/0660/0666/g'   /usr/lib/tmpfiles.d/static-nodes-permissions.conf
-      sudo sed -i '/vhost/s/0660/0666/g' /usr/lib/tmpfiles.d/static-nodes-permissions.conf
+      sudo mkdir -p /etc/tmpfiles.d
+      sudo cp /usr/lib/tmpfiles.d/static-nodes-permissions.conf /etc/tmpfiles.d/
+      sudo sed -i '/kvm/s/0660/0666/g'   /etc/tmpfiles.d/static-nodes-permissions.conf
+      sudo sed -i '/vhost/s/0660/0666/g' /etc/tmpfiles.d/static-nodes-permissions.conf
+      sudo tee /etc/udev/rules.d/99-kvm4all.rules <<- EOF
+      KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"
+      KERNEL=="vhost-vsock", GROUP="kvm", MODE="0666", OPTIONS+="static_node=vhost-vsock"
+      KERNEL=="vhost-net", GROUP="kvm", MODE="0666", OPTIONS+="static_node=vhost-net"
+      EOF
+      sudo udevadm control --reload-rules
       sudo modprobe kvm
       sudo modprobe vhost_vsock
       sudo modprobe vhost_net
+      [[ -e /dev/kvm ]] && sudo udevadm trigger --name-match=kvm
+      sudo udevadm trigger --name-match=vhost-vsock
+      sudo udevadm trigger --name-match=vhost-net
       [[ -e /dev/kvm ]] && sudo chmod 666 /dev/kvm
       sudo chmod 666 /dev/vhost-vsock
       sudo chmod 666 /dev/vhost-net

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -728,6 +728,7 @@ class MkosiConfig:
     repository_key_check: bool
     repositories: list[str]
     cache_only: bool
+    package_manager_trees: list[tuple[Path, Optional[Path]]]
 
     output_format: OutputFormat
     manifest_format: list[ManifestFormat]
@@ -753,7 +754,6 @@ class MkosiConfig:
 
     base_trees: list[Path]
     skeleton_trees: list[tuple[Path, Optional[Path]]]
-    package_manager_trees: list[tuple[Path, Optional[Path]]]
     extra_trees: list[tuple[Path, Optional[Path]]]
 
     remove_packages: list[str]
@@ -1138,6 +1138,16 @@ SETTINGS = (
         parse=config_parse_boolean,
         help="Only use the package cache when installing packages",
     ),
+    MkosiConfigSetting(
+        dest="package_manager_trees",
+        long="--package-manager-tree",
+        metavar="PATH",
+        section="Distribution",
+        parse=config_make_list_parser(delimiter=",", parse=make_source_target_paths_parser()),
+        default_factory=lambda ns: ns.skeleton_trees,
+        default_factory_depends=("skeleton_trees",),
+        help="Use a package manager tree to configure the package manager",
+    ),
 
     MkosiConfigSetting(
         dest="output_format",
@@ -1333,16 +1343,6 @@ SETTINGS = (
         paths=("mkosi.skeleton", "mkosi.skeleton.tar"),
         path_default=False,
         help="Use a skeleton tree to bootstrap the image before installing anything",
-    ),
-    MkosiConfigSetting(
-        dest="package_manager_trees",
-        long="--package-manager-tree",
-        metavar="PATH",
-        section="Content",
-        parse=config_make_list_parser(delimiter=",", parse=make_source_target_paths_parser()),
-        default_factory=lambda ns: ns.skeleton_trees,
-        default_factory_depends=("skeleton_trees",),
-        help="Use a package manager tree to configure the package manager",
     ),
     MkosiConfigSetting(
         dest="extra_trees",
@@ -2708,6 +2708,7 @@ def summary(config: MkosiConfig) -> str:
       Repo Signature/Key check: {yes_no(config.repository_key_check)}
                   Repositories: {line_join_list(config.repositories)}
         Use Only Package Cache: {yes_no(config.cache_only)}
+         Package Manager Trees: {line_join_source_target_list(config.package_manager_trees)}
 
     {bold("OUTPUT")}:
                  Output Format: {config.output_format}
@@ -2734,7 +2735,6 @@ def summary(config: MkosiConfig) -> str:
 
                     Base Trees: {line_join_list(config.base_trees)}
                 Skeleton Trees: {line_join_source_target_list(config.skeleton_trees)}
-         Package Manager Trees: {line_join_source_target_list(config.package_manager_trees)}
                    Extra Trees: {line_join_source_target_list(config.extra_trees)}
 
                Remove Packages: {line_join_list(config.remove_packages)}

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -489,6 +489,19 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
   reproducibility, as long as the package cache is already fully
   populated.
 
+`PackageManagerTrees=`, `--package-manager-tree=`
+
+: This option mirrors the above `SkeletonTrees=` option and defaults to the
+  same value if not configured otherwise, but installs the files to a
+  subdirectory of the workspace directory instead of the OS tree. This
+  subdirectory of the workspace is used to configure the package manager.
+
+: `SkeletonTrees=` and `PackageManagerTrees=` fulfill similar roles. Use
+  `SkeletonTrees=` if you want the files to be present in the final image. Use
+  `PackageManagerTrees=` if you don't want the files to be present in the final
+  image, e.g. when building an initrd or if you want to refer to paths outside
+  of the image in your repository configuration.
+
 ### [Output] Section
 
 `Format=`, `--format=`, `-t`
@@ -756,19 +769,6 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 : As with the base tree logic above, instead of a directory, a tar
   file may be provided too. `mkosi.skeleton.tar` will be automatically
   used if found in the local directory.
-
-`PackageManagerTrees=`, `--package-manager-tree=`
-
-: This option mirrors the above `SkeletonTrees=` option and defaults to the
-  same value if not configured otherwise, but installs the files to a
-  subdirectory of the workspace directory instead of the OS tree. This
-  subdirectory of the workspace is used to configure the package manager.
-
-: `SkeletonTrees=` and `PackageManagerTrees=` fulfill similar roles. Use
-  `SkeletonTrees=` if you want the files to be present in the final image. Use
-  `PackageManagerTrees=` if you don't want the files to be present in the final
-  image, e.g. when building an initrd or if you want to refer to paths outside
-  of the image in your repository configuration.
 
 `ExtraTrees=`, `--extra-tree=`
 


### PR DESCRIPTION
This makes more sense than the Content section, since these trees don't actually end up in the image.