### PR TITLE
Run distribution upgrade automatically in some scenarios

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1538,6 +1538,10 @@ def build_initrd(context: Context) -> Path:
     if (config.output_dir / config.output).exists():
         return config.output_dir / config.output
 
+    if args.force > 1 and config.cache_dir:
+        with complete_step(f"Removing cache entries of {config.name()} image…"):
+            rmtree(*(p for p in cache_tree_paths(config) if p.exists()))
+
     with complete_step("Building default initrd"):
         build_image(args, config, resources=context.resources)
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1415,10 +1415,6 @@ def install_package_directories(context: Context) -> None:
         for d in context.config.package_directories:
             install_tree(context, d, context.packages)
 
-    if any(context.packages.iterdir()):
-        with complete_step("Initializing local package repository…"):
-            context.config.distribution.createrepo(context)
-
 
 def install_extra_trees(context: Context) -> None:
     if not context.config.extra_trees:

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 from mkosi.config import Architecture
 from mkosi.context import Context
@@ -41,32 +41,7 @@ class Installer(DistributionInstaller):
 
     @classmethod
     def setup(cls, context: Context) -> None:
-        if context.config.local_mirror:
-            repos = [PacmanRepository("core", context.config.local_mirror)]
-        else:
-            repos = []
-
-            if context.config.architecture == Architecture.arm64:
-                url = f"{context.config.mirror or 'http://mirror.archlinuxarm.org'}/$arch/$repo"
-            else:
-                url = f"{context.config.mirror or 'https://geo.mirror.pkgbuild.com'}/$repo/os/$arch"
-
-            # Testing repositories have to go before regular ones to to take precedence.
-            for id in (
-                "core-testing",
-                "core-testing-debug",
-                "extra-testing",
-                "extra-testing-debug",
-                "core-debug",
-                "extra-debug",
-            ):
-                if id in context.config.repositories:
-                    repos += [PacmanRepository(id, url)]
-
-            for id in ("core", "extra"):
-                repos += [PacmanRepository(id, url)]
-
-        setup_pacman(context, repos)
+        setup_pacman(context, cls.repositories(context))
 
     @classmethod
     def install(cls, context: Context) -> None:
@@ -85,6 +60,31 @@ class Installer(DistributionInstaller):
     @classmethod
     def remove_packages(cls, context: Context, packages: Sequence[str]) -> None:
         invoke_pacman(context, "--remove", ["--nosave", "--recursive"], packages)
+
+    @classmethod
+    def repositories(cls, context: Context) -> Iterable[PacmanRepository]:
+        if context.config.local_mirror:
+            yield PacmanRepository("core", context.config.local_mirror)
+        else:
+            if context.config.architecture == Architecture.arm64:
+                url = f"{context.config.mirror or 'http://mirror.archlinuxarm.org'}/$arch/$repo"
+            else:
+                url = f"{context.config.mirror or 'https://geo.mirror.pkgbuild.com'}/$repo/os/$arch"
+
+            # Testing repositories have to go before regular ones to to take precedence.
+            for id in (
+                "core-testing",
+                "core-testing-debug",
+                "extra-testing",
+                "extra-testing-debug",
+                "core-debug",
+                "extra-debug",
+            ):
+                if id in context.config.repositories:
+                    yield PacmanRepository(id, url)
+
+            for id in ("core", "extra"):
+                yield PacmanRepository(id, url)
 
     @classmethod
     def architecture(cls, arch: Architecture) -> str:

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -9,6 +9,7 @@ from mkosi.installer.pacman import (
     PacmanRepository,
     createrepo_pacman,
     invoke_pacman,
+    localrepo_pacman,
     setup_pacman,
 )
 from mkosi.log import die
@@ -36,8 +37,8 @@ class Installer(DistributionInstaller):
         return Distribution.arch
 
     @classmethod
-    def createrepo(cls, context: "Context") -> None:
-        return createrepo_pacman(context)
+    def createrepo(cls, context: Context) -> None:
+        createrepo_pacman(context)
 
     @classmethod
     def setup(cls, context: Context) -> None:
@@ -66,6 +67,9 @@ class Installer(DistributionInstaller):
         if context.config.local_mirror:
             yield PacmanRepository("core", context.config.local_mirror)
         else:
+            if any(context.packages.iterdir()):
+                yield localrepo_pacman()
+
             if context.config.architecture == Architecture.arm64:
                 url = f"{context.config.mirror or 'http://mirror.archlinuxarm.org'}/$arch/$repo"
             else:

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -9,7 +9,7 @@ from mkosi.archive import extract_tar
 from mkosi.config import Architecture
 from mkosi.context import Context
 from mkosi.distributions import Distribution, DistributionInstaller, PackageType
