### PR TITLE
config: right strip newlines from contents read via path_read_text

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2318,8 +2318,11 @@ def parse_config(argv: Sequence[str] = ()) -> tuple[MkosiArgs, tuple[MkosiConfig
                         expandvars=False,
                     )
                     if p.exists():
-                        setattr(ns, s.dest,
-                                s.parse(p.read_text() if s.path_read_text else f, getattr(ns, s.dest, None)))
+                        setattr(
+                            ns,
+                            s.dest,
+                            s.parse(p.read_text().rstrip("\n") if s.path_read_text else f, getattr(ns, s.dest, None)),
+                        )
 
         if path.exists():
             logging.debug(f"Including configuration file {Path.cwd() / path}")


### PR DESCRIPTION
This is an attempted fix for #2031. I'm not super happy about possible fallout from this, because of the silent stripping of newlines, but let's see whether this works. @NekkoDroid could you have a look whether this solves your issue?