### PR TITLE
fedora: allow cross builds with dnf5

### DIFF
--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -34,10 +34,7 @@ def find_rpm_gpgkey(state: MkosiState, key: str, url: str) -> str:
 
 
 def dnf_executable(state: MkosiState) -> str:
-    # dnf5 does not support building for foreign architectures yet (missing --forcearch)
-    dnf = shutil.which("dnf5") if state.config.architecture.is_native() else None
-    dnf = dnf or shutil.which("dnf") or "yum"
-    return dnf
+    return shutil.which("dnf5") or shutil.which("dnf") or "yum"
 
 
 def setup_dnf(state: MkosiState, repos: Iterable[Repo], filelists: bool = True) -> None:


### PR DESCRIPTION
The `--forcearch` flag is global an can be used in dnf5 from v5.1.6 up.

dnf5 tracking issue: https://github.com/rpm-software-management/dnf5/issues/872
dnf5 release notes: https://github.com/rpm-software-management/dnf5/releases/tag/5.1.6

I've tried to do a cross-build amd64->arm64 locally, but scriplets of some packages seem to fail for unrelated reasons. Not sure if this is caused by my host distro or if there is some issue upstream.