### PR TITLE
ci: Add systemd-ukify to Debian packages

### DIFF
--- a/mkosi.conf.d/20-debian-ubuntu/mkosi.conf
+++ b/mkosi.conf.d/20-debian-ubuntu/mkosi.conf
@@ -6,6 +6,7 @@ Distribution=|ubuntu
 
 [Content]
 Packages=
+        ?exact-name(systemd-ukify)
         apt
         archlinux-keyring
         bash

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -204,6 +204,7 @@ def find_ovmf_firmware(config: MkosiConfig) -> tuple[Path, bool]:
         "/usr/share/edk2-ovmf/OVMF_CODE.secboot.fd",
         "/usr/share/qemu/OVMF_CODE.secboot.fd",
         "/usr/share/ovmf/OVMF.secboot.fd",
+        "/usr/share/OVMF/OVMF_CODE_4M.secboot.fd",
         "/usr/share/OVMF/OVMF_CODE.secboot.fd",
     ]
 
@@ -216,6 +217,7 @@ def find_ovmf_firmware(config: MkosiConfig) -> tuple[Path, bool]:
         "/usr/share/edk2-ovmf/OVMF_CODE.fd",
         "/usr/share/qemu/OVMF_CODE.fd",
         "/usr/share/ovmf/OVMF.fd",
+        "/usr/share/OVMF/OVMF_CODE_4M.fd",
         "/usr/share/OVMF/OVMF_CODE.fd",
     ]
 
@@ -246,11 +248,14 @@ def find_ovmf_vars(config: MkosiConfig) -> Path:
     elif config.architecture == Architecture.arm64:
         OVMF_VARS_LOCATIONS += ["/usr/share/AAVMF/AAVMF_VARS.fd"]
 
-    OVMF_VARS_LOCATIONS += ["/usr/share/edk2/ovmf/OVMF_VARS.fd",
-                            "/usr/share/edk2-ovmf/OVMF_VARS.fd",
-                            "/usr/share/qemu/OVMF_VARS.fd",
-                            "/usr/share/ovmf/OVMF_VARS.fd",
-                            "/usr/share/OVMF/OVMF_VARS.fd"]
+    OVMF_VARS_LOCATIONS += [
+        "/usr/share/edk2/ovmf/OVMF_VARS.fd",
+        "/usr/share/edk2-ovmf/OVMF_VARS.fd",
+        "/usr/share/qemu/OVMF_VARS.fd",
+        "/usr/share/ovmf/OVMF_VARS.fd",
+        "/usr/share/OVMF/OVMF_VARS_4M.fd",
+        "/usr/share/OVMF/OVMF_VARS.fd",
+    ]
 
     for location in OVMF_VARS_LOCATIONS:
         if os.path.exists(location):

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu.conf
@@ -6,6 +6,7 @@ Distribution=|ubuntu
 
 [Content]
 Packages=
+        ?exact-name(systemd-ukify)
         apt
         archlinux-keyring
         btrfs-progs


### PR DESCRIPTION
At least on trixie and sid it's a package of its own now. Let's see whether CI stops complaining with this.