### PR TITLE
ssh: add RuntimeDirectory=sshd

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1674,6 +1674,7 @@ def configure_ssh(state: MkosiState) -> None:
                 ExecStart=sshd -i -o UsePAM=no
                 StandardInput=socket
                 RuntimeDirectoryPreserve=yes
+                RuntimeDirectory=sshd
                 # ssh always exits with 255 even on normal disconnect, so let's mark that as success so we
                 # don't get noisy logs about SSH service failures.
                 SuccessExitStatus=255


### PR DESCRIPTION
[  209.582912] sshd[888]: fatal: Missing privilege separation directory: /run/sshd