### PR TITLE
tests: Test "none" output format as well

### DIFF
--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -10,9 +10,10 @@ from mkosi.qemu import find_virtiofsd
 
 from . import Image
 
+pytestmark = pytest.mark.integration
 
-@pytest.mark.integration
-@pytest.mark.parametrize("format", [f for f in OutputFormat if f != OutputFormat.none])
+
+@pytest.mark.parametrize("format", OutputFormat)
 def test_boot(format: OutputFormat) -> None:
     with Image(
         options=[
@@ -48,7 +49,7 @@ def test_boot(format: OutputFormat) -> None:
         if image.distribution == Distribution.rhel_ubi:
             return
 
-        if format == OutputFormat.tar or format.is_extension_image():
+        if format in (OutputFormat.tar, OutputFormat.none) or format.is_extension_image():
             return
 
         if format == OutputFormat.directory and not find_virtiofsd():


### PR DESCRIPTION
Let's build an image with "none" as well. There won't be any output, but we can at least test that nothing breaks when specifying "none" as the output format.

Also apply the "integration" marker to the entire file while we're at it.