### PR TITLE
Use a subdirectory of TMPDIR as the sandbox's /var/tmp

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2844,8 +2844,9 @@ def setup_workspace(args: Args, config: Config) -> Iterator[Path]:
             options=["--bind", config.workspace_dir_or_default(), config.workspace_dir_or_default()],
         )
         stack.callback(lambda: rmtree(workspace, sandbox=sandbox))
+        (workspace / "tmp").mkdir(mode=0o1777)
 
-        with scopedenv({"TMPDIR" : os.fspath(workspace)}):
+        with scopedenv({"TMPDIR" : os.fspath(workspace / "tmp")}):
             try:
                 yield Path(workspace)
             except BaseException:


### PR DESCRIPTION
Let's take TMPDIR into account instead of always using /var/tmp. We
also make sure we override TMPDIR to /var/tmp in the sandbox.