### PR TITLE
Add kernel-install plugin from mkosi-initrd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,37 @@ jobs:
     - name: Test man page generation
       run: pandoc -s mkosi.md -o mkosi.1
 
+  mkosi-initrd:
+    runs-on: ubuntu-22.04
+    needs: unit-test
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.distro }}-${{ github.ref }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - arch
+          - centos
+          - debian
+          - ubuntu
+          - fedora
+          - rocky
+          - alma
+          - opensuse
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./
+
+      # Make sure the latest changes from the pull request are used.
+      - name: Install
+        run: sudo ln -svf $PWD/bin/mkosi /usr/bin/mkosi
+        working-directory: ./
+
+      - name: Build ${{ matrix.distro }}
+        run: mkosi --directory "" -d ${{ matrix.distro }} --include mkosi-initrd build
+
   integration-test:
     runs-on: ubuntu-22.04
     needs: unit-test

--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ when not installed as a zipapp.
 Please note, that the python module exists solely for the usage of the
 mkosi binary and is not to be considered a public API.
 
+## kernel-install plugin
+
+mkosi can also be used as a kernel-install plugin to build initrds. To
+enable this feature, install `kernel-install/50-mkosi-initrd.install`
+into `/usr/lib/kernel/install.d` and install `mkosi-initrd/mkosi.conf`
+into `/usr/lib/mkosi-initrd`. Extra distro configuration for the initrd
+can be configured using drop-ins in `/usr/lib/mkosi-initrd`. Users can
+add their custom configuration in `/etc/mkosi-initrd`.
+
+Once installed, the mkosi plugin can be enabled by writing
+`initrd_generator=mkosi-initrd` to `/usr/lib/kernel/install.conf` or to
+`/etc/kernel/install.conf`.
+
 # Hacking on mkosi
 
 To hack on mkosi itself you will also need

--- a/kernel-install/50-mkosi-initrd.install
+++ b/kernel-install/50-mkosi-initrd.install
@@ -1,0 +1,44 @@
+#!/usr/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+set -e
+export LANG=C.UTF-8
+
+COMMAND="$1"
+KERNEL_VERSION="$2"
+BOOT_DIR_ABS="$3"
+KERNEL_IMAGE="$4"
+INITRD_OPTIONS_SHIFT=4
+
+# Skip this plugin if we're using a different generator.
+[ "${KERNEL_INSTALL_INITRD_GENERATOR}" != "mkosi-initrd" ] && exit 0
+
+: "${KERNEL_INSTALL_STAGING_AREA:?}"
+
+case "$COMMAND" in
+    add)
+        # If the initrd was provided on the kernel command line, we shouldn't generate our own.
+        [ "$#" -gt "$INITRD_OPTIONS_SHIFT" ] && exit 0
+
+        (
+            [ "$KERNEL_INSTALL_VERBOSE" -gt 0 ] && set -x
+
+            mkosi --directory "" \
+                  $([ -e /usr/lib/mkosi-initrd ] && echo --include=/usr/lib/mkosi-initrd) \
+                  $([ -e /etc/mkosi-initrd ] && echo --include=/etc/mkosi-initrd) \
+                  --image-version="$KERNEL_VERSION" \
+                  --environment="KERNEL_VERSION=$KERNEL_VERSION" \
+                  --workspace-dir=/var/tmp \
+                  --cache-dir=/var/cache \
+                  --output-dir="$KERNEL_INSTALL_STAGING_AREA" \
+                  --extra-tree="/usr/lib/modules/${KERNEL_VERSION}:/usr/lib/modules/${KERNEL_VERSION}"
+
+            rm "${KERNEL_INSTALL_STAGING_AREA}/initrd"
+            mv -v "${KERNEL_INSTALL_STAGING_AREA}"/initrd_*.cpio.zst "${KERNEL_INSTALL_STAGING_AREA}/initrd"
+        )
+        ;;
+
+    remove)
+        ;;
+esac
+
+exit 0

