### PR TITLE
Use bubblewrap to set up the tools tree instead of doing it ourselves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,6 @@ jobs:
           - opensuse
           - ubuntu
         tools:
-          - ""
           # TODO: Enable again when https://gitlab.com/qemu-project/qemu/-/issues/2070 is fixed and available in Arch.
           # - arch
           - debian
@@ -175,5 +174,5 @@ jobs:
             --verbose \
             -m integration \
             --distribution ${{ matrix.distro }} \
-            $([[ -n "${{ matrix.tools }}" ]] && echo --tools-tree-distribution=${{ matrix.tools }}) \
+            --tools-tree-distribution ${{ matrix.tools }} \
             tests/

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,12 +2,16 @@
 
 ## v20
 
+- The github action does not build and install systemd from source
+  anymore. Instead, `ToolsTree=default` can be used to make sure a
+  recent version of systemd is used to do the image build.
 - Added `EnvironmentFiles=` to read environment variables from
   environment files.
 - We drastically reduced how much of the host system we expose to
   scripts. Aside from `/usr`, a few directories in `/etc`, `/tmp`,
-  `/var/tmp` and various directory configured in mkosi settings, all
-  host directories are hidden from scripts and package managers.
+  `/var/tmp` and various directories configured in mkosi settings, all
+  host directories are hidden from scripts, package managers and other
+  tools executed by mkosi.
 - Added `SELinuxRelabel=` to specify whether to relabel selinux files
   or not.
 - Many fixes to tools trees were made and tools trees are now covered by

--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,5 @@
 name: setup-mkosi
-description: Install mkosi and all its dependencies
+description: Install mkosi
 
 runs:
   using: composite
@@ -40,91 +40,15 @@ runs:
       sudo apt-get update
       sudo apt-get install --assume-yes --no-install-recommends \
         archlinux-keyring \
-        btrfs-progs \
         bubblewrap \
         debian-archive-keyring \
         dnf \
-        e2fsprogs \
-        erofs-utils \
-        mtools \
-        ovmf \
         pacman-package-manager \
-        python3-pefile \
-        python3-pyelftools \
-        qemu-system-x86 \
-        squashfs-tools \
-        swtpm \
         systemd-container \
-        xfsprogs \
         zypper
 
       sudo pacman-key --init
       sudo pacman-key --populate archlinux
-
-  - name: Update systemd
-    shell: bash
-    working-directory: ${{ github.action_path }}
-    run: |
-      echo "deb-src http://archive.ubuntu.com/ubuntu/ $(lsb_release -cs) main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
-      sudo apt-get update
-      sudo apt-get build-dep systemd
-      sudo apt-get install --assume-yes --no-install-recommends libfdisk-dev libtss2-dev
-
-      git clone https://github.com/systemd/systemd-stable --single-branch --branch=v255-stable --depth=1 systemd
-      meson setup systemd/build systemd \
-        -D repart=true \
-        -D efi=true \
-        -D bootloader=true \
-        -D ukify=true \
-        -D firstboot=true \
-        -D blkid=true \
-        -D openssl=true \
-        -D tpm2=true
-
-      BINARIES=(
-        bootctl
-        kernel-install
-        systemctl
-        systemd-dissect
-        systemd-firstboot
-        systemd-measure
-        systemd-nspawn
-        systemd-repart
-        udevadm
-        ukify
-      )
-
-      ninja -C systemd/build ${BINARIES[@]}
-
-      for BINARY in "${BINARIES[@]}"; do
-        sudo ln -svf $PWD/systemd/build/$BINARY /usr/bin/$BINARY
-        $BINARY --version
-      done
-
-  # Make sure we have mkfs.xfs that can handle spaces in protofiles.
-  # TODO: Drop when we move to the next Ubuntu LTS.
-  - name: Update xfsprogs
-    shell: bash
-    working-directory: ${{ github.action_path }}
-    run: |
-      sudo apt-get install --assume-yes --no-install-recommends \
-        make \
-        gcc \
-        autoconf \
-        automake \
-        libtool \
-        libdevmapper-dev \
-        libblkid-dev \
-        libicu-dev \
-        libedit-dev \
-        libinih-dev \
-        liburcu-dev \
-        uuid-dev
-
-      git clone --single-branch --branch v6.4.0 https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git
-      cd xfsprogs-dev
-      make -j $(nproc)
-      sudo make install
 
   - name: Install
     shell: bash

