### PR TITLE
Mount pkgmngr/etc as a whole instead of individual files in it.

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1491,6 +1491,9 @@ def install_package_manager_trees(context: Context) -> None:
     # Ensure /etc exists in the package manager tree
     (context.pkgmngr / "etc").mkdir(exist_ok=True)
 
+    # Backwards compatibility symlink.
+    (context.pkgmngr / "etc/mtab").symlink_to("../proc/self/mounts")
+
     # Required to be able to access certificates in the sandbox when running from nix.
     if Path("/etc/static").is_symlink():
         (context.pkgmngr / "etc/static").symlink_to(Path("/etc/static").readlink())

--- a/mkosi/context.py
+++ b/mkosi/context.py
@@ -81,16 +81,13 @@ class Context:
             devices=devices,
             scripts=scripts,
             mounts=[
-                # These mounts are writable so bubblewrap can create extra directories or symlinks inside of it as
-                # needed. This isn't a problem as the package manager directory is created by mkosi and thrown away
-                # when the build finishes.
-                *[
-                    Mount(self.pkgmngr / "etc" / p.name, f"/etc/{p.name}")
-                    for p in (self.pkgmngr / "etc").iterdir()
-                ],
-                *mounts,
+                # This mount is writable so bubblewrap can create extra directories or symlinks inside of it as needed.
+                # This isn't a problem as the package manager directory is created by mkosi and thrown away when the
+                # build finishes.
+                Mount(self.pkgmngr / "etc", "/etc"),
                 Mount(self.pkgmngr / "var/log", "/var/log"),
                 *([Mount(p, p, ro=True)] if (p := self.pkgmngr / "usr").exists() else []),
+                *mounts,
             ],
             options=[
                 "--uid", "0",

--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -203,9 +203,6 @@ def sandbox_cmd(
 
     cmdline += ["--setenv", "PATH", f"/scripts:{path}", *options]
 
-    if not relaxed:
-        cmdline += ["--symlink", "../proc/self/mounts", "/etc/mtab"]
-
     # If we're using /usr from a tools tree, we have to use /etc/alternatives from the tools tree as well if it
     # exists since that points directly back to /usr. Apply this after the options so the caller can mount
     # something else to /etc without overriding this mount. In relaxed mode, we only do this if /etc/alternatives
@@ -221,6 +218,9 @@ def sandbox_cmd(
         mounts += [Mount("/etc/resolv.conf", "/etc/resolv.conf")]
 
     cmdline += finalize_mounts(mounts)
+
+    if not any(Path(m.dst) == Path("/etc") for m in mounts):
+        cmdline += ["--symlink", "../proc/self/mounts", "/etc/mtab"]
 
     # bubblewrap creates everything with a restricted mode so relax stuff as needed.
     ops = []


### PR DESCRIPTION
We stopped doing this because bubblewrap would create the /etc/mtab in the package manager tree /etc and leave it there after exiting, which would cause bubblewrap to fail the next time we executed it as the symlink already existed.

To avoid reintroducing this issue, we only have bubblewrap create the symlink if nothing's going to be mounted to /etc and create the symlink ourselves in the pkgmngr/etc.

These changes also make sure that the mounts from finalize_passwd_mounts() take precedence over the passwd and group files from pkgmngr/etc.