### PR TITLE
Simplify apivfs_cmd() and chroot_cmd()

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -442,7 +442,6 @@ def run_prepare_scripts(context: Context, build: bool) -> None:
             chroot = chroot_cmd(
                 context.root,
                 resolve=True,
-                tools=context.config.tools(),
                 options=[
                     "--bind", "/work", "/work",
                     "--chdir", "/work/src",
@@ -517,7 +516,6 @@ def run_build_scripts(context: Context) -> None:
             chroot = chroot_cmd(
                 context.root,
                 resolve=context.config.with_network,
-                tools=context.config.tools(),
                 options=[
                     "--bind", "/work", "/work",
                     "--chdir", "/work/src",
@@ -587,7 +585,6 @@ def run_postinst_scripts(context: Context) -> None:
             chroot = chroot_cmd(
                 context.root,
                 resolve=context.config.with_network,
-                tools=context.config.tools(),
                 options=[
                     "--bind", "/work", "/work",
                     "--chdir", "/work/src",
@@ -648,7 +645,6 @@ def run_finalize_scripts(context: Context) -> None:
             chroot = chroot_cmd(
                 context.root,
                 resolve=context.config.with_network,
-                tools=context.config.tools(),
                 options=[
                     "--bind", "/work", "/work",
                     "--chdir", "/work/src",

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -43,6 +43,7 @@ from mkosi.config import (
     format_tree,
     parse_config,
     summary,
+    want_selinux_relabel,
     yes_no,
 )
 from mkosi.context import Context
@@ -2354,25 +2355,7 @@ def run_firstboot(context: Context) -> None:
 
 
 def run_selinux_relabel(context: Context) -> None:
-    if context.config.selinux_relabel == ConfigFeature.disabled:
-        return
-
-    selinux = context.root / "etc/selinux/config"
-    if not selinux.exists():
-        if context.config.selinux_relabel == ConfigFeature.enabled:
-            die("SELinux relabel is requested but could not find selinux config at /etc/selinux/config")
-        return
-
-    policy = run(["sh", "-c", f". {selinux} && echo $SELINUXTYPE"],
-                 sandbox=context.sandbox(options=["--ro-bind", selinux, selinux]),
-                 stdout=subprocess.PIPE).stdout.strip()
-    if not policy:
-        if context.config.selinux_relabel == ConfigFeature.enabled:
-            die("SELinux relabel is requested but no selinux policy is configured in /etc/selinux/config")
-        return
-
-    if not find_binary("setfiles", root=context.config.tools()):
-        logging.info("setfiles is not installed, not relabeling files")
+    if not (policy := want_selinux_relabel(context.config, context.root)):
         return
 
     fc = context.root / "etc/selinux" / policy / "contexts/files/file_contexts"

--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -26,7 +26,7 @@ from mkosi.util import sort_packages
 
 def invoke_emerge(context: Context, packages: Sequence[str] = (), apivfs: bool = True) -> None:
     run(
-        apivfs_cmd(context.root, tools=context.config.tools()) + [
+        apivfs_cmd(context.root) + [
             # We can't mount the stage 3 /usr using `options`, because bwrap isn't available in the stage 3
             # tarball which is required by apivfs_cmd(), so we have to mount /usr from the tarball later
             # using another bwrap exec.
@@ -161,7 +161,6 @@ class Installer(DistributionInstaller):
 
         chroot = chroot_cmd(
             stage3,
-            tools=context.config.tools(),
             options=["--bind", context.cache_dir / "repos", "/var/db/repos"],
         )
 

--- a/mkosi/installer/__init__.py
+++ b/mkosi/installer/__init__.py
@@ -41,12 +41,12 @@ def clean_package_manager_metadata(context: Context) -> None:
 
 def package_manager_scripts(context: Context) -> dict[str, list[PathString]]:
     return {
-        "pacman": apivfs_cmd(context.root, tools=context.config.tools()) + pacman_cmd(context),
-        "zypper": apivfs_cmd(context.root, tools=context.config.tools()) + zypper_cmd(context),
-        "dnf"   : apivfs_cmd(context.root, tools=context.config.tools()) + dnf_cmd(context),
-        "rpm"   : apivfs_cmd(context.root, tools=context.config.tools()) + rpm_cmd(context),
+        "pacman": apivfs_cmd(context.root) + pacman_cmd(context),
+        "zypper": apivfs_cmd(context.root) + zypper_cmd(context),
+        "dnf"   : apivfs_cmd(context.root) + dnf_cmd(context),
+        "rpm"   : apivfs_cmd(context.root) + rpm_cmd(context),
     } | {
-        command: apivfs_cmd(context.root, tools=context.config.tools()) + apt_cmd(context, command) for command in (
+        command: apivfs_cmd(context.root) + apt_cmd(context, command) for command in (
             "apt",
             "apt-cache",
             "apt-cdrom",

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -113,7 +113,7 @@ def invoke_apt(
                     *finalize_crypto_mounts(tools=context.config.tools()),
                     *mounts,
                 ],
-            ) + (apivfs_cmd(context.root, tools=context.config.tools()) if apivfs else [])
+            ) + (apivfs_cmd(context.root) if apivfs else [])
         ),
         env=context.config.environment,
     )

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -139,7 +139,7 @@ def invoke_dnf(context: Context, command: str, packages: Iterable[str], apivfs: 
                     context.cache_dir / "lib" / dnf_subdir(context),
                     *finalize_crypto_mounts(tools=context.config.tools()),
                 ],
-            ) + (apivfs_cmd(context.root, tools=context.config.tools()) if apivfs else [])
+            ) + (apivfs_cmd(context.root) if apivfs else [])
         ),
         env=context.config.environment,
     )

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -99,7 +99,7 @@ def invoke_pacman(
                     "--bind", context.cache_dir / "cache/pacman/pkg", context.cache_dir / "cache/pacman/pkg",
                     *finalize_crypto_mounts(tools=context.config.tools()),
                 ],
-            ) + (apivfs_cmd(context.root, tools=context.config.tools()) if apivfs else [])
+            ) + (apivfs_cmd(context.root) if apivfs else [])
         ),
         env=context.config.environment,
     )

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -87,7 +87,7 @@ def invoke_zypper(
                     "--bind", context.cache_dir / "cache/zypp", context.cache_dir / "cache/zypp",
                     *finalize_crypto_mounts(tools=context.config.tools()),
                 ],
-            ) + (apivfs_cmd(context.root, tools=context.config.tools()) if apivfs else [])
+            ) + (apivfs_cmd(context.root) if apivfs else [])
         ),
         env=context.config.environment,
     )

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -30,6 +30,7 @@ from mkosi.config import (
     QemuFirmware,
     QemuVsockCID,
     format_bytes,
+    want_selinux_relabel,
 )
 from mkosi.log import die
 from mkosi.partition import finalize_root, find_partitions
