### PR TITLE
Add serpentOS and moss support

### DIFF
--- a/mkosi.conf.d/20-serpentos.conf
+++ b/mkosi.conf.d/20-serpentos.conf
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=serpentos
+
+[Content]
+ShimBootloader=none
+# Override the entire Packages thing:
+# Serpent OS has no attr, autoconf, automake, ca-certificates, ...
+Packages=
+Packages=
+        dash # provides /usr/bin/sh for now...
+        linux-kvm
+        moss
+        systemd

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -21,6 +21,7 @@ class PackageType(StrEnum):
     deb    = enum.auto()
     pkg    = enum.auto()
     ebuild = enum.auto()
+    moss   = enum.auto()
 
 
 class DistributionInstaller:
@@ -93,6 +94,7 @@ class Distribution(StrEnum):
     centos       = enum.auto()
     rhel         = enum.auto()
     rhel_ubi     = enum.auto()
+    serpentos    = enum.auto()
     openmandriva = enum.auto()
     rocky        = enum.auto()
     alma         = enum.auto()

--- a/mkosi/distributions/serpentos.py
+++ b/mkosi/distributions/serpentos.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
+from collections.abc import Iterable, Sequence
+
+from mkosi.config import Architecture, Config
+from mkosi.context import Context
+from mkosi.distributions import Distribution, DistributionInstaller, PackageType
+from mkosi.installer import PackageManager
+from mkosi.installer.moss import Moss
+from mkosi.log import die
+
+
+class Installer(DistributionInstaller):
+    @classmethod
+    def pretty_name(cls) -> str:
+        return "iSerpent OS"
+
+    @classmethod
+    def filesystem(cls) -> str:
+        return "btrfs"
+
+    @classmethod
+    def package_type(cls) -> PackageType:
+        return PackageType.moss
+
+    @classmethod
+    def default_release(cls) -> str:
+        return "rolling"
+
+    @classmethod
+    def default_tools_tree_distribution(cls) -> Distribution:
+        return Distribution.serpentos
+
+    @classmethod
+    def package_manager(cls, config: "Config") -> type[PackageManager]:
+        return Moss
+
+    @classmethod
+    def createrepo(cls, context: Context) -> None:
+        pass
+
+    @classmethod
+    def setup(cls, context: Context) -> None:
+        Moss.setup(context, cls.repositories(context))
+
+    @classmethod
+    def sync(cls, context: Context) -> None:
+        pass
+
+    @classmethod
+    def install(cls, context: Context) -> None:
+        # needed for moss to copy the kernel later
+        (context.root / "boot").mkdir(exist_ok=True)
+
+    @classmethod
+    def install_packages(cls, context: Context, packages: Sequence[str], apivfs: bool = True) -> None:
+        Moss.invoke(
+            context,
+            "install",
+            [],
+            packages,
+            apivfs=apivfs,
+        )
+
+    @classmethod
+    def remove_packages(cls, context: Context, packages: Sequence[str]) -> None:
+        Moss.invoke(context, "remove", [], packages)
+
+    @classmethod
+    def repositories(cls, context: Context) -> Iterable[Moss.Repository]:
+        url = "https://dev.serpentos.com/volatile/x86_64/stone.index"
+        if context.config.local_mirror:
+            url = context.config.local_mirror
+
+        yield Moss.Repository("volatile", "Default repository", url, 1000)
+
+    @classmethod
+    def architecture(cls, arch: Architecture) -> str:
+        a = {
+            Architecture.x86_64 : "x86_64",
+        }.get(arch)
+
+        if not a:
+            die(f"Architecture {a} is not supported by {cls.pretty_name()}")
+
+        return a
+

--- a/mkosi/installer/__init__.py
+++ b/mkosi/installer/__init__.py
@@ -102,6 +102,7 @@ def clean_package_manager_metadata(context: Context) -> None:
     for tool, paths in (("rpm",      ["var/lib/rpm", "usr/lib/sysimage/rpm"]),
                         ("dnf5",     ["usr/lib/sysimage/libdnf5"]),
                         ("dpkg",     ["var/lib/dpkg"]),
+                        ("moss",     [".moss"]),
                         (executable, [f"var/lib/{subdir}", f"var/cache/{subdir}"])):
         if always or not find_binary(tool, root=context.root):
             rmtree(*(context.root / p for p in paths if (context.root / p).exists()), sandbox=context.sandbox)

