### PR TITLE
Run depmod even if Bootable=no

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1757,9 +1757,6 @@ def configure_clock(state: MkosiState) -> None:
 
 
 def run_depmod(state: MkosiState) -> None:
-    if state.config.bootable == ConfigFeature.disabled:
-        return
-
     outputs = (
         "modules.dep",
         "modules.dep.bin",


### PR DESCRIPTION
Bootable=no disables the kernel modules logic but users might still want to generate a bootable image so let's run the depmod logic unconditionally.