### PR TITLE
bwrap: mount readonly nix store

### DIFF
--- a/mkosi/bubblewrap.py
+++ b/mkosi/bubblewrap.py
@@ -105,6 +105,9 @@ def bwrap(
         if p.is_symlink():
             cmdline += ["--symlink", p.readlink(), p]
 
+    if Path("/etc/static").is_symlink():
+        cmdline += ["--symlink", Path("/etc/static").readlink(), "/etc/static"]
+
     if network:
         cmdline += ["--bind", "/etc/resolv.conf", "/etc/resolv.conf"]
 

--- a/mkosi/bubblewrap.py
+++ b/mkosi/bubblewrap.py
@@ -79,6 +79,7 @@ def bwrap(
     cmdline: list[PathString] = [
         "bwrap",
         "--ro-bind", "/usr", "/usr",
+        "--ro-bind-try", "/nix/store", "/nix/store",
         "--bind", "/var/tmp", "/var/tmp",
         "--bind", "/tmp", "/tmp",
         "--bind", Path.cwd(), Path.cwd(),


### PR DESCRIPTION
#2201 breaks mkosi on NixOS, since binaries are located in `/nix/store` (and not in `/usr`).
The first commit simply mounts the nix store, if available.
The second commit was required to get ssl certificates to work on NixOS (without using a tools tree), since dnf would fail with certificate warnings.
On nixos, certificates are stored as follows:

- `/etc/ssl/certs/ca-bundle.crt` symlink to `/etc/static/ssl/certs/ca-bundle.crt`
- `/etc/static` symlink to `/nix/store/<HASH>-etc/etc`
I'm not sure if the second commit is mergeable as-is (I think it might break the tools tree method), but it would be amazing if we could find a working solution.