### PR TITLE
Filter and sort all mounts in sandbox_cmd()

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -65,7 +65,7 @@ from mkosi.run import (
     log_process_failure,
     run,
 )
-from mkosi.sandbox import chroot_cmd, finalize_crypto_mounts, finalize_passwd_mounts
+from mkosi.sandbox import Mount, chroot_cmd, finalize_crypto_mounts, finalize_passwd_mounts
 from mkosi.tree import copy_tree, move_tree, rmtree
 from mkosi.types import PathString
 from mkosi.user import CLONE_NEWNS, INVOKING_USER, become_root, unshare
@@ -449,28 +449,31 @@ def run_sync_scripts(context: Context) -> None:
         finalize_config_json(context.config) as json,
     ):
         for script in context.config.sync_scripts:
-            options = [
+            mounts = [
                 *sources,
                 *finalize_crypto_mounts(context.config.tools()),
-                "--ro-bind", script, "/work/sync",
-                "--ro-bind", json, "/work/config.json",
-                "--chdir", "/work/src",
+                Mount(script, "/work/sync", ro=True),
+                Mount(json, "/work/config.json", ro=True),
             ]
 
             if (p := INVOKING_USER.home()).exists():
-                # We use --bind here instead of --ro-bind to keep git worktrees working which encode absolute paths to
-                # the parent git repository and might need to modify the git config in the parent git repository when
-                # submodules are in use as well.
-                options += ["--bind", p, p]
+                # We use a writable mount here to keep git worktrees working which encode absolute paths to the parent
+                # git repository and might need to modify the git config in the parent git repository when submodules
+                # are in use as well.
+                mounts += [Mount(p, p)]
             if (p := Path(f"/run/user/{INVOKING_USER.uid}")).exists():
-                options += ["--ro-bind", p, p]
+                mounts += [Mount(p, p, ro=True)]
 
             with complete_step(f"Running sync script {script}…"):
                 run(
                     ["/work/sync", "final"],
                     env=env | context.config.environment,
                     stdin=sys.stdin,
-                    sandbox=context.sandbox(network=True, options=options),
+                    sandbox=context.sandbox(
+                        network=True,
+                        mounts=mounts,
+                        options=["--dir", "/work/src", "--chdir", "/work/src"]
+                    ),
                 )
 
 
@@ -533,14 +536,15 @@ def run_prepare_scripts(context: Context, build: bool) -> None:
                     stdin=sys.stdin,
                     sandbox=context.sandbox(
                         network=True,
-                        options=sources + [
-                            "--ro-bind", script, "/work/prepare",
-                            "--ro-bind", json, "/work/config.json",
-                            "--ro-bind", cd, "/work/scripts",
-                            "--bind", context.root, context.root,
+                        mounts=[
+                            *sources,
+                            Mount(script, "/work/prepare", ro=True),
+                            Mount(json, "/work/config.json", ro=True),
+                            Mount(cd, "/work/scripts", ro=True),
+                            Mount(context.root, context.root),
                             *context.config.distribution.package_manager(context.config).mounts(context),
-                            "--chdir", "/work/src",
                         ],
+                        options=["--dir", "/work/src", "--chdir", "/work/src"],
                         scripts=hd,
                     ) + (chroot if script.suffix == ".chroot" else []),
                 )
@@ -608,21 +612,22 @@ def run_build_scripts(context: Context) -> None:
                     stdin=sys.stdin,
                     sandbox=context.sandbox(
                         network=context.config.with_network,
-                        options=sources + [
-                            "--ro-bind", script, "/work/build-script",
-                            "--ro-bind", json, "/work/config.json",
-                            "--ro-bind", cd, "/work/scripts",
-                            "--bind", context.root, context.root,
-                            "--bind", context.install_dir, "/work/dest",
-                            "--bind", context.staging, "/work/out",
+                        mounts=[
+                            *sources,
+                            Mount(script, "/work/build-script", ro=True),
+                            Mount(json, "/work/config.json", ro=True),
+                            Mount(cd, "/work/scripts", ro=True),
+                            Mount(context.root, context.root),
+                            Mount(context.install_dir, "/work/dest"),
+                            Mount(context.staging, "/work/out"),
                             *(
-                                ["--bind", os.fspath(context.config.build_dir), "/work/build"]
+                                [Mount(context.config.build_dir, "/work/build")]
                                 if context.config.build_dir
                                 else []
                             ),
                             *context.config.distribution.package_manager(context.config).mounts(context),
-                            "--chdir", "/work/src",
                         ],
+                        options=["--dir", "/work/src", "--chdir", "/work/src"],
                         scripts=hd,
                     ) + (chroot if script.suffix == ".chroot" else []),
                 )
@@ -680,15 +685,16 @@ def run_postinst_scripts(context: Context) -> None:
                     stdin=sys.stdin,
                     sandbox=context.sandbox(
                         network=context.config.with_network,
-                        options=sources + [
-                            "--ro-bind", script, "/work/postinst",
-                            "--ro-bind", json, "/work/config.json",
-                            "--ro-bind", cd, "/work/scripts",
-                            "--bind", context.root, context.root,
-                            "--bind", context.staging, "/work/out",
+                        mounts=[
+                            *sources,
+                            Mount(script, "/work/postinst", ro=True),
+                            Mount(json, "/work/config.json", ro=True),
+                            Mount(cd, "/work/scripts", ro=True),
+                            Mount(context.root, context.root),
+                            Mount(context.staging, "/work/out"),
                             *context.config.distribution.package_manager(context.config).mounts(context),
-                            "--chdir", "/work/src",
                         ],
+                        options=["--dir", "/work/src", "--chdir", "/work/src"],
                         scripts=hd,
                     ) + (chroot if script.suffix == ".chroot" else []),
                 )
@@ -742,15 +748,16 @@ def run_finalize_scripts(context: Context) -> None:
                     stdin=sys.stdin,
                     sandbox=context.sandbox(
                         network=context.config.with_network,
-                        options=sources + [
-                            "--ro-bind", script, "/work/finalize",
-                            "--ro-bind", json, "/work/config.json",
-                            "--ro-bind", cd, "/work/scripts",
-                            "--bind", context.root, context.root,
-                            "--bind", context.staging, "/work/out",
+                        mounts=[
+                            *sources,
+                            Mount(script, "/work/finalize", ro=True),
+                            Mount(json, "/work/config.json", ro=True),
+                            Mount(cd, "/work/scripts", ro=True),
+                            Mount(context.root, context.root),
+                            Mount(context.staging, "/work/out"),
                             *context.config.distribution.package_manager(context.config).mounts(context),
-                            "--chdir", "/work/src",
                         ],
+                        options=["--dir", "/work/src", "--chdir", "/work/src"],
                         scripts=hd,
                     ) + (chroot if script.suffix == ".chroot" else []),
                 )
@@ -767,7 +774,7 @@ def certificate_common_name(context: Context, certificate: Path) -> str:
             "-in", certificate,
         ],
         stdout=subprocess.PIPE,
