### PR TITLE
man: `--debug-shell=` -> `--debug-shell`

### DIFF
--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -200,7 +200,7 @@ Those settings cannot be configured in the configuration files.
 
 : Enable additional debugging output.
 
-`--debug-shell=`
+`--debug-shell`
 
 : When executing a command in the image fails, mkosi will start an interactive
   shell in the image allowing further debugging.


### PR DESCRIPTION
`--debug-shell` refuses to take an argument, so the equal sign is misleading (aka. `--debug-shell=yes` errors out), so let's remove it from the `man` page.