### PR TITLE
Install libarchive-tools in Debian/Ubuntu tools tree

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu.conf
@@ -16,6 +16,7 @@ Packages=
         dpkg-dev
         erofs-utils
         grub2
+        libarchive-tools
         libtss2-dev
         makepkg
         openssh-client


### PR DESCRIPTION
makepkg needs bsdtar but is missing a dependency on libarchive-tools on Debian/Ubuntu so install it manually as a workaround.