### PR TITLE
Mention OVMF files with MS certs enrolled

### DIFF
--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -1340,6 +1340,13 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
   [virt-firmware](https://gitlab.com/kraxel/virt-firmware) project can
   be used to customize OVMF variable files.
 
+: Some distributions also provide variable files which already have
+  Microsoft's certificates for secure boot enrolled. For Fedora
+  and Debian these are `OVMF_VARS.secboot.fd` and `OVMF_VARS_4M.ms.fd`
+  under `/usr/share/OVMF` respectively. You can use `locate` and look
+  under `/usr/share/qemu/firmware` for hints on where to find these
+  files if your distribution ships them.
+
 `QemuKernel=`, `--qemu-kernel=`
 
 : Set the kernel image to use for qemu direct kernel boot. If not


### PR DESCRIPTION
Some distributions (at least Fedora and Debian) ship (edk2-)ovmf packages which provide firmware variable files which already have the MS secure boot certificates enrolled. This can be quite useful for testing secure boot without user enrolled keys/certs.

Unfortunately - similar to the `OVMF_VARS.fd` file - the name and location of these files is not standardized. I instead simply listed where they can be found on Fedora and Debian and provided instructions on how one might find them on other distributions. Based on the [file list](https://archlinux.org/packages/extra/any/edk2-ovmf/) arch does not seem to ship such a file sadly. For SUSE if have no clue.

x-ref: https://github.com/systemd/mkosi/pull/2152#discussion_r1424237350