### PR TITLE
Mount package manager trees

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,8 +53,7 @@
 - Implemented `WithDocs=` for `apt`.
 - On supported package managers, locale data for other locales is now
   stripped if the local is explicitly configured using `Locale=`.
-- `rpm` can now be configured in package manager trees in
-  `/usr/lib/rpm`.
+- `rpm` can now be configured in package manager trees in `/etc/rpm`.
 - All `rpm` plugins are now disabled when building images.
 - Added `KernelModulesIncludeHost=` and
   `KernelModulesInitrdIncludeHost=` to only include modules loaded on

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -14,25 +14,21 @@ def setup_apt(state: MkosiState, repos: Sequence[str]) -> None:
     (state.pkgmngr / "etc/apt/apt.conf.d").mkdir(exist_ok=True, parents=True)
     (state.pkgmngr / "etc/apt/preferences.d").mkdir(exist_ok=True, parents=True)
     (state.pkgmngr / "etc/apt/sources.list.d").mkdir(exist_ok=True, parents=True)
-    (state.pkgmngr / "var/log/apt").mkdir(exist_ok=True, parents=True)
-    (state.pkgmngr / "var/lib/apt").mkdir(exist_ok=True, parents=True)
 
     # TODO: Drop once apt 2.5.4 is widely available.
     with umask(~0o755):
         (state.root / "var/lib/dpkg").mkdir(parents=True, exist_ok=True)
         (state.root / "var/lib/dpkg/status").touch()
 
-    # We have a special apt.conf outside of pkgmngr dir that only configures "Dir" and "Dir::Etc"
-    # that we pass to APT_CONFIG to tell apt it should read config files in pkgmngr instead of
-    # in its usual locations. This is required because apt parses CLI configuration options after
-    # parsing its configuration files and as such we can't use CLI options to tell apt where to
-    # look for configuration files.
+    # We have a special apt.conf outside of pkgmngr dir that only configures "Dir::Etc" that we pass to APT_CONFIG to
+    # tell apt it should read config files from /etc/apt in case this is overridden by distributions. This is required
+    # because apt parses CLI configuration options after parsing its configuration files and as such we can't use CLI
+    # options to tell apt where to look for configuration files.
     config = state.workspace / "apt.conf"
     if not config.exists():
         config.write_text(
             textwrap.dedent(
-                f"""\
-                Dir "{state.pkgmngr}";
+                """\
                 Dir::Etc "etc/apt";
                 """
             )
@@ -52,8 +48,6 @@ def apt_cmd(state: MkosiState, command: str) -> list[PathString]:
     trustedkeys = (
         trustedkeys if trustedkeys.exists() else f"/usr/share/keyrings/{state.config.distribution}-archive-keyring.gpg"
     )
-    trustedkeys_dir = state.pkgmngr / "etc/apt/trusted.gpg.d"
-    trustedkeys_dir = trustedkeys_dir if trustedkeys_dir.exists() else "/usr/share/keyrings"
 
     cmdline: list[PathString] = [
         "env",
@@ -72,19 +66,16 @@ def apt_cmd(state: MkosiState, command: str) -> list[PathString]:
         "-o", "APT::Get::Allow-Remove-Essential=true",
         "-o", "APT::Sandbox::User=root",
         "-o", f"Dir::Cache={state.cache_dir / 'apt'}",
-        "-o", f"Dir::State={state.pkgmngr / 'var/lib/apt'}",
-        "-o", f"Dir::State::status={state.root / 'var/lib/dpkg/status'}",
-        "-o", f"Dir::Etc::trusted={trustedkeys}",
-        "-o", f"Dir::Etc::trustedparts={trustedkeys_dir}",
-        "-o", f"Dir::Log={state.pkgmngr / 'var/log/apt'}",
-        "-o", f"Dir::Bin::dpkg={shutil.which('dpkg')}",
+        "-o", f"Dir::State={state.cache_dir / 'apt'}",
+        "-o", f"Dir::State::Status={state.root / 'var/lib/dpkg/status'}",
+        "-o", f"Dir::Etc::Trusted={trustedkeys}",
+        "-o", f"Dir::Bin::DPkg={shutil.which('dpkg')}",
         "-o", "Debug::NoLocking=true",
         "-o", f"DPkg::Options::=--root={state.root}",
-        "-o", f"DPkg::Options::=--log={state.pkgmngr / 'var/log/apt/dpkg.log'}",
         "-o", "DPkg::Options::=--force-unsafe-io",
         "-o", "DPkg::Options::=--force-architecture",
         "-o", "DPkg::Options::=--force-depends",
-        "-o", "Dpkg::Use-Pty=false",
+        "-o", "DPkg::Use-Pty=false",
         "-o", "DPkg::Install::Recursive::Minimum=1000",
         "-o", "pkgCacheGen::ForceEssential=,",
     ]

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1+
 import textwrap
 from collections.abc import Iterable, Sequence
-from pathlib import Path
 from typing import NamedTuple
 
 from mkosi.bubblewrap import apivfs_cmd, bwrap
@@ -59,28 +58,23 @@ def setup_pacman(state: MkosiState, repositories: Iterable[PacmanRepository]) ->
         if any((state.pkgmngr / "etc/pacman.d/").glob("*.conf")):
             f.write(
                 textwrap.dedent(
-                    f"""\
+                    """\
 
-                    Include = {state.pkgmngr}/etc/pacman.d/*.conf
+                    Include = /etc/pacman.d/*.conf
                     """
                 )
             )
 
 
 def pacman_cmd(state: MkosiState) -> list[PathString]:
