### PR TITLE
Stop using the tools tree for the ssh verb

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3189,7 +3189,7 @@ def run_verb(args: MkosiArgs, images: Sequence[MkosiConfig]) -> None:
     with contextlib.ExitStack() as stack:
         if os.getuid() == 0 and args.verb != Verb.ssh:
             init_mount_namespace()
-            stack.enter_context(mount_usr(last.tools_tree))
+            stack.enter_context(mount_usr(last.tools_tree, umount=False))
 
         stack.enter_context(prepend_to_environ_path(last))
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -50,7 +50,7 @@ from mkosi.installer import clean_package_manager_metadata, package_manager_scri
 from mkosi.kmod import gen_required_kernel_modules, process_kernel_modules
 from mkosi.log import ARG_DEBUG, complete_step, die, log_notice, log_step
 from mkosi.manifest import Manifest
-from mkosi.mounts import mount, mount_overlay, mount_passwd, mount_usr
+from mkosi.mounts import mount, mount_overlay, mount_usr
 from mkosi.pager import page
 from mkosi.partition import Partition, finalize_root, finalize_roothash
 from mkosi.qemu import KernelType, QemuDeviceNode, copy_ephemeral, run_qemu, run_ssh
@@ -3183,14 +3183,13 @@ def run_verb(args: MkosiArgs, images: Sequence[MkosiConfig]) -> None:
     if args.verb == Verb.build:
         return
 
-    if last.tools_tree:
+    if last.tools_tree and args.verb != Verb.ssh:
         become_root()
 
     with contextlib.ExitStack() as stack:
-        if os.getuid() == 0:
+        if os.getuid() == 0 and args.verb != Verb.ssh:
             init_mount_namespace()
             stack.enter_context(mount_usr(last.tools_tree))
-            stack.enter_context(mount_passwd())
 
         stack.enter_context(prepend_to_environ_path(last))
 

--- a/mkosi/mounts.py
+++ b/mkosi/mounts.py
@@ -40,6 +40,7 @@ def mount(
     type: Optional[str] = None,
     read_only: bool = False,
     lazy: bool = False,
+    umount: bool = True,
 ) -> Iterator[Path]:
     if not where.exists():
         with umask(~0o755):
@@ -65,7 +66,8 @@ def mount(
         run(cmd)
         yield where
     finally:
-        run(["umount", "--no-mtab", *(["--lazy"] if lazy else []), where])
+        if umount:
+            run(["umount", "--no-mtab", *(["--lazy"] if lazy else []), where])
 
 
 @contextlib.contextmanager
@@ -119,7 +121,7 @@ def mount_overlay(
 
 
 @contextlib.contextmanager
-def mount_usr(tree: Optional[Path]) -> Iterator[None]:
+def mount_usr(tree: Optional[Path], umount: bool = True) -> Iterator[None]:
     if not tree:
         yield
         return
@@ -141,6 +143,7 @@ def mount_usr(tree: Optional[Path]) -> Iterator[None]:
             operation="--bind",
             read_only=True,
             lazy=True,
+            umount=umount,
         ):
             yield
     finally:


### PR DESCRIPTION
This allows us to run ssh out of the user namespace which means we can get rid of the passwd hack to make ssh work. ssh is widespread enough that we can require users to install it on the host machine instead of using the tools tree.