### PR TITLE
qemu: Remove --posix-acl and add --no-announce-submounts to virtiofsd

### DIFF
--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -313,7 +313,8 @@ def start_virtiofsd(directory: Path, *, uidmap: bool) -> Iterator[Path]:
         virtiofsd,
         "--shared-dir", directory,
         "--xattr",
-        "--posix-acl",
+        # qemu's client doesn't seem to support announcing submounts so disable the feature to avoid the warning.
+        "--no-announce-submounts",
     ]
 
     # Map the given user/group to root in the virtual machine for the virtiofs instance to make sure all files


### PR DESCRIPTION
--posix-acl causes an error from virtiofsd saying the client doesn't support this feature. We also get a warning about announcing submounts not being supported so let's make sure we disable both features to avoid these warnings/errors.