### PR TITLE
Set SYSTEMD_UPDATE_HWDB_BYPASS=1

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2850,6 +2850,7 @@ def load_environment(args: argparse.Namespace) -> dict[str, str]:
     env = {
         "SYSTEMD_TMPFILES_FORCE_SUBVOL": "0",
         "KERNEL_INSTALL_BYPASS": "1",
+        "SYSTEMD_HWDB_UPDATE_BYPASS": "1",
     }
 
     if args.image_id is not None:


### PR DESCRIPTION
We run systemd-hwdb ourselves, so let's set this new environment variable to skip its execution by package managers.