### PR TITLE
sandbox: Deal correctly with unmerged-usr

### DIFF
--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -137,6 +137,8 @@ def sandbox_cmd(
     for d in ("bin", "sbin", "lib", "lib32", "lib64"):
         if (p := tools / d).is_symlink():
             cmdline += ["--symlink", p.readlink(), Path("/") / p.relative_to(tools)]
+        elif p.is_dir():
+            cmdline += ["--ro-bind", p, Path("/") / p.relative_to(tools)]
 
     path = "/usr/bin:/usr/sbin" if tools != Path("/") else os.environ["PATH"]
 


### PR DESCRIPTION
If /bin and such are directories instead of symlinks, bind mount them in to the sandbox.

Fixes #2314