### PR TITLE
Do not use underscore in image names for directory

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -588,7 +588,13 @@ def config_default_output(namespace: argparse.Namespace) -> str:
     output = namespace.image_id or namespace.image or "image"
 
     if namespace.image_version:
-        output += f"_{namespace.image_version}"
+        # Discoverable Disk Image (DDI) compatible separator
+        separator = "_"
+        if namespace.output_format == OutputFormat.directory:
+            # systemd-machined compatible separator
+            separator = "-"
+
+        output += f"{separator}{namespace.image_version}"
 
     return output
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -898,6 +898,22 @@ def test_output_id_version(tmp_path: Path) -> None:
 
     assert config.output == "output_1.2.3"
 
+def test_output_id_version_directory(tmp_path: Path) -> None:
+    d = tmp_path
+
+    (d / "mkosi.conf").write_text(
+        """
+        [Output]
+        Format=directory
+        ImageId=output
+        ImageVersion=1.2.3
+        """
+    )
+
+    with chdir(d):
+        _, [config] = parse_config()
+
+    assert config.output == "output-1.2.3"
 
 def test_deterministic() -> None:
     assert Config.default() == Config.default()


### PR DESCRIPTION
For OutputFormat.directory when suffixing image_version (mkosi.version) do not use an underscore since that breaks systemd-machined/machinectl because underscore is invalid in machine names.

This is related to commit 7eb4ea8

Closes: #2367