### PR TITLE
Mount /etc/alternatives if it exists

### DIFF
--- a/mkosi/bubblewrap.py
+++ b/mkosi/bubblewrap.py
@@ -86,6 +86,7 @@ def bwrap(
         # This mount is writable so bwrap can create extra directories or symlinks inside of it as needed. This isn't a
         # problem as the package manager directory is created by mkosi and thrown away when the build finishes.
         "--bind", state.pkgmngr / "etc", "/etc",
+        "--ro-bind-try", "/etc/alternatives", "/etc/alternatives",
         "--bind", "/var/tmp", "/var/tmp",
         "--bind", "/tmp", "/tmp",
         "--bind", Path.cwd(), Path.cwd(),


### PR DESCRIPTION
In (at least) Debian, some binaries such as awk point to /etc/alternatives which would not exist and cause apt-key to fail without specifying the exact keyring (e.g. when using /etc/apt/trusted.gpg.d)

Fixes #2227