### PR TITLE
Allow including builtin configs

### DIFF
--- a/kernel-install/50-mkosi.install
+++ b/kernel-install/50-mkosi.install
@@ -142,6 +142,7 @@ def main() -> None:
         "--extra-tree=/usr/lib/firmware:/usr/lib/firmware",
         "--kernel-modules-exclude=.*",
         "--kernel-modules-include-host=yes",
+        "--include=mkosi-initrd",
     ]
 
     if context.verbose:

--- a/mkosi/__main__.py
+++ b/mkosi/__main__.py
@@ -7,11 +7,12 @@ import sys
 from types import FrameType
 from typing import Optional
 
+import mkosi.resources
 from mkosi import run_verb
 from mkosi.config import parse_config
 from mkosi.log import log_setup
 from mkosi.run import find_binary, run, uncaught_exception_handler
-from mkosi.util import INVOKING_USER
+from mkosi.util import INVOKING_USER, resource_path
 
 
 def onsigterm(signal: int, frame: Optional[FrameType]) -> None:
@@ -25,17 +26,19 @@ def main() -> None:
     log_setup()
     # Ensure that the name and home of the user we are running as are resolved as early as possible.
     INVOKING_USER.init()
-    args, images = parse_config(sys.argv[1:])
 
-    if args.debug:
-        faulthandler.enable()
+    with resource_path(mkosi.resources) as resources:
+        args, images = parse_config(sys.argv[1:])
 
-    try:
-        run_verb(args, images)
-    finally:
-        if sys.stderr.isatty() and find_binary("tput"):
-            run(["tput", "cnorm"], check=False)
-            run(["tput", "smam"], check=False)
+        if args.debug:
+            faulthandler.enable()
+
+        try:
+            run_verb(args, images, resources=resources)
+        finally:
+            if sys.stderr.isatty() and find_binary("tput"):
+                run(["tput", "cnorm"], check=False)
+                run(["tput", "smam"], check=False)
 
 
 if __name__ == "__main__":

--- a/mkosi/__main__.py
+++ b/mkosi/__main__.py
@@ -28,7 +28,7 @@ def main() -> None:
     INVOKING_USER.init()
 
     with resource_path(mkosi.resources) as resources:
-        args, images = parse_config(sys.argv[1:])
+        args, images = parse_config(sys.argv[1:], resources=resources)
 
         if args.debug:
             faulthandler.enable()

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2787,7 +2787,7 @@ def parse_config(argv: Sequence[str] = ()) -> tuple[Args, tuple[Config, ...]]:
                     continue
 
                 with chdir(p if p.is_dir() else Path.cwd()):
-                    parse_config(p if p.is_file() else Path("."), namespace, defaults)
+                    parse_config_one(p if p.is_file() else Path("."), namespace, defaults)
                 parsed_includes.add((st.st_dev, st.st_ino))
 
     class ConfigAction(argparse.Action):
@@ -2895,7 +2895,7 @@ def parse_config(argv: Sequence[str] = ()) -> tuple[Args, tuple[Config, ...]]:
 
         return triggered is not False
 
