### PR TITLE
Fix nspawn settings

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1020,10 +1020,6 @@ class MkosiConfig:
         return f"{self.output_with_version}.initrd"
 
     @property
-    def output_nspawn_settings(self) -> str:
-        return f"{self.output_with_version}.nspawn"
-
-    @property
     def output_checksum(self) -> str:
         return f"{self.output_with_version}.SHA256SUMS"
 


### PR DESCRIPTION
When --machine= is used, nspawn looks for a settings file named after the machine so we have to make sure to copy to the right location.

While we're at it, let's also stop considering the nspawn settings an output artifact, since this means we have to build the image to apply new settings. Instead, let's copy the settings when running the image and remove the copied file again afterwards. This means that new settings are applied immediately instead of only after a rebuild.