### PR TITLE
Extend timeout of systemd-machine-id-commit.service to 90s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,10 +15,6 @@
 /mkosi.egg-info
 /mkosi.cache
 /mkosi.output
-/mkosi.extra
-!mkosi.extra/usr/lib/systemd/mkosi-check-and-shutdown.sh
-!mkosi.extra/usr/lib/systemd/system/mkosi-check-and-shutdown.service
-!mkosi.extra/usr/lib/systemd/system-preset/*-mkosi.preset
 /mkosi.nspawn
 /mkosi.rootpw
 mkosi.local.conf

--- a/mkosi.extra/usr/lib/systemd/system/systemd-machine-id-commit.service.d/timeout.conf
+++ b/mkosi.extra/usr/lib/systemd/system/systemd-machine-id-commit.service.d/timeout.conf
@@ -1,0 +1,2 @@
+[Service]
+TimeoutSec=90s


### PR DESCRIPTION
Should hopefully reduce the number of CI failures.
See https://github.com/systemd/systemd/pull/31750