### PR TITLE
Stop using workspace cache subdirectory

### DIFF
--- a/mkosi/state.py
+++ b/mkosi/state.py
@@ -42,10 +42,7 @@ class MkosiState:
 
     @property
     def cache_dir(self) -> Path:
-        return (
-            self.config.cache_dir or
-            self.workspace / f"cache/{self.config.distribution}~{self.config.release}~{self.config.architecture}"
-        )
+        return self.config.cache_dir or (self.workspace / "cache")
 
     @property
     def install_dir(self) -> Path:


### PR DESCRIPTION
We don't do this for configured cache directories anymore, so don't do it for workspace cache directories anymore either.