### PR TITLE
Remove setuid/setgid bits from build and workspace directory

### DIFF
--- a/mkosi/user.py
+++ b/mkosi/user.py
@@ -67,20 +67,6 @@ class INVOKING_USER:
         return cache / "mkosi"
 
     @classmethod
-    def mkdir(cls, path: Path) -> Path:
-        cond = (
-            not cls.invoked_as_root or
-            (cls.is_regular_user() and any(p.exists() and p.stat().st_uid == cls.uid for p in path.parents))
-        )
-        run(
-            ["mkdir", "--parents", path],
-            user=cls.uid if cond else os.getuid(),
-            group=cls.gid if cond else os.getgid(),
-            extra_groups=cls.extra_groups() if cls.invoked_as_root and cond else None,
-        )
-        return path
-
-    @classmethod
     def rchown(cls, path: Path) -> None:
         if cls.is_regular_user() and any(p.stat().st_uid == cls.uid for p in path.parents) and path.exists():
             run(["chown", "--recursive", f"{INVOKING_USER.uid}:{INVOKING_USER.gid}", path])


### PR DESCRIPTION
Both of these can be inherited so remove them from both the workspace and the build directory where inheriting these bits could end up leaking stuff from the host into the image.

Also remove INVOKING_USER.mkdir() while we're at it as only one user was remaining which we can do much more easily by doing the logic before we go into the user namespace.