### PR TITLE
Use kernel-install entry token if available

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # mkosi Changelog
 
+## v20
+
+- During the image build we now install UKIs/kernels/initrds to `/boot`
+  instead of `/efi`. While this will generally not be noticeable, users
+  with custom systemd-repart ESP partition definitions will need to add
+  `CopyFiles=/boot:/` along with the usual `CopyFiles=/efi:/` to their
+  ESP partition definitions. By installing UKIs/kernels/initrds to
+  `/boot`, it becomes possible to use `/boot` to populate an XBOOTLDR
+  partition which wasn't possible before. Note that this is also safe to
+  do before `v20` so `CopyFiles=/boot:/` can unconditionally be added to
+  any ESP partition definition files.
+
 ## v19
 
 - Support for RHEL was added!

--- a/action.yaml
+++ b/action.yaml
@@ -82,6 +82,7 @@ runs:
 
       BINARIES=(
         bootctl
+        kernel-install
         systemctl
         systemd-dissect
         systemd-firstboot

--- a/action.yaml
+++ b/action.yaml
@@ -69,7 +69,7 @@ runs:
       sudo apt-get build-dep systemd
       sudo apt-get install --assume-yes --no-install-recommends libfdisk-dev libtss2-dev
 
-      git clone https://github.com/systemd/systemd --depth=1
+      git clone https://github.com/systemd/systemd-stable --single-branch --branch=v255-stable --depth=1 systemd
       meson setup systemd/build systemd \
         -D repart=true \
         -D efi=true \

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1858,8 +1858,8 @@ def check_systemd_tool(*tools: PathString, version: str, reason: str, hint: Opti
 
     v = systemd_tool_version(tool)
     if v < version:
-        die(f"Found '{tool}' version {v} but version {version} or newer is required to {reason}.",
-            hint=f"Use ToolsTree=default to get a newer version of '{tool}'.")
+        die(f"Found '{tool}' with version {v} but version {version} or newer is required to {reason}.",
+            hint=f"Use ToolsTree=default to get a newer version of '{tools[0]}'.")
 
 
 def check_tools(args: MkosiArgs, config: MkosiConfig) -> None:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1848,7 +1848,7 @@ def check_outputs(config: MkosiConfig) -> None:
 
 
 def systemd_tool_version(tool: PathString) -> GenericVersion:
-    return GenericVersion(run([tool, "--version"], stdout=subprocess.PIPE).stdout.split()[1])
+    return GenericVersion(run([tool, "--version"], stdout=subprocess.PIPE).stdout.split()[2].strip("()"))
 
 
 def check_systemd_tool(*tools: PathString, version: str, reason: str, hint: Optional[str] = None) -> None:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1447,9 +1447,10 @@ def build_uki(
         for p in state.config.extra_search_paths:
             cmd += ["--tools", p]
 
-    uki_config = state.pkgmngr / "etc/kernel/uki.conf"
-    if uki_config.exists():
-        cmd += ["--config", uki_config]
+    for d in ("etc/kernel", "usr/lib/kernel"):
+        uki_config = state.pkgmngr / d / "uki.conf"
+        if uki_config.exists():
+            cmd += ["--config", uki_config]
 
     if state.config.secure_boot:
         assert state.config.secure_boot_key

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -1868,6 +1868,7 @@ local directory:
   [Partition]
   Type=esp
   Format=vfat
+  CopyFiles=/boot:/
   CopyFiles=/efi:/
   SizeMinBytes=512M
   SizeMaxBytes=512M

--- a/tests/test_initrd.py
+++ b/tests/test_initrd.py
@@ -117,6 +117,7 @@ def test_initrd_luks(initrd: Image, passphrase: Path) -> None:
                 [Partition]
                 Type=esp
                 Format=vfat
+                CopyFiles=/boot:/
                 CopyFiles=/efi:/
                 SizeMinBytes=512M
                 SizeMaxBytes=512M


### PR DESCRIPTION
Let's try and look for the kernel-install entry token if
kernel-install v255 or newer is available. This makes us more
compatible with package manager upgrades as we'll use the same
directory that kernel-install will look for when invoked by a
package manager.