-        sandbox=context.sandbox(options=["--ro-bind", certificate, certificate]),
+        sandbox=context.sandbox(mounts=[Mount(certificate, certificate, ro=True)]),
     ).stdout
 
     for line in output.splitlines():
@@ -811,9 +818,9 @@ def pesign_prepare(context: Context) -> None:
             ],
             stdout=f,
             sandbox=context.sandbox(
-                options=[
-                    "--ro-bind", context.config.secure_boot_key, context.config.secure_boot_key,
-                    "--ro-bind", context.config.secure_boot_certificate, context.config.secure_boot_certificate,
+                mounts=[
+                    Mount(context.config.secure_boot_key, context.config.secure_boot_key, ro=True),
+                    Mount(context.config.secure_boot_certificate, context.config.secure_boot_certificate, ro=True),
                 ],
             ),
         )
@@ -829,9 +836,9 @@ def pesign_prepare(context: Context) -> None:
             "-d", context.workspace / "pesign",
         ],
         sandbox=context.sandbox(
-            options=[
-                "--ro-bind", context.workspace / "secure-boot.p12", context.workspace / "secure-boot.p12",
-                "--bind", context.workspace / "pesign", context.workspace / "pesign",
+            mounts=[
+                Mount(context.workspace / "secure-boot.p12", context.workspace / "secure-boot.p12", ro=True),
+                Mount(context.workspace / "pesign", context.workspace / "pesign"),
             ],
         ),
     )
@@ -869,20 +876,20 @@ def sign_efi_binary(context: Context, input: Path, output: Path) -> Path:
                 "--cert", context.config.secure_boot_certificate,
                 "--output", "/dev/stdout",
             ]
-            options: list[PathString] = [
-                "--ro-bind", context.config.secure_boot_certificate, context.config.secure_boot_certificate,
-                "--ro-bind", input, input,
+            mounts = [
+                Mount(context.config.secure_boot_certificate, context.config.secure_boot_certificate, ro=True),
+                Mount(input, input, ro=True),
             ]
             if context.config.secure_boot_key_source.type == KeySource.Type.engine:
                 cmd += ["--engine", context.config.secure_boot_key_source.source]
             if context.config.secure_boot_key.exists():
-                options += ["--ro-bind", context.config.secure_boot_key, context.config.secure_boot_key]
+                mounts += [Mount(context.config.secure_boot_key, context.config.secure_boot_key, ro=True)]
             cmd += [input]
             run(
                 cmd,
                 stdout=f,
                 sandbox=context.sandbox(
-                    options=options,
+                    mounts=mounts,
                     devices=context.config.secure_boot_key_source.type != KeySource.Type.file,
                 )
             )
@@ -908,9 +915,9 @@ def sign_efi_binary(context: Context, input: Path, output: Path) -> Path:
                 ],
                 stdout=f,
                 sandbox=context.sandbox(
-                    options=[
-                        "--ro-bind", context.workspace / "pesign", context.workspace / "pesign",
-                        "--ro-bind", input, input,
+                    mounts=[
+                        Mount(context.workspace / "pesign", context.workspace / "pesign", ro=True),
+                        Mount(input, input, ro=True),
                     ]
                 ),
             )
@@ -955,7 +962,7 @@ def install_systemd_boot(context: Context) -> None:
         run(
             ["bootctl", "install", "--root", context.root, "--all-architectures", "--no-variables"],
             env={"SYSTEMD_ESP_PATH": "/efi", "SYSTEMD_XBOOTLDR_PATH": "/boot"},
-            sandbox=context.sandbox(options=["--bind", context.root, context.root]),
+            sandbox=context.sandbox(mounts=[Mount(context.root, context.root)]),
         )
 
         if context.config.shim_bootloader != ShimBootloader.none:
@@ -984,10 +991,12 @@ def install_systemd_boot(context: Context) -> None:
                     ],
                     stdout=f,
                     sandbox=context.sandbox(
-                        options=[
-                            "--ro-bind",
-                            context.config.secure_boot_certificate,
-                            context.config.secure_boot_certificate,
+                        mounts=[
+                            Mount(
+                                context.config.secure_boot_certificate,
+                                context.config.secure_boot_certificate,
+                                ro=True
+                            ),
                         ],
                     ),
                 )
@@ -1003,7 +1012,7 @@ def install_systemd_boot(context: Context) -> None:
                     ],
                     stdout=f,
                     sandbox=context.sandbox(
-                        options=["--ro-bind", context.workspace / "mkosi.der", context.workspace / "mkosi.der"]
+                        mounts=[Mount(context.workspace / "mkosi.der", context.workspace / "mkosi.der", ro=True)]
                     ),
                 )
 
@@ -1018,22 +1027,24 @@ def install_systemd_boot(context: Context) -> None:
                         "--cert", context.config.secure_boot_certificate,
                         "--output", "/dev/stdout",
                     ]
