### PR TITLE
Restore subdirectory use for $BUILDDIR

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,13 +36,12 @@
 - We now automatically configure the qemu firmware, kernel cmdline and
   initrd based on what type of kernel is passed by the user via
   `-kernel` or `QemuKernel=`
-- We don't create subdirectories beneath the configured cache or build
-  directories anymore. To get back the previous behavior, configure the
-  cache and build directories as follows:
+- We don't create subdirectories beneath the configured cache directory
+  anymore. To get back the previous behavior, configure the cache directory
+  with subdirectories:
 
   ```conf
   CacheDirectory=mkosi.cache/%d~%r~%a
-  BuildDirectory=mkosi.builddir/%d~%r~%a
   ```
 
 ## v18

--- a/mkosi.conf.d/30-dirs.conf
+++ b/mkosi.conf.d/30-dirs.conf
@@ -1,8 +1,0 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later
-
-# These depend on the configured distribution, release and architecture
-# so we order this drop-in after all the other drop-ins.
-
-[Output]
-@CacheDirectory=mkosi.cache/%d~%r~%a
-@BuildDirectory=mkosi.builddir/%d~%r~%a

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2599,6 +2599,9 @@ def load_config(args: argparse.Namespace) -> MkosiConfig:
     if args.cmdline and not args.verb.supports_cmdline():
         die(f"Arguments after verb are not supported for {args.verb}.")
 
+    if args.build_dir:
+        args.build_dir = args.build_dir / f"{args.distribution}~{args.release}~{args.architecture}"
+
     if args.sign:
         args.checksum = True
 


### PR DESCRIPTION
Sharing of a directory for the (package) cache seems fine. The package manager shall use subdirectories and/or unique file names, so there should be no accidental conflict, and using the same cache directory allows the cache to be reused when possible. OTOH, sharing of the directory for the build directory is unlikely to be useful (since at least the configuration will usually be different, so the build would generally mean rebuilding anything anyway), but also the build system might not do cache invalidation strongly enough, leading to inadvertetent sharing of build artifacts. Let's avoid the issue completely but not sharing the build directory between different distributions releases or architectures.

This partially reverts b17810b4b571d0acbb307a6f7cd5c6456a45e4d3.