### PR TITLE
ci: Use pcid=off with qemu instead of disabling secure boot

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -88,6 +88,9 @@ class Image:
             "--cache-dir", "mkosi.cache",
             *(f"--kernel-command-line={i}" for i in kcl),
             "--qemu-vsock=yes",
+            # TODO: Drop once both Hyper-V bugs are fixed in Github Actions.
+            "--qemu-args=-cpu max,pcid=off",
+            "--qemu-mem=2G",
             verb,
             *args,
         ], check=check, stdin=stdin, stdout=sys.stdout, user=user, group=group)

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -32,8 +32,6 @@ def test_format(config: Image.Config, format: OutputFormat) -> None:
             "--kernel-command-line=systemd.unit=mkosi-check-and-shutdown.service",
             "--incremental",
             "--ephemeral",
-            # TODO: Drop once https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2038777 is fixed in Github Actions
-            "--qemu-firmware=uefi" if format in (OutputFormat.disk, OutputFormat.uki) else "--qemu-firmware=auto",
         ],
     ) as image:
         if image.config.distribution == Distribution.rhel_ubi and format in (OutputFormat.esp, OutputFormat.uki):
@@ -81,9 +79,7 @@ def test_bootloader(config: Image.Config, bootloader: Bootloader) -> None:
     if config.distribution == Distribution.rhel_ubi:
         return
 
-    # TODO: Use "auto" again instead of "uefi" once https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2038777 is
-    # fixed in Github Actions.
-    firmware = QemuFirmware.linux if bootloader == Bootloader.none else QemuFirmware.uefi
+    firmware = QemuFirmware.linux if bootloader == Bootloader.none else QemuFirmware.auto
 
     with Image(
         config,

--- a/tests/test_initrd.py
+++ b/tests/test_initrd.py
@@ -67,8 +67,6 @@ def test_initrd(initrd: Image) -> None:
             "--incremental",
             "--ephemeral",
             "--format=disk",
-            # TODO: Drop once https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2038777 is fixed in Github Actions
-            "--qemu-firmware=uefi",
         ]
     ) as image:
         image.build()
@@ -191,9 +189,6 @@ def test_initrd_luks(initrd: Image, passphrase: Path) -> None:
                 "--incremental",
                 "--ephemeral",
                 "--format=disk",
-                # TODO: Drop once https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2038777 is fixed in Github
-                # Actions.
-                "--qemu-firmware=uefi",
             ]
         ) as image:
             image.build()


### PR DESCRIPTION
This allows us to boot with secure boot again until the Hyper-V bug
is fixed that causes KVM to crash.

We also switch back to using 2Gs of ram by default as a second Hyper-V
bug prevents us from using any more on Github Actions.