### PR TITLE
Only run mount --make-rslave / if we didn't unshare a user namespace

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -56,7 +56,7 @@ from mkosi.mounts import mount_overlay
 from mkosi.pager import page
 from mkosi.partition import Partition, finalize_root, finalize_roothash
 from mkosi.qemu import KernelType, copy_ephemeral, run_qemu, run_ssh
-from mkosi.run import become_root, find_binary, fork_and_wait, init_mount_namespace, run
+from mkosi.run import CLONE_NEWNS, become_root, find_binary, fork_and_wait, run, unshare
 from mkosi.sandbox import chroot_cmd, finalize_crypto_mounts
 from mkosi.tree import copy_tree, move_tree, rmtree
 from mkosi.types import PathString
@@ -3365,7 +3365,9 @@ def run_clean(args: Args, config: Config) -> None:
 
 def run_build(args: Args, config: Config) -> None:
     become_root()
-    init_mount_namespace()
+    unshare(CLONE_NEWNS)
+    if INVOKING_USER.invoked_as_root:
+        run(["mount", "--make-rslave", "/"])
 
     # For extra safety when running as root, remount a bunch of stuff read-only.
     for d in ("/usr", "/etc", "/opt", "/srv", "/boot", "/efi", "/media", "/mnt"):

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -129,11 +129,6 @@ def become_root() -> None:
     INVOKING_USER.gid = SUBRANGE - 100
 
 
-def init_mount_namespace() -> None:
-    unshare(CLONE_NEWNS)
-    run(["mount", "--make-rslave", "/"])
-
-
 def make_foreground_process(*, new_process_group: bool = True) -> None:
     """
     If we're connected to a terminal, put the process in a new process group and make that the foreground


### PR DESCRIPTION
When unsharing a mount namespace in a different user namespace than the parent mount namespace, all mounts are marked as slave by default so we don't need to explicitly mark all of them as slave mounts.