### PR TITLE
Default to ttyAMA0 when building/booting arm images

### DIFF
--- a/mkosi/architecture.py
+++ b/mkosi/architecture.py
@@ -117,6 +117,12 @@ class Architecture(StrEnum):
 
         return a
 
+    def default_serial_tty(self) -> str:
+        return {
+            Architecture.arm   : "ttyAMA0",
+            Architecture.arm64 : "ttyAMA0",
+        }.get(self, "ttyS0")
+
     def supports_smbios(self) -> bool:
         return self in (Architecture.x86, Architecture.x86_64, Architecture.arm, Architecture.arm64)
 

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -59,6 +59,7 @@ class Installer(DistributionInstaller):
             "pacman",
             "python3-cryptography",
             "qemu-kvm-core",
+            "qemu-system-aarch64-core",
             "shadow-utils",
             "socat",
             "squashfs-tools",


### PR DESCRIPTION
On ARM, the first serial console is generally called ttyAMA0, so let's configure that as the console instead of ttyS0.