### PR TITLE
Always set rpm _topdir to /var/tmp

### DIFF
--- a/docs/building-rpms-from-source.md
+++ b/docs/building-rpms-from-source.md
@@ -65,7 +65,7 @@ mkosi-chroot \
     rpmspec \
     --query \
     "$DEPS" \
-    --define "_topdir mkosi" \
+    --define "_topdir /var/tmp" \
     --define "_sourcedir mkosi/rpm" \
     mkosi/rpm/mkosi.spec |
         grep -E -v "mkosi" |
@@ -77,7 +77,7 @@ if [ "$1" = "build" ]; then
         rpmbuild \
         -bd \
         --build-in-place \
-        --define "_topdir ." \
+        --define "_topdir /var/tmp" \
         --define "_sourcedir rpm" \
         --define "_build_name_fmt %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm" \
         rpm/mkosi.spec
@@ -94,12 +94,13 @@ fi
 ```
 
 To install non-dynamic dependencies, we use `rpmspec`. What's important
-is to set `_topdir` to the directory containing the upstream sources of
-the project that we want to build and to set `_sourcedir` to the
-directory containing the RPM spec for the project that we want to build.
-We run `rpmspec` inside the image to make sure all the RPM macros have
-their expected values and then run `dnf` outside the image to install
-the required dependencies.
+is to set `_sourcedir` to the directory containing the RPM sources for
+the RPM spec that we want to build. We run `rpmspec` inside the image to
+make sure all the RPM macros have their expected values and then run
+`dnf` outside the image to install the required dependencies.
+
+We always set `_topdir` to `/var/tmp` to avoid polluting the image with
+`rpmbuild` artifacts.
 
 Subpackages from the same RPM might depend on each other. We need to
 filter out those dependencies using `grep -E -v <package-name>`.
@@ -118,10 +119,9 @@ dependencies installed to be able to build the RPM.
 Next is the build script. We suffix the build script with `.chroot` so
 that mkosi runs it entirely inside the image. In the build script, we
 invoke `rpmbuild -bb --build-in-place` to have `rpmbuild` build the RPM
-in place from the upstream sources. Again `_topdir` and `_sourcedir`
-have to be configured to the upstream sources and the RPM spec sources
-respectively. We also have to override `_rpmdir` to point to the mkosi
-output directory (stored in `$OUTPUTDIR`). The build script
+in place from the upstream sources. Again, `_sourcedir` has to point to
+the RPM spec sources. We also have to override `_rpmdir` to point to the
+mkosi output directory (stored in `$OUTPUTDIR`). The build script
 `mkosi.build.chroot` then looks as follows:
 
 ```shell
@@ -133,7 +133,7 @@ env --chdir=mkosi \
     -bb \
     --build-in-place \
     $([ "$WITH_TESTS" = "0" ] && echo --nocheck) \
-    --define "_topdir $PWD" \
+    --define "_topdir /var/tmp" \
     --define "_sourcedir rpm" \
     --define "_rpmdir $OUTPUTDIR" \
     ${BUILDDIR:+--define} \

--- a/mkosi.conf.d/30-rpm/mkosi.build.chroot
+++ b/mkosi.conf.d/30-rpm/mkosi.build.chroot
@@ -6,7 +6,7 @@ rpmbuild \
     -bb \
     --build-in-place \
     $([ "$WITH_TESTS" = "0" ] && echo --nocheck) \
-    --define "_topdir $PWD" \
+    --define "_topdir /var/tmp" \
     --define "_sourcedir rpm" \
     --define "_rpmdir $PACKAGEDIR" \
     --define "_build_name_fmt %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm" \

--- a/mkosi.conf.d/30-rpm/mkosi.prepare
+++ b/mkosi.conf.d/30-rpm/mkosi.prepare
@@ -12,7 +12,7 @@ mkosi-chroot \
     rpmspec \
     --query \
     "$DEPS" \
-    --define "_topdir ." \
+    --define "_topdir /var/tmp" \
     --define "_sourcedir rpm" \
     rpm/mkosi.spec |
         grep -E -v "mkosi" |
@@ -23,7 +23,7 @@ if [ "$1" = "build" ]; then
         rpmbuild \
         -bd \
         --build-in-place \
-        --define "_topdir ." \
+        --define "_topdir /var/tmp" \
         --define "_sourcedir rpm" \
         --define "_build_name_fmt %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm" \
         rpm/mkosi.spec


### PR DESCRIPTION
_topdir is rpm's working directory. Set it /var/tmp so we don't pollute the image or source directories we're building from with rpmbuild artifacts.