### PR TITLE
Make mkosi.repart/ append to the default value for RepartDirectories=

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1259,7 +1259,6 @@ SETTINGS = (
         section="Output",
         parse=config_make_list_parser(delimiter=",", parse=make_path_parser()),
         paths=("mkosi.repart",),
-        path_default=False,
         help="Directory containing systemd-repart partition definitions",
     ),
     MkosiConfigSetting(


### PR DESCRIPTION
While for other list based settings that have a canonical path, we generally want to append them all to the user provided values, for RepartDirectories=, it probably makes more sense that if the user specifies it explicitly, it overrides all the directories defined by the project in mkosi.repart/ directories. Let's accomodate this by having mkosi.repart/ modify the default value for RepartDirectories= which is only used if the setting is not set explicitly.