### PR TITLE
ci: Build dnf based distros with opensuse tools tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,14 +115,6 @@ jobs:
             tools: opensuse
           - distro: ubuntu
             tools: opensuse
-          # Installing dnf in OpenSUSE images is broken until https://build.opensuse.org/request/show/1133852 shows up
-          # in the Tumbleweed repositories.
-          - distro: centos
-            tools: opensuse
-          - distro: fedora
-            tools: opensuse
-          - distro: opensuse
-            tools: opensuse
           # Debian test_boot[cpio] is super flaky on these combinations until the next v255 stable release with
           # https://github.com/systemd/systemd/pull/30511 is available in Debian unstable.
           - distro: debian

--- a/mkosi.conf.d/20-opensuse.conf
+++ b/mkosi.conf.d/20-opensuse.conf
@@ -16,8 +16,7 @@ Packages=
         cpio
         curl
         distribution-gpg-keys
-        # dnf-data is missing a dependency on coreutils which makes it postinstall script fail when using old zypper.
-        # dnf
+        dnf
         dosfstools
         e2fsprogs
         erofs-utils

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -166,7 +166,10 @@ def find_qemu_binary(config: MkosiConfig) -> str:
 
 def find_ovmf_firmware(config: MkosiConfig) -> tuple[Path, bool]:
     FIRMWARE_LOCATIONS = {
-        Architecture.x86_64: ["/usr/share/ovmf/x64/OVMF_CODE.secboot.fd"],
+        Architecture.x86_64: [
+            "/usr/share/ovmf/x64/OVMF_CODE.secboot.fd",
+            "/usr/share/qemu/ovmf-x86_64.smm.bin",
+        ],
         Architecture.x86: [
             "/usr/share/edk2/ovmf-ia32/OVMF_CODE.secboot.fd",
             "/usr/share/OVMF/OVMF32_CODE_4M.secboot.fd"
@@ -229,7 +232,10 @@ def find_ovmf_vars(config: MkosiConfig) -> Path:
     OVMF_VARS_LOCATIONS = []
 
     if config.architecture == Architecture.x86_64:
-        OVMF_VARS_LOCATIONS += ["/usr/share/ovmf/x64/OVMF_VARS.fd"]
+        OVMF_VARS_LOCATIONS += [
+            "/usr/share/ovmf/x64/OVMF_VARS.fd",
+            "/usr/share/qemu/ovmf-x86_64-vars.bin",
+        ]
     elif config.architecture == Architecture.x86:
         OVMF_VARS_LOCATIONS += [
             "/usr/share/edk2/ovmf-ia32/OVMF_VARS.fd",


### PR DESCRIPTION
dnf-data on opensuse had the missing dependency on ln added so we can now use opensuse tools trees to build dnf based distro images.