-from mkosi.installer.apt import AptRepository, createrepo_apt, invoke_apt, setup_apt
+from mkosi.installer.apt import AptRepository, createrepo_apt, invoke_apt, localrepo_apt, setup_apt
 from mkosi.log import die
 from mkosi.run import run
 from mkosi.sandbox import finalize_passwd_mounts
@@ -51,6 +51,9 @@ class Installer(DistributionInstaller):
                 signedby=None,
             )
             return
+
+        if any(context.packages.iterdir()):
+            yield localrepo_apt(context)
 
         mirror = context.config.mirror or "http://deb.debian.org/debian"
         signedby = "/usr/share/keyrings/debian-archive-keyring.gpg"
@@ -99,8 +102,8 @@ class Installer(DistributionInstaller):
         setup_apt(context, cls.repositories(context))
 
     @classmethod
-    def createrepo(cls, context: "Context") -> None:
-        return createrepo_apt(context)
+    def createrepo(cls, context: Context) -> None:
+        createrepo_apt(context)
 
     @classmethod
     def install(cls, context: Context) -> None:

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 from mkosi.config import Architecture
 from mkosi.context import Context
@@ -46,94 +46,7 @@ class Installer(DistributionInstaller):
 
     @classmethod
     def setup(cls, context: Context) -> None:
-        gpgurls = (
-            find_rpm_gpgkey(
-                context,
-                key=f"RPM-GPG-KEY-fedora-{context.config.release}-primary",
-                url="https://fedoraproject.org/fedora.gpg",
-            ),
-        )
-
-        repos = []
-
-        if context.config.local_mirror:
-            repos += [RpmRepository("fedora", f"baseurl={context.config.local_mirror}", gpgurls)]
-        elif context.config.release == "eln":
-            mirror = context.config.mirror or "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose"
-            for repo in ("Appstream", "BaseOS", "Extras", "CRB"):
-                url = f"baseurl={join_mirror(mirror, repo)}"
-                repos += [
-                    RpmRepository(repo.lower(), f"{url}/$basearch/os", gpgurls),
-                    RpmRepository(repo.lower(), f"{url}/$basearch/debug/tree", gpgurls, enabled=False),
-                    RpmRepository(repo.lower(), f"{url}/source/tree", gpgurls, enabled=False),
-                ]
-        elif (m := context.config.mirror):
-            directory = "development" if context.config.release == "rawhide" else "releases"
-            url = f"baseurl={join_mirror(m, f'fedora/linux/{directory}/$releasever/Everything')}"
-            repos += [
-                RpmRepository("fedora", f"{url}/$basearch/os", gpgurls),
-                RpmRepository("fedora-debuginfo", f"{url}/$basearch/debug/tree", gpgurls, enabled=False),
-                RpmRepository("fedora-source", f"{url}/source/tree", gpgurls, enabled=False),
-            ]
-
-            if context.config.release != "rawhide":
-                url = f"baseurl={join_mirror(m, 'fedora/linux/updates/$releasever/Everything')}"
-                repos += [
-                    RpmRepository("updates", f"{url}/$basearch", gpgurls),
-                    RpmRepository("updates-debuginfo", f"{url}/$basearch/debug", gpgurls, enabled=False),
-                    RpmRepository("updates-source", f"{url}/source/tree", gpgurls, enabled=False),
-                ]
-
-                url = f"baseurl={join_mirror(m, 'fedora/linux/updates/testing/$releasever/Everything')}"
-                repos += [
-                    RpmRepository("updates-testing", f"{url}/$basearch", gpgurls, enabled=False),
-                    RpmRepository("updates-testing-debuginfo", f"{url}/$basearch/debug", gpgurls, enabled=False),
-                    RpmRepository("updates-testing-source", f"{url}/source/tree", gpgurls, enabled=False)
-                ]
-        else:
-            url = "metalink=https://mirrors.fedoraproject.org/metalink?arch=$basearch"
-            repos += [
-                RpmRepository("fedora", f"{url}&repo=fedora-$releasever", gpgurls),
-                RpmRepository("fedora-debuginfo", f"{url}&repo=fedora-debug-$releasever", gpgurls, enabled=False),
-                RpmRepository("fedora-source", f"{url}&repo=fedora-source-$releasever", gpgurls, enabled=False),
-            ]
-
-            if context.config.release != "rawhide":
-                repos += [
-                    RpmRepository("updates", f"{url}&repo=updates-released-f$releasever", gpgurls),
-                    RpmRepository(
-                        "updates-debuginfo",
-                        f"{url}&repo=updates-released-debug-f$releasever",
-                        gpgurls,
-                        enabled=False,
-                    ),
-                    RpmRepository(
-                        "updates-source",
-                        f"{url}&repo=updates-released-source-f$releasever",
-                        gpgurls,
-                        enabled=False
-                    ),
-                    RpmRepository(
-                        "updates-testing",
-                        f"{url}&repo=updates-testing-f$releasever",
-                        gpgurls,
-                        enabled=False
-                    ),
-                    RpmRepository(
-                        "updates-testing-debuginfo",
-                        f"{url}&repo=updates-testing-debug-f$releasever",
-                        gpgurls,
-                        enabled=False,
-                    ),
-                    RpmRepository(
-                        "updates-testing-source",
-                        f"{url}&repo=updates-testing-source-f$releasever",
-                        gpgurls,
-                        enabled=False,
-                    ),
-                ]
-
-        setup_dnf(context, repos)
+        setup_dnf(context, cls.repositories(context))
 
     @classmethod
     def install(cls, context: Context) -> None:
