### PR TITLE
Add BuildSourcesEphemeral=

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,9 +38,10 @@
   `-kernel` or `QemuKernel=`
 - We don't create subdirectories beneath the configured cache directory
   anymore.
-- Source directories are now made ephemeral when running scripts. This
-  means any changes made to source directories while running scripts
-  will be undone after the scripts have finished executing.
+- Added `BuildSourcesEphemeral=` to make source directories ephemeral
+  when running scripts. This means any changes made to source
+  directories while running scripts will be undone after the scripts
+  have finished executing.
 - Workspace directories are now created outside of any source
   directories. mkosi will either use `XDG_CACHE_HOME`, `$HOME/.cache` or
   `/var/tmp` depending on the situation.

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -325,7 +325,7 @@ def mount_build_overlay(state: MkosiState, volatile: bool = False) -> Iterator[P
 def finalize_mounts(config: MkosiConfig) -> Iterator[list[PathString]]:
     with contextlib.ExitStack() as stack:
         sources = [
-            (stack.enter_context(mount_overlay([source])), target)
+            (stack.enter_context(mount_overlay([source])) if config.build_sources_ephemeral else source, target)
             for source, target
             in [(Path.cwd(), Path.cwd())] + [t.with_prefix(Path.cwd()) for t in config.build_sources]
         ]

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -776,6 +776,7 @@ class MkosiConfig:
     postinst_scripts: list[Path]
     finalize_scripts: list[Path]
     build_sources: list[ConfigTree]
+    build_sources_ephemeral: bool
     environment: dict[str, str]
     with_tests: bool
     with_network: bool
@@ -1466,6 +1467,13 @@ SETTINGS = (
         parse=config_make_list_parser(delimiter=",", parse=parse_tree),
         match=config_match_build_sources,
         help="Path for sources to build",
+    ),
+    MkosiConfigSetting(
+        dest="build_sources_ephemeral",
+        metavar="BOOL",
+        section="Content",
+        parse=config_parse_boolean,
+        help="Make build sources ephemeral when running scripts",
     ),
     MkosiConfigSetting(
         dest="environment",
@@ -2811,6 +2819,7 @@ Clean Package Manager Metadata: {yes_no_auto(config.clean_package_metadata)}
            Postinstall Scripts: {line_join_list(config.postinst_scripts)}
               Finalize Scripts: {line_join_list(config.finalize_scripts)}
                  Build Sources: {line_join_tree_list(config.build_sources)}
+       Build Sources Ephemeral: {yes_no(config.build_sources_ephemeral)}
             Script Environment: {line_join_list(env)}
     Run Tests in Build Scripts: {yes_no(config.with_tests)}
           Scripts With Network: {yes_no(config.with_network)}

--- a/mkosi/mounts.py
+++ b/mkosi/mounts.py
@@ -9,7 +9,6 @@ from collections.abc import Iterator, Sequence
 from pathlib import Path
 from typing import Optional
 
-from mkosi.log import complete_step
 from mkosi.run import run
 from mkosi.types import PathString
 from mkosi.util import INVOKING_USER, umask
@@ -26,12 +25,10 @@ def delete_whiteout_files(path: Path) -> None:
     Overlayfs uses such files to mark "whiteouts" (files present in
     the lower layers, but removed in the upper one).
     """
-
-    with complete_step("Removing overlay whiteout files…"):
-        for entry in path.rglob("*"):
-            # TODO: Use Path.stat() once we depend on Python 3.10+.
-            if stat_is_whiteout(os.stat(entry, follow_symlinks=False)):
-                entry.unlink()
+    for entry in path.rglob("*"):
+        # TODO: Use Path.stat() once we depend on Python 3.10+.
+        if stat_is_whiteout(os.stat(entry, follow_symlinks=False)):
+            entry.unlink()
 
 
 @contextlib.contextmanager
@@ -114,8 +111,7 @@ def mount_overlay(lowerdirs: Sequence[Path], upperdir: Optional[Path] = None, wh
             with mount("overlay", where, options=options, type="overlay"):
                 yield where
         finally:
-            with complete_step("Cleaning up overlayfs"):
-                delete_whiteout_files(upperdir)
+            delete_whiteout_files(upperdir)
 
 
 @contextlib.contextmanager

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -906,6 +906,13 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
   with all build sources mounted in it is mounted to `/work/src` inside
   the image's root directory.
 
+`BuildSourcesEphemeral=`, `--build-sources-ephemeral=`
+
+: Takes a boolean. Disabled by default. Configures whether changes to
+  source directories (The working directory and configured using
+  `BuildSources=`) are persisted. If enabled, all source directories
+  will be reset to their original state after scripts finish executing.
+
 `Environment=`, `--environment=`
 
 : Adds variables to the environment that package managers and the

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -99,6 +99,7 @@ def test_config() -> None:
                     "target": "/frob"
                 }
             ],
+            "BuildSourcesEphemeral": true,
             "CacheDirectory": "/is/this/the/cachedir",
             "CacheOnly": true,
             "Checksum": false,
@@ -268,6 +269,7 @@ def test_config() -> None:
         build_packages =  ["pkg1", "pkg2"],
         build_scripts =  [Path("/path/to/buildscript")],
         build_sources = [ConfigTree(Path("/qux"), Path("/frob"))],
+        build_sources_ephemeral = True,
         cache_dir = Path("/is/this/the/cachedir"),
         cache_only =  True,
         checksum =  False,


### PR DESCRIPTION
Unfortunately there are use cases where it's useful to persist changes to the source directory. A prime example is projects with Makefile that do not provide a properly functioning `make install`. The only way to use those with mkosi build scripts is to do an in-tree build in the build script and then mounting the source directory into the VM or container when booting it. For this to work we need changes to the source directory to be persisted. To support this use case, let's gate the ephemeral source directories behind an option that's disabled by default (for backwards compatibitity reasons).