### PR TITLE
Don't mount /srv and /mnt read-only

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3462,7 +3462,7 @@ def run_build(args: Args, config: Config) -> None:
         run(["mount", "--make-rslave", "/"])
 
     # For extra safety when running as root, remount a bunch of stuff read-only.
-    for d in ("/usr", "/etc", "/opt", "/srv", "/boot", "/efi", "/media", "/mnt"):
+    for d in ("/usr", "/etc", "/opt", "/boot", "/efi", "/media"):
         if Path(d).exists():
             run(["mount", "--rbind", d, d, "--options", "ro"])
 


### PR DESCRIPTION
It seems there are use cases where users expect to write their output
to a directory in /srv or /mnt so let's make that writable. This should
be safe as we set up a custom sandbox now so none of the tools we run
will have access to /srv and /mnt in the first place.