### PR TITLE
ci: Use nopcid instead of disabling secure boot

### DIFF
--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -694,7 +694,8 @@ def run_qemu(args: Args, config: Config) -> None:
             f"vhost-vsock-pci,guest-cid={cid},vhostfd={qemu_device_fds[QemuDeviceNode.vhost_vsock]}"
         ]
 
-    cmdline += ["-cpu", "max"]
+    # TODO: Remove once Hyper-V bug is fixed and deployed to Github Actions.
+    cmdline += ["-cpu", "max,pcid=off"]
 
     if config.qemu_gui:
         cmdline += ["-vga", "virtio"]

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -32,8 +32,6 @@ def test_format(config: Image.Config, format: OutputFormat) -> None:
             "--kernel-command-line=systemd.unit=mkosi-check-and-shutdown.service",
             "--incremental",
             "--ephemeral",
-            # TODO: Drop once https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2038777 is fixed in Github Actions
-            "--qemu-firmware=uefi" if format in (OutputFormat.disk, OutputFormat.uki) else "--qemu-firmware=auto",
         ],
     ) as image:
         if image.config.distribution == Distribution.rhel_ubi and format in (OutputFormat.esp, OutputFormat.uki):
@@ -81,9 +79,7 @@ def test_bootloader(config: Image.Config, bootloader: Bootloader) -> None:
     if config.distribution == Distribution.rhel_ubi:
         return
 
-    # TODO: Use "auto" again instead of "uefi" once https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2038777 is
-    # fixed in Github Actions.
-    firmware = QemuFirmware.linux if bootloader == Bootloader.none else QemuFirmware.uefi
+    firmware = QemuFirmware.linux if bootloader == Bootloader.none else QemuFirmware.auto
 
     with Image(
         config,

--- a/tests/test_initrd.py
+++ b/tests/test_initrd.py
@@ -67,8 +67,6 @@ def test_initrd(initrd: Image) -> None:
             "--incremental",
             "--ephemeral",
             "--format=disk",
-            # TODO: Drop once https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2038777 is fixed in Github Actions
-            "--qemu-firmware=uefi",
         ]
     ) as image:
         image.build()
@@ -191,9 +189,6 @@ def test_initrd_luks(initrd: Image, passphrase: Path) -> None:
                 "--incremental",
                 "--ephemeral",
                 "--format=disk",
-                # TODO: Drop once https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2038777 is fixed in Github
-                # Actions.
-                "--qemu-firmware=uefi",
             ]
         ) as image:
             image.build()


### PR DESCRIPTION
This allows us to boot with secure boot again until the Hyper-V bug is fixed that causes KVM to crash.