@@ -146,6 +59,81 @@ class Installer(DistributionInstaller):
     @classmethod
     def remove_packages(cls, context: Context, packages: Sequence[str]) -> None:
         invoke_dnf(context, "remove", packages)
+
+    @classmethod
+    def repositories(cls, context: Context) -> Iterable[RpmRepository]:
+        gpgurls = (
+            find_rpm_gpgkey(
+                context,
+                key=f"RPM-GPG-KEY-fedora-{context.config.release}-primary",
+                url="https://fedoraproject.org/fedora.gpg",
+            ),
+        )
+
+        if context.config.local_mirror:
+            yield RpmRepository("fedora", f"baseurl={context.config.local_mirror}", gpgurls)
+        elif context.config.release == "eln":
+            mirror = context.config.mirror or "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose"
+            for repo in ("Appstream", "BaseOS", "Extras", "CRB"):
+                url = f"baseurl={join_mirror(mirror, repo)}"
+                yield RpmRepository(repo.lower(), f"{url}/$basearch/os", gpgurls)
+                yield RpmRepository(repo.lower(), f"{url}/$basearch/debug/tree", gpgurls, enabled=False)
+                yield RpmRepository(repo.lower(), f"{url}/source/tree", gpgurls, enabled=False)
+        elif (m := context.config.mirror):
+            directory = "development" if context.config.release == "rawhide" else "releases"
+            url = f"baseurl={join_mirror(m, f'fedora/linux/{directory}/$releasever/Everything')}"
+            yield RpmRepository("fedora", f"{url}/$basearch/os", gpgurls)
+            yield RpmRepository("fedora-debuginfo", f"{url}/$basearch/debug/tree", gpgurls, enabled=False)
+            yield RpmRepository("fedora-source", f"{url}/source/tree", gpgurls, enabled=False)
+
+            if context.config.release != "rawhide":
+                url = f"baseurl={join_mirror(m, 'fedora/linux/updates/$releasever/Everything')}"
+                yield RpmRepository("updates", f"{url}/$basearch", gpgurls)
+                yield RpmRepository("updates-debuginfo", f"{url}/$basearch/debug", gpgurls, enabled=False)
+                yield RpmRepository("updates-source", f"{url}/source/tree", gpgurls, enabled=False)
+
+                url = f"baseurl={join_mirror(m, 'fedora/linux/updates/testing/$releasever/Everything')}"
+                yield RpmRepository("updates-testing", f"{url}/$basearch", gpgurls, enabled=False)
+                yield RpmRepository("updates-testing-debuginfo", f"{url}/$basearch/debug", gpgurls, enabled=False)
+                yield RpmRepository("updates-testing-source", f"{url}/source/tree", gpgurls, enabled=False)
+        else:
+            url = "metalink=https://mirrors.fedoraproject.org/metalink?arch=$basearch"
+            yield RpmRepository("fedora", f"{url}&repo=fedora-$releasever", gpgurls)
+            yield RpmRepository("fedora-debuginfo", f"{url}&repo=fedora-debug-$releasever", gpgurls, enabled=False)
+            yield RpmRepository("fedora-source", f"{url}&repo=fedora-source-$releasever", gpgurls, enabled=False)
+
+            if context.config.release != "rawhide":
+                yield RpmRepository("updates", f"{url}&repo=updates-released-f$releasever", gpgurls)
+                yield RpmRepository(
+                    "updates-debuginfo",
+                    f"{url}&repo=updates-released-debug-f$releasever",
+                    gpgurls,
+                    enabled=False,
+                )
+                yield RpmRepository(
+                    "updates-source",
+                    f"{url}&repo=updates-released-source-f$releasever",
+                    gpgurls,
+                    enabled=False
+                )
+                yield RpmRepository(
+                    "updates-testing",
+                    f"{url}&repo=updates-testing-f$releasever",
+                    gpgurls,
+                    enabled=False
+                )
+                yield RpmRepository(
+                    "updates-testing-debuginfo",
+                    f"{url}&repo=updates-testing-debug-f$releasever",
+                    gpgurls,
+                    enabled=False,
+                )
+                yield RpmRepository(
+                    "updates-testing-source",
+                    f"{url}&repo=updates-testing-source-f$releasever",
+                    gpgurls,
+                    enabled=False,
+                )
 
     @classmethod
     def architecture(cls, arch: Architecture) -> str:

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -10,7 +10,7 @@ from mkosi.distributions import (
     PackageType,
     join_mirror,
 )
