### PR TITLE
Sandbox more in bwrap()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,11 +125,6 @@ jobs:
             tools: centos
           - distro: debian
             tools: debian
-          # Fedora and CentOS don't package ubuntu-keyring.
-          - distro: ubuntu
-            tools: centos
-          - distro: ubuntu
-            tools: fedora
           # rpm in Debian is currently missing
           # https://github.com/rpm-software-management/rpm/commit/ea3187cfcf9cac87e5bc5e7db79b0338da9e355e
           - distro: fedora

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2058,20 +2058,7 @@ def run_depmod(state: MkosiState) -> None:
     if state.config.overlay or state.config.output_format.is_extension_image():
         return
 
-    outputs = (
-        "modules.dep",
-        "modules.dep.bin",
-        "modules.symbols",
-        "modules.symbols.bin",
-    )
-
     for kver, _ in gen_kernel_images(state):
-        if (
-            not state.config.kernel_modules_exclude and
-            all((state.root / "usr/lib/modules" / kver / o).exists() for o in outputs)
-        ):
-            continue
-
         process_kernel_modules(
             state.root, kver,
             state.config.kernel_modules_include,
@@ -2080,7 +2067,7 @@ def run_depmod(state: MkosiState) -> None:
         )
 
         with complete_step(f"Running depmod for {kver}"):
-            bwrap(chroot_cmd(state.root) + ["depmod", "--all", kver])
+            run(["depmod", "--all", "--basedir", state.root, kver])
 
 
 def run_sysusers(state: MkosiState) -> None:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -23,6 +23,7 @@ from typing import Optional, TextIO, Union, cast
 
 import mkosi.resources
 from mkosi.archive import extract_tar, make_cpio, make_tar
