### PR TITLE
kernel-install: Build microcode initrd

### DIFF
--- a/kernel-install/50-mkosi.install
+++ b/kernel-install/50-mkosi.install
@@ -9,11 +9,13 @@ import tempfile
 from pathlib import Path
 from typing import NamedTuple, Optional
 
+from mkosi.archive import make_cpio
 from mkosi.config import OutputFormat, __version__
 from mkosi.log import die, log_setup
 from mkosi.run import run, uncaught_exception_handler
 from mkosi.tree import copy_tree
 from mkosi.types import PathString
+from mkosi.util import umask
 
 
 class Context(NamedTuple):
@@ -39,6 +41,36 @@ def mandatory_variable(name: str) -> str:
         return os.environ[name]
     except KeyError:
         die(f"${name} must be set in the environment")
+
+
+def build_microcode_initrd(output: Path) -> Optional[Path]:
+    amd = Path("/usr/lib/firmware/amd-ucode")
+    intel = Path("/usr/lib/firmware/intel-ucode")
+
+    if not amd.exists() and not intel.exists():
+        logging.debug("/usr/lib/firmware/{amd-ucode,intel-ucode} not found, not adding microcode initrd")
+        return None
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp) / "initrd-microcode-root"
+        destdir = root / "kernel/x86/microcode"
+
+        with umask(~0o755):
+            destdir.mkdir(parents=True, exist_ok=True)
+
+        if amd.exists():
+            with (destdir / "AuthenticAMD.bin").open("wb") as f:
+                for p in amd.iterdir():
+                    f.write(p.read_bytes())
+
+        if intel.exists():
+            with (destdir / "GenuineIntel.bin").open("wb") as f:
+                for p in intel.iterdir():
+                    f.write(p.read_bytes())
+
+        make_cpio(root, output)
+
+    return output
 
 
 @uncaught_exception_handler()
@@ -155,6 +187,7 @@ def main() -> None:
 
     if format == OutputFormat.cpio:
         shutil.move(next(context.staging_area.glob("initrd*.cpio*")), context.staging_area / "initrd")
+        build_microcode_initrd(context.staging_area / "microcode")
     else:
         (context.staging_area / f"{output}.vmlinuz").unlink()
         (context.staging_area / f"{output}.initrd").unlink()

--- a/mkosi/archive.py
+++ b/mkosi/archive.py
@@ -1,17 +1,16 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 import os
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from pathlib import Path
 from typing import Optional
 
-from mkosi.context import Context
 from mkosi.log import log_step
 from mkosi.run import find_binary, run
-from mkosi.sandbox import finalize_passwd_mounts
+from mkosi.types import PathString
 
 
-def tar_binary(context: Context) -> str:
+def tar_binary(*, tools: Path = Path("/")) -> str:
     # Some distros (Mandriva) install BSD tar as "tar", hence prefer
     # "gtar" if it exists, which should be GNU tar wherever it exists.
     # We are interested in exposing same behaviour everywhere hence
@@ -19,11 +18,11 @@ def tar_binary(context: Context) -> str:
     # everywhere. In particular given the limited/different SELinux
     # support in BSD tar and the different command line syntax
     # compared to GNU tar.
-    return "gtar" if find_binary("gtar", root=context.config.tools()) else "tar"
+    return "gtar" if find_binary("gtar", root=tools) else "tar"
 
 
-def cpio_binary(context: Context) -> str:
-    return "gcpio" if find_binary("gcpio", root=context.config.tools()) else "cpio"
+def cpio_binary(*, tools: Path = Path("/")) -> str:
+    return "gcpio" if find_binary("gcpio", root=tools) else "cpio"
 
 
 def tar_exclude_apivfs_tmp() -> list[str]:
@@ -37,13 +36,13 @@ def tar_exclude_apivfs_tmp() -> list[str]:
     ]
 
 
