### PR TITLE
ci: Enable Debian builds with tools trees again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,16 +116,6 @@ jobs:
             tools: opensuse
           - distro: ubuntu
             tools: opensuse
-          # Debian test_boot[cpio] is super flaky on these combinations until the next v255 stable release with
-          # https://github.com/systemd/systemd/pull/30511 is available in Debian unstable.
-          - distro: debian
-            tools: arch
-          - distro: debian
-            tools: fedora
-          - distro: debian
-            tools: centos
-          - distro: debian
-            tools: debian
           # rpm in Debian is currently missing
           # https://github.com/rpm-software-management/rpm/commit/ea3187cfcf9cac87e5bc5e7db79b0338da9e355e
           - distro: fedora

--- a/mkosi.conf.d/20-debian/mkosi.conf
+++ b/mkosi.conf.d/20-debian/mkosi.conf
@@ -4,7 +4,6 @@
 Distribution=debian
 
 [Distribution]
-@Release=unstable
 Repositories=non-free-firmware
 
 [Content]

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -106,6 +106,9 @@ class Distribution(StrEnum):
     def is_apt_distribution(self) -> bool:
         return self in (Distribution.debian, Distribution.ubuntu)
 
+    def pretty_name(self) -> str:
+        return self.installer().pretty_name()
+
     def setup(self, context: "Context") -> None:
         return self.installer().setup(context)
 

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -125,8 +125,7 @@ class Installer(DistributionInstaller):
                     ),
                 ]
 
-        # TODO: Use `filelists=True` when F37 goes EOL.
-        setup_dnf(context, repos, filelists=fedora_release_at_most(context.config.release, "37"))
+        setup_dnf(context, repos, filelists=True)
 
     @classmethod
     def install(cls, context: Context) -> None:
@@ -156,12 +155,3 @@ class Installer(DistributionInstaller):
             die(f"Architecture {a} is not supported by Fedora")
 
         return a
-
-
-def fedora_release_at_most(release: str, threshold: str) -> bool:
-    if release in ("rawhide", "eln"):
-        return False
-    if threshold in ("rawhide", "eln"):
-        return True
-    # If neither is 'rawhide', both must be integers
-    return int(release) <= int(threshold)

--- a/mkosi/manifest.py
+++ b/mkosi/manifest.py
@@ -96,7 +96,6 @@ class Manifest:
             self.record_deb_packages(root)
         if self.config.distribution.package_type() == PackageType.pkg:
             self.record_pkg_packages(root)
-        # TODO: add implementations for other package managers
 
     def record_rpm_packages(self, root: Path) -> None:
         # On Debian, rpm/dnf ship with a patch to store the rpmdb under ~/ so rpm


### PR DESCRIPTION
The required fix in systemd is now in Debian so let's try enabling
these again.