### PR TITLE
apt: Set APT::System explicitly

### DIFF
--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -56,6 +56,7 @@ def apt_cmd(context: Context, command: str) -> list[PathString]:
         "DEBCONF_INTERACTIVE_SEEN=true",
         "INITRD=No",
         command,
+        "-o", "APT::System=Debian dpkg interface",
         "-o", f"APT::Architecture={debarch}",
         "-o", f"APT::Architectures={debarch}",
         "-o", f"APT::Install-Recommends={str(context.config.with_recommends).lower()}",


### PR DESCRIPTION
Let's circumvent apt's weird checks to see if something is a debian system by setting it explicitly.

Fixes #2308