### PR TITLE
Add QemuFirmwareVariables=

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -990,6 +990,7 @@ class MkosiConfig:
     qemu_swtpm: ConfigFeature
     qemu_cdrom: bool
     qemu_firmware: QemuFirmware
+    qemu_firmware_variables: Optional[Path]
     qemu_kernel: Optional[Path]
     qemu_drives: list[QemuDrive]
     qemu_args: list[str]
@@ -2016,6 +2017,13 @@ SETTINGS = (
         default=QemuFirmware.auto,
         help="Set qemu firmware to use",
         choices=QemuFirmware.values(),
+    ),
+    MkosiConfigSetting(
+        dest="qemu_firmware_variables",
+        metavar="PATH",
+        section="Host",
+        parse=config_make_path_parser(),
+        help="Set the path to the qemu firmware variables file to use",
     ),
     MkosiConfigSetting(
         dest="qemu_kernel",
@@ -3083,6 +3091,7 @@ def summary(config: MkosiConfig) -> str:
                 QEMU Use Swtpm: {config.qemu_swtpm}
                QEMU Use CD-ROM: {yes_no(config.qemu_cdrom)}
                  QEMU Firmware: {config.qemu_firmware}
+       QEMU Firmware Variables: {none_to_none(config.qemu_firmware_variables)}
           QEMU Extra Arguments: {line_join_list(config.qemu_args)}
 """
 

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -1290,13 +1290,25 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 `QemuFirmware=`, `--qemu-firmware=`
 
-: When used with the `qemu` verb, this option which firmware to use.
-  Takes one of `uefi`, `bios`, `linux`, or `auto`. Defaults to `auto`.
-  When set to `uefi`, the OVMF firmware is used. When set to `bios`, the
-  default SeaBIOS firmware is used. When set to `linux`, direct kernel
-  boot is used. See the `QemuKernel=` option for more details on which
-  kernel image is used with direct kernel boot. When set to `auto`,
-  `linux` is used if a cpio image is being booted, `uefi` otherwise.
+: When used with the `qemu` verb, this option specifies which firmware
+  to use. Takes one of `uefi`, `bios`, `linux`, or `auto`. Defaults to
+  `auto`. When set to `uefi`, the OVMF firmware is used. When set to
+  `bios`, the default SeaBIOS firmware is used. When set to `linux`,
+  direct kernel boot is used. See the `QemuKernel=` option for more
+  details on which kernel image is used with direct kernel boot. When
+  set to `auto`, `linux` is used if a cpio image is being booted, `uefi`
+  otherwise.
+
+`QemuFirmwareVariables=`, `--qemu-firmware-variables=`
+
+: When used with the `qemu` verb, this option specifies the path to the
+  the firmware variables file to use. Currently, this option is only
+  taken into account when the `uefi` firmware is used. If not specified,
+  mkosi will search for the default variables file and use that instead.
+
+: `virt-fw-vars` from the
+  [virt-firmware](https://gitlab.com/kraxel/virt-firmware) project can
+  be used to customize OVMF variable files.
 
 `QemuKernel=`, `--qemu-kernel=`
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -206,6 +206,7 @@ def test_config() -> None:
                 }
             ],
             "QemuFirmware": "linux",
+            "QemuFirmwareVariables": "/foo/bar",
             "QemuGui": true,
             "QemuKernel": null,
             "QemuKvm": "auto",
@@ -345,6 +346,7 @@ def test_config() -> None:
         qemu_cdrom = False,
         qemu_drives = [QemuDrive("abc", 200, Path("/foo/bar"), "abc,qed"), QemuDrive("abc", 200, None, "")],
         qemu_firmware = QemuFirmware.linux,
+        qemu_firmware_variables = Path("/foo/bar"),
         qemu_gui = True,
         qemu_kernel = None,
         qemu_kvm = ConfigFeature.auto,


### PR DESCRIPTION
This allows configuring the path to the qemu firmware variables to use. This allows users to configure their own variables using https://pypi.org/project/virt-firmware/ before passing it to mkosi.