### PR TITLE
Fix install_tree()

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1227,8 +1227,7 @@ def install_skeleton_trees(state: MkosiState) -> None:
 
     with complete_step("Copying in skeleton file trees…"):
         for tree in state.config.skeleton_trees:
-            source, target = tree.with_prefix()
-            install_tree(source, state.root, target, use_subvolumes=state.config.use_subvolumes)
+            install_tree(tree.source, state.root, tree.target, use_subvolumes=state.config.use_subvolumes)
 
 
 def install_package_manager_trees(state: MkosiState) -> None:
@@ -1237,8 +1236,12 @@ def install_package_manager_trees(state: MkosiState) -> None:
 
     with complete_step("Copying in package manager file trees…"):
         for tree in state.config.package_manager_trees:
-            source, target = tree.with_prefix()
-            install_tree(source, state.workspace / "pkgmngr", target, use_subvolumes=state.config.use_subvolumes)
+            install_tree(
+                tree.source,
+                state.workspace / "pkgmngr",
+                tree.target,
+                use_subvolumes=state.config.use_subvolumes
+            )
 
 
 def install_extra_trees(state: MkosiState) -> None:
@@ -1247,8 +1250,7 @@ def install_extra_trees(state: MkosiState) -> None:
 
     with complete_step("Copying in extra file trees…"):
         for tree in state.config.extra_trees:
-            source, target = tree.with_prefix()
-            install_tree(source, state.root, target, use_subvolumes=state.config.use_subvolumes)
+            install_tree(tree.source, state.root, tree.target, use_subvolumes=state.config.use_subvolumes)
 
 
 def install_build_dest(state: MkosiState) -> None:

--- a/mkosi/tree.py
+++ b/mkosi/tree.py
@@ -145,4 +145,5 @@ def install_tree(
     elif src.suffix == ".raw":
         run(["systemd-dissect", "--copy-from", src, "/", t])
     else:
-        die(f"Source tree {src} has unsupported source tree type \"{src.suffix}\"")
+        # If we get an unknown file without a target, we just copy it into /.
+        copy_tree(src, t, preserve_owner=False, use_subvolumes=use_subvolumes)


### PR DESCRIPTION
Let's make sure that all the skeleton, extra and package manager trees we get have absolute targets. That allows us to stop using with_prefix() when installing these trees, which means we pass target=None instead of target="/" which makes install_tree do the right thing.