### PR TITLE
Allow overriding dnf selection with $MKOSI_DNF

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2573,10 +2573,12 @@ def load_environment(args: argparse.Namespace) -> dict[str, str]:
         env["IMAGE_VERSION"] = args.image_version
     if args.source_date_epoch is not None:
         env["SOURCE_DATE_EPOCH"] = str(args.source_date_epoch)
-    if (proxy := os.environ.get("http_proxy")):
+    if proxy := os.getenv("http_proxy"):
         env["http_proxy"] = proxy
-    if (proxy := os.environ.get("https_proxy")):
+    if proxy := os.getenv("https_proxy"):
         env["https_proxy"] = proxy
+    if dnf := os.getenv("MKOSI_DNF"):
+        env["MKOSI_DNF"] = dnf
 
     for s in args.environment:
         key, sep, value = s.partition("=")

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -34,7 +34,10 @@ def find_rpm_gpgkey(state: MkosiState, key: str, url: str) -> str:
 
 
 def dnf_executable(state: MkosiState) -> str:
-    return shutil.which("dnf5") or shutil.which("dnf") or "yum"
+    # Allow the user to override autodetection with an environment variable
+    dnf = state.config.environment.get("MKOSI_DNF")
+
+    return dnf or shutil.which("dnf5") or shutil.which("dnf") or "yum"
 
 
 def setup_dnf(state: MkosiState, repos: Iterable[Repo], filelists: bool = True) -> None:

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -1842,6 +1842,9 @@ repository.
 * `$MKOSI_LESS` overrides options for `less` when it is invoked by
   `mkosi` to page output.
 
+* `$MKOSI_DNF` can be used to override the executable used as `dnf`.
+  This is particularly useful to select between `dnf` and `dnf5`.
+
 # EXAMPLES
 
 Create and run a raw *GPT* image with *ext4*, as `image.raw`:


### PR DESCRIPTION
dnf5 is nice, but it has some issues, for example installation of rhel9 currently fails with some error about signature. Using dnf instead work around the problem. Allow the user to override the selection using an environment variable.

(We have the tools directory, but it doesn't help here because we want to use 'dnf' instead of 'dnf5' and not different version of 'dnf5'.)