--- a/mkosi/__main__.py
+++ b/mkosi/__main__.py
@@ -2,7 +2,6 @@
 # PYTHON_ARGCOMPLETE_OK
 
 import faulthandler
-import shutil
 import signal
 import sys
 from types import FrameType
@@ -11,7 +10,7 @@ from typing import Optional
 from mkosi import run_verb
 from mkosi.config import parse_config
 from mkosi.log import log_setup
-from mkosi.run import run, uncaught_exception_handler
+from mkosi.run import find_binary, run, uncaught_exception_handler
 from mkosi.util import INVOKING_USER
 
 
@@ -34,7 +33,7 @@ def main() -> None:
     try:
         run_verb(args, images)
     finally:
-        if sys.stderr.isatty() and shutil.which("tput"):
+        if sys.stderr.isatty() and find_binary("tput"):
             run(["tput", "cnorm"], check=False)
             run(["tput", "smam"], check=False)
 

--- a/mkosi/archive.py
+++ b/mkosi/archive.py
@@ -1,18 +1,17 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 import os
-import shutil
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Optional
 
-from mkosi.bubblewrap import bwrap
 from mkosi.context import Context
 from mkosi.log import log_step
-from mkosi.mounts import finalize_passwd_mounts
+from mkosi.run import find_binary, run
+from mkosi.sandbox import finalize_passwd_mounts
 
 
-def tar_binary() -> str:
+def tar_binary(context: Context) -> str:
     # Some distros (Mandriva) install BSD tar as "tar", hence prefer
     # "gtar" if it exists, which should be GNU tar wherever it exists.
     # We are interested in exposing same behaviour everywhere hence
@@ -20,11 +19,11 @@ def tar_binary() -> str:
     # everywhere. In particular given the limited/different SELinux
     # support in BSD tar and the different command line syntax
     # compared to GNU tar.
-    return "gtar" if shutil.which("gtar") else "tar"
+    return "gtar" if find_binary("gtar", root=context.config.tools()) else "tar"
 
 
-def cpio_binary() -> str:
-    return "gcpio" if shutil.which("gcpio") else "cpio"
+def cpio_binary(context: Context) -> str:
+    return "gcpio" if find_binary("gcpio", root=context.config.tools()) else "cpio"
 
 
 def tar_exclude_apivfs_tmp() -> list[str]:
@@ -40,10 +39,9 @@ def tar_exclude_apivfs_tmp() -> list[str]:
 
 def make_tar(context: Context, src: Path, dst: Path) -> None:
     log_step(f"Creating tar archive {dst}…")
