### PR TITLE
Run sync scripts in relaxed sandbox without package manager trees

### DIFF
--- a/mkosi/context.py
+++ b/mkosi/context.py
@@ -80,6 +80,9 @@ class Context:
             devices=devices,
             scripts=scripts,
             options=[
+                "--uid", "0",
+                "--gid", "0",
+                "--cap-add", "ALL",
                 # These mounts are writable so bubblewrap can create extra directories or symlinks inside of it as
                 # needed. This isn't a problem as the package manager directory is created by mkosi and thrown away
                 # when the build finishes.

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -165,9 +165,6 @@ class Pacman(PackageManager):
                             *cls.mounts(context),
                             *sources,
                             "--chdir", "/work/src",
-                            # pacman will fail unless invoked as root so make sure we're uid/gid 0 in the sandbox.
-                            "--uid", "0",
-                            "--gid", "0",
                         ],
                     ) + (apivfs_cmd(context.root) if apivfs else [])
                 ),


### PR DESCRIPTION
Sync scripts run as the invoking user in the sandbox, which means
that they're not able to mount an overlayfs over /usr in the sandbox
to overlay extra files from package manager trees.

To circumvent the issue, let's run sync scripts in a relaxed sandbox
without package manager trees, which shouldn't be crucial to have
when running sync scripts.