### PR TITLE
mkosi-initrd: Copy md and dm udev rules from dracut

### DIFF
--- a/mkosi-initrd/mkosi.extra/usr/lib/udev/rules.d/10-mkosi-initrd-dm.rules
+++ b/mkosi-initrd/mkosi.extra/usr/lib/udev/rules.d/10-mkosi-initrd-dm.rules
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copied from https://github.com/dracutdevs/dracut/blob/059/modules.d/90dm/11-dm.rules
+
+SUBSYSTEM!="block", GOTO="dm_end"
+KERNEL!="dm-[0-9]*", GOTO="dm_end"
+ACTION!="add|change", GOTO="dm_end"
+OPTIONS+="db_persist"
+LABEL="dm_end"

--- a/mkosi-initrd/mkosi.extra/usr/lib/udev/rules.d/10-mkosi-initrd-md.rules
+++ b/mkosi-initrd/mkosi.extra/usr/lib/udev/rules.d/10-mkosi-initrd-md.rules
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copied from https://github.com/dracutdevs/dracut/blob/059/modules.d/90mdraid/59-persistent-storage-md.rules
+
+SUBSYSTEM!="block", GOTO="md_end"
+ACTION!="add|change", GOTO="md_end"
+# Also don't process disks that are slated to be a multipath device
+ENV{DM_MULTIPATH_DEVICE_PATH}=="1", GOTO="md_end"
+
+KERNEL!="md[0-9]*|md_d[0-9]*|md/*", KERNEL!="md*", GOTO="md_end"
+
+# partitions have no md/{array_state,metadata_version}
+ENV{DEVTYPE}=="partition", GOTO="md_ignore_state"
+
+# container devices have a metadata version of e.g. 'external:ddf' and
+# never leave state 'inactive'
+ATTR{md/metadata_version}=="external:[A-Za-z]*", ATTR{md/array_state}=="inactive", GOTO="md_ignore_state"
+TEST!="md/array_state", GOTO="md_end"
+ATTR{md/array_state}=="|clear|inactive", GOTO="md_end"
+
+LABEL="md_ignore_state"
+
+IMPORT{program}="/sbin/mdadm --detail --export $tempnode"
+IMPORT BLKID
+OPTIONS+="link_priority=100"
+OPTIONS+="watch"
+OPTIONS+="db_persist"
+LABEL="md_end"


### PR DESCRIPTION
Until these are upstreamed into their corresponding projects, let's carry the rules in mkosi-initrd.