### PR TITLE
Allow escaping in QemuArgs=

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2808,7 +2808,7 @@ SETTINGS = (
         dest="qemu_args",
         metavar="ARGS",
         section="Host",
-        parse=config_make_list_parser(delimiter=" "),
+        parse=config_make_list_parser(delimiter=" ", unescape=True),
         # Suppress the command line option because it's already possible to pass qemu args as normal
         # arguments.
         help=argparse.SUPPRESS,


### PR DESCRIPTION
Sometimes we need spaces inside the qemu argument so let's make sure that's possible.