### PR TITLE
Don't use smm on aarch64

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -352,6 +352,9 @@ class Architecture(StrEnum):
     def supports_fw_cfg(self) -> bool:
         return self in (Architecture.x86, Architecture.x86_64, Architecture.arm, Architecture.arm64)
 
+    def supports_smm(self) -> bool:
+        return self in (Architecture.x86, Architecture.x86_64)
+
     def default_qemu_machine(self) -> str:
         m = {
             Architecture.x86      : "q35",

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -537,7 +537,7 @@ def run_qemu(args: MkosiArgs, config: MkosiConfig, qemu_device_fds: Mapping[Qemu
 
     machine = f"type={config.architecture.default_qemu_machine()}"
     if firmware == QemuFirmware.uefi:
-        machine += f",smm={'on' if ovmf_supports_sb else 'off'}"
+        machine += f",smm={'on' if ovmf_supports_sb and config.architecture.supports_smm() else 'off'}"
     if shm:
         machine += ",memory-backend=mem"
 


### PR DESCRIPTION
This property is only supported on the x86 machines so stop trying to use it on arm.