### PR TITLE
Add microcode support

### DIFF
--- a/mkosi.conf.d/20-centos-fedora.conf
+++ b/mkosi.conf.d/20-centos-fedora.conf
@@ -24,6 +24,7 @@ Packages=
         erofs-utils
         grub2-pc
         kernel-core
+        microcode_ctl
         mtools
         openssh-clients
         openssl

--- a/mkosi.conf.d/20-centos.conf
+++ b/mkosi.conf.d/20-centos.conf
@@ -9,3 +9,6 @@ Distribution=|rocky
 @Release=9
 Repositories=epel
              epel-next
+
+[Content]
+Packages=linux-firmware

--- a/mkosi.conf.d/20-debian.conf
+++ b/mkosi.conf.d/20-debian.conf
@@ -5,9 +5,11 @@ Distribution=debian
 
 [Distribution]
 @Release=testing
+Repositories=non-free-firmware
 
 [Content]
 Packages=
+        amd64-microcode
         apt
         bash
         btrfs-progs
@@ -23,6 +25,7 @@ Packages=
         e2fsprogs
         erofs-utils
         grub-pc
+        intel-microcode
         libtss2-dev
         linux-image-cloud-amd64
         mtools

--- a/mkosi.conf.d/20-fedora.conf
+++ b/mkosi.conf.d/20-fedora.conf
@@ -11,6 +11,7 @@ Packages=
         archlinux-keyring
         btrfs-progs
         dnf5
+        amd-ucode-firmware
         pacman
         sbsigntools
         systemd-ukify

--- a/mkosi.conf.d/20-opensuse.conf
+++ b/mkosi.conf.d/20-opensuse.conf
@@ -41,6 +41,8 @@ Packages=
         systemd-container
         systemd-experimental
         tar
+        ucode-amd
+        ucode-intel
         udev
         util-linux
         virtiofsd

--- a/mkosi.conf.d/20-ubuntu.conf
+++ b/mkosi.conf.d/20-ubuntu.conf
@@ -9,9 +9,11 @@ Repositories=universe
 
 [Content]
 Packages=
+        amd64-microcode
         apt
         dbus-broker
         grub-pc
+        intel-microcode
         linux-kvm
         systemd
         systemd-boot


### PR DESCRIPTION
Let's make sure we add early CPIO initrds containing microcode when building bootable images. To make early loading of microcode work, an uncompressed initrd has to be prepended to the list of initrds containing the microcode at a canonical location.