-                    options: list[PathString] = [
-                        "--ro-bind",
-                        context.config.secure_boot_certificate,
-                        context.config.secure_boot_certificate,
-                        "--ro-bind", context.workspace / "mkosi.esl", context.workspace / "mkosi.esl",
+                    mounts = [
+                        Mount(
+                            context.config.secure_boot_certificate,
+                            context.config.secure_boot_certificate,
+                            ro=True
+                        ),
+                        Mount(context.workspace / "mkosi.esl", context.workspace / "mkosi.esl", ro=True),
                     ]
                     if context.config.secure_boot_key_source.type == KeySource.Type.engine:
                         cmd += ["--engine", context.config.secure_boot_key_source.source]
                     if context.config.secure_boot_key.exists():
-                        options += ["--ro-bind", context.config.secure_boot_key, context.config.secure_boot_key]
+                        mounts += [Mount(context.config.secure_boot_key, context.config.secure_boot_key, ro=True)]
                     cmd += [db, context.workspace / "mkosi.esl"]
                     run(
                         cmd,
                         stdout=f,
                         sandbox=context.sandbox(
-                            options=options,
+                            mounts=mounts,
                             devices=context.config.secure_boot_key_source.type != KeySource.Type.file,
                         ),
                     )
@@ -1296,10 +1307,10 @@ def grub_mkimage(
                 *modules,
             ],
             sandbox=context.sandbox(
-                options=[
-                    "--bind", context.root, context.root,
-                    "--ro-bind", earlyconfig.name, earlyconfig.name,
-                    *(["--ro-bind", str(sbat), str(sbat)] if sbat else []),
+                mounts=[
+                    Mount(context.root, context.root),
+                    Mount(earlyconfig.name, earlyconfig.name, ro=True),
+                    *([Mount(str(sbat), str(sbat), ro=True)] if sbat else []),
                 ],
             ),
         )
@@ -1405,10 +1416,10 @@ def grub_bios_setup(context: Context, partitions: Sequence[Partition]) -> None:
                 context.staging / context.config.output_with_format,
             ],
             sandbox=context.sandbox(
-                options=[
-                    "--bind", context.root, context.root,
-                    "--bind", context.staging, context.staging,
-                    "--bind", mountinfo.name, mountinfo.name,
+                mounts=[
+                    Mount(context.root, context.root),
+                    Mount(context.staging, context.staging),
+                    Mount(mountinfo.name, mountinfo.name),
                 ],
             ),
         )
@@ -1448,7 +1459,7 @@ def install_tree(
             sandbox=config.sandbox(
                 devices=True,
                 network=True,
-                options=["--ro-bind", src, src, "--bind", t.parent, t.parent],
+                mounts=[Mount(src, src, ro=True), Mount(t.parent, t.parent)],
             ),
         )
     else:
@@ -1869,7 +1880,7 @@ def extract_pe_section(context: Context, binary: Path, section: str, output: Pat
             [python_binary(context.config)],
             input=pefile,
             stdout=f,
-            sandbox=context.sandbox(options=["--ro-bind", binary, binary])
+            sandbox=context.sandbox(mounts=[Mount(binary, binary, ro=True)])
         )
 
     return output
@@ -1911,11 +1922,11 @@ def build_uki(
         "--uname", kver,
     ]
 
