### PR TITLE
Change user to invoking user for syncing

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3715,14 +3715,18 @@ def sync_repository_metadata(context: Context) -> None:
 
 
 def run_sync(args: Args, config: Config, *, resources: Path) -> None:
+    if os.getuid() == 0:
+        os.setgroups([INVOKING_USER.gid])
+        os.setgid(INVOKING_USER.gid)
+        os.setuid(INVOKING_USER.uid)
+
     if not (p := config.package_cache_dir_or_default()).exists():
-        INVOKING_USER.mkdir(p)
+        p.mkdir(parents=True, exist_ok=True)
 
     subdir = config.distribution.package_manager(config).subdir(config)
 
     for d in ("cache", "lib"):
-        src = config.package_cache_dir_or_default() / d / subdir
-        INVOKING_USER.mkdir(src)
+        (config.package_cache_dir_or_default() / d / subdir).mkdir(parents=True, exist_ok=True)
 
     with (
         complete_step(f"Syncing package manager metadata for {config.name()} image"),
@@ -3745,7 +3749,7 @@ def run_sync(args: Args, config: Config, *, resources: Path) -> None:
 
         src = config.package_cache_dir_or_default() / "cache" / subdir
         for p in config.distribution.package_manager(config).cache_subdirs(src):
-            INVOKING_USER.mkdir(p)
+            p.mkdir(parents=True, exist_ok=True)
 
         run_sync_scripts(context)
 
@@ -3871,13 +3875,13 @@ def run_verb(args: Args, images: Sequence[Config], *, resources: Path) -> None:
         )
 
         if tools and not (tools.output_dir_or_cwd() / tools.output_with_compression).exists():
-            run_sync(args, tools, resources=resources)
+            fork_and_wait(run_sync, args, tools, resources=resources)
             fork_and_wait(run_build, args, tools, resources=resources)
 
         if (config.output_dir_or_cwd() / config.output_with_compression).exists():
             continue
 
-        run_sync(args, config, resources=resources)
+        fork_and_wait(run_sync, args, config, resources=resources)
         fork_and_wait(run_build, args, config, resources=resources)
 
         build = True

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3711,7 +3711,7 @@ def sync_repository_metadata(context: Context) -> None:
             flock(context.config.package_cache_dir_or_default() / "cache" / subdir),
             flock(context.config.package_cache_dir_or_default() / "lib" / subdir),
         ):
-            context.config.distribution.sync(context)
+            context.config.distribution.package_manager(context.config).sync(context)
 
 
 def run_sync(args: Args, config: Config, *, resources: Path) -> None:

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -76,10 +76,6 @@ class DistributionInstaller:
     def createrepo(cls, context: "Context") -> None:
         raise NotImplementedError
 
-    @classmethod
-    def sync(cls, context: "Context") -> None:
-        raise NotImplementedError
-
 
 class Distribution(StrEnum):
     # Please consult docs/distribution-policy.md and contact one
@@ -160,9 +156,6 @@ class Distribution(StrEnum):
 
     def createrepo(self, context: "Context") -> None:
         return self.installer().createrepo(context)
-
-    def sync(self, context: "Context") -> None:
-        return self.installer().sync(context)
 
     def installer(self) -> type[DistributionInstaller]:
         modname = str(self).replace('-', '_')

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -45,10 +45,6 @@ class Installer(DistributionInstaller):
         Pacman.setup(context, cls.repositories(context))
 
     @classmethod
-    def sync(cls, context: Context) -> None:
-        Pacman.sync(context)
-
-    @classmethod
     def install(cls, context: Context) -> None:
         cls.install_packages(context, ["filesystem"], apivfs=False)
 

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -78,10 +78,6 @@ class Installer(DistributionInstaller):
         setup_rpm(context, dbpath=cls.dbpath(context))
 
     @classmethod
-    def sync(cls, context: Context) -> None:
-        Dnf.sync(context)
-
-    @classmethod
     def install(cls, context: Context) -> None:
         # Make sure glibc-minimal-langpack is installed instead of glibc-all-langpacks.
         cls.install_packages(context, ["filesystem", "glibc-minimal-langpack"], apivfs=False)

--- a/mkosi/distributions/custom.py
+++ b/mkosi/distributions/custom.py
@@ -23,10 +23,6 @@ class Installer(DistributionInstaller):
         pass
 
     @classmethod
-    def sync(cls, context: Context) -> None:
-        pass
-
-    @classmethod
     def install(cls, context: Context) -> None:
         pass
 

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -108,10 +108,6 @@ class Installer(DistributionInstaller):
         Apt.createrepo(context)
 
     @classmethod
-    def sync(cls, context: Context) -> None:
-        Apt.sync(context)
-
-    @classmethod
     def install(cls, context: Context) -> None:
         # Instead of using debootstrap, we replicate its core functionality here. Because dpkg does not have
         # an option to delay running pre-install maintainer scripts when it installs a package, it's

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -84,10 +84,6 @@ class Installer(DistributionInstaller):
         setup_rpm(context)
 
     @classmethod
-    def sync(cls, context: Context) -> None:
-        Dnf.sync(context)
-
-    @classmethod
     def install(cls, context: Context) -> None:
         cls.install_packages(context, ["filesystem"], apivfs=False)
 

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -68,13 +68,6 @@ class Installer(DistributionInstaller):
         setup_rpm(context)
 
     @classmethod
-    def sync(cls, context: Context) -> None:
-        if find_binary("zypper", root=context.config.tools()):
-            Zypper.sync(context)
-        else:
-            Dnf.sync(context)
-
-    @classmethod
     def install(cls, context: Context) -> None:
         cls.install_packages(context, ["filesystem", "distribution-release"], apivfs=False)
 

--- a/mkosi/installer/__init__.py
+++ b/mkosi/installer/__init__.py
@@ -61,6 +61,10 @@ class PackageManager:
 
         return mounts
 
+    @classmethod
+    def sync(cls, context: Context) -> None:
+        pass
+
 
 def clean_package_manager_metadata(context: Context) -> None:
     """

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -267,6 +267,14 @@ def resource_path(mod: ModuleType) -> Iterator[Path]:
 
     t = importlib.resources.files(mod)
     with as_file(t) as p:
+        # Make sure any temporary directory that the resources are unpacked in is accessible to the invoking user so
+        # that any commands executed as the invoking user can access files within it.
+        if (
+            p.parent.parent == Path(os.getenv("TMPDIR", "/tmp")) and
+            stat.S_IMODE(p.parent.stat().st_mode) == 0o700
+        ):
+            p.parent.chmod(0o755)
+
         yield p
 
 


### PR DESCRIPTION
We want to make sure all repository metadata that we cache in the
user's cache directory is owned by the invoking user. Let's achieve
that by running the sync stuff in a fork and dropping privileges if
we're running as root.