-from mkosi.installer.dnf import createrepo_dnf, invoke_dnf, setup_dnf
+from mkosi.installer.dnf import createrepo_dnf, invoke_dnf, localrepo_dnf, setup_dnf
 from mkosi.installer.rpm import RpmRepository, find_rpm_gpgkey
 from mkosi.log import die
 
@@ -42,7 +42,7 @@ class Installer(DistributionInstaller):
 
     @classmethod
     def createrepo(cls, context: Context) -> None:
-        return createrepo_dnf(context)
+        createrepo_dnf(context)
 
     @classmethod
     def setup(cls, context: Context) -> None:
@@ -72,7 +72,12 @@ class Installer(DistributionInstaller):
 
         if context.config.local_mirror:
             yield RpmRepository("fedora", f"baseurl={context.config.local_mirror}", gpgurls)
-        elif context.config.release == "eln":
+            return
+
+        if any(context.packages.iterdir()):
+            yield localrepo_dnf()
+
+        if context.config.release == "eln":
             mirror = context.config.mirror or "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose"
             for repo in ("Appstream", "BaseOS", "Extras", "CRB"):
                 url = f"baseurl={join_mirror(mirror, repo)}"

--- a/mkosi/distributions/mageia.py
+++ b/mkosi/distributions/mageia.py
@@ -5,18 +5,13 @@ from collections.abc import Iterable, Sequence
 
 from mkosi.config import Architecture
 from mkosi.context import Context
-from mkosi.distributions import (
-    Distribution,
-    DistributionInstaller,
-    PackageType,
-    join_mirror,
-)
-from mkosi.installer.dnf import createrepo_dnf, invoke_dnf, localrepo_dnf, setup_dnf
+from mkosi.distributions import Distribution, fedora, join_mirror
+from mkosi.installer.dnf import localrepo_dnf
 from mkosi.installer.rpm import RpmRepository, find_rpm_gpgkey
 from mkosi.log import die
 
 
-class Installer(DistributionInstaller):
+class Installer(fedora.Installer):
     @classmethod
     def pretty_name(cls) -> str:
         return "Mageia"
@@ -24,10 +19,6 @@ class Installer(DistributionInstaller):
     @classmethod
     def filesystem(cls) -> str:
         return "ext4"
-
-    @classmethod
-    def package_type(cls) -> PackageType:
-        return PackageType.rpm
 
     @classmethod
     def default_release(cls) -> str:
@@ -38,30 +29,14 @@ class Installer(DistributionInstaller):
         return Distribution.mageia
 
     @classmethod
-    def createrepo(cls, context: Context) -> None:
-        createrepo_dnf(context)
-
-    @classmethod
-    def setup(cls, context: Context) -> None:
-        setup_dnf(context, cls.repositories(context))
-
-    @classmethod
-    def install(cls, context: Context) -> None:
-        cls.install_packages(context, ["filesystem"], apivfs=False)
-
-    @classmethod
     def install_packages(cls, context: Context, packages: Sequence[str], apivfs: bool = True) -> None:
-        invoke_dnf(context, "install", packages, apivfs=apivfs)
+        super().install_packages(context, packages, apivfs)
 
         for d in context.root.glob("boot/vmlinuz-*"):
             kver = d.name.removeprefix("vmlinuz-")
             vmlinuz = context.root / "usr/lib/modules" / kver / "vmlinuz"
             if not vmlinuz.exists():
                 shutil.copy2(d, vmlinuz)
-
-    @classmethod
-    def remove_packages(cls, context: Context, packages: Sequence[str]) -> None:
-        invoke_dnf(context, "remove", packages)
 
     @classmethod
     def repositories(cls, context: Context) -> Iterable[RpmRepository]:

