### PR TITLE
Copy nspawn settings to the output directory again

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1282,6 +1282,10 @@ class Config:
         return f"{self.output}.initrd"
 
     @property
+    def output_nspawn_settings(self) -> str:
+        return f"{self.output}.nspawn"
+
+    @property
     def output_checksum(self) -> str:
         return f"{self.output}.SHA256SUMS"
 


### PR DESCRIPTION
machinectl pull-tar looks for a settings file so let's make sure the output directory can be used directly for this purpose by copying the nspawn settings file to the output directory again.