### PR TITLE
Use compression extension

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1924,7 +1924,7 @@ def maybe_compress(context: Context, compression: Compression, src: Path, dst: O
         return
 
     if not dst:
-        dst = src.parent / f"{src.name}.{compression}"
+        dst = src.parent / f"{src.name}{compression.extension()}"
 
     with complete_step(f"Compressing {src} with {compression}"):
         with src.open("rb") as i:


### PR DESCRIPTION
When `SplitArtifacts=yes` and `CompressOutput=zstd`, the file extensions should be `.zst` instead of `.zstd`.

Follow up for: 9f9426ac70bbefffa657ce4d92022231b524b870