### PR TITLE
Verify that output path is not a symlink in needs_build()

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3198,7 +3198,14 @@ def expand_specifier(s: str) -> str:
 def needs_build(args: Args, config: Config) -> bool:
     return (
         args.verb.needs_build() and
-        (args.force > 0 or not (config.output_dir_or_cwd() / config.output_with_compression).exists())
+        (
+            args.force > 0 or
+            not (config.output_dir_or_cwd() / config.output_with_compression).exists() or
+            # When the output is a directory, its name is the same as the symlink we create that points to the actual
+            # output when not building a directory. So if the full output path exists, we have to check that it's not
+            # a symlink as well.
+            (config.output_dir_or_cwd() / config.output_with_compression).is_symlink()
+        )
     )
 
 


### PR DESCRIPTION
Otherwise if we first build a disk image and then try to run "mkosi -t directory qemu" we won't actually rebuild the image as it will think the output already exists and we'll try to boot a disk image as a directory.