--- a/mkosi-initrd/mkosi.conf
+++ b/mkosi-initrd/mkosi.conf
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Output]
+ImageId=initrd
+Output=initrd
+Format=cpio
+ManifestFormat=
+CompressOutput=yes
+
+[Content]
+Bootable=no
+MakeInitrd=yes
+Packages=
+        systemd                   # sine qua non
+        udev
+        util-linux                # Make sure we pull in util-linux instead of util-linux-core as the latter does not
+                                  # include sulogin which is required for emergency logins
+        bash                      # for emergency logins
+        less                      # this makes 'systemctl' much nicer to use ;)
+        p11-kit                   # dl-opened by systemd
+        lvm2
+
+RemoveFiles=
+        # we don't need this after the binary catalogs have been built
+        /usr/lib/systemd/catalog
+        /etc/udev/hwdb.d
+        /usr/lib/udev/hwdb.d
+
+        # this is not needed by anything updated in the last 20 years
+        /etc/services
+
+        # Including kernel images in the initrd is generally not useful.
+        # This also stops mkosi from extracting the kernel image out of the image as a separate output.
+        /usr/lib/modules/*/vmlinuz

--- a/mkosi-initrd/mkosi.conf.d/10-arch.conf
+++ b/mkosi-initrd/mkosi.conf.d/10-arch.conf
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=arch
+
+[Content]
+Packages=
+        gzip # For compressed keymap unpacking by loadkeys
+
+RemoveFiles=
+        # Arch Linux doesn't split their gcc-libs package so we manually remove
+        # unneeded stuff here to make sure it doesn't end up in the initrd.
+        /usr/lib/libgfortran.so*
+        /usr/lib/libgo.so*
+        /usr/lib/libgomp.so*
+        /usr/lib/libgphobos.so*
+        /usr/lib/libobjc.so*

--- a/mkosi-initrd/mkosi.conf.d/10-centos-fedora.conf
+++ b/mkosi-initrd/mkosi.conf.d/10-centos-fedora.conf
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=|fedora
+Distribution=|centos
+Distribution=|alma
+Distribution=|rocky
+
+[Content]
+Packages=
+        # Various libraries that are dlopen'ed by cryptsetup and pcrphase services
+        libfido2
+        tpm2-tss
+
+        # File system checkers for supported root file systems
+        /usr/sbin/fsck.ext4
+        /usr/sbin/fsck.xfs
+
+        # fsck.btrfs is a dummy, checking is done in the kernel.

--- a/mkosi-initrd/mkosi.conf.d/10-debian-ubuntu.conf
+++ b/mkosi-initrd/mkosi.conf.d/10-debian-ubuntu.conf
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=|debian
+Distribution=|ubuntu
+
+[Content]
+Packages=
+        kmod     # Not pulled in as a dependency on Debian/Ubuntu
+        dmsetup  # Not pulled in as a dependency on Debian/Ubuntu

--- a/mkosi.conf.d/10-common.conf
+++ b/mkosi.conf.d/10-common.conf
@@ -9,6 +9,7 @@
 [Content]
 Autologin=yes
 BiosBootloader=grub
+BuildSourcesEphemeral=yes
 
 Packages=
         attr
@@ -24,3 +25,9 @@ Packages=
         nano
         pkg-config
         strace
+
+RemoveFiles=
+        # The grub install plugin doesn't play nice with booting from virtiofs.
+        /usr/lib/kernel/install.d/20-grub.install
+        # The dracut install plugin doesn't honor KERNEL_INSTALL_INITRD_GENERATOR.
+        /usr/lib/kernel/install.d/50-dracut.install

--- a/mkosi.conf.d/30-rpm/mkosi.build.chroot
+++ b/mkosi.conf.d/30-rpm/mkosi.build.chroot
@@ -1,0 +1,13 @@
+#!/bin/sh
+# SPDX-License-Identifier: LGPL-2.1-or-later
+set -ex
+
+rpmbuild \
+    -bb \
+    --build-in-place \
+    $([ "$WITH_TESTS" = "0" ] && echo --nocheck) \
+    --define "_topdir $PWD" \
+    --define "_sourcedir rpm" \
+    --define "_rpmdir $OUTPUTDIR" \
+    --define "_build_name_fmt %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm" \
+    rpm/mkosi.spec

--- a/mkosi.conf.d/30-rpm/mkosi.conf
+++ b/mkosi.conf.d/30-rpm/mkosi.conf
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+BuildSources=rpm
+Distribution=fedora
+
+[Content]
+Packages=rpm-build

--- a/mkosi.conf.d/30-rpm/mkosi.postinst
+++ b/mkosi.conf.d/30-rpm/mkosi.postinst
@@ -1,0 +1,5 @@
+#!/bin/sh
+# SPDX-License-Identifier: LGPL-2.1-or-later
+set -e
+
+rpm --install "$OUTPUTDIR"/*mkosi*.rpm

--- a/mkosi.conf.d/30-rpm/mkosi.prepare
+++ b/mkosi.conf.d/30-rpm/mkosi.prepare
@@ -1,0 +1,39 @@
+#!/bin/sh
+# SPDX-License-Identifier: LGPL-2.1-or-later
+set -e
+
+if [ "$1" = "build" ]; then
+    DEPS="--buildrequires"
+else
+    DEPS="--requires"
+fi
+
+mkosi-chroot \
+    rpmspec \
+    --query \
+    "$DEPS" \
+    --define "_topdir ." \
+    --define "_sourcedir rpm" \
+    rpm/mkosi.spec |
+        grep -E -v "mkosi" |
+        xargs -d '\n' dnf install --best
+
+if [ "$1" = "build" ]; then
+    until mkosi-chroot \
+        rpmbuild \
+        -bd \
+        --build-in-place \
+        --define "_topdir ." \
+        --define "_sourcedir rpm" \
+        --define "_build_name_fmt %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm" \
+        rpm/mkosi.spec
+    do
+        EXIT_STATUS=$?
+        if [ $EXIT_STATUS -ne 11 ]; then
+            exit $EXIT_STATUS
+        fi
+
+        dnf builddep SRPMS/mkosi-*.buildreqs.nosrc.rpm
+        rm SRPMS/mkosi-*.buildreqs.nosrc.rpm
+    done
+fi


### PR DESCRIPTION
Let's support kernel-install natively in mkosi. This commit moves
the kernel-install plugin from mkosi-initrd into mkosi itself with
a few adaptations:

- We look for initrd configuration in /usr/lib/mkosi-initrd and
  /etc/mkosi-initrd using "--include"
- We always include the host's kernel modules using --extra-tree
- We skip the mkosi-initrd plugin unless initrd_generator is
  explicitly set to "mkosi-initrd". This allows the mkosi package
  to be installed without also using it as the initrd generator if
  initrd_generator is not configured explicitly.

This commit also extends the default fedora image to build the mkosi
rpm if the spec sources are mounted at rpm/ using BuildSources=. We
also configure the default image to use mkosi-initrd as the initrd
generator and ukify as the uki generator, so that running kernel-install
in the booted image will build a UKI using mkosi-initrd and ukify.