### PR TITLE
Misc fixes for running mkosi as root on a shared build machines

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4023,7 +4023,7 @@ def sync_repository_metadata(context: Context) -> None:
 
 def run_sync(args: Args, config: Config, *, resources: Path) -> None:
     if os.getuid() == 0:
-        os.setgroups([INVOKING_USER.gid])
+        os.setgroups(os.getgrouplist(INVOKING_USER.name(), INVOKING_USER.gid))
         os.setgid(INVOKING_USER.gid)
         os.setuid(INVOKING_USER.uid)
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1565,7 +1565,7 @@ class Config:
             relaxed=relaxed,
             scripts=scripts,
             tools=self.tools(),
-            options=[*options, *mounts],
+            options=[*mounts, *options],
         )
 
 


### PR DESCRIPTION
We moved our testing onto a more powerful shared build machine recently and encountered some issues using a `/data` partition with a shared project group.

The `ExtraSearchPaths` issue was only triggered by a combination of `~/.cache` being on a different disk to the output-dir and not using a tools tree. Using a tools tree was later required anyway and it would be sensible to configure the cache directory to be in `/data`, but this may be a problem for someone else.

I have not encountered other issues from reordering the command-line, but could be missing something about how the code's supposed to work that makes this an inappropriate fix.


The user's groups when running sync patch was a result of the sync directory being owned by a gid that is not the user's primary gid, which made it not visible to the user.

I don't think this will have any other side-effects but I've not taken a deep look at the recent changes to sync.