### PR TITLE
ci: Disable jobs with arch linux tools trees for now.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,8 @@ jobs:
           - ubuntu
         tools:
           - ""
-          - arch
+          # TODO: Enable again when https://gitlab.com/qemu-project/qemu/-/issues/2070 is fixed and available in Arch.
+          # - arch
           - debian
           - fedora
           - opensuse


### PR DESCRIPTION
Arch has qemu 8.2 which has severely broken TCG acceleration (see https://gitlab.com/qemu-project/qemu/-/issues/2070). Let's disable the jobs with arch tools trees until the bug is fixed.