### PR TITLE
Mount BuildSources= when executing package managers

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -945,6 +945,7 @@ def parse_chdir(path: str) -> Optional[Path]:
         die(f"{path} is not a directory!")
     except OSError as e:
         die(f"Cannot change the directory to {path}: {e}")
+
     # Keep track of the current directory
     return Path.cwd()
 
@@ -1866,7 +1867,7 @@ SETTINGS = (
         section="Content",
         parse=config_make_list_parser(delimiter=",", parse=make_tree_parser(absolute=False)),
         match=config_match_build_sources,
-        default_factory=lambda _: [ConfigTree(Path.cwd(), None)],
+        default_factory=lambda ns: [ConfigTree(ns.directory, None)] if ns.directory else [],
         help="Path for sources to build",
     ),
     ConfigSetting(

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -3,6 +3,7 @@ import textwrap
 from collections.abc import Sequence
 
 from mkosi.context import Context
+from mkosi.mounts import finalize_source_mounts
 from mkosi.run import find_binary, run
 from mkosi.sandbox import apivfs_cmd, finalize_crypto_mounts
 from mkosi.types import PathString
@@ -111,7 +112,9 @@ def invoke_apt(
                     "--bind", context.cache_dir / "cache/apt", context.cache_dir / "cache/apt",
                     "--ro-bind", context.workspace / "apt.conf", context.workspace / "apt.conf",
                     *finalize_crypto_mounts(tools=context.config.tools()),
+                    *finalize_source_mounts(context.config),
                     *mounts,
+                    "--chdir", "/work/src",
                 ],
             ) + (apivfs_cmd(context.root) if apivfs else [])
         ),

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -111,6 +111,7 @@ def invoke_apt(
                     "--bind", context.cache_dir / "lib/apt", context.cache_dir / "lib/apt",
                     "--bind", context.cache_dir / "cache/apt", context.cache_dir / "cache/apt",
                     "--ro-bind", context.workspace / "apt.conf", context.workspace / "apt.conf",
+                    *(["--ro-bind", m, m] if (m := context.config.local_mirror) else []),
                     *finalize_crypto_mounts(tools=context.config.tools()),
                     *finalize_source_mounts(context.config),
                     *mounts,

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -138,6 +138,7 @@ def invoke_dnf(context: Context, command: str, packages: Iterable[str], apivfs: 
                     "--bind",
                     context.cache_dir / "lib" / dnf_subdir(context),
                     context.cache_dir / "lib" / dnf_subdir(context),
+                    *(["--ro-bind", m, m] if (m := context.config.local_mirror) else []),
                     *finalize_crypto_mounts(tools=context.config.tools()),
                     *finalize_source_mounts(context.config),
                     "--chdir", "/work/src",

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from mkosi.context import Context
 from mkosi.installer.rpm import RpmRepository, fixup_rpmdb_location, setup_rpm
+from mkosi.mounts import finalize_source_mounts
 from mkosi.run import find_binary, run
 from mkosi.sandbox import apivfs_cmd, finalize_crypto_mounts
 from mkosi.types import PathString
@@ -138,6 +139,8 @@ def invoke_dnf(context: Context, command: str, packages: Iterable[str], apivfs: 
                     context.cache_dir / "lib" / dnf_subdir(context),
                     context.cache_dir / "lib" / dnf_subdir(context),
                     *finalize_crypto_mounts(tools=context.config.tools()),
+                    *finalize_source_mounts(context.config),
+                    "--chdir", "/work/src",
                 ],
             ) + (apivfs_cmd(context.root) if apivfs else [])
         ),

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable, Sequence
 from typing import NamedTuple
 
 from mkosi.context import Context
+from mkosi.mounts import finalize_source_mounts
 from mkosi.run import run
 from mkosi.sandbox import apivfs_cmd, finalize_crypto_mounts
 from mkosi.types import PathString
@@ -98,6 +99,8 @@ def invoke_pacman(
                     "--bind", context.root, context.root,
                     "--bind", context.cache_dir / "cache/pacman/pkg", context.cache_dir / "cache/pacman/pkg",
                     *finalize_crypto_mounts(tools=context.config.tools()),
+                    *finalize_source_mounts(context.config),
+                    "--chdir", "/work/src",
                 ],
             ) + (apivfs_cmd(context.root) if apivfs else [])
         ),

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -98,6 +98,7 @@ def invoke_pacman(
                 options=[
                     "--bind", context.root, context.root,
                     "--bind", context.cache_dir / "cache/pacman/pkg", context.cache_dir / "cache/pacman/pkg",
+                    *(["--ro-bind", m, m] if (m := context.config.local_mirror) else []),
                     *finalize_crypto_mounts(tools=context.config.tools()),
                     *finalize_source_mounts(context.config),
                     "--chdir", "/work/src",

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -86,6 +86,7 @@ def invoke_zypper(
                 options=[
                     "--bind", context.root, context.root,
                     "--bind", context.cache_dir / "cache/zypp", context.cache_dir / "cache/zypp",
+                    *(["--ro-bind", m, m] if (m := context.config.local_mirror) else []),
                     *finalize_crypto_mounts(tools=context.config.tools()),
                     *finalize_source_mounts(context.config),
                     "--chdir", "/work/src",

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from mkosi.config import yes_no
 from mkosi.context import Context
 from mkosi.installer.rpm import RpmRepository, fixup_rpmdb_location, setup_rpm
+from mkosi.mounts import finalize_source_mounts
 from mkosi.run import run
 from mkosi.sandbox import apivfs_cmd, finalize_crypto_mounts
 from mkosi.types import PathString
@@ -86,6 +87,8 @@ def invoke_zypper(
                     "--bind", context.root, context.root,
                     "--bind", context.cache_dir / "cache/zypp", context.cache_dir / "cache/zypp",
                     *finalize_crypto_mounts(tools=context.config.tools()),
+                    *finalize_source_mounts(context.config),
+                    "--chdir", "/work/src",
                 ],
             ) + (apivfs_cmd(context.root) if apivfs else [])
         ),


### PR DESCRIPTION
Users might have local packages which need to be mounted into the sandbox as well. Let's make this possible by using BuildSources=.