### PR TITLE
mkosi-initrd: include libtss2 packages on ubuntu by name if they exist

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-ubuntu/mkosi.conf
@@ -17,10 +17,6 @@ Packages=
 
         # Various libraries that are dlopen'ed by systemd
         libfido2-1
-        ^libtss2-esys-[0-9\.]+-0$
-        libtss2-rc0
-        ^libtss2-mu[0-9\.-]+$
-        libtss2-tcti-device0
 
 RemovePackages=
         # TODO: Remove dpkg if dash ever loses its dependency on it.

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-ubuntu/mkosi.conf.d/10-debian-ubuntu-libtss-old.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-ubuntu/mkosi.conf.d/10-debian-ubuntu-libtss-old.conf
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[TriggerMatch]
+Distribution=debian
+Release=|bullseye
+Release=|bookworm
+
+[TriggerMatch]
+Distribution=ubuntu
+Release=|jammy
+Release=|lunar
+Release=|mantic
+
+[Content]
+Packages=
+        ^libtss2-esys-[0-9.]+-0$
+        libtss2-rc0
+        libtss2-tcti-device0
+        libtss2-mu0

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-ubuntu/mkosi.conf.d/10-debian-ubuntu-libtss.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-ubuntu/mkosi.conf.d/10-debian-ubuntu-libtss.conf
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[TriggerMatch]
+Distribution=debian
+Release=!bullseye
+Release=!bookworm
+
+[TriggerMatch]
+Distribution=ubuntu
+Release=!focal
+Release=!jammy
+Release=!lunar
+Release=!mantic
+
+[Content]
+Packages=
+        ^libtss2-esys-[0-9.]+-0$
+        libtss2-rc0
+        libtss2-tcti-device0
+        ^libtss2-mu-[0-9.]+-0$


### PR DESCRIPTION
Fixes: #2346