### PR TITLE
Add RepartOffline= option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## v20
 
+- We don't automatically set `--offline=no` anymore when we detect the
+  `Subvolumes=` setting is used in a `systemd-repart` partition
+  definition file. Instead, use the new `RepartOffline` option to
+  explicitly disable running `systemd-repart` in offline mode.
 - During the image build we now install UKIs/kernels/initrds to `/boot`
   instead of `/efi`. While this will generally not be noticeable, users
   with custom systemd-repart ESP partition definitions will need to add

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -910,6 +910,7 @@ class MkosiConfig:
     split_artifacts: bool
     repart_dirs: list[Path]
     sector_size: Optional[int]
+    repart_offline: bool
     overlay: bool
     use_subvolumes: ConfigFeature
     seed: Optional[uuid.UUID]
@@ -1458,6 +1459,13 @@ SETTINGS = (
         section="Output",
         parse=config_parse_sector_size,
         help="Set the disk image sector size",
+    ),
+    MkosiConfigSetting(
+        dest="repart_offline",
+        section="Output",
+        parse=config_parse_boolean,
+        help="Build disk images without using loopback devices",
+        default=True,
     ),
     MkosiConfigSetting(
         dest="overlay",
@@ -3006,6 +3014,7 @@ def summary(config: MkosiConfig) -> str:
                     Split Artifacts: {yes_no(config.split_artifacts)}
                  Repart Directories: {line_join_list(config.repart_dirs)}
                         Sector Size: {none_to_default(config.sector_size)}
+                     Repart Offline: {yes_no(config.repart_offline)}
                             Overlay: {yes_no(config.overlay)}
                      Use Subvolumes: {yes_no_auto(config.use_subvolumes)}
                                Seed: {none_to_random(config.seed)}

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -722,6 +722,26 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 : Override the default sector size that systemd-repart uses when building a disk
   image.
 
+`Offline=`, `--offline=`
+
+: Specifies whether to build disk images using loopback devices. Enabled
+  by default. When enabled, `systemd-repart` will not use loopback
+  devices to build disk images. When disabled, `systemd-repart` will
+  always use loopback devices to build disk images.
+
+: Note that when using `Offline=no` mkosi cannot run unprivileged and
+  the image build has to be done as the root user outside of any
+  containers and with loopback devices available on the host system.
+
+: There are currently two known scenarios where `Offline=no` has to be
+  used. The first is when using `Subvolumes=` in a repart partition
+  definition file, as subvolumes cannot be created without using
+  loopback devices. The second is when creating a system with SELinux
+  and an XFS root partition. Because `mkfs.xfs` does not support
+  populating an XFS filesystem with extended attributes, loopback
+  devices have to be used to ensure the SELinux extended attributes end
+  up in the generated XFS filesystem.
+
 `Overlay=`, `--overlay`
 
 : When used together with `BaseTrees=`, the output will consist only out of

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -223,6 +223,7 @@ def test_config() -> None:
                 "all"
             ],
             "RepartDirectories": [],
+            "RepartOffline": true,
             "Repositories": [],
             "RepositoryKeyCheck": false,
             "RootPassword": [
@@ -362,6 +363,7 @@ def test_config() -> None:
         remove_files = [],
         remove_packages = ["all"],
         repart_dirs = [],
+        repart_offline = True,
         repositories = [],
         repository_key_check = False,
         root_password = ("test1234", False),


### PR DESCRIPTION
Instead of auto-detecting all cases where --offline=no has to be used with systemd-repart, let's allow configuring it via an option so that if we discover any new cases, users can easily disable offline mode themselves.