### PR TITLE
Set $HOME to the user's home directory in sync scripts

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -462,6 +462,7 @@ def run_sync_scripts(context: Context) -> None:
                 # git repository and might need to modify the git config in the parent git repository when submodules
                 # are in use as well.
                 mounts += [Mount(p, p)]
+                env["HOME"] = os.fspath(p)
             if (p := Path(f"/run/user/{INVOKING_USER.uid}")).exists():
                 mounts += [Mount(p, p, ro=True)]
 


### PR DESCRIPTION
Makes sure git can find the user's git configuration.