### PR TITLE
spawn: inherit parent $PATH by default

### DIFF
--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -247,6 +247,13 @@ def spawn(
         # output.
         stdout = sys.stderr
 
+    env = {
+        "PATH": os.environ["PATH"],
+        "TERM": os.getenv("TERM", "vt220"),
+        "LANG": "C.UTF-8",
+        **env,
+    }
+
     try:
         with subprocess.Popen(
             cmdline,


### PR DESCRIPTION
Since eb2aaad7c2309a4f10af93c2b24ea660e433d1cf, `env` is an empty dict if not set explicitly.
On NixOS, this means `$PATH` will be unset (and there is no fallback like `/usr/bin`).