### PR TITLE
make_cpio: sort files used as cpio input

### DIFF
--- a/mkosi/archive.py
+++ b/mkosi/archive.py
@@ -89,6 +89,7 @@ def extract_tar(src: Path, dst: Path, log: bool = True) -> None:
 def make_cpio(src: Path, dst: Path, files: Optional[Iterable[Path]] = None) -> None:
     if not files:
         files = src.rglob("*")
+    files = sorted(files)
 
     log_step(f"Creating cpio archive {dst}…")
     bwrap(


### PR DESCRIPTION
Pathlib's glob functions return files in the order used by the filesystem. This may differ between implementations and configuration (file system, locale). For better reproducibility, the file list should be sorted.