### PR TITLE
Allow building CentOS/Fedora default images for arm64 architecture

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -8,7 +8,6 @@
 
 [Content]
 Autologin=yes
-BiosBootloader=grub
 ShimBootloader=signed
 BuildSourcesEphemeral=yes
 

--- a/mkosi.conf.d/15-x86-64.conf
+++ b/mkosi.conf.d/15-x86-64.conf
@@ -1,0 +1,5 @@
+[Match]
+Architecture=x86-64
+
+[Content]
+BiosBootloader=grub

--- a/mkosi.conf.d/20-centos-fedora/mkosi.conf
+++ b/mkosi.conf.d/20-centos-fedora/mkosi.conf
@@ -22,9 +22,7 @@ Packages=
         e2fsprogs
         edk2-ovmf
         erofs-utils
-        grub2-pc
         kernel-core
-        microcode_ctl
         mtools
         openssh-clients
         openssl

--- a/mkosi.conf.d/20-centos-fedora/mkosi.conf.d/20-x86-64.conf
+++ b/mkosi.conf.d/20-centos-fedora/mkosi.conf.d/20-x86-64.conf
@@ -1,0 +1,7 @@
+[Match]
+Architecture=x86-64
+
+[Content]
+Packages=
+        microcode_ctl
+        grub2-pc


### PR DESCRIPTION
Let's introduce a little conditionalization to allow building the CentOS/Fedora default images for arm64.