### PR TITLE
Add support for embedding devicetree into UKI

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1872,6 +1872,11 @@ def build_uki(
         "--ro-bind", stub, stub,
     ]
 
+    if context.config.devicetree:
+        dtb = context.root / f"usr/lib/linux-image-{kver}" / context.config.devicetree
+        cmd += ["--devicetree", dtb]
+        options += ["--ro-bind", dtb, dtb]
+
     if context.config.secure_boot:
         assert context.config.secure_boot_key
         assert context.config.secure_boot_certificate

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1255,6 +1255,7 @@ class Config:
     initrds: list[Path]
     initrd_packages: list[str]
     microcode_host: bool
+    devicetree: Optional[Path]
     kernel_command_line: list[str]
     kernel_modules_include: list[str]
     kernel_modules_exclude: list[str]
@@ -2133,6 +2134,12 @@ SETTINGS = (
         section="Content",
         parse=config_make_list_parser(delimiter=","),
         help="Add additional packages to the default initrd",
+    ),
+    ConfigSetting(
+        dest="devicetree",
+        section="Content",
+        parse=config_parse_string,
+        help="Devicetree included in UKI",
     ),
     ConfigSetting(
         dest="kernel_command_line",
@@ -3548,6 +3555,7 @@ def summary(config: Config) -> str:
                     Shim Bootloader: {config.shim_bootloader}
                             Initrds: {line_join_list(config.initrds)}
                     Initrd Packages: {line_join_list(config.initrd_packages)}
+                         Devicetree: {config.devicetree}
                 Kernel Command Line: {line_join_list(config.kernel_command_line)}
              Kernel Modules Include: {line_join_list(config.kernel_modules_include)}
              Kernel Modules Exclude: {line_join_list(config.kernel_modules_exclude)}

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -117,6 +117,7 @@ def test_config() -> None:
             "Dependencies": [
                 "dep1"
             ],
+            "Devicetree": "freescale/imx8mm-verdin-nonwifi-dev.dtb",
             "Distribution": "fedora",
             "Environment": {},
             "EnvironmentFiles": [],
@@ -320,6 +321,7 @@ def test_config() -> None:
         compress_output = Compression.bz2,
         credentials =  {"credkey": "credval"},
         dependencies = ("dep1",),
+        devicetree = Path("freescale/imx8mm-verdin-nonwifi-dev.dtb"),
         distribution = Distribution.fedora,
         environment = {},
         environment_files = [],


### PR DESCRIPTION
Resolves #2439

To easily use the dtbs provided with kernel packages allow specifying a devicetree name in mkosi.

It can be passed as parameter to ukify.
The dtb is typically installed by the kernel package.