-    bwrap(
-        context,
+    run(
         [
-            tar_binary(),
+            tar_binary(context),
             "--create",
             "--file", dst,
             "--directory", src,
@@ -60,17 +58,22 @@ def make_tar(context: Context, src: Path, dst: Path) -> None:
             ".",
         ],
         # Make sure tar uses user/group information from the root directory instead of the host.
-        options=finalize_passwd_mounts(src) if (src / "etc/passwd").exists() else [],
+        sandbox=context.sandbox(
+            options=[
+                "--bind", dst.parent, dst.parent,
+                "--ro-bind", src, src,
+                *(finalize_passwd_mounts(src) if (src / "etc/passwd").exists() else []),
+            ],
+        ),
     )
 
 
 def extract_tar(context: Context, src: Path, dst: Path, log: bool = True) -> None:
     if log:
         log_step(f"Extracting tar archive {src}…")
-    bwrap(
-        context,
+    run(
         [
-            tar_binary(),
+            tar_binary(context),
             "--extract",
             "--file", src,
             "--directory", dst,
@@ -86,7 +89,13 @@ def extract_tar(context: Context, src: Path, dst: Path, log: bool = True) -> Non
             *tar_exclude_apivfs_tmp(),
         ],
         # Make sure tar uses user/group information from the root directory instead of the host.
-        options=finalize_passwd_mounts(dst) if (dst / "etc/passwd").exists() else [],
+        sandbox=context.sandbox(
+            options=[
+                "--bind", dst, dst,
+                "--ro-bind", src, src,
+                *(finalize_passwd_mounts(dst) if (dst / "etc/passwd").exists() else []),
+            ],
+        ),
     )
 
 
@@ -96,10 +105,9 @@ def make_cpio(context: Context, src: Path, dst: Path, files: Optional[Iterable[P
     files = sorted(files)
 
     log_step(f"Creating cpio archive {dst}…")
-    bwrap(
-        context,
+    run(
         [
-            cpio_binary(),
+            cpio_binary(context),
             "--create",
             "--reproducible",
             "--null",
@@ -110,5 +118,11 @@ def make_cpio(context: Context, src: Path, dst: Path, files: Optional[Iterable[P
         ],
         input="\0".join(os.fspath(f.relative_to(src)) for f in files),
         # Make sure cpio uses user/group information from the root directory instead of the host.
-        options=finalize_passwd_mounts(dst),
+        sandbox=context.sandbox(
+            options=[
+                "--bind", dst.parent, dst.parent,
+                "--ro-bind", src, src,
+                *finalize_passwd_mounts(dst),
+            ],
+        ),
     )

--- a/mkosi/burn.py
+++ b/mkosi/burn.py
@@ -37,4 +37,5 @@ def run_burn(args: Args, config: Config) -> None:
             stdout=sys.stdout,
             env=os.environ,
             log=False,
+            sandbox=config.sandbox(devices=True, network=True, relaxed=True),
         )

--- a/mkosi/installer/rpm.py
+++ b/mkosi/installer/rpm.py
@@ -6,8 +6,8 @@ import subprocess
 from pathlib import Path
 from typing import NamedTuple, Optional
 
-from mkosi.bubblewrap import bwrap
 from mkosi.context import Context
+from mkosi.run import run
 from mkosi.tree import rmtree
 from mkosi.types import PathString
 
@@ -23,9 +23,9 @@ class RpmRepository(NamedTuple):
 
 
 def find_rpm_gpgkey(context: Context, key: str, url: str) -> str:
-    gpgpath = next(Path("/usr/share/distribution-gpg-keys").rglob(key), None)
+    gpgpath = next((context.config.tools() / "usr/share/distribution-gpg-keys").rglob(key), None)
     if gpgpath:
-        return f"file://{gpgpath}"
+        return f"file://{Path('/') / gpgpath.relative_to(context.config.tools())}"
 
     gpgpath = next(Path(context.pkgmngr / "etc/pki/rpm-gpg").rglob(key), None)
     if gpgpath:
@@ -40,26 +40,27 @@ def setup_rpm(context: Context) -> None:
     if not (confdir / "macros.lang").exists() and context.config.locale:
         (confdir / "macros.lang").write_text(f"%_install_langs {context.config.locale}")
 
-    plugindir = Path(bwrap(context, ["rpm", "--eval", "%{__plugindir}"], stdout=subprocess.PIPE).stdout.strip())
-    if plugindir.exists():
+    plugindir = Path(run(["rpm", "--eval", "%{__plugindir}"],
+                         sandbox=context.sandbox(), stdout=subprocess.PIPE).stdout.strip())
+    if (plugindir := context.config.tools() / plugindir.relative_to("/")).exists():
         with (confdir / "macros.disable-plugins").open("w") as f:
             for plugin in plugindir.iterdir():
                 f.write(f"%__transaction_{plugin.stem} %{{nil}}\n")
 
 
-def fixup_rpmdb_location(root: Path) -> None:
+def fixup_rpmdb_location(context: Context) -> None:
     # On Debian, rpm/dnf ship with a patch to store the rpmdb under ~/ so it needs to be copied back in the
     # right location, otherwise the rpmdb will be broken. See: https://bugs.debian.org/1004863. We also
     # replace it with a symlink so that any further rpm operations immediately use the correct location.
-    rpmdb_home = root / "root/.rpmdb"
+    rpmdb_home = context.root / "root/.rpmdb"
     if not rpmdb_home.exists() or rpmdb_home.is_symlink():
         return
 
     # Take into account the new location in F36
-    rpmdb = root / "usr/lib/sysimage/rpm"
+    rpmdb = context.root / "usr/lib/sysimage/rpm"
     if not rpmdb.exists():
-        rpmdb = root / "var/lib/rpm"
-    rmtree(rpmdb)
+        rpmdb = context.root / "var/lib/rpm"
+    rmtree(rpmdb, sandbox=context.sandbox(options=["--bind", rpmdb.parent, rpmdb.parent]))
     shutil.move(rpmdb_home, rpmdb)
     rpmdb_home.symlink_to(os.path.relpath(rpmdb, start=rpmdb_home.parent))
 

--- a/mkosi/partition.py
+++ b/mkosi/partition.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 
 from mkosi.log import die
 from mkosi.run import run
+from mkosi.types import PathString
 
 
 @dataclasses.dataclass(frozen=True)
@@ -30,9 +31,10 @@ class Partition:
     GRUB_BOOT_PARTITION_UUID = "21686148-6449-6e6f-744e-656564454649"
 
 
-def find_partitions(image: Path) -> list[Partition]:
+def find_partitions(image: Path, *, sandbox: Sequence[PathString]) -> list[Partition]:
     output = json.loads(run(["systemd-repart", "--json=short", image],
-                        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL).stdout)
+                            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                            sandbox=sandbox).stdout)
     return [Partition.from_dict(d) for d in output]
 
 

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -124,13 +124,6 @@ def make_executable(*paths: Path) -> None:
         os.chmod(path, st.st_mode | stat.S_IEXEC)
 
 
-def try_import(module: str) -> None:
-    try:
-        importlib.import_module(module)
-    except ModuleNotFoundError:
-        pass
-
-
 @contextlib.contextmanager
 def flock(path: Path) -> Iterator[int]:
     fd = os.open(path, os.O_CLOEXEC|os.O_RDONLY)


### PR DESCRIPTION
The problem with overmounting the host's /usr (in a private mount
namespace) is that we have no control over the symlinks in the root
directory (/lib, /bin, /lib64) and if these symlinks don't match
between the host distribution and the tools tree distribution, all
kinds of weird breakage starts happening. For example, using Fedora
tools trees on Arch Linux is currently broken because /lib64 on Arch
Linux points to /usr/lib whereas on Fedora it points to /usr/lib64.

Because we can't (and shouldn't) modify the symlinks of the host's
root filesystem, we need to set up the tools tree in a sandbox that
we chroot into, so that we have full control over the rootfs of the
sandbox and can make sure the symlinks are correct. Luckily, we
already do just that with bubblewrap, except that currently we mount
the tools tree over /usr ourselves and then just carry that over into
the bubblewrap sandbox.

Instead, we stop mounting over the host's /usr ourselves and have
bubblewrap pick the right /usr itself. We also copy the symlinks from
the tools tree or the host if there is no tools tree.

Because we don't mount over the host's /usr anymore, we have to run
every tool that should come from the tools tree with bubblewrap now.
The side effect of this is that almost all of our tools now run
sandboxed. We also have to make use of find_binary() everywhere
instead of shutil.which() to make sure we look for binaries in the
tools tree when required. Various other codepaths that look into /usr
also have to be modified to look into the tools tree when needed.

Also, because we don't unshare the user namespace in the main mkosi
process anymore now, we can get rid of a lot of chown()'s in qemu.py
and opening the qemu device file descriptors can be moved into
run_qemu() itself.

We also don't have to make sure all python modules are loaded anymore
as the host's /usr is never overmounted so the required python modules
will be available for the entire runtime of the mkosi process.

Because virtiofsd is now executed with bubblewrap, we use bubblewrap
to set up the required uidmap instead of relying on virtiofsd to do it
with newuidmap/newgidmap. Note that this breaks RuntimeTrees= as
virtiofsd unconditionally tries to drop groups with setgroups() which
fails with EPERM in an unprivileged user namespace set up by bubblewrap.
This is fixed by https://gitlab.com/virtio-fs/virtiofsd/-/merge_requests/207
which is still awaiting review.

To make this work codewise, this commit renames the bwrap() function
to sandbox_cmd() (similar to chroot_cmd() and apivfs_cmd()) which now
returns a command line instead of executing the command itself. run()
is modified to take an extra "sandbox" arguments which is simply the
part of the full command that sets up the sandbox. Context and Config
both learn new sandbox() methods which set up the sandbox for each
object respectively (mostly by adding extra bind mounts).


Because almost every call to run() now takes a sandbox, this gives us
a lot of control over the individual environment for each tool we run.
We make use of this to restrict each tool we run to the minimal possible
sandbox that that tool needs to run. By specifically mounting in the
required paths for each tool we run, we also make sure these are always
available instead of relying that somewhere we mount a path that has the
input in it.

Because we allow passing arbitrary options to mkosi qemu, mkosi boot and
various other verbs, we run these verbs with a relaxed sandbox, where we
mount in most directories from the host. This means that whatever
directories users specify will be available.

In terms of CI, the extra sandboxing means that our previous approach of
building various systemd binaries from source and symlinking them to
/usr/bin doesn't work anymore. Instead, we opt to always use tools trees
and drop the host builds from the testing matrix. This also simplifies
and speeds up the github action as we don't have to compile systemd and
xfsprogs from source and we have to install fewer packages.