@@ -326,7 +327,7 @@ def start_virtiofsd(config: Config, directory: Path, *, uidmap: bool) -> Iterato
         "--sandbox=chroot",
     ]
 
-    if not uidmap:
+    if not uidmap and want_selinux_relabel(config, directory, fatal=False):
         cmdline += ["--security-label"]
 
     # We create the socket ourselves and pass the fd to virtiofsd to avoid race conditions where we start qemu

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -289,6 +289,12 @@ def run(
         if preexec_fn:
             preexec_fn()
 
+    if (
+        sandbox and
+        subprocess.run(sandbox + ["sh", "-c", "command -v setpgid"], stdout=subprocess.DEVNULL).returncode == 0
+    ):
+        cmdline = ["setpgid", "--foreground", "--"] + cmdline
+
     try:
         # subprocess.run() will use SIGKILL to kill processes when an exception is raised.
         # We'd prefer it to use SIGTERM instead but since this we can't configure which signal
@@ -372,6 +378,13 @@ def spawn(
             make_foreground_process()
         if preexec_fn:
             preexec_fn()
+
+    if (
+        foreground and
+        sandbox and
+        subprocess.run(sandbox + ["sh", "-c", "command -v setpgid"], stdout=subprocess.DEVNULL).returncode == 0
+    ):
+        cmdline = ["setpgid", "--foreground", "--"] + cmdline
 
     try:
         with subprocess.Popen(

--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -95,7 +95,10 @@ def sandbox_cmd(
     if relaxed:
         cmdline += ["--bind", "/tmp", "/tmp"]
     else:
-        cmdline += ["--tmpfs", "/tmp"]
+        cmdline += [
+            "--tmpfs", "/tmp",
+            "--unshare-ipc",
+        ]
 
     if (tools / "nix/store").exists():
         cmdline += ["--bind", tools / "nix/store", "/nix/store"]


### PR DESCRIPTION
We move the setpgid logic to run(), avoiding the need to pass a tools argument to chroot_cmd() and apivfs_cmd().

We also try to remove as much logic from these functions as possible. Since we can't really assume that any logic we execute during the function will still hold true in the sandbox, so it's best to delay any logic execution until we're already in the sandbox (using the --ro-bind-try options of bubblewrap).

We also rework the /etc/resolv.conf handling to simply make sure that /run/systemd/resolve exists in the chroot since if /etc/resolv.conf is a symlink it'll always be to /run/systemd/resolve/stub-resolv.conf.