### PR TITLE
Disable debsig for dpkg by default as they do in debian.

### DIFF
--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -73,6 +73,7 @@ def apt_cmd(state: MkosiState, command: str) -> list[PathString]:
         "-o", "DPkg::Options::=--force-unsafe-io",
         "-o", "DPkg::Options::=--force-architecture",
         "-o", "DPkg::Options::=--force-depends",
+        "-o", "DPkg::Options::=--no-debsig",
         "-o", "DPkg::Use-Pty=false",
         "-o", "DPkg::Install::Recursive::Minimum=1000",
         "-o", "pkgCacheGen::ForceEssential=,",


### PR DESCRIPTION
From the default dpkg.conf:
```
# Do not enable debsig-verify by default; since the distribution is not using
# embedded signatures, debsig-verify would reject all packages.
no-debsig
```

Fixes https://github.com/systemd/mkosi/issues/2225.