### PR TITLE
Use --keep-directory-symlink from cp 9.5 onwards

### DIFF
--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -203,6 +203,8 @@ def apivfs_cmd(root: Path) -> list[PathString]:
         "--dev", root / "dev",
         # Make sure /etc/machine-id is not overwritten by any package manager post install scripts.
         "--ro-bind-try", root / "etc/machine-id", root / "etc/machine-id",
+        # Nudge gpg to create its sockets in /run by making sure /run/user/0 exists.
+        "--dir", root / "run/user/0",
         *finalize_passwd_mounts(root),
         "sh", "-c",
         f"chmod 1777 {root / 'tmp'} {root / 'var/tmp'} {root / 'dev/shm'} && "


### PR DESCRIPTION
--keep-directory-symlink instructs cp to not fail when trying to copy a directory onto a symlink but to follow the symlink instead.

The patch to introduce it was merged into coreutils and will be available from coreutils 9.5 onwards.

--copy-contents has to be added as well to make
--keep-directory-symlink work. --copy-contents is generally harmless for our use cases and won't change anything.

Fixes #2168 