### PR TITLE
Add qemu user static packages to default image

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -41,3 +41,6 @@ RemoveFiles=
 
 # Make sure that SELinux doesn't run in enforcing mode even if it's pulled in as a dependency.
 KernelCommandLine=console=ttyS0 enforcing=0
+
+[Host]
+@QemuMem=4G

--- a/mkosi.conf.d/15-memory.conf
+++ b/mkosi.conf.d/15-memory.conf
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Format=|esp
+Format=|uki
+Format=|cpio
+
+[Host]
+@QemuMem=8G

--- a/mkosi.conf.d/20-arch.conf
+++ b/mkosi.conf.d/20-arch.conf
@@ -34,6 +34,7 @@ Packages=
         pesign
         python-cryptography
         qemu-base
+        qemu-user-static
         sbsigntools
         shadow
         shim

--- a/mkosi.conf.d/20-fedora/mkosi.conf
+++ b/mkosi.conf.d/20-fedora/mkosi.conf
@@ -15,5 +15,6 @@ Packages=
         dnf5-plugins
         fedora-review
         pacman
+        qemu-user-static
         systemd-ukify
         zypper

--- a/mkosi.conf.d/20-opensuse.conf
+++ b/mkosi.conf.d/20-opensuse.conf
@@ -33,6 +33,7 @@ Packages=
         pesign
         perf
         qemu-headless
+        qemu-linux-user
         sbsigntools
         shadow
         shim

--- a/mkosi.conf.d/30-debian-ubuntu/mkosi.conf
+++ b/mkosi.conf.d/30-debian-ubuntu/mkosi.conf
@@ -36,6 +36,7 @@ Packages=
         python3-cryptography
         python3-pefile
         qemu-system
+        qemu-user-static
         sbsigntool
         shim-signed
         socat

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -79,7 +79,6 @@ class Image:
             "--cache-dir", "mkosi.cache",
             *(f"--kernel-command-line={i}" for i in kcl),
             "--qemu-vsock=yes",
-            "--qemu-mem=4G",
             verb,
             *args,
         ], check=check, stdin=stdin, stdout=sys.stdout, user=user, group=group)


### PR DESCRIPTION
Useful for debugging cross architecture builds. This is not packaged
in centos so we don't install it there.