### PR TITLE
Fix typing error

### DIFF
--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -159,7 +159,7 @@ def run(
 
     env = {
         "PATH": os.environ["PATH"],
-        "TERM": env.get("TERM") or os.getenv("TERM", "vt220"),
+        "TERM": os.getenv("TERM", "vt220"),
         "LANG": "C.UTF-8",
         **env,
     }
@@ -259,7 +259,7 @@ def spawn(
 
     env = {
         "PATH": os.environ["PATH"],
-        "TERM": env.get("TERM") or os.getenv("TERM", "vt220"),
+        "TERM": os.getenv("TERM", "vt220"),
         "LANG": "C.UTF-8",
         **env,
     }


### PR DESCRIPTION
We drop the special logic for TERM since we do **env later which will make sure any value for TERM from env overrides the default value we pick.