### PR TITLE
ci: Fix environment passthrough

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,6 @@ jobs:
         EOF
 
     - name: Run integration tests
-      run: sudo --preserve-env timeout -k 30 10m python3 -m pytest --tb=no -sv -m integration tests/
+      run: sudo --preserve-env timeout -k 30 1h python3 -m pytest --tb=no -sv -m integration tests/
       env:
         MKOSI_TEST_DISTRIBUTION: ${{ matrix.distro }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,6 @@ jobs:
         EOF
 
     - name: Run integration tests
-      run: sudo timeout -k 30 10m python3 -m pytest --tb=no -sv -m integration tests/
+      run: sudo --preserve-env timeout -k 30 10m python3 -m pytest --tb=no -sv -m integration tests/
       env:
         MKOSI_TEST_DISTRIBUTION: ${{ matrix.distro }}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,7 +18,7 @@ class Image:
         self.options = options
 
         if d := os.getenv("MKOSI_TEST_DISTRIBUTION"):
-            self.distribution = Distribution[d]
+            self.distribution = Distribution(d)
         elif detected := detect_distribution()[0]:
             self.distribution = detected
         else:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,8 +3,8 @@
 import os
 import tempfile
 from collections.abc import Sequence
-from typing import Optional
 from types import TracebackType
+from typing import Optional
 
 from mkosi.distributions import Distribution, detect_distribution
 from mkosi.log import die

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -72,3 +72,6 @@ class Image:
 
     def qemu(self, options: Sequence[str] = (), args: Sequence[str] = ()) -> CompletedProcess:
         return self.mkosi("qemu", options, args, user=INVOKING_USER.uid, group=INVOKING_USER.gid)
+
+    def summary(self, options: Sequence[str] = ()) -> CompletedProcess:
+        return self.mkosi("summary", options, user=INVOKING_USER.uid, group=INVOKING_USER.gid)

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 import os
+
 import pytest
 
 from mkosi.config import OutputFormat
 from mkosi.distributions import Distribution
+from mkosi.qemu import find_virtiofsd
 
 from . import Image
 
@@ -44,7 +46,10 @@ def test_boot(format: OutputFormat) -> None:
         if image.distribution == Distribution.rhel_ubi:
             return
 
-        if format in (OutputFormat.directory, OutputFormat.tar):
+        if format == OutputFormat.tar:
+            return
+
+        if format == OutputFormat.directory and not find_virtiofsd():
             return
 
         image.qemu(options=options)

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -29,6 +29,8 @@ def test_boot(format: OutputFormat) -> None:
 
         options = ["--format", str(format)]
 
+        image.summary(options)
+
         image.build(options=options)
 
         if format in (OutputFormat.disk, OutputFormat.directory) and os.getuid() == 0:


### PR DESCRIPTION
When using sudo we need to make sure to pass through environment variables.

Also run summary() as part of the boot tests to help with debugging.