### PR TITLE
Add ability to create passwordless root account

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1117,8 +1117,8 @@ def build_initrd(state: MkosiState) -> Path:
     # Default values are assigned via the parser so we go via the argument parser to construct
     # the config for the initrd.
 
-    password, hashed = state.config.root_password or (None, False)
-    if password:
+    if state.config.root_password:
+        password, hashed = state.config.root_password
         rootpwopt = f"hashed:{password}" if hashed else password
     else:
         rootpwopt = None
@@ -1845,7 +1845,8 @@ def run_firstboot(state: MkosiState) -> None:
     creds = []
 
     for option, cred, value in settings:
-        if not value:
+        # Check for None as password might be the empty string
+        if value is None:
             continue
 
         options += [option, value]

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -1073,7 +1073,7 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 : Set the system root password. If this option is not used, but a `mkosi.rootpw` file is found in the local
   directory, the password is automatically read from it. If the password starts with `hashed:`, it is treated
   as an already hashed root password. The root password is also stored in `/usr/lib/credstore` under the
-  appropriate systemd credential so that it applies even if only `/usr` is shipped in the image. The create
+  appropriate systemd credential so that it applies even if only `/usr` is shipped in the image. To create
   an unlocked account without any password use `hashed:` without a hash.
 
 `Autologin=`, `--autologin`

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -1073,7 +1073,8 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 : Set the system root password. If this option is not used, but a `mkosi.rootpw` file is found in the local
   directory, the password is automatically read from it. If the password starts with `hashed:`, it is treated
   as an already hashed root password. The root password is also stored in `/usr/lib/credstore` under the
-  appropriate systemd credential so that it applies even if only `/usr` is shipped in the image.
+  appropriate systemd credential so that it applies even if only `/usr` is shipped in the image. The create
+  an unlocked account without any password use `hashed:` without a hash.
 
 `Autologin=`, `--autologin`
 


### PR DESCRIPTION
This PR adds the ability to use a passwordless root accounts using `hashed:` (without an actual hash following it). Using `RootPassword=hashed:` instead of `RootPassword=` allows to preserve the intended behaviour that assigning the empty value resets previous assignments (and supporting the latter would also have complicated the configparser a decent bit.

Fixes #2091 