-    options: list[PathString] = [
-        "--bind", output.parent, output.parent,
-        "--ro-bind", context.workspace / "cmdline", context.workspace / "cmdline",
-        "--ro-bind", context.root / "usr/lib/os-release", context.root / "usr/lib/os-release",
-        "--ro-bind", stub, stub,
+    mounts = [
+        Mount(output.parent, output.parent),
+        Mount(context.workspace / "cmdline", context.workspace / "cmdline", ro=True),
+        Mount(context.root / "usr/lib/os-release", context.root / "usr/lib/os-release", ro=True),
+        Mount(stub, stub, ro=True),
     ]
 
     if context.config.secure_boot:
@@ -1932,13 +1943,13 @@ def build_uki(
                 "--secureboot-certificate",
                 context.config.secure_boot_certificate,
             ]
-            options += [
-                "--ro-bind", context.config.secure_boot_certificate, context.config.secure_boot_certificate,
+            mounts += [
+                Mount(context.config.secure_boot_certificate, context.config.secure_boot_certificate, ro=True),
             ]
             if context.config.secure_boot_key_source.type == KeySource.Type.engine:
                 cmd += ["--signing-engine", context.config.secure_boot_key_source.source]
             if context.config.secure_boot_key.exists():
-                options += ["--ro-bind", context.config.secure_boot_key, context.config.secure_boot_key]
+                mounts += [Mount(context.config.secure_boot_key, context.config.secure_boot_key, ro=True)]
         else:
             pesign_prepare(context)
             cmd += [
@@ -1948,7 +1959,7 @@ def build_uki(
                 "--secureboot-certificate-name",
                 certificate_common_name(context, context.config.secure_boot_certificate),
             ]
-            options += ["--ro-bind", context.workspace / "pesign", context.workspace / "pesign"]
+            mounts += [Mount(context.workspace / "pesign", context.workspace / "pesign", ro=True)]
 
         if want_signed_pcrs(context.config):
             cmd += [
@@ -1956,28 +1967,28 @@ def build_uki(
                 "--pcr-banks", "sha1,sha256",
             ]
             if context.config.secure_boot_key.exists():
-                options += ["--ro-bind", context.config.secure_boot_key, context.config.secure_boot_key]
+                mounts += [Mount(context.config.secure_boot_key, context.config.secure_boot_key)]
             if context.config.secure_boot_key_source.type == KeySource.Type.engine:
                 cmd += [
                     "--signing-engine", context.config.secure_boot_key_source.source,
                     "--pcr-public-key", context.config.secure_boot_certificate,
                 ]
-                options += [
-                    "--ro-bind", context.config.secure_boot_certificate, context.config.secure_boot_certificate,
+                mounts += [
+                    Mount(context.config.secure_boot_certificate, context.config.secure_boot_certificate, ro=True),
                 ]
 
     cmd += ["build", "--linux", kimg]
-    options += ["--ro-bind", kimg, kimg]
+    mounts += [Mount(kimg, kimg, ro=True)]
 
     for initrd in initrds:
         cmd += ["--initrd", initrd]
-        options += ["--ro-bind", initrd, initrd]
+        mounts += [Mount(initrd, initrd, ro=True)]
 
     with complete_step(f"Generating unified kernel image for kernel version {kver}"):
         run(
             cmd,
             sandbox=context.sandbox(
-                options=options,
+                mounts=mounts,
                 devices=context.config.secure_boot_key_source.type != KeySource.Type.file,
             ),
         )
@@ -2036,7 +2047,7 @@ def find_entry_token(context: Context) -> str:
         return context.config.image_id or context.config.distribution.name
 
     output = json.loads(run(["kernel-install", "--root", context.root, "--json=pretty", "inspect"],
-                            sandbox=context.sandbox(options=["--ro-bind", context.root, context.root]),
+                            sandbox=context.sandbox(mounts=[Mount(context.root, context.root, ro=True)]),
                             stdout=subprocess.PIPE,
                             env={"SYSTEMD_ESP_PATH": "/efi", "SYSTEMD_XBOOTLDR_PATH": "/boot"}).stdout)
     logging.debug(json.dumps(output, indent=4))
@@ -2431,18 +2442,20 @@ def calculate_signature(context: Context) -> None:
     if sys.stderr.isatty():
         env |= dict(GPGTTY=os.ttyname(sys.stderr.fileno()))
 
-    options: list[PathString] = ["--perms", "755", "--dir", home, "--bind", home, home]
+    options: list[PathString] = ["--perms", "755", "--dir", home]
+    mounts = [Mount(home, home)]
 
     # gpg can communicate with smartcard readers via this socket so bind mount it in if it exists.
     if (p := Path("/run/pcscd/pcscd.comm")).exists():
-        options += ["--perms", "755", "--dir", p.parent, "--bind", p, p]
+        options += ["--perms", "755", "--dir", p.parent]
+        mounts += [Mount(p, p)]
 
     with (
         complete_step("Signing SHA256SUMS…"),
         open(context.staging / context.config.output_checksum, "rb") as i,
         open(context.staging / context.config.output_signature, "wb") as o,
     ):
-        run(cmdline, env=env, stdin=i, stdout=o, sandbox=context.sandbox(options=options))
+        run(cmdline, env=env, stdin=i, stdout=o, sandbox=context.sandbox(mounts=mounts, options=options))
 
 
 def dir_size(path: Union[Path, os.DirEntry[str]]) -> int:
@@ -2736,7 +2749,7 @@ def run_depmod(context: Context, *, cache: bool = False) -> None:
 
         with complete_step(f"Running depmod for {kver}"):
             run(["depmod", "--all", "--basedir", context.root, kver],
-                sandbox=context.sandbox(options=["--bind", context.root, context.root]))
+                sandbox=context.sandbox(mounts=[Mount(context.root, context.root)]))
 
 
 def run_sysusers(context: Context) -> None:
@@ -2746,7 +2759,7 @@ def run_sysusers(context: Context) -> None:
 
     with complete_step("Generating system users"):
         run(["systemd-sysusers", "--root", context.root],
-            sandbox=context.sandbox(options=["--bind", context.root, context.root]))
+            sandbox=context.sandbox(mounts=[Mount(context.root, context.root)]))
 
 
 def run_tmpfiles(context: Context) -> None:
@@ -2766,8 +2779,8 @@ def run_tmpfiles(context: Context) -> None:
         ]
 
         sandbox = context.sandbox(
-            options=[
-                "--bind", context.root, context.root,
+            mounts=[
+                Mount(context.root, context.root),
                 # systemd uses acl.h to parse ACLs in tmpfiles snippets which uses the host's passwd so we have to
                 # mount the image's passwd over it to make ACL parsing work.
                 *finalize_passwd_mounts(context.root)
@@ -2794,9 +2807,9 @@ def run_preset(context: Context) -> None:
 
     with complete_step("Applying presets…"):
         run(["systemctl", "--root", context.root, "preset-all"],
-            sandbox=context.sandbox(options=["--bind", context.root, context.root]))
+            sandbox=context.sandbox(mounts=[Mount(context.root, context.root)]))
         run(["systemctl", "--root", context.root, "--global", "preset-all"],
-            sandbox=context.sandbox(options=["--bind", context.root, context.root]))
+            sandbox=context.sandbox(mounts=[Mount(context.root, context.root)]))
 
 
 def run_hwdb(context: Context) -> None:
@@ -2809,7 +2822,7 @@ def run_hwdb(context: Context) -> None:
 
     with complete_step("Generating hardware database"):
         run(["systemd-hwdb", "--root", context.root, "--usr", "--strict", "update"],
-            sandbox=context.sandbox(options=["--bind", context.root, context.root]))
+            sandbox=context.sandbox(mounts=[Mount(context.root, context.root)]))
 
     # Remove any existing hwdb in /etc in favor of the one we just put in /usr.
     (context.root / "etc/udev/hwdb.bin").unlink(missing_ok=True)
@@ -2856,7 +2869,7 @@ def run_firstboot(context: Context) -> None:
 
     with complete_step("Applying first boot settings"):
         run(["systemd-firstboot", "--root", context.root, "--force", *options],
-            sandbox=context.sandbox(options=["--bind", context.root, context.root]))
+            sandbox=context.sandbox(mounts=[Mount(context.root, context.root)]))
 
         # Initrds generally don't ship with only /usr so there's not much point in putting the credentials in
         # /usr/lib/credstore.
@@ -2877,7 +2890,7 @@ def run_selinux_relabel(context: Context) -> None:
 
     with complete_step(f"Relabeling files using {policy} policy"):
         run(["setfiles", "-mFr", context.root, "-c", binpolicy, fc, context.root],
-            sandbox=context.sandbox(options=["--bind", context.root, context.root]),
+            sandbox=context.sandbox(mounts=[Mount(context.root, context.root)]),
             check=context.config.selinux_relabel == ConfigFeature.enabled)
 
 
@@ -3018,27 +3031,27 @@ def make_image(
         "--seed", str(context.config.seed),
         context.staging / context.config.output_with_format,
     ]
-    options: list[PathString] = ["--bind", context.staging, context.staging]
+    mounts = [Mount(context.staging, context.staging)]
 
     if root:
         cmdline += ["--root", root]
-        options += ["--bind", root, root]
+        mounts += [Mount(root, root)]
     if not context.config.architecture.is_native():
         cmdline += ["--architecture", str(context.config.architecture)]
     if not (context.staging / context.config.output_with_format).exists():
         cmdline += ["--empty=create"]
     if context.config.passphrase:
         cmdline += ["--key-file", context.config.passphrase]
-        options += ["--ro-bind", context.config.passphrase, context.config.passphrase]
+        mounts += [Mount(context.config.passphrase, context.config.passphrase, ro=True)]
     if context.config.verity_key:
         cmdline += ["--private-key", context.config.verity_key]
         if context.config.verity_key_source.type != KeySource.Type.file:
             cmdline += ["--private-key-source", str(context.config.verity_key_source)]
         if context.config.verity_key.exists():
-            options += ["--ro-bind", context.config.verity_key, context.config.verity_key]
+            mounts += [Mount(context.config.verity_key, context.config.verity_key, ro=True)]
     if context.config.verity_certificate:
         cmdline += ["--certificate", context.config.verity_certificate]
-        options += ["--ro-bind", context.config.verity_certificate, context.config.verity_certificate]
+        mounts += [Mount(context.config.verity_certificate, context.config.verity_certificate, ro=True)]
     if skip:
         cmdline += ["--defer-partitions", ",".join(skip)]
     if split:
@@ -3053,7 +3066,7 @@ def make_image(
 
     for d in definitions:
         cmdline += ["--definitions", d]
-        options += ["--ro-bind", d, d]
+        mounts += [Mount(d, d, ro=True)]
 
     with complete_step(msg):
         output = json.loads(
@@ -3066,7 +3079,7 @@ def make_image(
                         not context.config.repart_offline or
                         context.config.verity_key_source.type != KeySource.Type.file
                     ),
-                    options=options,
+                    mounts=mounts,
                 ),
             ).stdout
         )
