### PR TITLE
Use package manager specific subdirectories in the cache directory

### DIFF
--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -81,7 +81,7 @@ def apt_cmd(state: MkosiState, command: str) -> list[PathString]:
         "-o", "APT::Get::Allow-Change-Held-Packages=true",
         "-o", "APT::Get::Allow-Remove-Essential=true",
         "-o", "APT::Sandbox::User=root",
-        "-o", f"Dir::Cache={state.cache_dir}",
+        "-o", f"Dir::Cache={state.cache_dir / 'apt'}",
         "-o", f"Dir::State={state.pkgmngr / 'var/lib/apt'}",
         "-o", f"Dir::State::status={state.root / 'var/lib/dpkg/status'}",
         "-o", f"Dir::Etc::trusted={trustedkeys}",

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -106,7 +106,7 @@ def dnf_cmd(state: MkosiState) -> list[PathString]:
         f"--releasever={state.config.release}",
         f"--installroot={state.root}",
         "--setopt=keepcache=1",
-        f"--setopt=cachedir={state.cache_dir}",
+        f"--setopt=cachedir={state.cache_dir / ('libdnf5' if dnf.endswith('dnf5') else 'dnf')}",
         f"--setopt=reposdir={state.pkgmngr / 'etc/yum.repos.d'}",
         f"--setopt=varsdir={state.pkgmngr / 'etc/dnf/vars'}",
         f"--setopt=persistdir={state.pkgmngr / 'var/lib/dnf'}",

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -87,12 +87,15 @@ def pacman_cmd(state: MkosiState) -> list[PathString]:
     gpgdir = state.pkgmngr / "etc/pacman.d/gnupg/"
     gpgdir = gpgdir if gpgdir.exists() else Path("/etc/pacman.d/gnupg/")
 
+    with umask(~0o755):
+        (state.cache_dir / "pacman/pkg").mkdir(parents=True, exist_ok=True)
+
     cmdline: list[PathString] = [
         "pacman",
         "--config", state.pkgmngr / "etc/pacman.conf",
         "--root", state.root,
         "--logfile=/dev/null",
-        "--cachedir", state.cache_dir,
+        "--cachedir", state.cache_dir / "pacman/pkg",
         "--gpgdir", gpgdir,
         "--hookdir", state.root / "etc/pacman.d/hooks",
         "--arch", state.config.distribution.architecture(state.config.architecture),

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -55,7 +55,7 @@ def zypper_cmd(state: MkosiState) -> list[PathString]:
         f"ZYPP_CONF={state.pkgmngr / 'etc/zypp/zypp.conf'}",
         "zypper",
         f"--root={state.root}",
-        f"--cache-dir={state.cache_dir}",
+        f"--cache-dir={state.cache_dir / 'zypp'}",
         f"--reposd-dir={state.pkgmngr / 'etc/zypp/repos.d'}",
         "--gpg-auto-import-keys" if state.config.repository_key_check else "--no-gpg-checks",
         "--non-interactive",


### PR DESCRIPTION
We want to be able to set --cache-dir=/var/cache to automatically reuse the system cache for each installed package manager, so let's make sure we use the right subdirectories for each package manager to make that work properly.