### PR TITLE
Speed up empty_directory()

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1559,8 +1559,7 @@ def print_output_size(path: Path) -> None:
 
 def empty_directory(path: Path) -> None:
     try:
-        for f in os.listdir(path):
-            rmtree(path / f)
+        rmtree(*path.iterdir())
     except FileNotFoundError:
         pass
 

--- a/mkosi/tree.py
+++ b/mkosi/tree.py
@@ -83,8 +83,8 @@ def copy_tree(config: MkosiConfig, src: Path, dst: Path, *, preserve_owner: bool
         run(copy)
 
 
-def rmtree(path: Path) -> None:
-    run(["rm", "-rf", "--", path])
+def rmtree(*paths: Path) -> None:
+    run(["rm", "-rf", "--", *paths])
 
 
 def move_tree(config: MkosiConfig, src: Path, dst: Path) -> None:


### PR DESCRIPTION
Let's invoke rm once instead of N times.