### PR TITLE
Fix broken KernelModuleIncludes implementation

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2798,7 +2798,7 @@ Clean Package Manager Metadata: {yes_no_auto(config.clean_package_metadata)}
 
          Kernel Modules Initrd: {yes_no(config.kernel_modules_initrd)}
  Kernel Modules Initrd Include: {line_join_list(config.kernel_modules_initrd_include)}
- Kernel Modules Initrd Exclude: {line_join_list(config.kernel_modules_initrd_include)}
+ Kernel Modules Initrd Exclude: {line_join_list(config.kernel_modules_initrd_exclude)}
 
                         Locale: {none_to_default(config.locale)}
                Locale Messages: {none_to_default(config.locale_messages)}


### PR DESCRIPTION
The new implementation behaves as described in the documentation, i.e.
the inclusion patterns will override any exclusions. The old
implementation was broken for the include case, if anything matched an
exclusion pattern it would not get added to the image regardless of any
inclusion patterns.