### PR TITLE
kernel-install: Don't copy pacman gpg sockets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Run ruff
       run: |
         ruff --version
-        ruff mkosi/ tests/ kernel-install/50-mkosi.install
+        ruff check mkosi/ tests/ kernel-install/50-mkosi.install
 
     - name: Check that tabs are not used in code
       run: sh -c '! git grep -P "\\t" "*.py"'

--- a/kernel-install/50-mkosi.install
+++ b/kernel-install/50-mkosi.install
@@ -14,7 +14,6 @@ from mkosi.archive import make_cpio
 from mkosi.config import OutputFormat, __version__
 from mkosi.log import die, log_setup
 from mkosi.run import find_binary, run, uncaught_exception_handler
-from mkosi.tree import copy_tree
 from mkosi.types import PathString
 from mkosi.util import umask
 
@@ -176,7 +175,11 @@ def main() -> None:
                 continue
 
             (Path(d) / "etc" / p).parent.mkdir(parents=True, exist_ok=True)
-            copy_tree(Path("/etc") / p, Path(d) / "etc" / p, dereference=True)
+            if (Path("/etc") / p).resolve().is_file():
+                shutil.copy2(Path("/etc") / p, Path(d) / "etc" / p)
+            else:
+                shutil.copytree(Path("/etc") / p, Path(d) / "etc" / p,
+                                ignore=shutil.ignore_patterns("S.*"), dirs_exist_ok=True)
 
         cmdline += ["--package-manager-tree", d]
 


### PR DESCRIPTION
These should be created in /run but gpg's logic for that is broken for the root user (it checks for /run/user/0 which will never exist) so the sockets are created in the gpg home dir (/etc/pacman.d/gnupg) instead. Let's make sure we don't try to copy those as they cause issues with cp -R.

Fixes #2547