### PR TITLE
lock the correct file for newgidmap

### DIFF
--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -99,7 +99,7 @@ def become_root() -> None:
     ]
 
     newgidmap = [
-        "flock", "--exclusive", "--no-fork", "/etc/subuid", "newgidmap", pid,
+        "flock", "--exclusive", "--no-fork", "/etc/subgid", "newgidmap", pid,
         0, subgid, SUBRANGE - 100,
         SUBRANGE - 100, os.getgid(), 1,
         SUBRANGE - 100 + 1, subgid + SUBRANGE - 100 + 1, 99


### PR DESCRIPTION
Previously /etc/subuid was locked for both newuidmap and newgidmap, this is incorrect as newgidmap edits /etc/subgid.
This change fixes that.