### PR TITLE
Fix kernel module glob

### DIFF
--- a/mkosi/kmod.py
+++ b/mkosi/kmod.py
@@ -25,7 +25,7 @@ def filter_kernel_modules(
     host: bool,
 ) -> list[Path]:
     modulesd = root / "usr/lib/modules" / kver
-    modules = {m for m in modulesd.rglob("*.ko*")}
+    modules = set((modulesd / "kernel").rglob("*.ko*"))
 
     if host:
         include = [*include, *loaded_modules()]


### PR DESCRIPTION
When dkms modules are installed there will be .ko modules in directories other than "kernel" so make sure we only look for modules in the "kernel" directory.