+from mkosi.bubblewrap import bwrap, chroot_cmd
 from mkosi.burn import run_burn
 from mkosi.config import (
     BiosBootloader,
@@ -50,14 +51,12 @@ from mkosi.installer import clean_package_manager_metadata, package_manager_scri
 from mkosi.kmod import gen_required_kernel_modules, process_kernel_modules
 from mkosi.log import ARG_DEBUG, complete_step, die, log_notice, log_step
 from mkosi.manifest import Manifest
-from mkosi.mounts import mount, mount_overlay, mount_usr
+from mkosi.mounts import mount_overlay, mount_usr
 from mkosi.pager import page
 from mkosi.partition import Partition, finalize_root, finalize_roothash
 from mkosi.qemu import KernelType, QemuDeviceNode, copy_ephemeral, run_qemu, run_ssh
 from mkosi.run import (
     become_root,
-    bwrap,
-    chroot_cmd,
     find_binary,
     fork_and_wait,
     init_mount_namespace,
@@ -65,7 +64,7 @@ from mkosi.run import (
     run_openssl,
 )
 from mkosi.state import MkosiState
-from mkosi.tree import copy_tree, install_tree, move_tree, rmtree
+from mkosi.tree import copy_tree, move_tree, rmtree
 from mkosi.types import PathString
 from mkosi.util import (
     INVOKING_USER,
@@ -107,7 +106,7 @@ def mount_base_trees(state: MkosiState) -> Iterator[None]:
             if path.is_dir():
                 bases += [path]
             elif path.suffix == ".tar":
-                extract_tar(path, d)
+                extract_tar(state, path, d)
                 bases += [d]
             elif path.suffix == ".raw":
                 run(["systemd-dissect", "-M", path, d])
@@ -354,23 +353,15 @@ def mount_build_overlay(state: MkosiState, volatile: bool = False) -> Iterator[P
 
 
 @contextlib.contextmanager
-def finalize_mounts(config: MkosiConfig) -> Iterator[list[PathString]]:
+def finalize_source_mounts(config: MkosiConfig) -> Iterator[list[PathString]]:
     with contextlib.ExitStack() as stack:
-        sources = [
+        mounts = [
             (stack.enter_context(mount_overlay([source])) if config.build_sources_ephemeral else source, target)
             for source, target
             in [(Path.cwd(), Path.cwd())] + [t.with_prefix(Path.cwd()) for t in config.build_sources]
         ]
 
-        # bwrap() mounts /home and /var read-only during execution. So let's add the bind mount options for the
-        # directories that could be in /home or /var that we do need to be writable.
-        sources += [
-            (d, d)
-            for d in (config.workspace_dir_or_default(), config.cache_dir, config.output_dir, config.build_dir)
-            if d
-        ]
-
-        yield flatten(["--bind", src, target] for src, target in sorted(set(sources), key=lambda s: s[1]))
+        yield flatten(["--bind", src, target] for src, target in sorted(set(mounts), key=lambda s: s[1]))
 
 
 def script_maybe_chroot(script: Path, mountpoint: str) -> list[str]:
@@ -451,7 +442,7 @@ def run_prepare_scripts(state: MkosiState, build: bool) -> None:
             step_msg = "Running prepare script {}…"
             arg = "final"
 
-        mounts = stack.enter_context(finalize_mounts(state.config))
+        sources = stack.enter_context(finalize_source_mounts(state.config))
         cd = stack.enter_context(finalize_chroot_scripts(state))
 
         for script in state.config.prepare_scripts:
@@ -475,10 +466,10 @@ def run_prepare_scripts(state: MkosiState, build: bool) -> None:
 
             with complete_step(step_msg.format(script)):
                 bwrap(
+                    state,
                     script_maybe_chroot(script, "/work/prepare") + [arg],
                     network=True,
-                    readonly=True,
-                    options=mounts,
+                    options=sources,
                     scripts=hd,
                     env=env | state.config.environment,
                     stdin=sys.stdin,
@@ -516,7 +507,7 @@ def run_build_scripts(state: MkosiState) -> None:
     with (
         mount_build_overlay(state, volatile=True),
         finalize_chroot_scripts(state) as cd,
-        finalize_mounts(state.config) as mounts,
+        finalize_source_mounts(state.config) as sources,
     ):
         for script in state.config.build_scripts:
             helpers = {
@@ -548,10 +539,10 @@ def run_build_scripts(state: MkosiState) -> None:
                 complete_step(f"Running build script {script}…"),
             ):
                 bwrap(
+                    state,
                     script_maybe_chroot(script, "/work/build-script") + cmdline,
                     network=state.config.with_network,
-                    readonly=True,
-                    options=mounts,
+                    options=sources,
                     scripts=hd,
                     env=env | state.config.environment,
                     stdin=sys.stdin,
@@ -577,7 +568,7 @@ def run_postinst_scripts(state: MkosiState) -> None:
 
     with (
         finalize_chroot_scripts(state) as cd,
-        finalize_mounts(state.config) as mounts,
+        finalize_source_mounts(state.config) as sources,
     ):
         for script in state.config.postinst_scripts:
             helpers = {
@@ -603,10 +594,10 @@ def run_postinst_scripts(state: MkosiState) -> None:
                 complete_step(f"Running postinstall script {script}…"),
             ):
                 bwrap(
+                    state,
                     script_maybe_chroot(script, "/work/postinst") + ["final"],
                     network=state.config.with_network,
-                    readonly=True,
-                    options=mounts,
+                    options=sources,
                     scripts=hd,
                     env=env | state.config.environment,
                     stdin=sys.stdin,
@@ -632,7 +623,7 @@ def run_finalize_scripts(state: MkosiState) -> None:
 
     with (
         finalize_chroot_scripts(state) as cd,
-        finalize_mounts(state.config) as mounts,
+        finalize_source_mounts(state.config) as sources,
     ):
         for script in state.config.finalize_scripts:
             helpers = {
@@ -658,10 +649,10 @@ def run_finalize_scripts(state: MkosiState) -> None:
                 complete_step(f"Running finalize script {script}…"),
             ):
                 bwrap(
+                    state,
                     script_maybe_chroot(script, "/work/finalize"),
                     network=state.config.with_network,
-                    readonly=True,
-                    options=mounts,
+                    options=sources,
                     scripts=hd,
                     env=env | state.config.environment,
                     stdin=sys.stdin,
@@ -1152,6 +1143,7 @@ def prepare_grub_bios(state: MkosiState, partitions: Sequence[Partition]) -> Non
         earlyconfig.flush()
 
         bwrap(
+            state,
             [
                 mkimage,
                 "--directory", directory,
@@ -1165,7 +1157,7 @@ def prepare_grub_bios(state: MkosiState, partitions: Sequence[Partition]) -> Non
                 "part_gpt",
                 "biosdisk",
                 "search",
-                "search_fs_file"
+                "search_fs_file",
             ],
             options=["--bind", state.root / "usr", "/usr"],
         )
@@ -1210,12 +1202,41 @@ def install_grub_bios(state: MkosiState, partitions: Sequence[Partition]) -> Non
     with complete_step("Installing grub boot loader…"):
         # We don't setup the mountinfo bind mount with bwrap because we need to know the child process pid to
         # be able to do the mount and we don't know the pid beforehand.
-        bwrap(["sh", "-c", f"mount --bind {mountinfo} /proc/$$/mountinfo && exec $0 \"$@\"",
-               setup,
-               "--directory", state.root / "efi" / prefix / "i386-pc",
-               *(["--verbose"] if ARG_DEBUG.get() else []),
-               state.staging / state.config.output_with_format],
-              options=["--bind", state.root / "usr", "/usr"])
+        bwrap(
+            state,
+            [
+                "sh", "-c", f"mount --bind {mountinfo} /proc/$$/mountinfo && exec $0 \"$@\"",
+                setup,
+                "--directory", state.root / "efi" / prefix / "i386-pc",
+                *(["--verbose"] if ARG_DEBUG.get() else []),
+                state.staging / state.config.output_with_format,
+            ],
+            options=["--bind", state.root / "usr", "/usr"],
+        )
+
+
+def install_tree(
+    state: MkosiState,
+    src: Path,
+    dst: Path,
+    target: Optional[Path] = None,
+) -> None:
+    t = dst
+    if target:
+        t = dst / target.relative_to("/")
+
+    with umask(~0o755):
+        t.parent.mkdir(parents=True, exist_ok=True)
+
+    if src.is_dir() or (src.is_file() and target):
+        copy_tree(src, t, preserve_owner=False, use_subvolumes=state.config.use_subvolumes)
+    elif src.suffix == ".tar":
+        extract_tar(state, src, t)
+    elif src.suffix == ".raw":
+        run(["systemd-dissect", "--copy-from", src, "/", t])
+    else:
+        # If we get an unknown file without a target, we just copy it into /.
+        copy_tree(src, t, preserve_owner=False, use_subvolumes=state.config.use_subvolumes)
 
 
 def install_base_trees(state: MkosiState) -> None:
@@ -1224,7 +1245,7 @@ def install_base_trees(state: MkosiState) -> None:
 
     with complete_step("Copying in base trees…"):
         for path in state.config.base_trees:
-            install_tree(path, state.root, use_subvolumes=state.config.use_subvolumes)
+            install_tree(state, path, state.root)
 
 
 def install_skeleton_trees(state: MkosiState) -> None:
@@ -1233,7 +1254,7 @@ def install_skeleton_trees(state: MkosiState) -> None:
 
     with complete_step("Copying in skeleton file trees…"):
         for tree in state.config.skeleton_trees:
-            install_tree(tree.source, state.root, tree.target, use_subvolumes=state.config.use_subvolumes)
+            install_tree(state, tree.source, state.root, tree.target)
 
 
 def install_package_manager_trees(state: MkosiState) -> None:
@@ -1242,12 +1263,7 @@ def install_package_manager_trees(state: MkosiState) -> None:
 
     with complete_step("Copying in package manager file trees…"):
         for tree in state.config.package_manager_trees:
-            install_tree(
-                tree.source,
-                state.workspace / "pkgmngr",
-                tree.target,
-                use_subvolumes=state.config.use_subvolumes
-            )
+            install_tree(state, tree.source, state.workspace / "pkgmngr", tree.target)
 
 
 def install_extra_trees(state: MkosiState) -> None:
@@ -1256,7 +1272,7 @@ def install_extra_trees(state: MkosiState) -> None:
 
     with complete_step("Copying in extra file trees…"):
         for tree in state.config.extra_trees:
-            install_tree(tree.source, state.root, tree.target, use_subvolumes=state.config.use_subvolumes)
+            install_tree(state, tree.source, state.root, tree.target)
 
 
 def install_build_dest(state: MkosiState) -> None:
@@ -1339,6 +1355,7 @@ def build_initrd(state: MkosiState) -> Path:
         *(["--hostname", state.config.hostname] if state.config.hostname else []),
         *(["--root-password", rootpwopt] if rootpwopt else []),
         *([f"--environment={k}='{v}'" for k, v in state.config.environment.items()]),
+        *(["--tools-tree", str(state.config.tools_tree)] if state.config.tools_tree else []),
         *(["-f"] * state.args.force),
     ]
 
@@ -1391,7 +1408,7 @@ def build_microcode_initrd(state: MkosiState) -> Optional[Path]:
             for p in intel.iterdir():
                 f.write(p.read_bytes())
 
-    make_cpio(root, microcode)
+    make_cpio(state, root, microcode)
 
     return microcode
 
@@ -1402,7 +1419,7 @@ def build_kernel_modules_initrd(state: MkosiState, kver: str) -> Path:
         return kmods
 
     make_cpio(
-        state.root, kmods,
+        state, state.root, kmods,
         gen_required_kernel_modules(
             state.root, kver,
             state.config.kernel_modules_initrd_include,
@@ -1669,7 +1686,7 @@ def install_uki(state: MkosiState, partitions: Sequence[Partition]) -> None:
 
 def make_uki(state: MkosiState, stub: Path, kver: str, kimg: Path, output: Path) -> None:
     microcode = build_microcode_initrd(state)
-    make_cpio(state.root, state.workspace / "initrd")
+    make_cpio(state, state.root, state.workspace / "initrd")
     maybe_compress(state.config, state.config.compress_output, state.workspace / "initrd", state.workspace / "initrd")
 
     initrds = [microcode] if microcode else []
@@ -2619,9 +2636,9 @@ def build_image(args: MkosiArgs, config: MkosiConfig) -> None:
         copy_initrd(state)
 
         if state.config.output_format == OutputFormat.tar:
-            make_tar(state.root, state.staging / state.config.output_with_format)
+            make_tar(state, state.root, state.staging / state.config.output_with_format)
         elif state.config.output_format == OutputFormat.cpio:
-            make_cpio(state.root, state.staging / state.config.output_with_format)
+            make_cpio(state, state.root, state.staging / state.config.output_with_format)
         elif state.config.output_format == OutputFormat.uki:
             assert stub and kver and kimg
             make_uki(state, stub, kver, kimg, state.staging / state.config.output_with_format)
@@ -3016,72 +3033,6 @@ def finalize_tools(args: MkosiArgs, images: Sequence[MkosiConfig]) -> Sequence[M
     return new
 
 
-@contextlib.contextmanager
-def mount_tools(tree: Optional[Path]) -> Iterator[None]:
-    if not tree:
-        yield
-        return
-
-    with contextlib.ExitStack() as stack:
-        stack.enter_context(mount_usr(tree))
-
-        # On top of /usr, we also need the certificates, keyrings and crypto policies from the tools tree which are
-        # unfortunately not always in /usr. To make things work, we mount those directories into the host as well.
-        # Because the directories might not exist on the host (which means we can't mount over them), we mount a
-        # writable directory on top of their parent directory using overlayfs so we can create the required mountpoints
-        # without running into permission errors.
-
-        overlays = set()
-        dirs = [
-            subdir
-            for subdir in (
-                Path("etc/pki"),
-                Path("etc/ssl"),
-                Path("etc/crypto-policies"),
-                Path("etc/ca-certificates"),
-                Path("etc/pacman.d"),
-                Path("var/lib/ca-certificates"),
-            )
-            if (tree / subdir).exists()
-        ]
-
-        for subdir in dirs:
-            if (Path("/") / subdir).exists():
-                continue
-
-            if subdir.parent not in overlays:
-                tmp = stack.enter_context(tempfile.TemporaryDirectory(dir="/var/tmp"))
-                stack.enter_context(mount_overlay([Path("/") / subdir.parent], Path(tmp), Path("/") / subdir.parent))
-                overlays.add(subdir.parent)
-
-            (Path("/") / subdir).mkdir(parents=True, exist_ok=True)
-
-        for subdir in dirs:
-            stack.enter_context(
-                mount(what=tree / subdir, where=Path("/") / subdir, operation="--bind", read_only=True)
-            )
-
-        yield
-
-
-@contextlib.contextmanager
-def hide_host_directories() -> Iterator[None]:
-    with contextlib.ExitStack() as stack:
-
-        # We want to limit the effect of host specific admin configuration on image builds, so we hide various config
-        # directories that we can't override using CLI options or environment variables so that they don't affect our
-        # builds.
-
-        for d in ("/etc/rpm",):
-            if not Path(d).exists():
-                continue
-
-            tmp = stack.enter_context(tempfile.TemporaryDirectory())
-            stack.enter_context(mount(what=tmp, where=Path(d), operation="--bind"))
-
-        yield
-
-
 def check_workspace_directory(config: MkosiConfig) -> None:
     wd = config.workspace_dir_or_default()
 
@@ -3214,8 +3165,7 @@ def run_verb(args: MkosiArgs, images: Sequence[MkosiConfig]) -> None:
 
             with (
                 complete_step(f"Building {config.name()} image"),
-                mount_tools(config.tools_tree),
-                hide_host_directories(),
+                mount_usr(config.tools_tree),
                 prepend_to_environ_path(config),
             ):
                 # After tools have been mounted, check if we have what we need

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2454,7 +2454,7 @@ def make_extension_image(state: MkosiState, output: Path) -> None:
         "--root", state.root,
         "--dry-run=no",
         "--no-pager",
-        "--offline=yes",
+        f"--offline={yes_no(state.config.repart_offline)}",
         "--seed", str(state.config.seed) if state.config.seed else "random",
         "--empty=create",
         "--size=auto",

--- a/mkosi/bubblewrap.py
+++ b/mkosi/bubblewrap.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: LGPL-2.1+
+import enum
+import logging
+import os
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Optional
+
+from mkosi.log import ARG_DEBUG_SHELL
+from mkosi.mounts import finalize_passwd_mounts
+from mkosi.run import find_binary, log_process_failure, run
+from mkosi.state import MkosiState
+from mkosi.types import _FILE, CompletedProcess, PathString
+from mkosi.util import flatten, one_zero
+
+
+# https://github.com/torvalds/linux/blob/master/include/uapi/linux/capability.h
+class Capability(enum.Enum):
+    CAP_NET_ADMIN = 12
+
+
+def have_effective_cap(capability: Capability) -> bool:
+    for line in Path("/proc/self/status").read_text().splitlines():
+        if line.startswith("CapEff:"):
+            hexcap = line.removeprefix("CapEff:").strip()
+            break
+    else:
+        logging.warning(f"\"CapEff:\" not found in /proc/self/status, assuming we don't have {capability}")
+        return False
+
+    return (int(hexcap, 16) & (1 << capability.value)) != 0
+
+
+def finalize_mounts(state: MkosiState) -> list[PathString]:
+    mounts = [
+        ((state.config.tools_tree or Path("/")) / subdir, Path("/") / subdir, True)
+        for subdir in (
+            Path("etc/pki"),
+            Path("etc/ssl"),
+            Path("etc/crypto-policies"),
+            Path("etc/ca-certificates"),
+            Path("etc/pacman.d"),
+            Path("var/lib/ca-certificates"),
+        )
+        if ((state.config.tools_tree or Path("/")) / subdir).exists()
+    ]
+
+    mounts += [
+        (d, d, False)
+        for d in (state.workspace, state.config.cache_dir, state.config.output_dir, state.config.build_dir)
+        if d
+    ]
+
+    return flatten(
+        ["--ro-bind" if readonly else "--bind", src, target]
+        for src, target, readonly
+        in sorted(set(mounts), key=lambda s: s[1])
+    )
+
+
+def bwrap(
+    state: MkosiState,
+    cmd: Sequence[PathString],
+    *,
+    network: bool = False,
+    options: Sequence[PathString] = (),
+    log: bool = True,
+    scripts: Optional[Path] = None,
+    env: Mapping[str, str] = {},
+    stdin: _FILE = None,
+    stdout: _FILE = None,
+    input: Optional[str] = None,
+) -> CompletedProcess:
+    cmdline: list[PathString] = [
+        "bwrap",
+        "--ro-bind", "/usr", "/usr",
+        "--bind", "/var/tmp", "/var/tmp",
+        "--bind", "/tmp", "/tmp",
+        "--bind", Path.cwd(), Path.cwd(),
+        "--chdir", Path.cwd(),
+        "--unshare-pid",
+        "--unshare-ipc",
+        "--unshare-cgroup",
+        *(["--unshare-net"] if not network and have_effective_cap(Capability.CAP_NET_ADMIN) else []),
+        "--die-with-parent",
+        "--proc", "/proc",
+        "--dev", "/dev",
+        "--setenv", "SYSTEMD_OFFLINE", one_zero(network),
+    ]
+
+    for p in Path("/").iterdir():
+        if p.is_symlink():
+            cmdline += ["--symlink", p.readlink(), p]
+
+    if network:
+        cmdline += ["--bind", "/etc/resolv.conf", "/etc/resolv.conf"]
+
+    cmdline += finalize_mounts(state) + [
+        "--setenv", "PATH", f"{scripts or ''}:{os.environ['PATH']}",
+        *options,
+        "sh", "-c", "chmod 1777 /dev/shm && exec $0 \"$@\"",
+    ]
+
+    if setpgid := find_binary("setpgid"):
+        cmdline += [setpgid, "--foreground", "--"]
+
+    try:
+        result = run([*cmdline, *cmd], env=env, log=False, stdin=stdin, stdout=stdout, input=input)
+    except subprocess.CalledProcessError as e:
+        if log:
+            log_process_failure([os.fspath(s) for s in cmd], e.returncode)
+        if ARG_DEBUG_SHELL.get():
+            run([*cmdline, "sh"], stdin=sys.stdin, check=False, env=env, log=False)
+        raise e
+
+    return result
+
+
+def apivfs_cmd(root: Path) -> list[PathString]:
+    cmdline: list[PathString] = [
+        "bwrap",
+        "--dev-bind", "/", "/",
+        "--chdir", Path.cwd(),
+        "--tmpfs", root / "run",
+        "--tmpfs", root / "tmp",
+        "--bind", os.getenv("TMPDIR", "/var/tmp"), root / "var/tmp",
+        "--proc", root / "proc",
+        "--dev", root / "dev",
+        # APIVFS generally means chrooting is going to happen so unset TMPDIR just to be safe.
+        "--unsetenv", "TMPDIR",
+    ]
+
+    if (root / "etc/machine-id").exists():
+        # Make sure /etc/machine-id is not overwritten by any package manager post install scripts.
+        cmdline += ["--ro-bind", root / "etc/machine-id", root / "etc/machine-id"]
+
+    cmdline += finalize_passwd_mounts(root)
+
+    if setpgid := find_binary("setpgid"):
+        cmdline += [setpgid, "--foreground", "--"]
+
+    chmod = f"chmod 1777 {root / 'tmp'} {root / 'var/tmp'} {root / 'dev/shm'}"
+    # Make sure anything running in the root directory thinks it's in a container. $container can't always be
+    # accessed so we write /run/host/container-manager as well which is always accessible.
+    container = f"mkdir {root}/run/host && echo mkosi >{root}/run/host/container-manager"
+
+    cmdline += ["sh", "-c", f"{chmod} && {container} && exec $0 \"$@\""]
+
+    return cmdline
+
+
+def chroot_cmd(root: Path, *, resolve: bool = False, options: Sequence[PathString] = ()) -> list[PathString]:
+    cmdline: list[PathString] = [
+        "sh", "-c",
+        # No exec here because we need to clean up the /work directory afterwards.
+        f"trap 'rm -rf {root / 'work'}' EXIT && mkdir -p {root / 'work'} && chown 777 {root / 'work'} && $0 \"$@\"",
+        "bwrap",
+        "--dev-bind", root, "/",
+        "--setenv", "container", "mkosi",
+        "--setenv", "HOME", "/",
+        "--setenv", "PATH", "/work/scripts:/usr/bin:/usr/sbin",
+    ]
+
+    if resolve:
+        p = Path("etc/resolv.conf")
+        if (root / p).is_symlink():
+            # For each component in the target path, bubblewrap will try to create it if it doesn't exist
+            # yet. If a component in the path is a dangling symlink, bubblewrap will end up calling
+            # mkdir(symlink) which obviously fails if multiple components of the dangling symlink path don't
+            # exist yet. As a workaround, we resolve the symlink ourselves so that bubblewrap will correctly
+            # create all missing components in the target path.
+            p = p.parent / (root / p).readlink()
+
+        cmdline += ["--ro-bind", "/etc/resolv.conf", Path("/") / p]
+
+    cmdline += [*options]
+
+    if setpgid := find_binary("setpgid", root=root):
+        cmdline += [setpgid, "--foreground", "--"]
+
+    return apivfs_cmd(root) + cmdline

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -30,7 +30,7 @@ from typing import Any, Callable, Optional, TypeVar, Union, cast
 from mkosi.distributions import Distribution, detect_distribution
 from mkosi.log import ARG_DEBUG, ARG_DEBUG_SHELL, Style, die
 from mkosi.pager import page
-from mkosi.run import run, run_openssl
+from mkosi.run import run
 from mkosi.types import PathString, SupportsRead
 from mkosi.util import INVOKING_USER, StrEnum, chdir, flatten, is_power_of_2
 from mkosi.versioncomp import GenericVersion
@@ -3034,8 +3034,8 @@ def load_credentials(args: argparse.Namespace) -> dict[str, str]:
 
     if "ssh.authorized_keys.root" not in creds:
         if args.ssh_certificate:
-            pubkey = run_openssl(["x509", "-in", args.ssh_certificate, "-pubkey", "-noout"],
-                                 stdout=subprocess.PIPE).stdout.strip()
+            pubkey = run(["openssl", "x509", "-in", args.ssh_certificate, "-pubkey", "-noout"],
+                          stdout=subprocess.PIPE, env=dict(OPENSSL_CONF="/dev/null")).stdout.strip()
             sshpubkey = run(["ssh-keygen", "-f", "/dev/stdin", "-i", "-m", "PKCS8"],
                             input=pubkey, stdout=subprocess.PIPE).stdout.strip()
             creds["ssh.authorized_keys.root"] = sshpubkey

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -126,7 +126,7 @@ class Installer(DistributionInstaller):
         for deb in essential:
             with tempfile.NamedTemporaryFile() as f:
                 run(["dpkg-deb", "--fsys-tarfile", deb], stdout=f)
-                extract_tar(Path(f.name), state.root, log=False)
+                extract_tar(state, Path(f.name), state.root, log=False)
 
         # Finally, run apt to properly install packages in the chroot without having to worry that maintainer
         # scripts won't find basic tools that they depend on.

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -6,11 +6,11 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from mkosi.archive import extract_tar
+from mkosi.bubblewrap import bwrap
 from mkosi.config import Architecture
 from mkosi.distributions import Distribution, DistributionInstaller, PackageType
 from mkosi.installer.apt import invoke_apt, setup_apt
 from mkosi.log import die
-from mkosi.run import run
 from mkosi.state import MkosiState
 from mkosi.util import umask
 
@@ -125,7 +125,7 @@ class Installer(DistributionInstaller):
 
         for deb in essential:
             with tempfile.NamedTemporaryFile() as f:
-                run(["dpkg-deb", "--fsys-tarfile", deb], stdout=f)
+                bwrap(state, ["dpkg-deb", "--fsys-tarfile", deb], stdout=f)
                 extract_tar(state, Path(f.name), state.root, log=False)
 
         # Finally, run apt to properly install packages in the chroot without having to worry that maintainer

--- a/mkosi/installer/__init__.py
+++ b/mkosi/installer/__init__.py
@@ -2,13 +2,13 @@
 
 import os
 
+from mkosi.bubblewrap import apivfs_cmd
 from mkosi.config import ConfigFeature
 from mkosi.installer.apt import apt_cmd
 from mkosi.installer.dnf import dnf_cmd
 from mkosi.installer.pacman import pacman_cmd
 from mkosi.installer.rpm import rpm_cmd
 from mkosi.installer.zypper import zypper_cmd
-from mkosi.run import apivfs_cmd
 from mkosi.state import MkosiState
 from mkosi.tree import rmtree
 from mkosi.types import PathString

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -3,7 +3,7 @@ import shutil
 import textwrap
 from collections.abc import Sequence
 
-from mkosi.run import apivfs_cmd, bwrap
+from mkosi.bubblewrap import apivfs_cmd, bwrap
 from mkosi.state import MkosiState
 from mkosi.types import PathString
 from mkosi.util import sort_packages, umask
@@ -109,5 +109,5 @@ def invoke_apt(
     apivfs: bool = True,
 ) -> None:
     cmd = apivfs_cmd(state.root) if apivfs else []
-    bwrap(cmd + apt_cmd(state, command) + [operation, *sort_packages(packages)],
+    bwrap(state, cmd + apt_cmd(state, command) + [operation, *sort_packages(packages)],
           network=True, env=state.config.environment)

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -3,8 +3,8 @@ import shutil
 import textwrap
 from collections.abc import Iterable
 
+from mkosi.bubblewrap import apivfs_cmd, bwrap
 from mkosi.installer.rpm import RpmRepository, fixup_rpmdb_location, setup_rpm
-from mkosi.run import apivfs_cmd, bwrap
 from mkosi.state import MkosiState
 from mkosi.types import PathString
 from mkosi.util import sort_packages
@@ -111,7 +111,7 @@ def dnf_cmd(state: MkosiState) -> list[PathString]:
 
 def invoke_dnf(state: MkosiState, command: str, packages: Iterable[str], apivfs: bool = True) -> None:
     cmd = apivfs_cmd(state.root) if apivfs else []
-    bwrap(cmd + dnf_cmd(state) + [command, *sort_packages(packages)],
+    bwrap(state, cmd + dnf_cmd(state) + [command, *sort_packages(packages)],
           network=True, env=state.config.environment)
 
     fixup_rpmdb_location(state.root)

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable, Sequence
 from pathlib import Path
 from typing import NamedTuple
 
-from mkosi.run import apivfs_cmd, bwrap
+from mkosi.bubblewrap import apivfs_cmd, bwrap
 from mkosi.state import MkosiState
 from mkosi.types import PathString
 from mkosi.util import sort_packages, umask
@@ -96,5 +96,5 @@ def invoke_pacman(
     apivfs: bool = True,
 ) -> None:
     cmd = apivfs_cmd(state.root) if apivfs else []
-    bwrap(cmd + pacman_cmd(state) + [operation, *options, *sort_packages(packages)],
+    bwrap(state, cmd + pacman_cmd(state) + [operation, *options, *sort_packages(packages)],
           network=True, env=state.config.environment)

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -2,9 +2,9 @@
 import textwrap
 from collections.abc import Sequence
 
+from mkosi.bubblewrap import apivfs_cmd, bwrap
 from mkosi.config import yes_no
 from mkosi.installer.rpm import RpmRepository, fixup_rpmdb_location, setup_rpm
-from mkosi.run import apivfs_cmd, bwrap
 from mkosi.state import MkosiState
 from mkosi.types import PathString
 from mkosi.util import sort_packages
@@ -76,7 +76,7 @@ def invoke_zypper(
     apivfs: bool = True,
 ) -> None:
     cmd = apivfs_cmd(state.root) if apivfs else []
-    bwrap(cmd + zypper_cmd(state) + [verb, *options, *sort_packages(packages)],
+    bwrap(state, cmd + zypper_cmd(state) + [verb, *options, *sort_packages(packages)],
           network=True, env=state.config.environment)
 
     fixup_rpmdb_location(state.root)

--- a/mkosi/kmod.py
+++ b/mkosi/kmod.py
@@ -8,7 +8,7 @@ from collections.abc import Iterator, Sequence
 from pathlib import Path
 
 from mkosi.log import complete_step, log_step
-from mkosi.run import bwrap, chroot_cmd
+from mkosi.run import run
 
 
 def loaded_modules() -> list[str]:
@@ -76,8 +76,8 @@ def resolve_module_dependencies(root: Path, kver: str, modules: Sequence[str]) -
     info = ""
     for i in range(0, len(nametofile.keys()), 8500):
         chunk = list(nametofile.keys())[i:i+8500]
-        info += bwrap(chroot_cmd(root) + ["modinfo", "--set-version", kver, "--null", *chunk],
-                      stdout=subprocess.PIPE).stdout.strip()
+        info += run(["modinfo", "--basedir", root, "--set-version", kver, "--null", *chunk],
+                    stdout=subprocess.PIPE).stdout.strip()
 
     log_step("Calculating required kernel modules and firmware")
 

--- a/mkosi/resources/mkosi-tools/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf
@@ -16,6 +16,7 @@ Packages=
         dnf
         dosfstools
         e2fsprogs
+        kmod
         less
         mtools
         nano

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos-fedora/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos-fedora/mkosi.conf
@@ -21,4 +21,5 @@ Packages=
         squashfs-tools
         systemd-container
         systemd-udev
+        ubu-keyring
         xz

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -16,7 +16,6 @@ import shutil
 import signal
 import subprocess
 import sys
-import tempfile
 import threading
 from collections.abc import Awaitable, Collection, Iterator, Mapping, Sequence
 from pathlib import Path
@@ -435,8 +434,3 @@ class MkosiAsyncioThread(threading.Thread):
                 raise self.exc.get_nowait()
             except queue.Empty:
                 pass
-
-
-def run_openssl(args: Sequence[PathString], stdout: _FILE = None) -> CompletedProcess:
-    with tempfile.NamedTemporaryFile(prefix="mkosi-openssl.cnf") as config:
-        return run(["openssl", *args], stdout=stdout, env=dict(OPENSSL_CONF=config.name))

--- a/tests/test_initrd.py
+++ b/tests/test_initrd.py
@@ -239,7 +239,7 @@ def test_initrd_size(initrd: Image) -> None:
         Distribution.debian: 40,
         Distribution.ubuntu: 36,
         Distribution.arch: 47,
-        Distribution.opensuse: 36,
+        Distribution.opensuse: 39,
     }.get(initrd.config.distribution, 48)
 
     assert (Path(initrd.output_dir.name) / "initrd").stat().st_size <= maxsize


### PR DESCRIPTION
Let's not make the full root filesystem available to commands
running in bwrap(). Instead, limit it to some select directories.

- /usr
- Various directories from /etc. Note that this also means we can
  get rid of mount_tools() as all these directories are now mounted
  in bwrap() instead. This also allows us to get rid of the overlay
  hack in mount_tools() to create the necessary mount points. The
  goal is to get rid of as many of these as possible over time.
- /var/tmp
- /tmp

Because to make this work we have to pass MkosiConfig into bwrap(),
we split off a new file bubblewrap.py with all the bubblewrap stuff.

We don't want to make the functions from archive.py depend on
MkosiConfig, so we use run() there now to invoke bubblewrap instead
of the bwrap() function.