### PR TITLE
Pass uname to ukify

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1318,6 +1318,7 @@ def extract_pe_section(state: MkosiState, binary: Path, section: str, output: Pa
 
 def build_uki(
     state: MkosiState,
+    kver: str,
     kimg: Path,
     initrds: Sequence[Path],
     output: Path,
@@ -1353,6 +1354,7 @@ def build_uki(
         "--stub", stub,
         "--output", output,
         "--efi-arch", arch,
+        "--uname", kver,
     ]
 
     if not state.config.tools_tree:
@@ -1477,7 +1479,7 @@ def install_uki(state: MkosiState, partitions: Sequence[Partition]) -> None:
         with umask(~0o700):
             boot_binary.parent.mkdir(parents=True, exist_ok=True)
 
-        build_uki(state, kimg, initrds, boot_binary, roothash=roothash)
+        build_uki(state, kver, kimg, initrds, boot_binary, roothash=roothash)
 
         if not (state.staging / state.config.output_split_initrd).exists():
             # Extract the combined initrds from the UKI so we can use it to direct kernel boot with qemu
@@ -1509,11 +1511,11 @@ def make_uki(state: MkosiState, output: Path) -> None:
     initrds += [state.workspace / "initrd"]
 
     try:
-        _, kimg = next(gen_kernel_images(state))
+        kver, kimg = next(gen_kernel_images(state))
     except StopIteration:
         die("A kernel must be installed in the image to build a UKI")
 
-    build_uki(state, kimg, initrds, output)
+    build_uki(state, kver, kimg, initrds, output)
     extract_pe_section(state, output, ".linux", state.staging / state.config.output_split_kernel)
     extract_pe_section(state, output, ".initrd", state.staging / state.config.output_split_initrd)
 

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -41,7 +41,6 @@ class Installer(DistributionInstaller):
             "apt",
             "archlinux-keyring",
             "bash",
-            "binutils",
             "btrfs-progs",
             "bubblewrap",
             "ca-certificates",


### PR DESCRIPTION
Let's avoid triggering ukify's autodetect logic by passing in the
kernel version ourselves.