### PR TITLE
Set atime and mtime of scripts to zero

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -356,6 +356,7 @@ def finalize_scripts(scripts: Mapping[str, Sequence[PathString]] = {}) -> Iterat
             )
 
             make_executable(Path(d) / name)
+            os.utime(Path(d) / name, (0, 0))
 
         yield Path(d)
 


### PR DESCRIPTION
Otherwise, stuff like meson reconfigure will rerun every time because we write the script again every time we run the build script.