### PR TITLE
Rename Compression.zst to Compression.zstd

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1203,7 +1203,7 @@ def build_kernel_modules_initrd(state: MkosiState, kver: str) -> Path:
     # this is not ideal since the compressed kernel modules will all be decompressed on boot which
     # requires significant memory.
     if state.config.distribution.is_apt_distribution():
-        maybe_compress(state.config, Compression.zst, kmods, kmods)
+        maybe_compress(state.config, Compression.zstd, kmods, kmods)
 
     return kmods
 
@@ -1433,7 +1433,7 @@ def compressor_command(compression: Compression) -> list[PathString]:
         return [gzip_binary(), "--fast", "--stdout", "-"]
     elif compression == Compression.xz:
         return ["xz", "--check=crc32", "--fast", "-T0", "--stdout", "-"]
-    elif compression == Compression.zst:
+    elif compression == Compression.zstd:
         return ["zstd", "-q", "-T0", "--stdout", "-"]
     else:
         die(f"Unknown compression {compression}")

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -130,7 +130,8 @@ class ManifestFormat(StrEnum):
 
 class Compression(StrEnum):
     none = enum.auto()
-    zst  = enum.auto()
+    zstd = enum.auto()
+    zst  = "zstd"
     xz   = enum.auto()
     bz2  = enum.auto()
     gz   = enum.auto()
@@ -283,7 +284,7 @@ def config_parse_compression(value: Optional[str], old: Optional[Compression]) -
     try:
         return Compression[value]
     except KeyError:
-        return Compression.zst if parse_boolean(value) else Compression.none
+        return Compression.zstd if parse_boolean(value) else Compression.none
 
 
 def config_parse_seed(value: Optional[str], old: Optional[str]) -> Optional[uuid.UUID]:
@@ -314,7 +315,7 @@ def config_default_compression(namespace: argparse.Namespace) -> Compression:
         if namespace.distribution.is_centos_variant() and int(namespace.release) <= 8:
             return Compression.xz
         else:
-            return Compression.zst
+            return Compression.zstd
     else:
         return Compression.none
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -311,7 +311,7 @@ def config_parse_source_date_epoch(value: Optional[str], old: Optional[int]) -> 
 
 
 def config_default_compression(namespace: argparse.Namespace) -> Compression:
-    if namespace.output_format in (OutputFormat.cpio, OutputFormat.uki, OutputFormat.esp):
+    if namespace.output_format in (OutputFormat.tar, OutputFormat.cpio, OutputFormat.uki, OutputFormat.esp):
         if namespace.distribution.is_centos_variant() and int(namespace.release) <= 8:
             return Compression.xz
         else:

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -607,13 +607,14 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 `CompressOutput=`, `--compress-output=`
 
-: Configure compression for the resulting image or archive. The
-  argument can be either a boolean or a compression algorithm (`xz`,
-  `zstd`). `xz` compression is used by default. Note that when applied
-  to block device image types this means the image cannot be started
-  directly but needs to be decompressed first. This also means that
-  the `shell`, `boot`, `qemu` verbs are not available when this option
-  is used. Implied for `tar` and `cpio`.
+: Configure compression for the resulting image or archive. The argument can be
+  either a boolean or a compression algorithm (`xz`, `zstd`). `zstd`
+  compression is used by default, except CentOS and derivatives up to version
+  8, which default to `xz`. Note that when applied to block device image types,
+  compression means the image cannot be started directly but needs to be
+  decompressed first. This also means that the `shell`, `boot`, `qemu` verbs
+  are not available when this option is used. Implied for `tar`, `cpio`, `uki`,
+  and `esp`.
 
 `OutputDirectory=`, `--output-dir=`, `-O`
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,18 +27,19 @@ from mkosi.util import chdir
 
 
 def test_compression_enum_creation() -> None:
-    assert Compression("none") == Compression.none
-    assert Compression("zst") == Compression.zst
-    assert Compression("xz") == Compression.xz
-    assert Compression("bz2") == Compression.bz2
-    assert Compression("gz") == Compression.gz
-    assert Compression("lz4") == Compression.lz4
-    assert Compression("lzma") == Compression.lzma
+    assert Compression["none"] == Compression.none
+    assert Compression["zstd"] == Compression.zstd
+    assert Compression["zst"] == Compression.zstd
+    assert Compression["xz"] == Compression.xz
+    assert Compression["bz2"] == Compression.bz2
+    assert Compression["gz"] == Compression.gz
+    assert Compression["lz4"] == Compression.lz4
+    assert Compression["lzma"] == Compression.lzma
 
 
 def test_compression_enum_bool() -> None:
     assert not bool(Compression.none)
-    assert bool(Compression.zst)
+    assert bool(Compression.zstd)
     assert bool(Compression.xz)
     assert bool(Compression.bz2)
     assert bool(Compression.gz)
@@ -48,7 +49,8 @@ def test_compression_enum_bool() -> None:
 
 def test_compression_enum_str() -> None:
     assert str(Compression.none) == "none"
-    assert str(Compression.zst)  == "zst"
+    assert str(Compression.zstd) == "zstd"
+    assert str(Compression.zst)  == "zstd"
     assert str(Compression.xz)   == "xz"
     assert str(Compression.bz2)  == "bz2"
     assert str(Compression.gz)   == "gz"


### PR DESCRIPTION
But also leave a fallback Compression.zst with value "zstd" as a fallback in case anybody used that. To test this we also change the construction of Compression instances in test_config.py to use __get_item__ instead of __new__, since that actually supports construction via the value and is also the one actually used in config.py

Fixes: #2072