### PR TITLE
Don't use configured default value when empty string is assigned

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2216,7 +2216,8 @@ def parse_config(argv: Sequence[str] = ()) -> tuple[MkosiArgs, tuple[MkosiConfig
         for d in setting.default_factory_depends:
             finalize_default(SETTINGS_LOOKUP_BY_DEST[d], namespace, defaults)
 
-        if setting.dest in defaults:
+        # If the setting was assigned the empty string, we don't use any configured default value.
+        if not hasattr(namespace, setting.dest) and setting.dest in defaults:
             default = getattr(defaults, setting.dest)
         elif setting.default_factory:
             default = setting.default_factory(namespace)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -252,6 +252,22 @@ def test_profiles(tmp_path: Path) -> None:
     assert config.qemu_kvm == ConfigFeature.enabled
 
 
+def test_override_default(tmp_path: Path) -> None:
+    d = tmp_path
+
+    (d / "mkosi.conf").write_text(
+        """\
+        [Host]
+        @ToolsTree=default
+        """
+    )
+
+    with chdir(d):
+        _, [config] = parse_config(["--tools-tree", ""])
+
+    assert config.tools_tree is None
+
+
 def test_parse_load_verb(tmp_path: Path) -> None:
     with chdir(tmp_path):
         assert parse_config(["build"])[0].verb == Verb.build


### PR DESCRIPTION
Currently, if a setting is assigned the empty string on the CLI, any default value configured in the config file is still used. Let's change this and not use any configured default value when the empty string is assigned so that default values configured in config files can be overridden from the CLI.