### PR TITLE
Process all overlays before we do any bind mounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 /dist
 /mkosi.build
 /mkosi.egg-info
+/mkosi.cache
+/mkosi.output
 /mkosi.extra
 !mkosi.extra/usr/lib/systemd/mkosi-check-and-shutdown.sh
 !mkosi.extra/usr/lib/systemd/system/mkosi-check-and-shutdown.service

--- a/mkosi.cache/.gitignore
+++ b/mkosi.cache/.gitignore
@@ -1,2 +1,0 @@
-*
-!/.gitignore

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -5,6 +5,7 @@
 # default to directory output where disk space isn't a problem.
 @Format=directory
 @CacheDirectory=mkosi.cache
+@OutputDirectory=mkosi.output
 
 [Content]
 Autologin=yes

--- a/mkosi.output/.gitignore
+++ b/mkosi.output/.gitignore
@@ -1,2 +1,0 @@
-*
-!/.gitignore


### PR DESCRIPTION
Otherwise, later overlays will hide earlier bind mounts.