### PR TITLE
Check sync scripts are executable in run_sync()

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2528,7 +2528,6 @@ def check_inputs(config: Config) -> None:
                 die(f"Initrd {p} is not a file")
 
     for script in itertools.chain(
-        config.sync_scripts,
         config.prepare_scripts,
         config.build_scripts,
         config.postinst_scripts,
@@ -4025,6 +4024,10 @@ def run_sync(args: Args, config: Config, *, resources: Path) -> None:
         os.setgroups(os.getgrouplist(INVOKING_USER.name(), INVOKING_USER.gid))
         os.setgid(INVOKING_USER.gid)
         os.setuid(INVOKING_USER.uid)
+
+    for script in config.sync_scripts:
+        if not os.access(script, os.X_OK):
+            die(f"{script} is not executable")
 
     if not (p := config.package_cache_dir_or_default()).exists():
         p.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
check_inputs() is only invoked after sync scripts have already run, so do the check in run_sync() instead.