@@ -3207,25 +3220,25 @@ def make_extension_image(context: Context, output: Path) -> None:
         "--size=auto",
         output,
     ]
-    options: list[PathString] = [
-        "--bind", output.parent, output.parent,
-        "--ro-bind", context.root, context.root,
+    mounts = [
+        Mount(output.parent, output.parent),
+        Mount(context.root, context.root, ro=True),
     ]
 
     if not context.config.architecture.is_native():
         cmdline += ["--architecture", str(context.config.architecture)]
     if context.config.passphrase:
         cmdline += ["--key-file", context.config.passphrase]
-        options += ["--ro-bind", context.config.passphrase, context.config.passphrase]
+        mounts += [Mount(context.config.passphrase, context.config.passphrase, ro=True)]
     if context.config.verity_key:
         cmdline += ["--private-key", context.config.verity_key]
         if context.config.verity_key_source.type != KeySource.Type.file:
             cmdline += ["--private-key-source", str(context.config.verity_key_source)]
         if context.config.verity_key.exists():
-            options += ["--ro-bind", context.config.verity_key, context.config.verity_key]
+            mounts += [Mount(context.config.verity_key, context.config.verity_key, ro=True)]
     if context.config.verity_certificate:
         cmdline += ["--certificate", context.config.verity_certificate]
-        options += ["--ro-bind", context.config.verity_certificate, context.config.verity_certificate]
+        mounts += [Mount(context.config.verity_certificate, context.config.verity_certificate, ro=True)]
     if context.config.sector_size:
         cmdline += ["--sector-size", str(context.config.sector_size)]
 
@@ -3237,7 +3250,7 @@ def make_extension_image(context: Context, output: Path) -> None:
 
     with complete_step(f"Building {context.config.output_format} extension image"):
         r = context.resources / f"repart/definitions/{context.config.output_format}.repart.d"
-        options += ["--ro-bind", r, r]
+        mounts += [Mount(r, r, ro=True)]
         run(
             cmdline + ["--definitions", r],
             env=env,
@@ -3246,7 +3259,7 @@ def make_extension_image(context: Context, output: Path) -> None:
                     not context.config.repart_offline or
                     context.config.verity_key_source.type != KeySource.Type.file
                 ),
-                options=options,
+                mounts=mounts,
             ),
         )
 
@@ -3360,14 +3373,14 @@ def copy_repository_metadata(context: Context) -> None:
 
                 # cp doesn't support excluding directories but we can imitate it by bind mounting an empty directory
                 # over the directories we want to exclude.
-                exclude = flatten(["--ro-bind", tmp, os.fspath(p)] for p in caches)
+                exclude = [Mount(tmp, p, ro=True) for p in caches]
 
                 dst = context.package_cache_dir / d / subdir
                 with umask(~0o755):
                     dst.mkdir(parents=True, exist_ok=True)
 
-                def sandbox(*, options: Sequence[PathString] = ()) -> list[PathString]:
-                    return context.sandbox(options=[*options, *exclude])
+                def sandbox(*, mounts: Sequence[Mount] = ()) -> list[PathString]:
+                    return context.sandbox(mounts=[*mounts, *exclude])
 
                 copy_tree(
                     src, dst,
@@ -3518,7 +3531,7 @@ def setfacl(config: Config, root: Path, uid: int, allow: bool) -> None:
         ],
         # Supply files via stdin so we don't clutter --debug run output too much
         input="\n".join([str(root), *(os.fspath(p) for p in root.rglob("*") if p.is_dir())]),
-        sandbox=config.sandbox(options=["--bind", root, root]),
+        sandbox=config.sandbox(mounts=[Mount(root, root)]),
     )
 
 
@@ -3530,7 +3543,7 @@ def acl_maybe_toggle(config: Config, root: Path, uid: int, *, always: bool) -> I
 
     # getfacl complains about absolute paths so make sure we pass a relative one.
     if root.exists():
-        sandbox = config.sandbox(options=["--bind", root, root, "--chdir", root])
+        sandbox = config.sandbox(mounts=[Mount(root, root)], options=["--chdir", root])
         has_acl = f"user:{uid}:rwx" in run(["getfacl", "-n", "."], sandbox=sandbox, stdout=subprocess.PIPE).stdout
 
         if not has_acl and not always:
