### PR TITLE
Add sysext, confext and portable support

### DIFF
--- a/docs/sysext.md
+++ b/docs/sysext.md
@@ -47,7 +47,7 @@ top of it by writing the following to `mkosi.images/btrfs/mkosi.conf`:
 Dependencies=base
 
 [Output]
-Format=disk
+Format=sysext
 Overlay=yes
 
 [Content]
@@ -58,61 +58,14 @@ Packages=btrfs-progs
 `BaseTrees=` point to our base image and `Overlay=yes` instructs mkosi
 to only package the files added on top of the base tree.
 
-We'll also want to mark our extension as a system extension. We'll
-assume that our extension is intended for an initramfs, so we'll need to
-configure it as such with `SYSEXT_SCOPE=`. To do that, write the
-following to
-`mkosi.images/btrfs/mkosi.extra/usr/lib/extension-release.d/extension-release.btrfs`:
-
-```conf
-ID=<distribution>
-VERSION_ID=<distribution-version>
-ARCHITECTURE=<architecture>
-SYSEXT_SCOPE=initrd
-```
-
-We'll want to package this up as a signed extension, so let's define the
-necessary systemd-repart files to make that possible:
-
-`mkosi.images/btrfs/mkosi.repart/10-root.conf`:
-
-```conf
-[Partition]
-Type=root
-Format=squashfs
-CopyFiles=/usr/
-Verity=data
-VerityMatchKey=root
-Minimize=best
-```
-
-`mkosi.images/btrfs/mkosi.repart/20-root-verity.conf`:
-
-```conf
-[Partition]
-Type=root-verity
-Verity=hash
-VerityMatchKey=root
-Minimize=best
-```
-
-`mkosi.images/btrfs/mkosi.repart/30-root-verity-sig.conf`:
-
-```conf
-[Partition]
-Type=root-verity-sig
-Verity=signature
-VerityMatchKey=root
-```
-
-Of course we can't sign anything without a key, so let's generate one
+We can't sign the extension image without a key, so let's generate one
 with `mkosi genkey` (or write your own private key and certificate
 yourself to `mkosi.key` and `mkosi.crt` respectively). Note that this
 key will need to be loaded into your kernel keyring either at build time
 or via MOK for systemd to accept the system extension at runtime as
 trusted.
 
-Finally, you build the base image and the extensions by running
+Finally, you can build the base image and the extensions by running
 `mkosi -f`. You'll find `btrfs.raw` in `mkosi.output` which is the
 extension image.
 

--- a/mkosi.conf.d/20-debian.conf
+++ b/mkosi.conf.d/20-debian.conf
@@ -45,6 +45,7 @@ Packages=
         systemd
         systemd-boot
         systemd-container
+        systemd-resolved
         systemd-sysv
         tar
         tzdata

--- a/mkosi.extra/usr/lib/systemd/system-preset/00-mkosi.preset
+++ b/mkosi.extra/usr/lib/systemd/system-preset/00-mkosi.preset
@@ -4,20 +4,13 @@
 disable ssh.service
 disable sshd.service
 
-# These might get pulled in as dependencies but we don't want them running.
-disable dnsmasq.service
-disable isc-dhcp-server.service
-disable isc-dhcp-server6.service
-
-# Pulled in via dracut-network by kexec-tools on Fedora.
-disable NetworkManager*
-
 # Make sure dbus-broker is started by default on Debian/Ubuntu.
 enable dbus-broker.service
 
-# systemd-networkd is disabled by default on Fedora so make sure it is enabled.
+# Make sure we have networking available.
 enable systemd-networkd.service
 enable systemd-networkd-wait-online.service
+enable systemd-resolved.service
 
 # We install dnf in some images but it's only going to be used rarely,
 # so let's not have dnf create its cache.

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -585,8 +585,9 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
   archive is generated), `disk` (a block device OS image with a GPT
   partition table), `uki` (a unified kernel image with the OS image in
   the `.initrd` PE section), `esp` (`uki` but wrapped in a disk image
-  with only an ESP partition) or `none` (the OS image is solely intended
-  as a build image to produce another artifact).
+  with only an ESP partition), `sysext`, `confext`, `portable` or `none`
+  (the OS image is solely intended as a build image to produce another
+  artifact).
 
 : If the `disk` output format is used, the disk image is generated using
   `systemd-repart`. The repart partition definition files to use can be

