### PR TITLE
Parse mkosi.local.conf before parsing any other files

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2292,6 +2292,9 @@ def parse_config(argv: Sequence[str] = ()) -> tuple[MkosiArgs, tuple[MkosiConfig
             return False
 
         if extras:
+            if (path.parent / "mkosi.local.conf").exists():
+                parse_config(path.parent / "mkosi.local.conf", namespace, defaults)
+
             for s in SETTINGS:
                 ns = defaults if s.path_default else namespace
                 for f in s.paths:

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -252,6 +252,10 @@ grouped by section below.
 Configuration is parsed in the following order:
 
 * The command line arguments are parsed
+* `mkosi.local.conf` is parsed if it exists. This file should be in the
+  gitignore (or equivalent) and is intended for local configuration.
+* Any default paths (depending on the option) are configured if the
+  corresponding path exists.
 * `mkosi.conf` is parsed if it exists in the directory configured with
   `--directory=` or the current working directory if `--directory=` is
   not used.
@@ -259,8 +263,6 @@ Configuration is parsed in the following order:
   directory and each file with the `.conf` extension in `mkosi.conf.d/`
   is parsed. Any directory in `mkosi.conf.d` is parsed as if it were
   a regular top level directory.
-* Any default paths (depending on the option) are configured if the
-  corresponding path exists.
 
 Note that if the same setting is configured twice, the later assignment
 overrides the earlier assignment unless the setting is a list based
@@ -291,6 +293,11 @@ specific settings, and do not take into account changes made to the
 setting in configuration files that have not been parsed yet. Also note
 that matching against a setting and then changing its value afterwards
 in a different config file may lead to unexpected results.
+
+The `[Match]` section of a `mkosi.conf` file in a directory applies to
+the entire directory. If the conditions are not satisfied, the entire
+directory is skipped. The `[Match]` sections of files in `mkosi.conf.d/`
+and `mkosi.local.conf` only apply to the file itself.
 
 Command line options that take no argument are shown without `=` in
 their long version. In the config files, they should be specified with a

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -270,6 +270,34 @@ def test_override_default(tmp_path: Path) -> None:
     assert config.tools_tree is None
 
 
+def test_local_config(tmp_path: Path) -> None:
+    d = tmp_path
+
+    (d / "mkosi.local.conf").write_text(
+        """\
+        [Distribution]
+        Distribution=debian
+        """
+    )
+
+    with chdir(d):
+        _, [config] = parse_config()
+
+    assert config.distribution == Distribution.debian
+
+    (d / "mkosi.conf").write_text(
+        """\
+        [Distribution]
+        Distribution=fedora
+        """
+    )
+
+    with chdir(d):
+        _, [config] = parse_config()
+
+    assert config.distribution == Distribution.fedora
+
+
 def test_parse_load_verb(tmp_path: Path) -> None:
     with chdir(tmp_path):
         assert parse_config(["build"])[0].verb == Verb.build


### PR DESCRIPTION
Currently extra local configuration is a bit implicit, users have to add a drop-in in mkosi.conf.d/ named 00-local.conf or so and add that to the gitignore. This file will then unconditionally override settings from mkosi.conf even if that's not intended.

Let's make local configuration a bit more explicit by parsing mkosi.local.conf in a directory first before parsing anything else. This makes local configuration easy to detect and grep for, and makes sure that local configuration is by default overridden by non-local configuration.