-    def parse_config(
+    def parse_config_one(
         path: Path,
         namespace: argparse.Namespace,
         defaults: argparse.Namespace,
@@ -2912,7 +2912,7 @@ def parse_config(argv: Sequence[str] = ()) -> tuple[Args, tuple[Config, ...]]:
 
         if extras:
             if (path.parent / "mkosi.local.conf").exists():
-                parse_config(path.parent / "mkosi.local.conf", namespace, defaults)
+                parse_config_one(path.parent / "mkosi.local.conf", namespace, defaults)
 
             for s in SETTINGS:
                 ns = defaults if s.path_default else namespace
@@ -2975,13 +2975,13 @@ def parse_config(argv: Sequence[str] = ()) -> tuple[Args, tuple[Config, ...]]:
                 setattr(namespace, "profile", profile)
 
                 with chdir(p if p.is_dir() else Path.cwd()):
-                    parse_config(p if p.is_file() else Path("."), namespace, defaults)
+                    parse_config_one(p if p.is_file() else Path("."), namespace, defaults)
 
         if extras and (path.parent / "mkosi.conf.d").exists():
             for p in sorted((path.parent / "mkosi.conf.d").iterdir()):
                 if p.is_dir() or p.suffix == ".conf":
                     with chdir(p if p.is_dir() else Path.cwd()):
-                        parse_config(p if p.is_file() else Path("."), namespace, defaults)
+                        parse_config_one(p if p.is_file() else Path("."), namespace, defaults)
 
         return True
 
@@ -3026,7 +3026,7 @@ def parse_config(argv: Sequence[str] = ()) -> tuple[Args, tuple[Config, ...]]:
     include = ()
 
     if args.directory is not None:
-        parse_config(Path("."), namespace, defaults, profiles=True)
+        parse_config_one(Path("."), namespace, defaults, profiles=True)
 
         finalize_default(SETTINGS_LOOKUP_BY_DEST["images"], namespace, defaults)
         include = getattr(namespace, "images")
@@ -3054,7 +3054,7 @@ def parse_config(argv: Sequence[str] = ()) -> tuple[Args, tuple[Config, ...]]:
                 setattr(ns_copy, "image", name)
 
                 with chdir(p if p.is_dir() else Path.cwd()):
-                    if not parse_config(p if p.is_file() else Path("."), ns_copy, defaults_copy):
+                    if not parse_config_one(p if p.is_file() else Path("."), ns_copy, defaults_copy):
                         continue
 
                 finalize_defaults(ns_copy, defaults_copy)

--- a/mkosi/context.py
+++ b/mkosi/context.py
@@ -14,10 +14,11 @@ from mkosi.util import flatten, umask
 class Context:
     """State related properties."""
 
-    def __init__(self, args: Args, config: Config, workspace: Path) -> None:
+    def __init__(self, args: Args, config: Config, *, workspace: Path, resources: Path) -> None:
         self.args = args
         self.config = config
         self.workspace = workspace
+        self.resources = resources
 
         with umask(~0o755):
             # Using a btrfs subvolume as the upperdir in an overlayfs results in EXDEV so make sure we create

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -474,6 +474,10 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 : Note that each path containing extra configuration is only parsed
   once, even if included more than once with `Include=`.
 
+: The builtin configs for the mkosi default initrd and default tools
+  tree can be included by including the literal value `mkosi-initrd` and
+  `mkosi-tools` respectively.
+
 `InitrdInclude=`, `--initrd-include=`
 
 : Same as `Include=`, but the extra configuration files or directories

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -195,12 +195,12 @@ def uncaught_exception_handler(exit: Callable[[int], NoReturn] = sys.exit) -> It
         exit(rc)
 
 
-def fork_and_wait(target: Callable[[], None]) -> None:
+def fork_and_wait(target: Callable[..., None], *args: Any, **kwargs: Any) -> None:
     pid = os.fork()
     if pid == 0:
         with uncaught_exception_handler(exit=os._exit):
             make_foreground_process()
-            target()
+            target(*args, **kwargs)
 
     try:
         _, status = os.waitpid(pid, 0)

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -183,7 +183,7 @@ def is_power_of_2(x: int) -> bool:
 
 
 @contextlib.contextmanager
-def resource_path(mod: ModuleType, path: str) -> Iterator[Path]:
+def resource_path(mod: ModuleType) -> Iterator[Path]:
 
     # We backport as_file() from python 3.12 here temporarily since it added directory support.
     # TODO: Remove once minimum python version is 3.12.
@@ -276,7 +276,7 @@ def resource_path(mod: ModuleType, path: str) -> Iterator[Path]:
         return child
 
     t = importlib.resources.files(mod)
-    with as_file(t.joinpath(path)) as p:
+    with as_file(t) as p:
         yield p
 
 


### PR DESCRIPTION
Let's make it possible to include builtin configurations using
e.g. Include=mkosi-initrd. This allows building the default initrd
or default tools tree independently whereas currently these can only
be built as part of another image.