--- a/mkosi/distributions/openmandriva.py
+++ b/mkosi/distributions/openmandriva.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 import shutil
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 from mkosi.config import Architecture
 from mkosi.context import Context
@@ -43,28 +43,7 @@ class Installer(DistributionInstaller):
 
     @classmethod
     def setup(cls, context: Context) -> None:
-        mirror = context.config.mirror or "http://mirror.openmandriva.org"
-
-        gpgurls = (
-            find_rpm_gpgkey(
-                context,
-                "RPM-GPG-KEY-OpenMandriva",
-                "https://raw.githubusercontent.com/OpenMandrivaAssociation/openmandriva-repos/master/RPM-GPG-KEY-OpenMandriva",
-            ),
-        )
-
-        repos = []
-
-        if context.config.local_mirror:
-            repos += [RpmRepository("main-release", f"baseurl={context.config.local_mirror}", gpgurls)]
-        else:
-            url = f"baseurl={join_mirror(mirror, '$releasever/repository/$basearch/main')}"
-            repos += [
-                RpmRepository("main-release", f"{url}/release", gpgurls),
-                RpmRepository("main-updates", f"{url}/updates", gpgurls),
-            ]
-
-        setup_dnf(context, repos)
+        setup_dnf(context, cls.repositories(context))
 
     @classmethod
     def install(cls, context: Context) -> None:
@@ -87,6 +66,25 @@ class Installer(DistributionInstaller):
     @classmethod
     def remove_packages(cls, context: Context, packages: Sequence[str]) -> None:
         invoke_dnf(context, "remove", packages)
+
+    @classmethod
+    def repositories(cls, context: Context) -> Iterable[RpmRepository]:
+        mirror = context.config.mirror or "http://mirror.openmandriva.org"
+
+        gpgurls = (
+            find_rpm_gpgkey(
+                context,
+                "RPM-GPG-KEY-OpenMandriva",
+                "https://raw.githubusercontent.com/OpenMandrivaAssociation/openmandriva-repos/master/RPM-GPG-KEY-OpenMandriva",
+            ),
+        )
+
+        if context.config.local_mirror:
+            yield RpmRepository("main-release", f"baseurl={context.config.local_mirror}", gpgurls)
+        else:
+            url = f"baseurl={join_mirror(mirror, '$releasever/repository/$basearch/main')}"
+            yield RpmRepository("main-release", f"{url}/release", gpgurls)
+            yield RpmRepository("main-updates", f"{url}/updates", gpgurls)
 
     @classmethod
     def architecture(cls, arch: Architecture) -> str:

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -2,7 +2,7 @@
 
 import tempfile
 import xml.etree.ElementTree as ElementTree
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from pathlib import Path
 
 from mkosi.config import Architecture
@@ -50,54 +50,11 @@ class Installer(DistributionInstaller):
 
     @classmethod
     def setup(cls, context: Context) -> None:
-        release = context.config.release
-        if release == "leap":
-            release = "stable"
-
-        mirror = context.config.mirror or "https://download.opensuse.org"
-
-        # If the release looks like a timestamp, it's Tumbleweed. 13.x is legacy
-        # (14.x won't ever appear). For anything else, let's default to Leap.
-        if context.config.local_mirror:
-            release_url = f"{context.config.local_mirror}"
-            updates_url = None
-        if release.isdigit() or release == "tumbleweed":
-            release_url = f"{mirror}/tumbleweed/repo/oss/"
-            updates_url = f"{mirror}/update/tumbleweed/"
-        elif release in ("current", "stable"):
-            release_url = f"{mirror}/distribution/openSUSE-{release}/repo/oss/"
-            updates_url = f"{mirror}/update/openSUSE-{release}/"
-        else:
-            release_url = f"{mirror}/distribution/leap/{release}/repo/oss/"
-            updates_url = f"{mirror}/update/leap/{release}/oss/"
-
         zypper = find_binary("zypper", root=context.config.tools())
-
-        # If we need to use a local mirror, create a temporary repository definition
-        # that doesn't get in the image, as it is valid only at image build time.
-        if context.config.local_mirror:
-            repos = [RpmRepository(id="local-mirror", url=f"baseurl={context.config.local_mirror}", gpgurls=())]
-        else:
-            repos = [
-                RpmRepository(
-                    id="repo-oss",
-                    url=f"baseurl={release_url}",
-                    gpgurls=fetch_gpgurls(context, release_url) if not zypper else (),
-                ),
-            ]
-            if updates_url is not None:
-                repos += [
-                    RpmRepository(
-                        id="repo-update",
-                        url=f"baseurl={updates_url}",
-                        gpgurls=fetch_gpgurls(context, updates_url) if not zypper else (),
-                    )
-                ]
-
         if zypper:
