### PR TITLE
Reuse existing scripts for mkosi-install

### DIFF
--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -3,7 +3,7 @@ import os
 import textwrap
 from collections.abc import Iterable, Sequence
 from pathlib import Path
-from typing import NamedTuple, Optional
+from typing import NamedTuple, Optional, cast
 
 from mkosi.config import Config
 from mkosi.context import Context
@@ -62,12 +62,12 @@ class Apt(PackageManager):
                 "apt-mark",
                 "apt-sortpkgs",
             )
-        } | {
-            "mkosi-install"  : apivfs_cmd(context.root) + cls.cmd(context, "apt-get") + ["install"],
-            "mkosi-upgrade"  : apivfs_cmd(context.root) + cls.cmd(context, "apt-get") + ["upgrade"],
-            "mkosi-remove"   : apivfs_cmd(context.root) + cls.cmd(context, "apt-get") + ["purge"],
-            "mkosi-reinstall": apivfs_cmd(context.root) + cls.cmd(context, "apt-get") + ["install", "--reinstall"],
-        }
+        } | cast(dict[str, list[PathString]], {
+            "mkosi-install"  : ["apt-get", "install"],
+            "mkosi-upgrade"  : ["apt-get", "upgrade"],
+            "mkosi-remove"   : ["apt-get", "purge"],
+            "mkosi-reinstall": ["apt-get", "install", "--reinstall"],
+        })
 
     @classmethod
     def setup(cls, context: Context, repos: Iterable[Repository]) -> None:

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -41,10 +41,10 @@ class Dnf(PackageManager):
         return {
             "dnf": apivfs_cmd(context.root) + cls.cmd(context),
             "rpm": apivfs_cmd(context.root) + rpm_cmd(context),
-            "mkosi-install"  : apivfs_cmd(context.root) + cls.cmd(context) + ["install"],
-            "mkosi-upgrade"  : apivfs_cmd(context.root) + cls.cmd(context) + ["upgrade"],
-            "mkosi-remove"   : apivfs_cmd(context.root) + cls.cmd(context) + ["remove"],
-            "mkosi-reinstall": apivfs_cmd(context.root) + cls.cmd(context) + ["reinstall"],
+            "mkosi-install"  : ["dnf", "install"],
+            "mkosi-upgrade"  : ["dnf", "upgrade"],
+            "mkosi-remove"   : ["dnf", "remove"],
+            "mkosi-reinstall": ["dnf", "reinstall"],
         }
 
     @classmethod

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -38,10 +38,10 @@ class Pacman(PackageManager):
     def scripts(cls, context: Context) -> dict[str, list[PathString]]:
         return {
             "pacman": apivfs_cmd(context.root) + cls.cmd(context),
-            "mkosi-install"  : apivfs_cmd(context.root) + cls.cmd(context) + ["--sync", "--needed"],
-            "mkosi-upgrade"  : apivfs_cmd(context.root) + cls.cmd(context) + ["--sync", "--sysupgrade", "--needed"],
-            "mkosi-remove"   : apivfs_cmd(context.root) + cls.cmd(context) + ["--remove", "--recursive", "--nosave"],
-            "mkosi-reinstall": apivfs_cmd(context.root) + cls.cmd(context) + ["--sync"],
+            "mkosi-install"  : ["pacman", "--sync", "--needed"],
+            "mkosi-upgrade"  : ["pacman", "--sync", "--sysupgrade", "--needed"],
+            "mkosi-remove"   : ["pacman", "--remove", "--recursive", "--nosave"],
+            "mkosi-reinstall": ["pacman", "--sync"],
         }
 
     @classmethod

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -31,6 +31,7 @@ class Zypper(PackageManager):
     @classmethod
     def scripts(cls, context: Context) -> dict[str, list[PathString]]:
         install: list[PathString] = [
+            "zypper",
             "install",
             "--download", "in-advance",
             "--recommends" if context.config.with_recommends else "--no-recommends",
@@ -39,10 +40,10 @@ class Zypper(PackageManager):
         return {
             "zypper": apivfs_cmd(context.root) + cls.cmd(context),
             "rpm"   : apivfs_cmd(context.root) + rpm_cmd(context),
-            "mkosi-install"  : apivfs_cmd(context.root) + cls.cmd(context) + install,
-            "mkosi-upgrade"  : apivfs_cmd(context.root) + cls.cmd(context) + ["update"],
-            "mkosi-remove"   : apivfs_cmd(context.root) + cls.cmd(context) + ["remove", "--clean-deps"],
-            "mkosi-reinstall": apivfs_cmd(context.root) + cls.cmd(context) + install + ["--force"],
+            "mkosi-install"  : install,
+            "mkosi-upgrade"  : ["zypper", "update"],
+            "mkosi-remove"   : ["zypper", "remove", "--clean-deps"],
+            "mkosi-reinstall": install + ["--force"],
         }
 
     @classmethod


### PR DESCRIPTION
Otherwise we'll expand the full command line twice, once as part of the mkosi-install script, in which apt-get is expanded again.