@@ -3648,7 +3661,7 @@ def run_shell(args: Args, config: Config) -> None:
                 ],
                 stdin=sys.stdin,
                 env=config.environment,
-                sandbox=config.sandbox(network=True, devices=True, options=["--bind", fname, fname]),
+                sandbox=config.sandbox(network=True, devices=True, mounts=[Mount(fname, fname)]),
             )
 
         if config.output_format == OutputFormat.directory:

--- a/mkosi/archive.py
+++ b/mkosi/archive.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from mkosi.log import log_step
 from mkosi.run import find_binary, run
-from mkosi.sandbox import SandboxProtocol, finalize_passwd_mounts, nosandbox
+from mkosi.sandbox import Mount, SandboxProtocol, finalize_passwd_mounts, nosandbox
 from mkosi.util import umask
 
 
@@ -61,7 +61,7 @@ def make_tar(src: Path, dst: Path, *, tools: Path = Path("/"), sandbox: SandboxP
             ],
             stdout=f,
             # Make sure tar uses user/group information from the root directory instead of the host.
-            sandbox=sandbox(options=["--ro-bind", src, src, *finalize_passwd_mounts(src)]),
+            sandbox=sandbox(mounts=[Mount(src, src, ro=True), *finalize_passwd_mounts(src)]),
         )
 
 
@@ -100,7 +100,7 @@ def extract_tar(
             stdin=f,
             sandbox=sandbox(
                 # Make sure tar uses user/group information from the root directory instead of the host.
-                options=["--ro-bind", src, src, "--bind", dst, dst, *finalize_passwd_mounts(dst)]
+                mounts=[Mount(src, src, ro=True), Mount(dst, dst), *finalize_passwd_mounts(dst)]
             ),
         )
 
@@ -132,5 +132,5 @@ def make_cpio(
             ],
             input="\0".join(os.fspath(f.relative_to(src)) for f in files),
             stdout=f,
-            sandbox=sandbox(options=["--ro-bind", src, src, *finalize_passwd_mounts(src)]),
+            sandbox=sandbox(mounts=[Mount(src, src, ro=True), *finalize_passwd_mounts(src)]),
         )

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -13,6 +13,7 @@ from mkosi.installer import PackageManager
 from mkosi.installer.apt import Apt
 from mkosi.log import die
 from mkosi.run import run
+from mkosi.sandbox import Mount
 from mkosi.util import listify, umask
 
 
@@ -153,7 +154,7 @@ class Installer(DistributionInstaller):
                     f"-oDPkg::Pre-Install-Pkgs::=cat >{f.name}",
                     "?essential", "?exact-name(usr-is-merged)",
                 ],
-                mounts=("--bind", f.name, f.name),
+                mounts=[Mount(f.name, f.name)],
             )
 
             essential = f.read().strip().splitlines()

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -14,7 +14,7 @@ from mkosi.installer.rpm import RpmRepository, find_rpm_gpgkey, setup_rpm
 from mkosi.installer.zypper import Zypper
 from mkosi.log import die
 from mkosi.run import find_binary, run
-from mkosi.sandbox import finalize_crypto_mounts
+from mkosi.sandbox import Mount, finalize_crypto_mounts
 from mkosi.util import listify, sort_packages
 
 
@@ -168,7 +168,7 @@ def fetch_gpgurls(context: Context, repourl: str) -> tuple[str, ...]:
             ],
             sandbox=context.sandbox(
                 network=True,
-                options=["--bind", d, d, *finalize_crypto_mounts(context.config.tools())],
+                mounts=[Mount(d, d), *finalize_crypto_mounts(context.config.tools())],
             ),
         )
         xml = (Path(d) / "repomd.xml").read_text()

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -11,7 +11,7 @@ from mkosi.installer import PackageManager
 from mkosi.installer.rpm import RpmRepository, rpm_cmd
 from mkosi.mounts import finalize_source_mounts
 from mkosi.run import run
-from mkosi.sandbox import apivfs_cmd
+from mkosi.sandbox import Mount, apivfs_cmd
 from mkosi.types import _FILE, CompletedProcess, PathString
 
 
@@ -131,12 +131,8 @@ class Zypper(PackageManager):
                 sandbox=(
                     context.sandbox(
                         network=True,
-                        options=[
-                            "--bind", context.root, context.root,
-                            *cls.mounts(context),
-                            *sources,
-                            "--chdir", "/work/src",
-                        ],
+                        mounts=[Mount(context.root, context.root), *cls.mounts(context), *sources],
+                        options=["--dir", "/work/src", "--chdir", "/work/src"],
                     ) + (apivfs_cmd(context.root) if apivfs else [])
                 ),
                 env=context.config.environment,
@@ -150,7 +146,7 @@ class Zypper(PackageManager):
     @classmethod
     def createrepo(cls, context: Context) -> None:
         run(["createrepo_c", context.packages],
-            sandbox=context.sandbox(options=["--bind", context.packages, context.packages]))
+            sandbox=context.sandbox(mounts=[Mount(context.packages, context.packages)]))
 
         (context.pkgmngr / "etc/zypp/repos.d/mkosi-local.repo").write_text(
             textwrap.dedent(

--- a/mkosi/kmod.py
+++ b/mkosi/kmod.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from mkosi.log import complete_step, log_step
 from mkosi.run import run
-from mkosi.sandbox import SandboxProtocol, nosandbox
+from mkosi.sandbox import Mount, SandboxProtocol, nosandbox
 
 
 def loaded_modules() -> list[str]:
@@ -91,7 +91,7 @@ def resolve_module_dependencies(
         info += run(
             ["modinfo", "--basedir", root, "--set-version", kver, "--null", *chunk],
             stdout=subprocess.PIPE,
-            sandbox=sandbox(options=["--ro-bind", root, root])
+            sandbox=sandbox(mounts=[Mount(root, root, ro=True)]),
         ).stdout.strip()
 
     log_step("Calculating required kernel modules and firmware")

--- a/mkosi/manifest.py
+++ b/mkosi/manifest.py
@@ -14,6 +14,7 @@ from mkosi.distributions import PackageType
 from mkosi.installer.apt import Apt
 from mkosi.log import complete_step
 from mkosi.run import run
+from mkosi.sandbox import Mount
 
 
 @dataclasses.dataclass
@@ -110,7 +111,7 @@ class Manifest:
                 "--queryformat", r"%{NEVRA}\t%{SOURCERPM}\t%{NAME}\t%{ARCH}\t%{LONGSIZE}\t%{INSTALLTIME}\n",
             ],
             stdout=subprocess.PIPE,
-            sandbox=self.context.sandbox(options=["--ro-bind", self.context.root, self.context.root]),
+            sandbox=self.context.sandbox(mounts=[Mount(self.context.root, self.context.root)]),
         )
 
         packages = sorted(c.stdout.splitlines())
@@ -156,7 +157,7 @@ class Manifest:
                     ],
                     stdout=subprocess.PIPE,
                     stderr=subprocess.DEVNULL,
