### PR TITLE
Mount TMPDIR inside the sandbox

### DIFF
--- a/mkosi/context.py
+++ b/mkosi/context.py
@@ -76,6 +76,8 @@ class Context:
             devices=devices,
             scripts=scripts,
             options=[
+                # TMPDIR is used by some subprocesses so must be made available
+                *(["--bind", os.fspath(p), os.fspath(p)] if (p := os.environ.get("TMPDIR")) else []),
                 # These mounts are writable so bubblewrap can create extra directories or symlinks inside of it as
                 # needed. This isn't a problem as the package manager directory is created by mkosi and thrown away
                 # when the build finishes.


### PR DESCRIPTION
systemd-repart copies files into a directory in TMPDIR before running mksquashfs.

mkosi sets TMPDIR to the workspace directory to keep its tempfiles organised.

When running in a tools tree sandbox it mounts / as a tmpfs and the root directory of the build image on top at its usual path. This root directory is inside the workspace directory, but the workspace directory itself is not mounted.

This results in repart copying files into a tmpfs, which could cause problems for large trees,
but also results in extended attributes being lost since tmpfs doesn't support them.

This in turn results in it being impossible to create non-strict system extension images
since the extended attribute to enable this gets lost.