### PR TITLE
Overlay /usr from package manager trees on top of /usr in bwrap()

### DIFF
--- a/kernel-install/50-mkosi.install
+++ b/kernel-install/50-mkosi.install
@@ -104,7 +104,7 @@ def main() -> None:
         "--format", str(format),
         "--output", output,
         "--workspace-dir=/var/tmp",
-        "--cache-dir=/var/cache",
+        "--cache-dir=/var",
         "--output-dir", context.staging_area,
         "--extra-tree", f"/usr/lib/modules/{context.kernel_version}:/usr/lib/modules/{context.kernel_version}",
         "--extra-tree=/usr/lib/firmware:/usr/lib/firmware",

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1921,7 +1921,11 @@ def unlink_output(args: MkosiArgs, config: MkosiConfig) -> None:
     if remove_package_cache:
         if config.cache_dir and config.cache_dir.exists() and any(config.cache_dir.iterdir()):
             with complete_step("Clearing out package cache…"):
-                empty_directory(config.cache_dir)
+                rmtree(*(
+                    config.cache_dir / p / d
+                    for p in ("cache", "lib")
+                    for d in ("apt", "dnf", "libdnf5", "pacman", "zypp")
+                ))
 
 
 def cache_tree_paths(config: MkosiConfig) -> tuple[Path, Path, Path]:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1299,6 +1299,9 @@ def install_package_manager_trees(state: MkosiState) -> None:
         for tree in state.config.package_manager_trees:
             install_tree(state, tree.source, state.workspace / "pkgmngr", tree.target)
 
+    # Ensure /etc exists in the package manager tree
+    (state.pkgmngr / "etc").mkdir(exist_ok=True)
+
 
 def install_extra_trees(state: MkosiState) -> None:
     if not state.config.extra_trees:
@@ -1552,11 +1555,6 @@ def build_uki(
     if not state.config.tools_tree:
         for p in state.config.extra_search_paths:
             cmd += ["--tools", p]
-
-    for d in ("etc/kernel", "usr/lib/kernel"):
-        uki_config = state.pkgmngr / d / "uki.conf"
-        if uki_config.exists():
-            cmd += ["--config", uki_config]
 
     if state.config.secure_boot:
         assert state.config.secure_boot_key

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -20,6 +20,9 @@ def setup_apt(state: MkosiState, repos: Sequence[str]) -> None:
         (state.root / "var/lib/dpkg").mkdir(parents=True, exist_ok=True)
         (state.root / "var/lib/dpkg/status").touch()
 
+    (state.cache_dir / "lib/apt").mkdir(exist_ok=True, parents=True)
+    (state.cache_dir / "cache/apt").mkdir(exist_ok=True, parents=True)
+
     # We have a special apt.conf outside of pkgmngr dir that only configures "Dir::Etc" that we pass to APT_CONFIG to
     # tell apt it should read config files from /etc/apt in case this is overridden by distributions. This is required
     # because apt parses CLI configuration options after parsing its configuration files and as such we can't use CLI
@@ -65,8 +68,8 @@ def apt_cmd(state: MkosiState, command: str) -> list[PathString]:
         "-o", "APT::Get::Allow-Change-Held-Packages=true",
         "-o", "APT::Get::Allow-Remove-Essential=true",
         "-o", "APT::Sandbox::User=root",
-        "-o", f"Dir::Cache={state.cache_dir / 'apt'}",
-        "-o", f"Dir::State={state.cache_dir / 'apt'}",
+        "-o", f"Dir::Cache={state.cache_dir / 'cache/apt'}",
+        "-o", f"Dir::State={state.cache_dir / 'lib/apt'}",
         "-o", f"Dir::State::Status={state.root / 'var/lib/dpkg/status'}",
         "-o", f"Dir::Etc::Trusted={trustedkeys}",
         "-o", f"Dir::Log={state.workspace}",

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -69,6 +69,7 @@ def apt_cmd(state: MkosiState, command: str) -> list[PathString]:
         "-o", f"Dir::State={state.cache_dir / 'apt'}",
         "-o", f"Dir::State::Status={state.root / 'var/lib/dpkg/status'}",
         "-o", f"Dir::Etc::Trusted={trustedkeys}",
+        "-o", f"Dir::Log={state.workspace}",
         "-o", f"Dir::Bin::DPkg={shutil.which('dpkg')}",
         "-o", "Debug::NoLocking=true",
         "-o", f"DPkg::Options::=--root={state.root}",

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -76,7 +76,8 @@ def dnf_cmd(state: MkosiState) -> list[PathString]:
         f"--releasever={state.config.release}",
         f"--installroot={state.root}",
         "--setopt=keepcache=1",
-        f"--setopt=cachedir={state.cache_dir / ('libdnf5' if dnf.endswith('dnf5') else 'dnf')}",
+        f"--setopt=cachedir={state.cache_dir / 'cache' / ('libdnf5' if dnf.endswith('dnf5') else 'dnf')}",
+        f"--setopt=persistdir={state.cache_dir / 'lib' / ('libdnf5' if dnf.endswith('dnf5') else 'dnf')}",
         f"--setopt=install_weak_deps={int(state.config.with_recommends)}",
         "--setopt=check_config_file_age=0",
         "--disable-plugin=*" if dnf.endswith("dnf5") else "--disableplugin=*",
@@ -107,7 +108,6 @@ def dnf_cmd(state: MkosiState) -> list[PathString]:
             "--config=/etc/dnf/dnf.conf",
             "--setopt=reposdir=/etc/yum.repos.d",
             "--setopt=varsdir=/etc/dnf/vars",
-            "--setopt=persistdir=/var/lib/dnf",
         ]
 
     return cmdline

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -26,6 +26,8 @@ def setup_pacman(state: MkosiState, repositories: Iterable[PacmanRepository]) ->
     with umask(~0o755):
         (state.root / "var/lib/pacman").mkdir(exist_ok=True, parents=True)
 
