### PR TITLE
ci: Free up disk space asynchronously

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         mkfs.btrfs btrfs.raw
         sudo mkdir -p /mnt/mkosi
         LOOP="$(sudo losetup --find --show --direct-io=on btrfs.raw)"
-        sudo mount "$LOOP" /mnt/mkosi --options compress=zstd,user_subvol_rm_allowed
+        sudo mount "$LOOP" /mnt/mkosi --options compress=zstd:1,user_subvol_rm_allowed,noatime,discard=async,space_cache=v2
         sudo chown "$(id -u):$(id -g)" /mnt/mkosi
 
     - name: Configure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,10 +125,14 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./
 
+    # Freeing up disk space with rm -rf can take multiple minutes. Since we don't need the extra free space
+    # immediately, we remove the files in the background. However, we first move them to a different location so that
+    # nothing tries to use anything in these directories anymore while we're busy deleting them.
     - name: Free disk space
       run: |
-        sudo rm -rf /usr/local
-        sudo rm -rf /opt/hostedtoolcache
+        sudo mv /usr/local /usr/local.trash
+        sudo mv /opt/hostedtoolcache /opt/hostedtoolcache.trash
+        sudo systemd-run rm -rf /usr/local.trash /opt/hostedtoolcache.trash
 
     - name: Install
       run: |


### PR DESCRIPTION
Free-ing up disk space can take up to 8 minutes so let's make sure we do it asynchronously since we don't need the free space immediately.