-                    sandbox=self.context.sandbox(options=["--ro-bind", self.context.root, self.context.root]),
+                    sandbox=self.context.sandbox(mounts=[Mount(self.context.root, self.context.root, ro=True)]),
                 )
                 changelog = c.stdout.strip()
                 source = SourcePackageManifest(srpm, changelog)
@@ -174,7 +175,7 @@ class Manifest:
                     r'${Package}\t${source:Package}\t${Version}\t${Architecture}\t${Installed-Size}\t${db-fsys:Last-Modified}\n',
             ],
             stdout=subprocess.PIPE,
-            sandbox=self.context.sandbox(options=["--ro-bind", self.context.root, self.context.root]),
+            sandbox=self.context.sandbox(mounts=[Mount(self.context.root, self.context.root, ro=True)]),
         )
 
         packages = sorted(c.stdout.splitlines())

--- a/mkosi/partition.py
+++ b/mkosi/partition.py
@@ -7,7 +7,7 @@ from typing import Any, Optional
 
 from mkosi.log import die
 from mkosi.run import run
-from mkosi.sandbox import SandboxProtocol, nosandbox
+from mkosi.sandbox import Mount, SandboxProtocol, nosandbox
 
 
 @dataclasses.dataclass(frozen=True)
@@ -37,7 +37,7 @@ def find_partitions(image: Path, *, sandbox: SandboxProtocol = nosandbox) -> lis
             ["systemd-repart", "--json=short", image],
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
-            sandbox=sandbox(options=["--ro-bind", image, image]),
+            sandbox=sandbox(mounts=[Mount(image, image, ro=True)]),
         ).stdout
     )
     return [Partition.from_dict(d) for d in output]

--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -5,18 +5,45 @@ import os
 import uuid
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Optional, Protocol
+from typing import NamedTuple, Optional, Protocol
 
 from mkosi.types import PathString
 from mkosi.user import INVOKING_USER
 from mkosi.util import flatten, one_zero, startswith
 
 
+class Mount(NamedTuple):
+    src: PathString
+    dst: PathString
+    devices: bool = False
+    ro: bool = False
+    required: bool = True
+
+    def __hash__(self) -> int:
+        return hash((Path(self.src), Path(self.dst), self.devices, self.ro, self.required))
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Mount):
+            return False
+
+        return self.__hash__() == other.__hash__()
+
+    def options(self) -> list[str]:
+        if self.devices:
+            opt = "--dev-bind" if self.required else "--dev-bind-try"
+        elif self.ro:
+            opt = "--ro-bind" if self.required else "--ro-bind-try"
+        else:
+            opt = "--bind" if self.required else "--bind-try"
+
+        return [opt, os.fspath(self.src), os.fspath(self.dst)]
+
+
 class SandboxProtocol(Protocol):
-    def __call__(self, *, options: Sequence[PathString] = ()) -> list[PathString]: ...
+    def __call__(self, *, mounts: Sequence[Mount] = ()) -> list[PathString]: ...
 
 
-def nosandbox(*, options: Sequence[PathString] = ()) -> list[PathString]:
+def nosandbox(*, mounts: Sequence[Mount] = ()) -> list[PathString]:
     return []
 
 
@@ -37,21 +64,19 @@ def have_effective_cap(capability: Capability) -> bool:
     return (int(hexcap, 16) & (1 << capability.value)) != 0
 
 
-def finalize_passwd_mounts(root: Path) -> list[PathString]:
+def finalize_passwd_mounts(root: Path) -> list[Mount]:
     """
     If passwd or a related file exists in the apivfs directory, bind mount it over the host files while we
     run the command, to make sure that the command we run uses user/group information from the apivfs
     directory instead of from the host.
     """
