### PR TITLE
opensuse: Add python3-pefile to tools tree and default image

### DIFF
--- a/mkosi.conf.d/20-opensuse.conf
+++ b/mkosi.conf.d/20-opensuse.conf
@@ -30,8 +30,9 @@ Packages=
         openssh-server
         openssl
         ovmf
-        pesign
         perf
+        pesign
+        python3-pefile
         qemu-headless
         qemu-linux-user
         sbsigntools

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-opensuse.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-opensuse.conf
@@ -18,6 +18,7 @@ Packages=
         ovmf
         pesign
         policycoreutils
+        python3-pefile
         qemu-headless
         sbsigntools
         shadow


### PR DESCRIPTION
This dependency was dropped in opensuse's systemd packaging so add it ourselves.

See https://build.opensuse.org/request/show/1144939.