### PR TITLE
Make sure the default initrd cache is properly cleaned up by mkosi clean

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ ignore_missing_imports = true
 [tool.ruff]
 target-version = "py39"
 line-length = 119
-select = ["E", "F", "I", "UP"]
+lint.select = ["E", "F", "I", "UP"]
 
 [tool.pytest.ini_options]
 markers = [


### PR DESCRIPTION
Instead of doing the cleanup in build_default_initrd(), let's split off
finalize_default_initrd() so that we can clean up the cache in run_clean()
instead.