### PR TITLE
Populate only using the archlinux keyring

### DIFF
--- a/mkosi.prepare.chroot
+++ b/mkosi.prepare.chroot
@@ -3,5 +3,5 @@
 
 if [ "$1" = "final" ] && command -v pacman-key; then
     pacman-key --init
-    pacman-key --populate
+    pacman-key --populate archlinux
 fi

--- a/mkosi/resources/mkosi-tools/mkosi.prepare.chroot
+++ b/mkosi/resources/mkosi-tools/mkosi.prepare.chroot
@@ -3,5 +3,5 @@
 
 if [ "$1" = "final" ] && command -v pacman-key; then
     pacman-key --init
-    pacman-key --populate
+    pacman-key --populate archlinux
 fi


### PR DESCRIPTION
Otherwise on Debian and Ubuntu we end up adding the Debian/Ubuntu keyrings as well which is useless and slows down builds.