### PR TITLE
Output file names now use `Output=` without version appended

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,10 @@
   is enabled.
 - Added `SecureBootAutoEnroll=` to control automatic enrollment of secureboot
   keys separately from signing `systemd-boot` and generated UKIs.
+- `ImageVersion=` is no longer automatically appended to the output files,
+  instead this is automatically appended to `Output=` if not specified and
+  results in the `%o` specifier being equivalent to `%i` or `%i_%v` depending
+  on if `ImageVersion=` is specified.
 
 ## v19
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2490,8 +2490,8 @@ def finalize_staging(state: MkosiState) -> None:
             continue
 
         name = f.name
-        if not name.startswith(state.config.output_with_version):
-            name = f"{state.config.output_with_version}-{name}"
+        if not name.startswith(state.config.output):
+            name = f"{state.config.output}-{name}"
         if name != f.name:
             f.rename(state.staging / name)
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1847,21 +1847,19 @@ def empty_directory(path: Path) -> None:
 def unlink_output(args: MkosiArgs, config: MkosiConfig) -> None:
     # We remove any cached images if either the user used --force twice, or he/she called "clean" with it
     # passed once. Let's also remove the downloaded package cache if the user specified one additional
-    # "--force". Let's also remove all versions if the user specified one additional "--force".
+    # "--force".
 
     if args.verb == Verb.clean:
         remove_build_cache = args.force > 0
         remove_package_cache = args.force > 1
-        prefix = config.output if args.force > 1 else config.output_with_version
     else:
         remove_build_cache = args.force > 1
         remove_package_cache = args.force > 2
-        prefix = config.output if args.force > 2 else config.output_with_version
 
     with complete_step("Removing output files…"):
         if config.output_dir_or_cwd().exists():
             for p in config.output_dir_or_cwd().iterdir():
-                if p.name.startswith(prefix):
+                if p.name.startswith(config.output):
                     rmtree(p)
 
     if remove_build_cache:

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -525,6 +525,15 @@ def config_default_compression(namespace: argparse.Namespace) -> Compression:
         return Compression.none
 
 
+def config_default_output(namespace: argparse.Namespace) -> str:
+    output = namespace.image_id or namespace.image or "image"
+
+    if namespace.image_version:
+        output += f"_{namespace.image_version}"
+
+    return output
+
+
 def config_default_distribution(namespace: argparse.Namespace) -> Distribution:
     detected = detect_distribution()[0]
 
@@ -1553,6 +1562,8 @@ SETTINGS = (
         section="Output",
         specifier="o",
         parse=config_parse_output,
+        default_factory=config_default_output,
+        default_factory_depends=("image_id", "image_version"),
         help="Output name",
     ),
     MkosiConfigSetting(
@@ -3104,9 +3115,6 @@ def load_config(args: MkosiArgs, config: argparse.Namespace) -> MkosiConfig:
 
     if config.sign:
         config.checksum = True
-
-    if config.output is None:
-        config.output = config.image_id or config.image or "image"
 
     config.credentials = load_credentials(config)
     config.kernel_command_line_extra = load_kernel_command_line_extra(config)

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1233,17 +1233,8 @@ class MkosiConfig:
         })
 
     @property
-    def output_with_version(self) -> str:
-        output = self.output
-
-        if self.image_version:
-            output += f"_{self.image_version}"
-
-        return output
-
-    @property
     def output_with_format(self) -> str:
-        return self.output_with_version + self.output_format.extension()
+        return self.output + self.output_format.extension()
 
     @property
     def output_with_compression(self) -> str:
@@ -1256,31 +1247,31 @@ class MkosiConfig:
 
     @property
     def output_split_uki(self) -> str:
-        return f"{self.output_with_version}.efi"
+        return f"{self.output}.efi"
 
     @property
     def output_split_kernel(self) -> str:
-        return f"{self.output_with_version}.vmlinuz"
+        return f"{self.output}.vmlinuz"
 
     @property
     def output_split_initrd(self) -> str:
-        return f"{self.output_with_version}.initrd"
+        return f"{self.output}.initrd"
 
     @property
     def output_checksum(self) -> str:
-        return f"{self.output_with_version}.SHA256SUMS"
+        return f"{self.output}.SHA256SUMS"
 
     @property
     def output_signature(self) -> str:
-        return f"{self.output_with_version}.SHA256SUMS.gpg"
+        return f"{self.output}.SHA256SUMS.gpg"
 
     @property
     def output_manifest(self) -> str:
-        return f"{self.output_with_version}.manifest"
+        return f"{self.output}.manifest"
 
     @property
     def output_changelog(self) -> str:
-        return f"{self.output_with_version}.changelog"
+        return f"{self.output}.changelog"
 
     def cache_manifest(self) -> dict[str, Any]:
         return {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -783,6 +783,23 @@ def test_specifiers(tmp_path: Path) -> None:
         assert {k: v for k, v in config.environment.items() if k in expected} == expected
 
 
+def test_output_id_version(tmp_path: Path) -> None:
+    d = tmp_path
+
+    (d / "mkosi.conf").write_text(
+        """
+        [Output]
+        ImageId=output
+        ImageVersion=1.2.3
+        """
+    )
+
+    with chdir(d):
+        _, [config] = parse_config()
+
+    assert config.output == "output_1.2.3"
+
+
 def test_deterministic() -> None:
     assert MkosiConfig.default() == MkosiConfig.default()
 


### PR DESCRIPTION
Previously when `Output=` was not specified its value was set to the value of `ImageId=` or `image` and only when actually writing the file was the version appended. This did not match the documentation, which states that the value of `Output=` is set to `ImageId=` and `ImageVersion=` if they exist. The main problem this causes is that you cannot specify `%o` to get the entire output name (without extension) and it is impossible supporting a format with and without version.

This came to my attention when I was adding a custom Initrd and wanting to reference it as `%O/%o.cpio.zst` when I had a version specified.

This change primarily adjust the implementation matching the documentation. A side-effect which appeared during the adjust is in how clearing of output files are handled: When specifying `clean -ff` or `-fff` elsewhere it now clears the entire output directory instead of the output name without version prefix.

The other incompatibility to previous versions to my knowledge is if someone explicitly specified `Output=` and referenced it with `%o_%v` as a workaround (would need to be updated to simply `%o`) and if you want preserve the output name with the version appended `Output=%i_%v` needs to be used (or `Output=` needs to be omitted)