--- a/mkosi/installer/moss.py
+++ b/mkosi/installer/moss.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
+import os
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+from typing import NamedTuple
+
+from mkosi.config import Config
+from mkosi.context import Context
+from mkosi.installer import PackageManager
+from mkosi.mounts import finalize_source_mounts
+from mkosi.run import find_binary, run
+from mkosi.sandbox import apivfs_cmd
+from mkosi.types import PathString
+from mkosi.util import sort_packages
+
+
+def _moss_cache_dir(context: Context) -> Path:
+    moss_cache_dir = context.config.package_cache_dir_or_default() / "moss"
+    return moss_cache_dir
+
+
+class Moss(PackageManager):
+    class Repository(NamedTuple):
+        id: str
+        description: str
+        uri: str
+        priority: int
+
+    @classmethod
+    def executable(cls, config: Config) -> str:
+        # Allow the user to override autodetection with an environment variable
+        moss = config.environment.get("MKOSI_MOSS")
+        root = config.tools()
+
+        return Path(moss or find_binary("moss", root=root) or "moss").name
+
+    @classmethod
+    def subdir(cls, config: Config) -> Path:
+        return Path("moss")
+
+    @classmethod
+    def cache_subdirs(cls, cache: Path) -> list[Path]:
+        return [
+            p / "moss"
+            for p in cache.iterdir()
+            if p.is_dir() and "-" in p.name and "mkosi" not in p.name
+        ]
+
+    @classmethod
+    def scripts(cls, context: Context) -> dict[str, list[PathString]]:
+        return {
+            "moss": apivfs_cmd(context.root) + cls.cmd(context),
+            "mkosi-install": ["moss", "install"],
+            "mkosi-upgrade": ["moss", "sync"],
+            "mkosi-remove": ["moss", "remove"],
+        }
+
+    @classmethod
+    def mounts(cls, context: Context) -> list[PathString]:
+        return [
+            *super().mounts(context),
+            # Moss has all its cache in `,moss/cache`, mount that from the outside
+            "--bind",
+            _moss_cache_dir(context),
+            Path("/.moss/cache"),
+        ]
+
+    @classmethod
+    def setup(cls, context: Context, repositories: Iterable[Repository]) -> None:
+        # Create custom cache dir for moss
+        moss_cache_dir = _moss_cache_dir(context)
+        moss_cache_dir.mkdir(exist_ok=True)
+        (context.root / ".moss").mkdir(exist_ok=True)
+        (context.root / ".moss" / "cache").mkdir(exist_ok=True)
+
+        for repo in repositories:
+            cls.invoke(
+                context,
+                "repo",
+                [
+                    "add",
+                    "-c",
+                    repo.description,
+                    "-p",
+                    f"{repo.priority}",
+                    repo.id,
+                    repo.uri,
+                ],
+            )
+
+    @classmethod
+    def cmd(cls, context: Context) -> list[PathString]:
+        moss = cls.executable(context.config)
+        return [
+            moss,
+            "--directory",
+            context.root,
+            "--yes-all",
+        ]
+
+    @classmethod
+    def invoke(
+        cls,
+        context: Context,
+        operation: str,
+        options: Sequence[str] = (),
+        packages: Sequence[str] = (),
+        apivfs: bool = True,
+    ) -> None:
+        with finalize_source_mounts(
+            context.config,
+            ephemeral=os.getuid() == 0 and context.config.build_sources_ephemeral,
+        ) as sources:
+            run(
+                cls.cmd(context) + [operation, *options, *sort_packages(packages)],
+                sandbox=(
+                    context.sandbox(
+                        network=True,
+                        options=[
+                            "--bind",
+                            context.root,
+                            context.root,
+                            *cls.mounts(context),
+                            *sources,
+                            "--chdir",
+                            "/work/src",
+                        ],
+                    )
+                    + (apivfs_cmd(context.root) if apivfs else [])
+                ),
+                env=context.config.environment,
+            )

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-serpentos.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-serpentos.conf
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=serpentos
+
+[Content]
+Packages=
+        dash # for /bin/sh
+        # Various libraries that are dlopen'ed by systemd
+
+        # File system checkers for supported root file systems
+        e2fsprogs
+        xfsprogs
+
+        # fsck.btrfs is a dummy, checking is done in the kernel.
+
+        util-linux
+
+RemoveFiles=
+        /.moss
+
+        # Remove all files that are only required for development.
+        /usr/lib/*.a # static libs
+        /usr/lib/gconv # encoding conversion
+        /usr/lib/kernel # kernel-install files
+
+        /usr/share/defaults/*
+        # Remove docs
+        /usr/share/doc/*
+        /usr/share/i18n/*
+        /usr/share/info/*
+        /usr/share/man/*
+
+        # Remove locale config
+        /usr/share/locale/*

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/20-stub.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/20-stub.conf
@@ -3,6 +3,7 @@
 [Match]
 Format=uki
 Distribution=!arch
+Distribution=!serpentos
 
 [Content]
 Packages=systemd-boot


### PR DESCRIPTION
SerpentOS (https://serpentos.com/) is a new Linux distribution that is currently investing heavily into new tooling to build and package software.

It also uses a new package manager called `moss` to quickly install software.

This commit adds support for both serpentos as well as its package manager.

There are a couple of limitations though:

* I did not add tests as building moss needs to be build from rust sources at this time 
* mkosi can not create disk images from inside serpent OS (systemd-repart is too old there)
* You can not create bootable SOS images (systemd-ukify is missing)

The devs are focusing on the tooling right now and did not update the packages in a while.

This PR potentially enables doing tests using mkosi definitions, so I think this PR is valuable even at this time. I think the bit of code that this PR adds will also stay stable: None of the commands used changed in a long time (they were even stable across a rewrite of the entire packager in rust).