-    gpgdir = state.pkgmngr / "etc/pacman.d/gnupg/"
-    gpgdir = gpgdir if gpgdir.exists() else Path("/etc/pacman.d/gnupg/")
-
     with umask(~0o755):
         (state.cache_dir / "pacman/pkg").mkdir(parents=True, exist_ok=True)
 
     return [
         "pacman",
-        "--config", state.pkgmngr / "etc/pacman.conf",
         "--root", state.root,
         "--logfile=/dev/null",
         "--cachedir", state.cache_dir / "pacman/pkg",
-        "--gpgdir", gpgdir,
         "--hookdir", state.root / "etc/pacman.d/hooks",
         "--arch", state.config.distribution.architecture(state.config.architecture),
         "--color", "auto",

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -57,12 +57,11 @@ def setup_zypper(state: MkosiState, repos: Sequence[RpmRepository]) -> None:
 def zypper_cmd(state: MkosiState) -> list[PathString]:
     return [
         "env",
-        f"ZYPP_CONF={state.pkgmngr / 'etc/zypp/zypp.conf'}",
-        f"RPM_CONFIGDIR={state.pkgmngr / 'usr/lib/rpm'}",
+        "ZYPP_CONF=/etc/zypp/zypp.conf",
+        "HOME=/",
         "zypper",
-        f"--root={state.root}",
+        f"--installroot={state.root}",
         f"--cache-dir={state.cache_dir / 'zypp'}",
-        f"--reposd-dir={state.pkgmngr / 'etc/zypp/repos.d'}",
         "--gpg-auto-import-keys" if state.config.repository_key_check else "--no-gpg-checks",
         "--non-interactive",
     ]

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -596,15 +596,9 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 : `mkosi` will look for the package manager configuration and related
   files in the configured package manager trees. Unless specified
   otherwise, it will use the configuration file from its canonical
-  location in the package manager trees. For example, it will look for
-  `etc/dnf/dnf.conf` in the package manager trees if `dnf` is used to
-  install packages.
-
-: Extra rpm configuration should be put in `usr/lib/rpm` in the package
-  manager trees. Any configuration in `etc/rpm` will be ignored. The
-  extra configuration in `usr/lib/rpm` should mimick the layout of
-  `usr/lib/rpm` on the host. For example, extra macro files should go in
-  `usr/lib/rpm/macros.d` in the package manager trees.
+  location in `/etc` in the package manager trees. For example, it will
+  look for `etc/dnf/dnf.conf` in the package manager trees if `dnf` is
+  used to install packages.
 
 : `SkeletonTrees=` and `PackageManagerTrees=` fulfill similar roles. Use
   `SkeletonTrees=` if you want the files to be present in the final image. Use


### PR DESCRIPTION
Now that /etc and /var are free game when running within bwrap() because we don't mount in the directories from the host anymore, let's take advantage of that by mounting all our package manager configuration to the canonical location in /etc instead of configuring the package managers via their CLI or config file to look in the right directory.

This also makes us look for rpm configuration in /etc/rpm instead of /usr/lib/rpm as that's now possible.