### PR TITLE
ci: enable jammy-proposed-updates to get new libsolv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Enable proposed-updates
+        run: |
+          sudo mkdir -p /etc/apt/sources.list.d/
+          echo 'deb http://azure.archive.ubuntu.com/ubuntu jammy-proposed restricted main universe' | sudo tee /etc/apt/sources.list.d/proposed.list
       - uses: ./
 
       # Make sure the latest changes from the pull request are used.
@@ -143,6 +147,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Enable proposed-updates
+      run: |
+        sudo mkdir -p /etc/apt/sources.list.d/
+        echo 'deb http://azure.archive.ubuntu.com/ubuntu jammy-proposed restricted main universe' | sudo tee /etc/apt/sources.list.d/proposed.list
     - uses: ./
 
     # Make sure the latest changes from the pull request are used.


### PR DESCRIPTION
rawhide and tumbleweed now compress repodata with zstd which cannot be handled by libsolv in jammy. Enable jammy-proposed to get new version with the fix.

This reverts commit 4cec733f9186edec10904c30b4afd3d1c8857d9d.