### PR TITLE
Drop SYSTEMD_LOG_LEVEL=debug when installing systemd-boot

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -808,7 +808,7 @@ def install_systemd_boot(state: MkosiState) -> None:
         bwrap(
             state,
             ["bootctl", "install", "--root", state.root, "--all-architectures", "--no-variables"],
-            env={"SYSTEMD_ESP_PATH": "/efi", "SYSTEMD_LOG_LEVEL": "debug"},
+            env={"SYSTEMD_ESP_PATH": "/efi"},
         )
 
         if state.config.shim_bootloader != ShimBootloader.none:


### PR DESCRIPTION
This seems to have gotten in accidentally.