### PR TITLE
ci: Enable KVM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
         Environment=SYSTEMD_REPART_MKFS_OPTIONS_EROFS="--quiet"
 
         [Host]
-        QemuKvm=no
+        QemuKvm=yes
         EOF
 
         # Work around for https://src.fedoraproject.org/rpms/grub2/pull-request/61 by disabling obsoletes.

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -32,6 +32,8 @@ def test_format(config: Image.Config, format: OutputFormat) -> None:
             "--kernel-command-line=systemd.unit=mkosi-check-and-shutdown.service",
             "--incremental",
             "--ephemeral",
+            # TODO: Drop once https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2038777 is fixed in Github Actions
+            "--qemu-firmware=uefi" if format in (OutputFormat.disk, OutputFormat.uki) else "--qemu-firmware=auto",
         ],
     ) as image:
         if image.config.distribution == Distribution.rhel_ubi and format in (OutputFormat.esp, OutputFormat.uki):
@@ -79,7 +81,9 @@ def test_bootloader(config: Image.Config, bootloader: Bootloader) -> None:
     if config.distribution == Distribution.rhel_ubi:
         return
 
-    firmware = QemuFirmware.linux if bootloader == Bootloader.none else QemuFirmware.auto
+    # TODO: Use "auto" again instead of "uefi" once https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2038777 is
+    # fixed in Github Actions.
+    firmware = QemuFirmware.linux if bootloader == Bootloader.none else QemuFirmware.uefi
 
     with Image(
         config,

--- a/tests/test_initrd.py
+++ b/tests/test_initrd.py
@@ -63,6 +63,8 @@ def test_initrd(initrd: Image) -> None:
             "--incremental",
             "--ephemeral",
             "--format=disk",
+            # TODO: Drop once https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2038777 is fixed in Github Actions
+            "--qemu-firmware=uefi",
         ]
     ) as image:
         image.build()
@@ -185,6 +187,9 @@ def test_initrd_luks(initrd: Image, passphrase: Path) -> None:
                 "--incremental",
                 "--ephemeral",
                 "--format=disk",
+                # TODO: Drop once https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2038777 is fixed in Github
+                # Actions.
+                "--qemu-firmware=uefi",
             ]
         ) as image:
             image.build()


### PR DESCRIPTION
Since https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/, it seems that KVM has started working, so let's make sure we take advantage of it to speed up CI.