+    (state.cache_dir / "cache/pacman/pkg").mkdir(parents=True, exist_ok=True)
+
     config = state.pkgmngr / "etc/pacman.conf"
     if config.exists():
         return
@@ -67,14 +69,11 @@ def setup_pacman(state: MkosiState, repositories: Iterable[PacmanRepository]) ->
 
 
 def pacman_cmd(state: MkosiState) -> list[PathString]:
-    with umask(~0o755):
-        (state.cache_dir / "pacman/pkg").mkdir(parents=True, exist_ok=True)
-
     return [
         "pacman",
         "--root", state.root,
         "--logfile=/dev/null",
-        "--cachedir", state.cache_dir / "pacman/pkg",
+        "--cachedir", state.cache_dir / "cache/pacman/pkg",
         "--hookdir", state.root / "etc/pacman.d/hooks",
         "--arch", state.config.distribution.architecture(state.config.architecture),
         "--color", "auto",

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -61,7 +61,7 @@ def zypper_cmd(state: MkosiState) -> list[PathString]:
         "HOME=/",
         "zypper",
         f"--installroot={state.root}",
-        f"--cache-dir={state.cache_dir / 'zypp'}",
+        f"--cache-dir={state.cache_dir / 'cache/zypp'}",
         "--gpg-auto-import-keys" if state.config.repository_key_check else "--no-gpg-checks",
         "--non-interactive",
     ]

--- a/mkosi/mounts.py
+++ b/mkosi/mounts.py
@@ -75,6 +75,7 @@ def mount_overlay(
     lowerdirs: Sequence[Path],
     upperdir: Optional[Path] = None,
     where: Optional[Path] = None,
+    lazy: bool = False,
 ) -> Iterator[Path]:
     with contextlib.ExitStack() as stack:
         if upperdir is None:
@@ -114,7 +115,7 @@ def mount_overlay(
             options.append("userxattr")
 
         try:
-            with mount("overlay", where, options=options, type="overlay"):
+            with mount("overlay", where, options=options, type="overlay", lazy=lazy):
                 yield where
         finally:
             delete_whiteout_files(upperdir)

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -595,10 +595,10 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 : `mkosi` will look for the package manager configuration and related
   files in the configured package manager trees. Unless specified
-  otherwise, it will use the configuration file from its canonical
-  location in `/etc` in the package manager trees. For example, it will
-  look for `etc/dnf/dnf.conf` in the package manager trees if `dnf` is
-  used to install packages.
+  otherwise, it will use the configuration files from their canonical
+  locations in `/usr` or `/etc` in the package manager trees. For
+  example, it will look for `etc/dnf/dnf.conf` in the package manager
+  trees if `dnf` is used to install packages.
 
 : `SkeletonTrees=` and `PackageManagerTrees=` fulfill similar roles. Use
   `SkeletonTrees=` if you want the files to be present in the final image. Use

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -2213,11 +2213,6 @@ Note that despite the name, qemu's `-append` option replaces
 the default kernel commandline embedded in the kernel
 and any previous `-append` specifications.
 
-`mkosi` builds a Unified Kernel Image (UKI).
-Further customization, e.g. a splash image, can be applied using a configuration
-for `ukify` in `/etc/kernel/uki.conf` inside the skeleton tree.
-`ukify` is run from the same working directory as mkosi itself.
-
 The UKI is also copied into the output directory and may be booted directly:
 ```console
 $ mkosi qemu -kernel mkosi.output/fedora~38/image.efi


### PR DESCRIPTION
Let's allow package manager configuration to be put in /usr as well by simply overlaying /usr from the package manager tree on top of /usr.