### PR TITLE
Only install amd-ucode-firmware on x86-64

### DIFF
--- a/mkosi.conf.d/20-fedora/mkosi.conf
+++ b/mkosi.conf.d/20-fedora/mkosi.conf
@@ -8,7 +8,6 @@ Distribution=fedora
 
 [Content]
 Packages=
-        amd-ucode-firmware
         archlinux-keyring
         btrfs-progs
         dnf5

--- a/mkosi.conf.d/20-fedora/mkosi.conf.d/20-x86_64.conf
+++ b/mkosi.conf.d/20-fedora/mkosi.conf.d/20-x86_64.conf
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Architecture=x86-64
+
+[Content]
+Packages=
+        amd-ucode-firmware


### PR DESCRIPTION
Fixes #2391