-def make_tar(context: Context, src: Path, dst: Path) -> None:
+def make_tar(src: Path, dst: Path, *, tools: Path = Path("/"), sandbox: Sequence[PathString] = ()) -> None:
     log_step(f"Creating tar archive {dst}…")
 
     with dst.open("wb") as f:
         run(
             [
-                tar_binary(context),
+                tar_binary(tools=tools),
                 "--create",
                 "--file", "-",
                 "--directory", src,
@@ -60,19 +59,25 @@ def make_tar(context: Context, src: Path, dst: Path) -> None:
                 ".",
             ],
             stdout=f,
-            # Make sure tar uses user/group information from the root directory instead of the host.
-            sandbox=context.sandbox(options=["--ro-bind", src, src, *finalize_passwd_mounts(src)]),
+            sandbox=sandbox,
         )
 
 
-def extract_tar(context: Context, src: Path, dst: Path, log: bool = True) -> None:
+def extract_tar(
+    src: Path,
+    dst: Path,
+    *,
+    log: bool = True,
+    tools: Path = Path("/"),
+    sandbox: Sequence[PathString] = (),
+) -> None:
     if log:
         log_step(f"Extracting tar archive {src}…")
 
     with src.open("rb") as f:
         run(
             [
-                tar_binary(context),
+                tar_binary(tools=tools),
                 "--extract",
                 "--file", "-",
                 "--directory", dst,
@@ -88,12 +93,18 @@ def extract_tar(context: Context, src: Path, dst: Path, log: bool = True) -> Non
                 *tar_exclude_apivfs_tmp(),
             ],
             stdin=f,
-            # Make sure tar uses user/group information from the root directory instead of the host.
-            sandbox=context.sandbox(options=["--bind", dst, dst, *finalize_passwd_mounts(dst)]),
+            sandbox=sandbox,
         )
 
 
-def make_cpio(context: Context, src: Path, dst: Path, files: Optional[Iterable[Path]] = None) -> None:
+def make_cpio(
+    src: Path,
+    dst: Path,
+    *,
+    files: Optional[Iterable[Path]] = None,
+    tools: Path = Path("/"),
+    sandbox: Sequence[PathString] = (),
+) -> None:
     if not files:
         files = src.rglob("*")
     files = sorted(files)
@@ -103,7 +114,7 @@ def make_cpio(context: Context, src: Path, dst: Path, files: Optional[Iterable[P
     with dst.open("wb") as f:
         run(
             [
-                cpio_binary(context),
+                cpio_binary(tools=tools),
                 "--create",
                 "--reproducible",
                 "--null",
@@ -114,5 +125,5 @@ def make_cpio(context: Context, src: Path, dst: Path, files: Optional[Iterable[P
             input="\0".join(os.fspath(f.relative_to(src)) for f in files),
             stdout=f,
             # Make sure cpio uses user/group information from the root directory instead of the host.
-            sandbox=context.sandbox(options=["--ro-bind", src, src, *finalize_passwd_mounts(dst)]),
+            sandbox=sandbox,
         )

--- a/mkosi/distributions/gentoo.py
+++ b/mkosi/distributions/gentoo.py
@@ -132,7 +132,11 @@ class Installer(DistributionInstaller):
 
         if not any(stage3.iterdir()):
             with complete_step(f"Extracting {stage3_tar.name} to {stage3}"):
-                extract_tar(context, stage3_tar, stage3)
+                extract_tar(
+                    stage3_tar, stage3,
+                    tools=context.config.tools(),
+                    sandbox=context.sandbox(options=["--bind", context.root, context.root]),
+                )
 
         for d in ("binpkgs", "distfiles", "repos/gentoo"):
             (context.cache_dir / d).mkdir(parents=True, exist_ok=True)

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -122,7 +122,7 @@ def invoke_apt(
 
 
 def createrepo_apt(context: Context) -> None:
-    with (context.packages / "Packages").open("w") as f:
+    with (context.packages / "Packages").open("wb") as f:
         run(["dpkg-scanpackages", context.packages],
             stdout=f, sandbox=context.sandbox(options=["--ro-bind", context.packages, context.packages]))
 


### PR DESCRIPTION
Let's make sure we build a microcode initrd as well in the
kernel-install plugin. It's a bit too complicated to reuse
the build_microcode_initrd() function we have already due to
sandboxing so we opt to duplicate it instead.