### PR TITLE
initrd: Install util-linux-core on Fedora

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -12,8 +12,6 @@ MakeInitrd=yes
 Packages=
         systemd                   # sine qua non
         udev
-        util-linux                # Make sure we pull in util-linux instead of util-linux-core as the latter does not
-                                  # include sulogin which is required for emergency logins
         bash                      # for emergency logins
         less                      # this makes 'systemctl' much nicer to use ;)
         p11-kit                   # dl-opened by systemd

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-arch.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-arch.conf
@@ -14,6 +14,8 @@ Packages=
         libfido2
         tpm2-tss
 
+        util-linux
+
 RemoveFiles=
         # Arch Linux doesn't split their gcc-libs package so we manually remove
         # unneeded stuff here to make sure it doesn't end up in the initrd.

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-centos.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-centos.conf
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=|centos
+Distribution=|alma
+Distribution=|rocky
+Distribution=|rhel
+
+[Content]
+Packages=
+        util-linux

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-ubuntu.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-ubuntu.conf
@@ -13,6 +13,8 @@ Packages=
         # isn't used on Debian so we don't install xfsprogs.
         e2fsprogs
 
+        util-linux
+
         # Various libraries that are dlopen'ed by systemd
         libfido2-1
         ^libtss2-esys-[0-9\.]+-0$

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-fedora.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-fedora.conf
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=fedora
+
+[Content]
+Packages=
+        util-linux-core

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-opensuse.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-opensuse.conf
@@ -15,6 +15,8 @@ Packages=
 
         # fsck.btrfs is a dummy, checking is done in the kernel.
 
+        util-linux
+
 RemoveFiles=
         /usr/share/locale/*
         /usr/etc/services


### PR DESCRIPTION
With https://bodhi.fedoraproject.org/updates/FEDORA-2023-7ba9a1b546, sulogin is moved to util-linux-core on Fedora which means util-linux-core has everything required for the initrd so let's use util-linux-core instead of util-linux to save on disk space.