### PR TITLE
util: add a fallback username and home for INVOKING_USER

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2604,7 +2604,7 @@ def show_docs(args: MkosiArgs) -> None:
 
 
 def expand_specifier(s: str) -> str:
-    return s.replace("%u", INVOKING_USER.name)
+    return s.replace("%u", INVOKING_USER.name())
 
 
 def needs_build(args: MkosiArgs, config: MkosiConfig) -> bool:

--- a/mkosi/__main__.py
+++ b/mkosi/__main__.py
@@ -13,6 +13,7 @@ from mkosi import run_verb
 from mkosi.config import parse_config
 from mkosi.log import ARG_DEBUG, log_setup
 from mkosi.run import ensure_exc_info, run
+from mkosi.util import INVOKING_USER
 
 
 @contextlib.contextmanager
@@ -43,6 +44,8 @@ def propagate_failed_return() -> Iterator[None]:
 @propagate_failed_return()
 def main() -> None:
     log_setup()
+    # Ensure that the name and home of the user we are running as are resolved as early as possible.
+    INVOKING_USER.init()
     args, images = parse_config(sys.argv[1:])
 
     if args.debug:

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -219,7 +219,7 @@ def parse_path(value: str,
 
     if expanduser:
         if path.is_relative_to("~") and not INVOKING_USER.is_running_user():
-            path = INVOKING_USER.home / path.relative_to("~")
+            path = INVOKING_USER.home() / path.relative_to("~")
         path = path.expanduser()
 
     if required and not path.exists():
@@ -955,14 +955,14 @@ class MkosiConfig:
         # directory in /home as well as /home might be on a separate partition or subvolume which means that to take
         # advantage of reflinks and such, the workspace directory has to be on the same partition/subvolume.
         if (
-            Path.cwd().is_relative_to(INVOKING_USER.home) and
-            (INVOKING_USER.home / ".cache").exists() and
+            Path.cwd().is_relative_to(INVOKING_USER.home()) and
+            (INVOKING_USER.home() / ".cache").exists() and
             (
-                self.cache_dir and self.cache_dir.is_relative_to(INVOKING_USER.home) or
-                self.output_dir and self.output_dir.is_relative_to(INVOKING_USER.home)
+                self.cache_dir and self.cache_dir.is_relative_to(INVOKING_USER.home()) or
+                self.output_dir and self.output_dir.is_relative_to(INVOKING_USER.home())
             )
         ):
-            return INVOKING_USER.home / ".cache"
+            return INVOKING_USER.home() / ".cache"
 
         return Path("/var/tmp")
 

--- a/mkosi/mounts.py
+++ b/mkosi/mounts.py
@@ -157,7 +157,8 @@ def mount_passwd(root: Path = Path("/")) -> Iterator[None]:
         passwd.write("root:x:0:0:root:/root:/bin/sh\n")
         if INVOKING_USER.uid != 0:
             name = INVOKING_USER.name()
-            passwd.write(f"{name}:x:{INVOKING_USER.uid}:{INVOKING_USER.gid}:{name}:/home/{name}:/bin/sh\n")
+            home = INVOKING_USER.home()
+            passwd.write(f"{name}:x:{INVOKING_USER.uid}:{INVOKING_USER.gid}:{name}:{home}:/bin/sh\n")
         passwd.flush()
         os.fchown(passwd.file.fileno(), INVOKING_USER.uid, INVOKING_USER.gid)
 

--- a/mkosi/mounts.py
+++ b/mkosi/mounts.py
@@ -156,7 +156,7 @@ def mount_passwd(root: Path = Path("/")) -> Iterator[None]:
     with tempfile.NamedTemporaryFile(prefix="mkosi.passwd", mode="w") as passwd:
         passwd.write("root:x:0:0:root:/root:/bin/sh\n")
         if INVOKING_USER.uid != 0:
-            name = INVOKING_USER.name
+            name = INVOKING_USER.name()
             passwd.write(f"{name}:x:{INVOKING_USER.uid}:{INVOKING_USER.gid}:{name}:/home/{name}:/bin/sh\n")
         passwd.flush()
         os.fchown(passwd.file.fileno(), INVOKING_USER.uid, INVOKING_USER.gid)


### PR DESCRIPTION
At build time, e.g. during reproducible builds, usernames are not guaranteed to be resolvable. Have a fallback so that our tests can be run in the scenario.

Fixes: #2081