-            setup_zypper(context, repos)
+            setup_zypper(context, cls.repositories(context))
         else:
-            setup_dnf(context, repos)
+            setup_dnf(context, cls.repositories(context))
 
     @classmethod
     def install(cls, context: Context) -> None:
@@ -120,6 +77,46 @@ class Installer(DistributionInstaller):
             invoke_zypper(context, "remove", packages, ["--clean-deps"])
         else:
             invoke_dnf(context, "remove", packages)
+
+    @classmethod
+    def repositories(cls, context: Context) -> Iterable[RpmRepository]:
+        zypper = find_binary("zypper", root=context.config.tools())
+
+        release = context.config.release
+        if release == "leap":
+            release = "stable"
+
+        mirror = context.config.mirror or "https://download.opensuse.org"
+
+        # If the release looks like a timestamp, it's Tumbleweed. 13.x is legacy
+        # (14.x won't ever appear). For anything else, let's default to Leap.
+        if context.config.local_mirror:
+            release_url = f"{context.config.local_mirror}"
+            updates_url = None
+        if release.isdigit() or release == "tumbleweed":
+            release_url = f"{mirror}/tumbleweed/repo/oss/"
+            updates_url = f"{mirror}/update/tumbleweed/"
+        elif release in ("current", "stable"):
+            release_url = f"{mirror}/distribution/openSUSE-{release}/repo/oss/"
+            updates_url = f"{mirror}/update/openSUSE-{release}/"
+        else:
+            release_url = f"{mirror}/distribution/leap/{release}/repo/oss/"
+            updates_url = f"{mirror}/update/leap/{release}/oss/"
+
+        if context.config.local_mirror:
+            yield RpmRepository(id="local-mirror", url=f"baseurl={context.config.local_mirror}", gpgurls=())
+        else:
+            yield RpmRepository(
+                id="repo-oss",
+                url=f"baseurl={release_url}",
+                gpgurls=fetch_gpgurls(context, release_url) if not zypper else (),
+            )
+            if updates_url is not None:
+                yield RpmRepository(
+                    id="repo-update",
+                    url=f"baseurl={updates_url}",
+                    gpgurls=fetch_gpgurls(context, updates_url) if not zypper else (),
+                )
 
     @classmethod
     def architecture(cls, arch: Architecture) -> str:

--- a/mkosi/distributions/ubuntu.py
+++ b/mkosi/distributions/ubuntu.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 from mkosi.config import Architecture
 from mkosi.context import Context
 from mkosi.distributions import debian
-from mkosi.installer.apt import AptRepository
+from mkosi.installer.apt import AptRepository, localrepo_apt
 
 
 class Installer(debian.Installer):
@@ -35,6 +35,9 @@ class Installer(debian.Installer):
                 signedby=None,
             )
             return
+
+        if any(context.packages.iterdir()):
+            yield localrepo_apt(context)
 
         if context.config.architecture in (Architecture.x86, Architecture.x86_64):
             mirror = context.config.mirror or "http://archive.ubuntu.com/ubuntu"

--- a/mkosi/distributions/ubuntu.py
+++ b/mkosi/distributions/ubuntu.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
+from collections.abc import Iterable
+
 from mkosi.config import Architecture
 from mkosi.context import Context
 from mkosi.distributions import debian
+from mkosi.installer.apt import AptRepository
 
 
 class Installer(debian.Installer):
@@ -15,33 +18,46 @@ class Installer(debian.Installer):
         return "lunar"
 
     @staticmethod
-    def repositories(context: Context, local: bool = True) -> list[str]:
-        if context.config.local_mirror and local:
-            return [f"deb [trusted=yes] {context.config.local_mirror} {context.config.release} main"]
+    def repositories(context: Context, local: bool = True) -> Iterable[AptRepository]:
+        types = ("deb", "deb-src")
 
-        archives = ("deb", "deb-src")
+        # From kinetic onwards, the usr-is-merged package is available in universe and is required by
+        # mkosi to set up a proper usr-merged system so we add the universe repository unconditionally.
+        components = ["main"] + (["universe"] if context.config.release not in ("focal", "jammy") else [])
+        components = (*components, *context.config.repositories)
+
+        if context.config.local_mirror and local:
+            yield AptRepository(
+                types=("deb",),
+                url=context.config.local_mirror,
+                suite=context.config.release,
+                components=("main",),
+                signedby=None,
+            )
+            return
 
         if context.config.architecture in (Architecture.x86, Architecture.x86_64):
             mirror = context.config.mirror or "http://archive.ubuntu.com/ubuntu"
         else:
             mirror = context.config.mirror or "http://ports.ubuntu.com"
 
