### PR TITLE
tests: mark distributions and outputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,4 @@ jobs:
         EOF
 
     - name: Run integration tests
-      run: sudo --preserve-env timeout -k 30 1h python3 -m pytest --tb=no -sv -m integration tests/
-      env:
-        MKOSI_TEST_DISTRIBUTION: ${{ matrix.distro }}
+      run: sudo --preserve-env timeout -k 30 1h python3 -m pytest --tb=no -sv -m integration -D ${{ matrix.distro }} tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,3 +73,9 @@ ignore_missing_imports = true
 target-version = "py39"
 line-length = 119
 select = ["E", "F", "I", "UP"]
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: mark a test as an integration test."
+]
+addopts = "-m \"not integration\""

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-markers =
-    integration: mark a test as an integration test.
-addopts = -m "not integration"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: LGPL-2.1+
+from typing import Any, Optional, cast
+
+import pytest
+
+from mkosi.distributions import Distribution, detect_distribution
+
+from . import Image
+
+
+def pytest_addoption(parser: Any) -> None:
+    parser.addoption(
+        "-D",
+        "--distribution",
+        metavar="DISTRIBUTION",
+        help="Run the integration tests for the given distribution.",
+        default=detect_distribution()[0],
+        type=Distribution,
+        choices=[Distribution(d) for d in Distribution.values()],
+    )
+    parser.addoption(
+        "-R",
+        "--release",
+        metavar="RELEASE",
+        help="Run the integration tests for the given release.",
+    )
+
+
+@pytest.fixture(scope="session")
+def config(request: Any) -> Image.Config:
+    distribution = cast(Distribution, request.config.getoption("--distribution"))
+    release = cast(Optional[str], request.config.getoption("--release"))
+    if release is None:
+        release = distribution.default_release()
+
+    return Image.Config(distribution=distribution, release=release)

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -14,15 +14,16 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.mark.parametrize("format", OutputFormat)
-def test_boot(format: OutputFormat) -> None:
+def test_boot(config: Image.Config, format: OutputFormat) -> None:
     with Image(
+        config,
         options=[
             "--kernel-command-line=systemd.unit=mkosi-check-and-shutdown.service",
             "--incremental",
             "--ephemeral",
         ],
     ) as image:
-        if image.distribution == Distribution.rhel_ubi and format in (OutputFormat.esp, OutputFormat.uki):
+        if image.config.distribution == Distribution.rhel_ubi and format in (OutputFormat.esp, OutputFormat.uki):
             pytest.skip("Cannot build RHEL-UBI images with format 'esp' or 'uki'")
 
         options = ["--format", str(format)]
@@ -40,13 +41,13 @@ def test_boot(format: OutputFormat) -> None:
             image.boot(options=options, args=args)
 
         if (
-            image.distribution == Distribution.ubuntu and
+            image.config.distribution == Distribution.ubuntu and
             format in (OutputFormat.cpio, OutputFormat.uki, OutputFormat.esp)
         ):
             # https://bugs.launchpad.net/ubuntu/+source/linux-kvm/+bug/2045561
             pytest.skip("Cannot boot Ubuntu UKI/cpio images in qemu until we switch back to linux-kvm")
 
-        if image.distribution == Distribution.rhel_ubi:
+        if image.config.distribution == Distribution.rhel_ubi:
             return
 
         if format in (OutputFormat.tar, OutputFormat.none) or format.is_extension_image():

--- a/tests/test_sysext.py
+++ b/tests/test_sysext.py
@@ -9,8 +9,9 @@ from . import Image
 pytestmark = pytest.mark.integration
 
 
-def test_sysext() -> None:
+def test_sysext(config: Image.Config) -> None:
     with Image(
+        config,
         options=[
             "--incremental",
             "--clean-package-metadata=no",
@@ -20,6 +21,7 @@ def test_sysext() -> None:
         image.build()
 
         with Image(
+            image.config,
             options=[
                 "--directory", "",
                 "--base-tree", Path(image.output_dir.name) / "image",


### PR DESCRIPTION
This allows for fine-grained choices of which integration tests to run