### PR TITLE
Only enable sha256 PCR bank for swtpm

### DIFF
--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -33,7 +33,7 @@ from mkosi.config import (
     systemd_tool_version,
     want_selinux_relabel,
 )
-from mkosi.log import die
+from mkosi.log import ARG_DEBUG, die
 from mkosi.partition import finalize_root, find_partitions
 from mkosi.run import AsyncioThread, find_binary, fork_and_wait, run, spawn
 from mkosi.tree import copy_tree, rmtree
@@ -285,6 +285,11 @@ def find_ovmf_vars(config: Config) -> Path:
 @contextlib.contextmanager
 def start_swtpm(config: Config) -> Iterator[Path]:
     with tempfile.TemporaryDirectory(prefix="mkosi-swtpm") as state:
+        # swtpm_setup is noisy and doesn't have a --quiet option so we pipe it's stdout to /dev/null.
+        run(["swtpm_setup", "--tpm-state", state, "--tpm2", "--pcr-banks", "sha256", "--config", "/dev/null"],
+            sandbox=config.sandbox(options=["--bind", state, state]),
+            stdout=None if ARG_DEBUG.get() else subprocess.DEVNULL)
+
         cmdline = ["swtpm", "socket", "--tpm2", "--tpmstate", f"dir={state}"]
 
         # We create the socket ourselves and pass the fd to swtpm to avoid race conditions where we start qemu before

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos-fedora/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos-fedora/mkosi.conf
@@ -23,6 +23,7 @@ Packages=
         qemu-kvm-core
         shadow-utils
         squashfs-tools
+        swtpm-tools
         systemd-container
         systemd-udev
         ubu-keyring

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu.conf
@@ -29,6 +29,7 @@ Packages=
         qemu-system
         sbsigntool
         squashfs-tools
+        swtpm-tools
         systemd-boot
         systemd-container
         systemd-coredump


### PR DESCRIPTION
Mimicks the same change in systemd-vmspawn
(https://github.com/systemd/systemd/commit/519bad6c2c23d3c2dc9558878becb485f3ae9057)