-        signedby = "[signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg]"
+        signedby = "/usr/share/keyrings/ubuntu-archive-keyring.gpg"
 
-        # From kinetic onwards, the usr-is-merged package is available in universe and is required by
-        # mkosi to set up a proper usr-merged system so we add the universe repository unconditionally.
-        components = ["main"] + (["universe"] if context.config.release not in ("focal", "jammy") else [])
-        components = ' '.join((*components, *context.config.repositories))
+        yield AptRepository(
+            types=types,
+            url=mirror,
+            suite=context.config.release,
+            components=components,
+            signedby=signedby,
+        )
 
-        repos = [
-            f"{archive} {signedby} {mirror} {context.config.release} {components}"
-            for archive in archives
-        ]
-
-        repos += [
-            f"{archive} {signedby} {mirror} {context.config.release}-updates {components}"
-            for archive in archives
-        ]
+        yield AptRepository(
+            types=types,
+            url=mirror,
+            suite=f"{context.config.release}-updates",
+            components=components,
+            signedby=signedby,
+        )
 
         # Security updates repos are never mirrored. But !x86 are on the ports server.
         if context.config.architecture in [Architecture.x86, Architecture.x86_64]:
@@ -49,9 +65,11 @@ class Installer(debian.Installer):
         else:
             mirror = "http://ports.ubuntu.com/"
 
-        repos += [
-            f"{archive} {signedby} {mirror} {context.config.release}-security {components}"
-            for archive in archives
-        ]
+        yield AptRepository(
+            types=types,
+            url=mirror,
+            suite=f"{context.config.release}-security",
+            components=components,
+            signedby=signedby,
+        )
 
-        return repos

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -154,14 +154,12 @@ def createrepo_apt(context: Context) -> None:
         run(["dpkg-scanpackages", context.packages],
             stdout=f, sandbox=context.sandbox(options=["--ro-bind", context.packages, context.packages]))
 
-    (context.pkgmngr / "etc/apt/sources.list.d").mkdir(parents=True, exist_ok=True)
-    (context.pkgmngr / "etc/apt/sources.list.d/mkosi-packages.sources").write_text(
-        f"""\
-        Enabled: yes
-        Types: deb
-        URIs: file:///work/packages
-        Suites: {context.config.release}
-        Components: main
-        Trusted: yes
-        """
+
+def localrepo_apt(context: Context) -> AptRepository:
+    return AptRepository(
+        types=("deb",),
+        url="file:///work/packages",
+        suite=context.config.release,
+        components=("main",),
+        signedby=None,
     )

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1+
 import textwrap
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
+from typing import NamedTuple, Optional
 
 from mkosi.context import Context
 from mkosi.installer import finalize_package_manager_mounts
@@ -11,7 +12,27 @@ from mkosi.types import PathString
 from mkosi.util import sort_packages, umask
 
 
-def setup_apt(context: Context, repos: Sequence[str]) -> None:
+class AptRepository(NamedTuple):
+    types: tuple[str, ...]
+    url: str
+    suite: str
+    components: tuple[str, ...]
+    signedby: Optional[str]
+
+    def __str__(self) -> str:
+        return textwrap.dedent(
+            f"""\
+            Types: {" ".join(self.types)}
+            URIs: {self.url}
+            Suites: {self.suite}
+            Components: {" ".join(self.components)}
+            {"Signed-By" if self.signedby else "Trusted"}: {self.signedby or "yes"}
+
+            """
+        )
+
+
+def setup_apt(context: Context, repos: Iterable[AptRepository]) -> None:
     (context.pkgmngr / "etc/apt").mkdir(exist_ok=True, parents=True)
     (context.pkgmngr / "etc/apt/apt.conf.d").mkdir(exist_ok=True, parents=True)
     (context.pkgmngr / "etc/apt/preferences.d").mkdir(exist_ok=True, parents=True)
@@ -39,11 +60,11 @@ def setup_apt(context: Context, repos: Sequence[str]) -> None:
             )
         )
 
-    sources = context.pkgmngr / "etc/apt/sources.list"
+    sources = context.pkgmngr / "etc/apt/sources.list.d/mkosi.sources"
     if not sources.exists():
         with sources.open("w") as f:
             for repo in repos:
-                f.write(f"{repo}\n")
+                f.write(str(repo))
 
 
 def apt_cmd(context: Context, command: str) -> list[PathString]:

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1+
 import textwrap
 from collections.abc import Iterable, Sequence
