### PR TITLE
qemu: allow checking device availability with actually used  flags

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2579,7 +2579,7 @@ def run_verb(args: MkosiArgs, images: Sequence[MkosiConfig]) -> None:
     qemu_device_fds = {
         d: os.open(d.device(), os.O_RDWR|os.O_CLOEXEC|os.O_NONBLOCK)
         for d in QemuDeviceNode
-        if d.available(log=True)
+        if d.available(log=True, flags=os.O_RDWR|os.O_CLOEXEC|os.O_NONBLOCK)
     }
 
     # Get the user UID/GID either on the host or in the user namespace running the build


### PR DESCRIPTION
On an Arch machine I hadn't used mkosi with in a while I just stumbled over a permission denied although `/dev/vhost-vsock` was world writable. The `os.access` with flags `os.R_OK|os.W_OK` worked, but the `os.open` with `os.O_RDWR|os.O_CLOEXEC|os.O_NONBLOCK` did not. Though this just papers over the issue, let's check the access with the flags used for the open call to not just crash.