### PR TITLE
tests: Make more robust on distros with recent systemd

### DIFF
--- a/mkosi.extra/usr/lib/systemd/system/mkosi-check-and-shutdown.service
+++ b/mkosi.extra/usr/lib/systemd/system/mkosi-check-and-shutdown.service
@@ -5,6 +5,7 @@ After=multi-user.target network-online.target
 Requires=multi-user.target
 SuccessAction=exit
 FailureAction=exit
+SuccessActionExitStatus=123
 
 [Service]
 Type=oneshot

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -91,7 +91,13 @@ class Distribution(StrEnum):
     custom       = enum.auto()
 
     def is_centos_variant(self) -> bool:
-        return self in (Distribution.centos, Distribution.alma, Distribution.rocky)
+        return self in (
+            Distribution.centos,
+            Distribution.alma,
+            Distribution.rocky,
+            Distribution.rhel,
+            Distribution.rhel_ubi,
+        )
 
     def is_dnf_distribution(self) -> bool:
         return self in (

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -182,7 +182,12 @@ def uncaught_exception_handler(exit: Callable[[int], NoReturn]) -> Iterator[None
         # Failures from qemu, ssh and systemd-nspawn are expected and we won't log stacktraces for those.
         # Failures from self come from the forks we spawn to build images in a user namespace. We've already done all
         # the logging for those failures so we don't log stacktraces for those either.
-        if ARG_DEBUG.get() and e.cmd and e.cmd[0] not in ("self", "qemu", "ssh", "systemd-nspawn"):
+        if (
+            ARG_DEBUG.get() and
+            e.cmd and
+            e.cmd[0] not in ("self", "ssh", "systemd-nspawn") and
+            not e.cmd[0].startswith("qemu")
+        ):
             sys.excepthook(*ensure_exc_info())
 
         # We always log when subprocess.CalledProcessError is raised, so we don't log again here.


### PR DESCRIPTION
Let's make use of the fact that we can communicate the exit status from VMs on recent versions of systemd. Even when it fails to run qemu will often exit with exit status 0 so let's make our successful exit status 123 and check for that instead of 0.