+from pathlib import Path
 from typing import NamedTuple
 
 from mkosi.context import Context
@@ -10,6 +11,7 @@ from mkosi.run import run
 from mkosi.sandbox import apivfs_cmd
 from mkosi.types import PathString
 from mkosi.util import sort_packages, umask
+from mkosi.versioncomp import GenericVersion
 
 
 class PacmanRepository(NamedTuple):
@@ -110,7 +112,13 @@ def invoke_pacman(
 
 
 def createrepo_pacman(context: Context) -> None:
-    run(["repo-add", context.packages / "mkosi-packages.db.tar", *context.packages.glob("*.pkg.tar*")])
+    run(
+        [
+            "repo-add",
+            context.packages / "mkosi-packages.db.tar",
+            *sorted(context.packages.glob("*.pkg.tar*"), key=lambda p: GenericVersion(Path(p).name)),
+        ]
+    )
 
     with (context.pkgmngr / "etc/pacman.conf").open("a") as f:
         f.write(

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -111,7 +111,7 @@ def invoke_pacman(
         )
 
 
-def createrepo_pacman(context: Context) -> None:
+def createrepo_pacman(context: Context, *, force: bool = False) -> None:
     run(
         [
             "repo-add",
@@ -120,12 +120,6 @@ def createrepo_pacman(context: Context) -> None:
         ]
     )
 
-    with (context.pkgmngr / "etc/pacman.conf").open("a") as f:
-        f.write(
-            textwrap.dedent(
-                """\
-                [mkosi-packages]
-                Server = file:///work/packages
-                """
-            )
-        )
+
+def localrepo_pacman() -> PacmanRepository:
+    return PacmanRepository(id="mkosi-packages", url="file:///work/packages")

--- a/mkosi/installer/rpm.py
+++ b/mkosi/installer/rpm.py
@@ -16,10 +16,13 @@ class RpmRepository(NamedTuple):
     id: str
     url: str
     gpgurls: tuple[str, ...]
+    gpgcheck: bool = True
     enabled: bool = True
     sslcacert: Optional[Path] = None
     sslclientkey: Optional[Path] = None
     sslclientcert: Optional[Path] = None
+    metadata_expire: Optional[int] = None
+    priority: Optional[int] = None
 
 
 def find_rpm_gpgkey(context: Context, key: str, url: str) -> str:

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -44,13 +44,16 @@ def setup_zypper(context: Context, repos: Iterable[RpmRepository]) -> None:
                         [{repo.id}]
                         name={repo.id}
                         {repo.url}
-                        gpgcheck=1
+                        gpgcheck={int(repo.gpgcheck)}
                         enabled={int(repo.enabled)}
                         autorefresh=1
                         keeppackages=1
                         """
                     )
                 )
+
+                if repo.priority is not None:
+                    f.write(f"priority={repo.priority}\n")
 
                 for i, url in enumerate(repo.gpgurls):
                     f.write("gpgkey=" if i == 0 else len("gpgkey=") * " ")
@@ -103,17 +106,12 @@ def createrepo_zypper(context: Context) -> None:
     run(["createrepo_c", context.packages],
         sandbox=context.sandbox(options=["--bind", context.packages, context.packages]))
 
-    (context.pkgmngr / "etc/zypp/repos.d").mkdir(parents=True, exist_ok=True)
-    (context.pkgmngr / "etc/zypp/repos.d/mkosi-packages.repo").write_text(
-        textwrap.dedent(
-            """\
-            [mkosi-packages]
-            name=mkosi-packages
-            gpgcheck=0
-            enabled=1
-            baseurl=file:///work/packages
-            autorefresh=0
-            priority=50
-            """
-        )
+
+def localrepo_zypper() -> RpmRepository:
+    return RpmRepository(
+        id="mkosi-packages",
+        url="baseurl=file:///work/packages",
+        gpgcheck=False,
+        gpgurls=(),
+        priority=50,
     )

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1+
 import textwrap
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 from mkosi.config import yes_no
 from mkosi.context import Context
@@ -13,7 +13,7 @@ from mkosi.types import PathString
 from mkosi.util import sort_packages
 
 
-def setup_zypper(context: Context, repos: Sequence[RpmRepository]) -> None:
+def setup_zypper(context: Context, repos: Iterable[RpmRepository]) -> None:
     config = context.pkgmngr / "etc/zypp/zypp.conf"
     config.parent.mkdir(exist_ok=True, parents=True)
 


### PR DESCRIPTION
If we notice extra packages were added by the build script to the
local packages repository or if we're running an incremental build
and there are local packages, do a distribution upgrade so that local
packages can be upgraded without having to throw away the cached
images.
