### PR TITLE
Use signed-by instead of setting Dir::Etc::trusted

### DIFF
--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -45,26 +45,29 @@ class Installer(DistributionInstaller):
             return [f"deb [trusted=yes] {state.config.local_mirror} {state.config.release} {components}"]
 
         mirror = state.config.mirror or "http://deb.debian.org/debian"
+        signedby = "[signed-by=/usr/share/keyrings/debian-archive-keyring.gpg]"
 
         repos = [
-            f"{archive} {mirror} {state.config.release} {components}"
+            f"{archive} {signedby} {mirror} {state.config.release} {components}"
             for archive in archives
         ]
 
         # Debug repos are typically not mirrored.
-        repos += [f"deb http://deb.debian.org/debian-debug {state.config.release}-debug {components}"]
+        url = "http://deb.debian.org/debian-debug"
+        repos += [f"deb {signedby} {url} {state.config.release}-debug {components}"]
 
         if state.config.release in ("unstable", "sid"):
             return repos
 
         repos += [
-            f"{archive} {mirror} {state.config.release}-updates {components}"
+            f"{archive} {signedby} {mirror} {state.config.release}-updates {components}"
             for archive in archives
         ]
 
-        # Security updates repos are never mirrored
+        # Security updates repos are never mirrored.
+        url = "http://security.debian.org/debian-security "
         repos += [
-            f"{archive} http://security.debian.org/debian-security {state.config.release}-security {components}"
+            f"{archive} {signedby} {url} {state.config.release}-security {components}"
             for archive in archives
         ]
 

--- a/mkosi/distributions/ubuntu.py
+++ b/mkosi/distributions/ubuntu.py
@@ -26,18 +26,20 @@ class Installer(debian.Installer):
         else:
             mirror = state.config.mirror or "http://ports.ubuntu.com"
 
+        signedby = "[signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg]"
+
         # From kinetic onwards, the usr-is-merged package is available in universe and is required by
         # mkosi to set up a proper usr-merged system so we add the universe repository unconditionally.
         components = ["main"] + (["universe"] if state.config.release not in ("focal", "jammy") else [])
         components = ' '.join((*components, *state.config.repositories))
 
         repos = [
-            f"{archive} {mirror} {state.config.release} {components}"
+            f"{archive} {signedby} {mirror} {state.config.release} {components}"
             for archive in archives
         ]
 
         repos += [
-            f"{archive} {mirror} {state.config.release}-updates {components}"
+            f"{archive} {signedby} {mirror} {state.config.release}-updates {components}"
             for archive in archives
         ]
 
@@ -48,7 +50,7 @@ class Installer(debian.Installer):
             mirror = "http://ports.ubuntu.com/"
 
         repos += [
-            f"{archive} {mirror} {state.config.release}-security {components}"
+            f"{archive} {signedby} {mirror} {state.config.release}-security {components}"
             for archive in archives
         ]
 

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -47,11 +47,6 @@ def setup_apt(state: MkosiState, repos: Sequence[str]) -> None:
 def apt_cmd(state: MkosiState, command: str) -> list[PathString]:
     debarch = state.config.distribution.architecture(state.config.architecture)
 
-    trustedkeys = state.pkgmngr / "etc/apt/trusted.gpg"
-    trustedkeys = (
-        trustedkeys if trustedkeys.exists() else f"/usr/share/keyrings/{state.config.distribution}-archive-keyring.gpg"
-    )
-
     cmdline: list[PathString] = [
         "env",
         f"APT_CONFIG={state.workspace / 'apt.conf'}",
@@ -71,7 +66,6 @@ def apt_cmd(state: MkosiState, command: str) -> list[PathString]:
         "-o", f"Dir::Cache={state.cache_dir / 'cache/apt'}",
         "-o", f"Dir::State={state.cache_dir / 'lib/apt'}",
         "-o", f"Dir::State::Status={state.root / 'var/lib/dpkg/status'}",
-        "-o", f"Dir::Etc::Trusted={trustedkeys}",
         "-o", f"Dir::Log={state.workspace}",
         "-o", f"Dir::Bin::DPkg={shutil.which('dpkg')}",
         "-o", "Debug::NoLocking=true",


### PR DESCRIPTION
apt complains about using the latter so let's use signed-by.