### PR TITLE
Only set some environment variables when invoking package managers

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3484,8 +3484,6 @@ def load_kernel_command_line_extra(args: argparse.Namespace) -> list[str]:
 def load_environment(args: argparse.Namespace) -> dict[str, str]:
     env = {
         "SYSTEMD_TMPFILES_FORCE_SUBVOL": "0",
-        "KERNEL_INSTALL_BYPASS": "1",
-        "SYSTEMD_HWDB_UPDATE_BYPASS": "1",
         "TERM": finalize_term(),
     }
 

--- a/mkosi/installer/__init__.py
+++ b/mkosi/installer/__init__.py
@@ -29,6 +29,23 @@ class PackageManager:
         return {}
 
     @classmethod
+    def finalize_environment(cls, context: Context) -> dict[str, str]:
+        env = {
+            "HOME": "/", # Make sure rpm doesn't pick up ~/.rpmmacros and ~/.rpmrc.
+        }
+
+        if "SYSTEMD_HWDB_UPDATE_BYPASS" not in context.config.environment:
+            env["SYSTEMD_HWDB_UPDATE_BYPASS"] = "1"
+
+        if (
+            "KERNEL_INSTALL_BYPASS" not in context.config.environment and
+            context.config.bootable != ConfigFeature.disabled
+        ):
+            env["KERNEL_INSTALL_BYPASS"] = "1"
+
+        return env
+
+    @classmethod
     def mounts(cls, context: Context) -> list[Mount]:
         mounts = [
             *finalize_crypto_mounts(tools=context.config.tools()),

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -100,7 +100,7 @@ class Dnf(PackageManager):
 
         cmdline: list[PathString] = [
             "env",
-            "HOME=/", # Make sure rpm doesn't pick up ~/.rpmmacros and ~/.rpmrc.
+            *([f"{k}={v}" for k, v in cls.finalize_environment(context).items()]),
             dnf,
             "--assumeyes",
             "--best",

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -127,6 +127,8 @@ class Pacman(PackageManager):
     @classmethod
     def cmd(cls, context: Context) -> list[PathString]:
         return [
+            "env",
+            *([f"{k}={v}" for k, v in cls.finalize_environment(context).items()]),
             "pacman",
             "--root=/buildroot",
             "--logfile=/dev/null",

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -99,11 +99,14 @@ class Zypper(PackageManager):
                     f.write("\n")
 
     @classmethod
+    def finalize_environment(cls, context: Context) -> dict[str, str]:
+        return super().finalize_environment(context) | {"ZYPP_CONF": "/etc/zypp/zypp.conf"}
+
+    @classmethod
     def cmd(cls, context: Context) -> list[PathString]:
         return [
             "env",
-            "ZYPP_CONF=/etc/zypp/zypp.conf",
-            "HOME=/",
+            *([f"{k}={v}" for k, v in cls.finalize_environment(context).items()]),
             "zypper",
             "--installroot=/buildroot",
             "--cache-dir=/var/cache/zypp",


### PR DESCRIPTION
We really only want to set KERNEL_INSTALL_BYPASS and SYSTEMD_HWDB_UPDATE_BYPASS when we're invoking package managers so let's make sure those are only set when invoking package managers.

Let's also allow users to override both all of these and let's not set them when Bootable=no so distros can do whatever they want if mkosi's bootable image logic is not being used.