### PR TITLE
Move creation of /etc/static symlink to package manager tree setup

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1292,15 +1292,19 @@ def install_skeleton_trees(state: MkosiState) -> None:
 
 
 def install_package_manager_trees(state: MkosiState) -> None:
+    # Ensure /etc exists in the package manager tree
+    (state.pkgmngr / "etc").mkdir(exist_ok=True)
+
+    # Required to be able to access certificates in the sandbox when running from nix.
+    if Path("/etc/static").is_symlink():
+        (state.pkgmngr / "etc/static").symlink_to(Path("/etc/static").readlink())
+
     if not state.config.package_manager_trees:
         return
 
     with complete_step("Copying in package manager file trees…"):
         for tree in state.config.package_manager_trees:
             install_tree(state, tree.source, state.workspace / "pkgmngr", tree.target)
-
-    # Ensure /etc exists in the package manager tree
-    (state.pkgmngr / "etc").mkdir(exist_ok=True)
 
 
 def install_extra_trees(state: MkosiState) -> None:

--- a/mkosi/bubblewrap.py
+++ b/mkosi/bubblewrap.py
@@ -111,9 +111,6 @@ def bwrap(
         if p.is_symlink():
             cmdline += ["--symlink", p.readlink(), p]
 
-    if Path("/etc/static").is_symlink():
-        cmdline += ["--symlink", Path("/etc/static").readlink(), "/etc/static"]
-
     if network:
         cmdline += ["--bind", "/etc/resolv.conf", "/etc/resolv.conf"]
 


### PR DESCRIPTION
bwrap's --symlink is not idempotent, so let's create the symlink when setting up the package manager tree instead.