--- a/mkosi/resources/repart/definitions/confext.repart.d/10-root.conf
+++ b/mkosi/resources/repart/definitions/confext.repart.d/10-root.conf
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+[Partition]
+Type=root
+Format=erofs
+CopyFiles=/etc/
+Verity=data
+VerityMatchKey=root
+Minimize=best

--- a/mkosi/resources/repart/definitions/confext.repart.d/20-root-verity.conf
+++ b/mkosi/resources/repart/definitions/confext.repart.d/20-root-verity.conf
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+[Partition]
+Type=root-verity
+Verity=hash
+VerityMatchKey=root
+Minimize=best

--- a/mkosi/resources/repart/definitions/confext.repart.d/30-root-verity-sig.conf
+++ b/mkosi/resources/repart/definitions/confext.repart.d/30-root-verity-sig.conf
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+[Partition]
+Type=root-verity-sig
+Verity=signature
+VerityMatchKey=root

--- a/mkosi/resources/repart/definitions/portable.repart.d/10-root.conf
+++ b/mkosi/resources/repart/definitions/portable.repart.d/10-root.conf
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+[Partition]
+Type=root
+Format=erofs
+CopyFiles=/
+Verity=data
+VerityMatchKey=root
+Minimize=best

--- a/mkosi/resources/repart/definitions/portable.repart.d/20-root-verity.conf
+++ b/mkosi/resources/repart/definitions/portable.repart.d/20-root-verity.conf
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+[Partition]
+Type=root-verity
+Verity=hash
+VerityMatchKey=root
+Minimize=best

--- a/mkosi/resources/repart/definitions/portable.repart.d/30-root-verity-sig.conf
+++ b/mkosi/resources/repart/definitions/portable.repart.d/30-root-verity-sig.conf
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+[Partition]
+Type=root-verity-sig
+Verity=signature
+VerityMatchKey=root

--- a/mkosi/resources/repart/definitions/sysext.repart.d/10-root.conf
+++ b/mkosi/resources/repart/definitions/sysext.repart.d/10-root.conf
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+[Partition]
+Type=root
+Format=erofs
+CopyFiles=/usr/
+Verity=data
+VerityMatchKey=root
+Minimize=best

--- a/mkosi/resources/repart/definitions/sysext.repart.d/20-root-verity.conf
+++ b/mkosi/resources/repart/definitions/sysext.repart.d/20-root-verity.conf
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+[Partition]
+Type=root-verity
+Verity=hash
+VerityMatchKey=root
+Minimize=best

--- a/mkosi/resources/repart/definitions/sysext.repart.d/30-root-verity-sig.conf
+++ b/mkosi/resources/repart/definitions/sysext.repart.d/30-root-verity-sig.conf
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+[Partition]
+Type=root-verity-sig
+Verity=signature
+VerityMatchKey=root

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -98,6 +98,9 @@ class Image:
     def summary(self, options: Sequence[str] = ()) -> CompletedProcess:
         return self.mkosi("summary", options, user=INVOKING_USER.uid, group=INVOKING_USER.gid)
 
+    def genkey(self) -> CompletedProcess:
+        return self.mkosi("genkey", ["--force"], user=INVOKING_USER.uid, group=INVOKING_USER.gid)
+
 
 @pytest.fixture(scope="session", autouse=True)
 def suspend_capture_stdin(pytestconfig: Any) -> Iterator[None]:

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -27,7 +27,7 @@ def test_boot(format: OutputFormat) -> None:
         options = ["--format", str(format)]
 
         image.summary(options)
-
+        image.genkey()
         image.build(options=options)
 
         if format in (OutputFormat.disk, OutputFormat.directory) and os.getuid() == 0:
@@ -45,7 +45,7 @@ def test_boot(format: OutputFormat) -> None:
         if image.distribution == Distribution.rhel_ubi:
             return
 
-        if format == OutputFormat.tar:
+        if format == OutputFormat.tar or format.is_extension_image():
             return
 
         if format == OutputFormat.directory and not find_virtiofsd():


### PR DESCRIPTION
This uses the new --make-ddi= option in systemd-repart added in v255 to add explicit support for sysexts, confexts and portable services.

On top of using the new repart option to generate the extension images, we also write the extension-release file in case of sysexts and confexts and make sure we skip a bunch of our automatic features when building extension images or enabling the Overlay= option as in these cases many of our automatic features are undesireable.