### PR TITLE
mkosi-initrd: Make locale configurable

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -36,7 +36,7 @@ RemoveFiles=
         /usr/lib/modules/*/System.map
 
 # Configure locale explicitly so that all other locale data is stripped on distros whose package manager supports it.
-Locale=C.UTF-8
+@Locale=C.UTF-8
 WithDocs=no
 
 # Make sure various core modules are always included in the initrd.


### PR DESCRIPTION
Now that we use it as the default initrd, let's make the locale configurable so we can override it when building an image.