### PR TITLE
mkosi: include binutils in the packages for building

### DIFF
--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -41,6 +41,7 @@ class Installer(DistributionInstaller):
             "apt",
             "archlinux-keyring",
             "bash",
+            "binutils",
             "btrfs-progs",
             "bubblewrap",
             "ca-certificates",


### PR DESCRIPTION
On aarch64 the dependencies are different than x86 and we don't end up with binutils getting picked up, which means readelf isn't available for systemd-ukify when using mkosi-kernel on aarch64.  Explicitly add bintuils to the list of packages, this allows mkosi-kernel to work properly on an aarch64 machine.