### PR TITLE
Stop using /etc/crypto-policies from host or tools tree

### DIFF
--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -57,7 +57,6 @@ def finalize_crypto_mounts(tools: Path = Path("/")) -> list[PathString]:
         for subdir in (
             Path("etc/pki"),
             Path("etc/ssl"),
-            Path("etc/crypto-policies"),
             Path("etc/ca-certificates"),
             Path("etc/pacman.d/gnupg"),
             Path("var/lib/ca-certificates"),


### PR DESCRIPTION
Instead we provide our policy for rpm-sequoia that generally follows the sequoia default policy except SHA1 is allowed as various distributions still use SHA1 in their GPG keys.