### PR TITLE
Always mount context.root to /buildroot

### DIFF
--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -134,7 +134,6 @@ class Apt(PackageManager):
             "-o", "Dir::State=/var/lib/apt",
             "-o", "Dir::Log=/var/log/apt",
             "-o", f"Dir::State::Status={context.root / 'var/lib/dpkg/status'}",
-            "-o", f"Dir::Log={context.workspace}",
             "-o", f"Dir::Bin::DPkg={find_binary('dpkg', root=context.config.tools())}",
             "-o", "Debug::NoLocking=true",
             "-o", f"DPkg::Options::=--root={context.root}",

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -52,7 +52,7 @@ class Apt(PackageManager):
     def scripts(cls, context: Context) -> dict[str, list[PathString]]:
         return {
             **{
-                command: apivfs_cmd(context.root) + cls.cmd(context, command) for command in (
+                command: apivfs_cmd() + cls.cmd(context, command) for command in (
                     "apt",
                     "apt-cache",
                     "apt-cdrom",
@@ -133,10 +133,10 @@ class Apt(PackageManager):
             "-o", "Dir::Cache=/var/cache/apt",
             "-o", "Dir::State=/var/lib/apt",
             "-o", "Dir::Log=/var/log/apt",
-            "-o", f"Dir::State::Status={context.root / 'var/lib/dpkg/status'}",
+            "-o", "Dir::State::Status=/buildroot/var/lib/dpkg/status",
             "-o", f"Dir::Bin::DPkg={find_binary('dpkg', root=context.config.tools())}",
             "-o", "Debug::NoLocking=true",
-            "-o", f"DPkg::Options::=--root={context.root}",
+            "-o", "DPkg::Options::=--root=/buildroot",
             "-o", "DPkg::Options::=--force-unsafe-io",
             "-o", "DPkg::Options::=--force-architecture",
             "-o", "DPkg::Options::=--force-depends",
@@ -184,9 +184,9 @@ class Apt(PackageManager):
                 sandbox=(
                     context.sandbox(
                         network=True,
-                        mounts=[Mount(context.root, context.root), *cls.mounts(context), *sources, *mounts],
+                        mounts=[Mount(context.root, "/buildroot"), *cls.mounts(context), *sources, *mounts],
                         options=["--dir", "/work/src", "--chdir", "/work/src"],
-                    ) + (apivfs_cmd(context.root) if apivfs else [])
+                    ) + (apivfs_cmd() if apivfs else [])
                 ),
                 env=context.config.environment,
                 stdout=stdout,

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -39,8 +39,8 @@ class Dnf(PackageManager):
     @classmethod
     def scripts(cls, context: Context) -> dict[str, list[PathString]]:
         return {
-            "dnf": apivfs_cmd(context.root) + cls.cmd(context),
-            "rpm": apivfs_cmd(context.root) + rpm_cmd(context),
+            "dnf": apivfs_cmd() + cls.cmd(context),
+            "rpm": apivfs_cmd() + rpm_cmd(),
             "mkosi-install"  : ["dnf", "install"],
             "mkosi-upgrade"  : ["dnf", "upgrade"],
             "mkosi-remove"   : ["dnf", "remove"],
@@ -105,7 +105,7 @@ class Dnf(PackageManager):
             "--assumeyes",
             "--best",
             f"--releasever={context.config.release}",
-            f"--installroot={context.root}",
+            "--installroot=/buildroot",
             "--setopt=keepcache=1",
             "--setopt=logdir=/var/log",
             f"--setopt=cachedir=/var/cache/{cls.subdir(context.config)}",
@@ -170,9 +170,9 @@ class Dnf(PackageManager):
                     sandbox=(
                         context.sandbox(
                             network=True,
-                            mounts=[Mount(context.root, context.root), *cls.mounts(context), *sources],
+                            mounts=[Mount(context.root, "/buildroot"), *cls.mounts(context), *sources],
                             options=["--dir", "/work/src", "--chdir", "/work/src"],
-                        ) + (apivfs_cmd(context.root) if apivfs else [])
+                        ) + (apivfs_cmd() if apivfs else [])
                     ),
                     env=context.config.environment,
                     stdout=stdout,

--- a/mkosi/installer/rpm.py
+++ b/mkosi/installer/rpm.py
@@ -67,5 +67,5 @@ def setup_rpm(context: Context, *, dbpath: str = "/usr/lib/sysimage/rpm") -> Non
         )
 
 
-def rpm_cmd(context: Context) -> list[PathString]:
-    return ["env", "HOME=/", "rpm", "--root", context.root]
+def rpm_cmd() -> list[PathString]:
+    return ["env", "HOME=/", "rpm", "--root=/buildroot"]

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -38,8 +38,8 @@ class Zypper(PackageManager):
         ]
 
         return {
-            "zypper": apivfs_cmd(context.root) + cls.cmd(context),
-            "rpm"   : apivfs_cmd(context.root) + rpm_cmd(context),
+            "zypper": apivfs_cmd() + cls.cmd(context),
+            "rpm"   : apivfs_cmd() + rpm_cmd(),
             "mkosi-install"  : install,
             "mkosi-upgrade"  : ["zypper", "update"],
             "mkosi-remove"   : ["zypper", "remove", "--clean-deps"],
@@ -105,7 +105,7 @@ class Zypper(PackageManager):
             "ZYPP_CONF=/etc/zypp/zypp.conf",
             "HOME=/",
             "zypper",
-            f"--installroot={context.root}",
+            "--installroot=/buildroot",
             "--cache-dir=/var/cache/zypp",
             "--gpg-auto-import-keys" if context.config.repository_key_check else "--no-gpg-checks",
             "--non-interactive",
@@ -131,9 +131,9 @@ class Zypper(PackageManager):
                 sandbox=(
                     context.sandbox(
                         network=True,
-                        mounts=[Mount(context.root, context.root), *cls.mounts(context), *sources],
+                        mounts=[Mount(context.root, "/buildroot"), *cls.mounts(context), *sources],
                         options=["--dir", "/work/src", "--chdir", "/work/src"],
-                    ) + (apivfs_cmd(context.root) if apivfs else [])
+                    ) + (apivfs_cmd() if apivfs else [])
                 ),
                 env=context.config.environment,
                 stdout=stdout,

--- a/mkosi/manifest.py
+++ b/mkosi/manifest.py
@@ -105,13 +105,13 @@ class Manifest:
         c = run(
             [
                 "rpm",
-                f"--root={self.context.root}",
+                "--root=/buildroot",
                 "--query",
                 "--all",
                 "--queryformat", r"%{NEVRA}\t%{SOURCERPM}\t%{NAME}\t%{ARCH}\t%{LONGSIZE}\t%{INSTALLTIME}\n",
             ],
             stdout=subprocess.PIPE,
-            sandbox=self.context.sandbox(mounts=[Mount(self.context.root, self.context.root)]),
+            sandbox=self.context.sandbox(mounts=[Mount(self.context.root, "/buildroot")]),
         )
 
         packages = sorted(c.stdout.splitlines())
@@ -150,14 +150,14 @@ class Manifest:
                 c = run(
                     [
                         "rpm",
-                        f"--root={self.context.root}",
+                        "--root=/buildroot",
                         "--query",
                         "--changelog",
                         nevra,
                     ],
                     stdout=subprocess.PIPE,
                     stderr=subprocess.DEVNULL,
-                    sandbox=self.context.sandbox(mounts=[Mount(self.context.root, self.context.root, ro=True)]),
+                    sandbox=self.context.sandbox(mounts=[Mount(self.context.root, "/buildroot", ro=True)]),
                 )
                 changelog = c.stdout.strip()
                 source = SourcePackageManifest(srpm, changelog)
@@ -169,13 +169,13 @@ class Manifest:
         c = run(
             [
                 "dpkg-query",
-                f"--admindir={self.context.root / 'var/lib/dpkg'}",
+                "--admindir=/buildroot/var/lib/dpkg",
                 "--show",
                 "--showformat",
                     r'${Package}\t${source:Package}\t${Version}\t${Architecture}\t${Installed-Size}\t${db-fsys:Last-Modified}\n',
             ],
             stdout=subprocess.PIPE,
-            sandbox=self.context.sandbox(mounts=[Mount(self.context.root, self.context.root, ro=True)]),
+            sandbox=self.context.sandbox(mounts=[Mount(self.context.root, "/buildroot", ro=True)]),
         )
 
         packages = sorted(c.stdout.splitlines())
@@ -211,7 +211,7 @@ class Manifest:
                 result = Apt.invoke(
                     self.context,
                     "changelog",
-                    ["--quiet", "--quiet", "-o", f"Dir={self.context.root}", name],
+                    ["--quiet", "--quiet", "-o", "Dir=/buildroot", name],
                     stdout=subprocess.PIPE,
                 )
                 source_package = SourcePackageManifest(source, result.stdout.strip())


### PR DESCRIPTION
Let's leak fewer host specific details into the sandbox by always mounting the image root directory to /buildroot in the sandbox. This also simplifies debugging as the image rootfs will always be at /rootfs instead of in some host specific path.