### PR TITLE
Have systemd-repart generate fstab and crypttab if requested

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2653,6 +2653,7 @@ def make_image(
     msg: str,
     skip: Sequence[str] = [],
     split: bool = False,
+    tabs: bool = False,
     root: Optional[Path] = None,
     definitions: Sequence[Path] = [],
 ) -> list[Partition]:
@@ -2664,7 +2665,7 @@ def make_image(
         "--json=pretty",
         "--no-pager",
         f"--offline={yes_no(context.config.repart_offline)}",
-        "--seed", str(context.config.seed) if context.config.seed else "random",
+        "--seed", str(context.config.seed),
         context.staging / context.config.output_with_format,
     ]
     options: list[PathString] = ["--bind", context.staging, context.staging]
@@ -2691,6 +2692,11 @@ def make_image(
         cmdline += ["--split=yes"]
     if context.config.sector_size:
         cmdline += ["--sector-size", str(context.config.sector_size)]
+    if tabs and systemd_tool_version(context.config, "systemd-repart") >= 256:
+        cmdline += [
+            "--generate-fstab=/etc/fstab",
+            "--generate-crypttab=/etc/crypttab",
+        ]
 
     for d in definitions:
         cmdline += ["--definitions", d]
@@ -2723,6 +2729,7 @@ def make_disk(
     msg: str,
     skip: Sequence[str] = [],
     split: bool = False,
+    tabs: bool = False,
 ) -> list[Partition]:
     if context.config.output_format != OutputFormat.disk:
         return []
@@ -2789,7 +2796,7 @@ def make_disk(
 
         definitions = [defaults]
 
-    return make_image(context, msg=msg, skip=skip, split=split, root=context.root, definitions=definitions)
+    return make_image(context, msg=msg, skip=skip, split=split, tabs=tabs, root=context.root, definitions=definitions)
 
 
 def make_esp(context: Context, uki: Path) -> list[Partition]:
@@ -3059,7 +3066,7 @@ def build_image(context: Context) -> None:
         run_finalize_scripts(context)
 
     normalize_mtime(context.root, context.config.source_date_epoch)
-    partitions = make_disk(context, skip=("esp", "xbootldr"), msg="Generating disk image")
+    partitions = make_disk(context, skip=("esp", "xbootldr"), tabs=True, msg="Generating disk image")
     install_uki(context, partitions)
     prepare_grub_efi(context)
     prepare_grub_bios(context, partitions)

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1200,7 +1200,7 @@ class Config:
     repart_offline: bool
     overlay: bool
     use_subvolumes: ConfigFeature
-    seed: Optional[uuid.UUID]
+    seed: uuid.UUID
 
     packages: list[str]
     build_packages: list[str]
@@ -1840,6 +1840,7 @@ SETTINGS = (
         metavar="UUID",
         section="Output",
         parse=config_parse_seed,
+        default=uuid.uuid4(),
         help="Set the seed for systemd-repart",
     ),
 
@@ -3626,8 +3627,8 @@ def json_type_transformer(refcls: Union[type[Args], type[Config]]) -> Callable[[
     def path_list_transformer(pathlist: list[str], fieldtype: type[list[Path]]) -> list[Path]:
         return [Path(p) for p in pathlist]
 
-    def optional_uuid_transformer(optuuid: Optional[str], fieldtype: type[Optional[uuid.UUID]]) -> Optional[uuid.UUID]:
-        return uuid.UUID(optuuid) if optuuid is not None else None
+    def uuid_transformer(uuidstr: str, fieldtype: type[uuid.UUID]) -> uuid.UUID:
+        return uuid.UUID(uuidstr)
 
     def root_password_transformer(
         rootpw: Optional[list[Union[str, bool]]], fieldtype: type[Optional[tuple[str, bool]]]
@@ -3691,7 +3692,7 @@ def json_type_transformer(refcls: Union[type[Args], type[Config]]) -> Callable[[
         Path: path_transformer,
         Optional[Path]: optional_path_transformer,
         list[Path]: path_list_transformer,
-        Optional[uuid.UUID]: optional_uuid_transformer,
+        uuid.UUID: uuid_transformer,
         Optional[tuple[str, bool]]: root_password_transformer,
         list[ConfigTree]: config_tree_transformer,
         tuple[str, ...]: str_tuple_transformer,


### PR DESCRIPTION
If systemd-repart is new enough, let's specify --generate-fstab= and --generate-crypttab= so that these files are automatically generated and included in the disk image if the corresponding new settings are used in any partition definition files.

We also make sure systemd-repart always uses the same seed by
generating the random seed ourselves instead of leaving it up to
systemd-repart.

See https://github.com/systemd/systemd/pull/30636.