### PR TITLE
Fix incremental caching

### DIFF
--- a/mkosi.conf.d/10-common.conf
+++ b/mkosi.conf.d/10-common.conf
@@ -4,6 +4,7 @@
 # These images are (among other things) used for running mkosi which means we need some disk space available so
 # default to directory output where disk space isn't a problem.
 @Format=directory
+@CacheDirectory=mkosi.cache
 
 [Content]
 Autologin=yes

--- a/mkosi.conf.d/30-dirs.conf
+++ b/mkosi.conf.d/30-dirs.conf
@@ -1,8 +1,0 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later
-
-# These depend on the configured distribution, release and architecture
-# so we order this drop-in after all the other drop-ins.
-
-[Output]
-@CacheDirectory=mkosi.cache/%d~%r~%a
-@BuildDirectory=mkosi.builddir/%d~%r~%a

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -929,6 +929,9 @@ class MkosiConfig:
 
     def cache_manifest(self) -> dict[str, Any]:
         return {
+            "distribution": self.distribution,
+            "release": self.release,
+            "architecture": self.architecture,
             "packages": self.packages,
             "build_packages": self.build_packages,
             "repositories": self.repositories,


### PR DESCRIPTION
- Make sure the distribution, release and architecture are also part of the cache manifest
- Remove the output name from the cache key and use the distribution, release, architecture and optionally image name instead.
- Use MkosiEncoder to serialize the cache manifest.