### PR TITLE
Allow specifying minimum mkosi version

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -38,6 +38,7 @@ from mkosi.config import (
     SecureBootSignTool,
     ShimBootloader,
     Verb,
+    __version__,
     format_bytes,
     format_tree,
     parse_config,
@@ -3003,6 +3004,12 @@ def run_verb(args: MkosiArgs, images: Sequence[MkosiConfig]) -> None:
 
         page(text, args.pager)
         return
+
+    for config in images:
+        if not config.minimum_version or config.minimum_version <= __version__:
+            continue
+
+        die(f"mkosi {config.minimum_version} or newer is required to build this configuration (found {__version__})")
 
     for config in images:
         check_workspace_directory(config)

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2693,7 +2693,7 @@ def parse_config(argv: Sequence[str] = ()) -> tuple[MkosiArgs, tuple[MkosiConfig
     if not images:
         die("No images defined in mkosi.images/")
 
-    images = [load_config(ns) for ns in images]
+    images = [load_config(args, ns) for ns in images]
     images = resolve_deps(images, include)
 
     return args, tuple(images)
@@ -2817,6 +2817,9 @@ def load_environment(args: argparse.Namespace) -> dict[str, str]:
 
 
 def load_args(args: argparse.Namespace) -> MkosiArgs:
+    if args.cmdline and not args.verb.supports_cmdline():
+        die(f"Arguments after verb are not supported for {args.verb}.")
+
     if args.debug:
         ARG_DEBUG.set(args.debug)
     if args.debug_shell:
@@ -2825,57 +2828,54 @@ def load_args(args: argparse.Namespace) -> MkosiArgs:
     return MkosiArgs.from_namespace(args)
 
 
-def load_config(args: argparse.Namespace) -> MkosiConfig:
-    if args.cmdline and not args.verb.supports_cmdline():
-        die(f"Arguments after verb are not supported for {args.verb}.")
+def load_config(args: MkosiArgs, config: argparse.Namespace) -> MkosiConfig:
+    if config.build_dir:
+        config.build_dir = config.build_dir / f"{config.distribution}~{config.release}~{config.architecture}"
 
-    if args.build_dir:
-        args.build_dir = args.build_dir / f"{args.distribution}~{args.release}~{args.architecture}"
+    if config.sign:
+        config.checksum = True
 
-    if args.sign:
-        args.checksum = True
+    if config.output is None:
+        config.output = config.image_id or config.image or "image"
 
-    if args.output is None:
-        args.output = args.image_id or args.image or "image"
+    config.credentials = load_credentials(config)
+    config.kernel_command_line_extra = load_kernel_command_line_extra(config)
+    config.environment = load_environment(config)
 
-    args.credentials = load_credentials(args)
-    args.kernel_command_line_extra = load_kernel_command_line_extra(args)
-    args.environment = load_environment(args)
-
-    if args.secure_boot and args.verb != Verb.genkey:
-        if args.secure_boot_key is None and args.secure_boot_certificate is None:
+    if config.secure_boot and args.verb != Verb.genkey:
+        if config.secure_boot_key is None and config.secure_boot_certificate is None:
             die("UEFI SecureBoot enabled, but couldn't find the certificate and private key.",
                 hint="Consider generating them with 'mkosi genkey'.")
-        if args.secure_boot_key is None:
+        if config.secure_boot_key is None:
             die("UEFI SecureBoot enabled, certificate was found, but not the private key.",
                 hint="Consider placing it in mkosi.key")
-        if args.secure_boot_certificate is None:
+        if config.secure_boot_certificate is None:
             die("UEFI SecureBoot enabled, private key was found, but not the certificate.",
                 hint="Consider placing it in mkosi.crt")
 
-    if args.repositories and not (
-        args.distribution.is_dnf_distribution() or
-        args.distribution.is_apt_distribution() or
-        args.distribution == Distribution.arch
+    if config.repositories and not (
+        config.distribution.is_dnf_distribution() or
+        config.distribution.is_apt_distribution() or
+        config.distribution == Distribution.arch
     ):
         die("Sorry, the --repositories option is only supported on pacman, dnf and apt based distributions")
 
-    if args.overlay and not args.base_trees:
+    if config.overlay and not config.base_trees:
         die("--overlay can only be used with --base-tree")
 
-    if args.incremental and not args.cache_dir:
+    if config.incremental and not config.cache_dir:
         die("A cache directory must be configured in order to use --incremental")
 
     # For unprivileged builds we need the userxattr OverlayFS mount option, which is only available
     # in Linux v5.11 and later.
     if (
-        (args.build_scripts or args.base_trees) and
+        (config.build_scripts or config.base_trees) and
         GenericVersion(platform.release()) < GenericVersion("5.11") and
         os.geteuid() != 0
     ):
         die("This unprivileged build configuration requires at least Linux v5.11")
 
-    return MkosiConfig.from_namespace(args)
+    return MkosiConfig.from_namespace(config)
 
 
 def yes_no(b: bool) -> str:

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -464,6 +464,11 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
   image and will be pulled in as dependencies of this image when
   `Images=` is used.
 
+`MinimumVersion=`, `--minimum-version=`
+
+: The minimum mkosi version required to build this configuration. If
+  specified multiple times, the highest specified version is used.
+
 ### [Distribution] Section
 
 `Distribution=`, `--distribution=`, `-d`

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -28,6 +28,7 @@ from mkosi.config import (
     Verb,
 )
 from mkosi.distributions import Distribution
+from mkosi.versioncomp import GenericVersion
 
 
 @pytest.mark.parametrize("path", [None, "/baz/qux"])
@@ -169,6 +170,7 @@ def test_config() -> None:
                 "json",
                 "changelog"
             ],
+            "MinimumVersion": "123",
             "Mirror": null,
             "NSpawnSettings": null,
             "Output": "outfile",
@@ -329,6 +331,7 @@ def test_config() -> None:
         locale_messages = "",
         make_initrd = False,
         manifest_format = [ManifestFormat.json, ManifestFormat.changelog],
+        minimum_version = GenericVersion("123"),
         mirror = None,
         nspawn_settings = None,
         output = "outfile",


### PR DESCRIPTION
Currently, users often get a confusing message about some property
not existing when they try to use an older version of mkosi to build
a configuration that requires a newer version. Let's improve on this
by allowing configurations to declare the minimum version required to
build the configuration.