### PR TITLE
Do not use underscore in image names

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -588,7 +588,7 @@ def config_default_output(namespace: argparse.Namespace) -> str:
     output = namespace.image_id or namespace.image or "image"
 
     if namespace.image_version:
-        output += f"_{namespace.image_version}"
+        output += f"-{namespace.image_version}"
 
     return output
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -896,7 +896,7 @@ def test_output_id_version(tmp_path: Path) -> None:
     with chdir(d):
         _, [config] = parse_config()
 
-    assert config.output == "output_1.2.3"
+    assert config.output == "output-1.2.3"
 
 
 def test_deterministic() -> None:


### PR DESCRIPTION
When suffixing image_version (mkosi.version) do not use an underscore since that breaks systemd-machined/machinectl because undescore are invalid in machine names.

This is related to commit 7eb4ea8

Closes: #2367