### PR TITLE
fix sync when running as sudo and finalize when image lacks packaging directories

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3741,7 +3741,8 @@ def run_sync(args: Args, config: Config, *, resources: Path) -> None:
         install_package_manager_trees(context)
         context.config.distribution.setup(context)
 
-        sync_repository_metadata(context)
+        with rchown_package_manager_dirs(config):
+            sync_repository_metadata(context)
 
         src = config.package_cache_dir_or_default() / "cache" / subdir
         for p in config.distribution.package_manager(config).cache_subdirs(src):

--- a/mkosi/installer/__init__.py
+++ b/mkosi/installer/__init__.py
@@ -41,7 +41,7 @@ class PackageManager:
 
         for d in ("cache", "lib"):
             src = context.package_cache_dir / d / subdir
-            mounts += ["--bind", src, Path("/var") / d / subdir]
+            mounts += ["--bind-try", src, Path("/var") / d / subdir]
 
             # If we're not operating on the configured package cache directory, we're operating on a snapshot of the
             # repository metadata in the image root directory. To make sure any downloaded packages are still cached in

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -30,6 +30,8 @@ class Dnf(PackageManager):
 
     @classmethod
     def cache_subdirs(cls, cache: Path) -> list[Path]:
+        if not cache.exists():
+            return []
         return [
             p / "packages"
             for p in cache.iterdir()


### PR DESCRIPTION
Recent-ish changes to package cache behaviour broke creating sysexts with finalize scripts for me and the repo sync changes made running with sudo fail for me.

These changes make things work, though it's possible it may be better to change finalize's context to have the same package cache dir as earlier steps rather than falling back to `root / "var"`, and while `rchown_package_manager_dirs` works to fix the permissions of directories created by the package manager it causes the logs about cleaning up permissions to be emitted multiple times and it may be strange to have it running nested inside itself.