### PR TITLE
Add used package manager to cache manifest

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1402,6 +1402,7 @@ class Config:
             "release": self.release,
             "mirror": self.mirror,
             "architecture": self.architecture,
+            "package_manager": self.distribution.package_manager(self).executable(self),
             "packages": self.packages,
             "build_packages": self.build_packages,
             "repositories": self.repositories,


### PR DESCRIPTION
If the package manager changes, the cache is invalid as the repository metadata directories change as well, so let's invalidate the cache when that happens.