### PR TITLE
Revert "ci: enable jammy-proposed-updates to get new libsolv"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,10 +99,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Enable proposed-updates
-        run: |
-          sudo mkdir -p /etc/apt/sources.list.d/
-          echo 'deb http://azure.archive.ubuntu.com/ubuntu jammy-proposed restricted main universe' | sudo tee /etc/apt/sources.list.d/proposed.list
       - uses: ./
 
       # Make sure the latest changes from the pull request are used.
@@ -147,10 +143,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Enable proposed-updates
-      run: |
-        sudo mkdir -p /etc/apt/sources.list.d/
-        echo 'deb http://azure.archive.ubuntu.com/ubuntu jammy-proposed restricted main universe' | sudo tee /etc/apt/sources.list.d/proposed.list
     - uses: ./
 
     # Make sure the latest changes from the pull request are used.


### PR DESCRIPTION
libsolv has migrated to jammy-updates, so we can disable the proposed-updates repository again.

This reverts commit 698834c7794f0100eba8ff17125cffc8f6ac8a63.