-    options: list[PathString] = []
-
-    for f in ("passwd", "group", "shadow", "gshadow"):
-        options += ["--ro-bind-try", root / "etc" / f, f"/etc/{f}"]
-
-    return options
+    return [
+        Mount(root / "etc" / f, f"/etc/{f}", ro=True, required=False)
+        for f in ("passwd", "group", "shadow", "gshadow")
+    ]
 
 
-def finalize_crypto_mounts(tools: Path = Path("/")) -> list[PathString]:
+def finalize_crypto_mounts(tools: Path = Path("/")) -> list[Mount]:
     mounts = [
         (tools / subdir, Path("/") / subdir)
         for subdir in (
@@ -64,11 +89,11 @@ def finalize_crypto_mounts(tools: Path = Path("/")) -> list[PathString]:
         if (tools / subdir).exists()
     ]
 
-    return flatten(
-        ["--ro-bind", src, target]
+    return [
+        Mount(src, target, ro=True)
         for src, target
         in sorted(set(mounts), key=lambda s: s[1])
-    )
+    ]
 
 
 def sandbox_cmd(
@@ -78,6 +103,7 @@ def sandbox_cmd(
     scripts: Optional[Path] = None,
     tools: Path = Path("/"),
     relaxed: bool = False,
+    mounts: Sequence[Mount] = (),
     options: Sequence[PathString] = (),
 ) -> list[PathString]:
     cmdline: list[PathString] = []
@@ -93,7 +119,6 @@ def sandbox_cmd(
 
     cmdline += [
         "bwrap",
-        "--ro-bind", tools / "usr", "/usr",
         *(["--unshare-net"] if not network and have_effective_cap(Capability.CAP_NET_ADMIN) else []),
         "--die-with-parent",
         "--proc", "/proc",
@@ -101,9 +126,10 @@ def sandbox_cmd(
         # We mounted a subdirectory of TMPDIR to /var/tmp so we unset TMPDIR so that /tmp or /var/tmp are used instead.
         "--unsetenv", "TMPDIR",
     ]
+    allmounts = [Mount(tools / "usr", "/usr", ro=True)]
 
     if relaxed:
-        cmdline += ["--bind", "/tmp", "/tmp"]
+        allmounts += [Mount("/tmp", "/tmp")]
     else:
         cmdline += [
             "--tmpfs", "/tmp",
@@ -111,13 +137,13 @@ def sandbox_cmd(
         ]
 
     if (tools / "nix/store").exists():
-        cmdline += ["--bind", tools / "nix/store", "/nix/store"]
+        allmounts += [Mount(tools / "nix/store", "/nix/store")]
 
     if devices or relaxed:
-        cmdline += [
-            "--bind", "/sys", "/sys",
-            "--bind", "/run", "/run",
-            "--dev-bind", "/dev", "/dev",
+        allmounts += [
+            Mount("/sys", "/sys"),
+            Mount("/run", "/run"),
+            Mount("/dev", "/dev", devices=True),
         ]
     else:
         cmdline += ["--dev", "/dev"]
@@ -127,7 +153,7 @@ def sandbox_cmd(
 
         for d in dirs:
             if Path(d).exists():
-                cmdline += ["--bind", d, d]
+                allmounts += [Mount(d, d)]
 
         if len(Path.cwd().parents) >= 2:
             # `Path.parents` only supports slices and negative indexing from Python 3.10 onwards.
@@ -139,23 +165,21 @@ def sandbox_cmd(
             d = ""
 
         if d and d not in (*dirs, "/home", "/usr", "/nix", "/tmp"):
-            cmdline += ["--bind", d, d]
+            allmounts += [Mount(d, d)]
 
     if vartmp:
-        cmdline += ["--bind", vartmp, "/var/tmp"]
+        allmounts += [Mount(vartmp, "/var/tmp")]
 
     for d in ("bin", "sbin", "lib", "lib32", "lib64"):
         if (p := tools / d).is_symlink():
             cmdline += ["--symlink", p.readlink(), Path("/") / p.relative_to(tools)]
         elif p.is_dir():
-            cmdline += ["--ro-bind", p, Path("/") / p.relative_to(tools)]
+            allmounts += [Mount(p, Path("/") / p.relative_to(tools), ro=True)]
 
     path = "/usr/bin:/usr/sbin" if tools != Path("/") else os.environ["PATH"]
 
-    cmdline += [
-        "--setenv", "PATH", f"/scripts:{path}",
-        *options,
-    ]
+    cmdline += ["--setenv", "PATH", f"/scripts:{path}", *options]
+    allmounts = [*allmounts, *mounts]
 
     if not relaxed:
         cmdline += ["--symlink", "../proc/self/mounts", "/etc/mtab"]
@@ -166,13 +190,15 @@ def sandbox_cmd(
     # already exists on the host as otherwise we'd modify the host's /etc by creating the mountpoint ourselves (or
     # fail when trying to create it).
     if (tools / "etc/alternatives").exists() and (not relaxed or Path("/etc/alternatives").exists()):
-        cmdline += ["--ro-bind", tools / "etc/alternatives", "/etc/alternatives"]
+        allmounts += [Mount(tools / "etc/alternatives", "/etc/alternatives", ro=True)]
 
     if scripts:
-        cmdline += ["--ro-bind", scripts, "/scripts"]
+        allmounts += [Mount(scripts, "/scripts", ro=True)]
 
     if network and not relaxed and Path("/etc/resolv.conf").exists():
-        cmdline += ["--bind", "/etc/resolv.conf", "/etc/resolv.conf"]
+        allmounts += [Mount("/etc/resolv.conf", "/etc/resolv.conf")]
+
+    cmdline += flatten(mount.options() for mount in allmounts)
 
     # bubblewrap creates everything with a restricted mode so relax stuff as needed.
     ops = []
@@ -204,7 +230,7 @@ def apivfs_cmd(root: Path) -> list[PathString]:
         "--ro-bind-try", root / "etc/machine-id", root / "etc/machine-id",
         # Nudge gpg to create its sockets in /run by making sure /run/user/0 exists.
         "--dir", root / "run/user/0",
-        *finalize_passwd_mounts(root),
+        *flatten(mount.options() for mount in finalize_passwd_mounts(root)),
         "sh", "-c",
         f"chmod 1777 {root / 'tmp'} {root / 'var/tmp'} {root / 'dev/shm'} && "
         f"chmod 755 {root / 'run'} && "

--- a/mkosi/vmspawn.py
+++ b/mkosi/vmspawn.py
@@ -20,6 +20,7 @@ from mkosi.qemu import (
     find_ovmf_firmware,
 )
 from mkosi.run import run
+from mkosi.sandbox import Mount
 from mkosi.types import PathString
 from mkosi.util import flock_or_die
 
@@ -93,7 +94,7 @@ def run_vmspawn(args: Args, config: Config) -> None:
                     "--offline=yes",
                     fname,
                 ],
-                sandbox=config.sandbox(options=["--bind", fname, fname]),
+                sandbox=config.sandbox(mounts=[Mount(fname, fname)]),
             )
 
         kcl = config.kernel_command_line_extra


### PR DESCRIPTION
We don't want users of sandbox_cmd() to have to care about mount
ordering. Currently, if mounts with a more general destination are
ordered after mounts with a more specific destination, the earlier
mount is hidden by the later mount. By sorting by destination, we
avoid this issue.