### PR TITLE
Add CleanScripts=

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -455,7 +455,7 @@ def run_configure_scripts(config: Config) -> Config:
         for script in config.configure_scripts:
             with complete_step(f"Running configure script {script}…"):
                 result = run(
-                    ["/work/configure", "final"],
+                    ["/work/configure"],
                     env=env | config.environment,
                     sandbox=config.sandbox(
                         tools=Path("/"),

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1336,6 +1336,7 @@ class Config:
     build_scripts: list[Path]
     postinst_scripts: list[Path]
     finalize_scripts: list[Path]
+    clean_scripts: list[Path]
     build_sources: list[ConfigTree]
     build_sources_ephemeral: bool
     environment: dict[str, str]
@@ -1518,6 +1519,22 @@ class Config:
     @property
     def output_changelog(self) -> str:
         return f"{self.output}.changelog"
+
+    @property
+    def outputs(self) -> list[str]:
+        return [
+            self.output,
+            self.output_with_format,
+            self.output_with_compression,
+            self.output_split_uki,
+            self.output_split_kernel,
+            self.output_split_initrd,
+            self.output_nspawn_settings,
+            self.output_checksum,
+            self.output_signature,
+            self.output_manifest,
+            self.output_changelog,
+        ]
 
     def cache_manifest(self) -> dict[str, Any]:
         return {
@@ -1982,6 +1999,16 @@ SETTINGS = (
         parse=config_parse_seed,
         default=uuid.uuid4(),
         help="Set the seed for systemd-repart",
+    ),
+    ConfigSetting(
+        dest="clean_scripts",
+        long="--clean-script",
+        metavar="PATH",
+        section="Output",
+        parse=config_make_list_parser(delimiter=",", parse=make_path_parser()),
+        paths=("mkosi.clean",),
+        path_default=False,
+        help="Clean script to run after cleanup",
     ),
 
     ConfigSetting(
@@ -3730,6 +3757,7 @@ def summary(config: Config) -> str:
                             Overlay: {yes_no(config.overlay)}
                      Use Subvolumes: {config.use_subvolumes}
                                Seed: {none_to_random(config.seed)}
+                      Clean Scripts: {line_join_list(config.clean_scripts)}
 
     {bold("CONTENT")}:
                            Packages: {line_join_list(config.packages)}

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1729,6 +1729,15 @@ SETTINGS = (
         help="Specify the minimum required mkosi version",
     ),
     ConfigSetting(
+        dest="configure_scripts",
+        long="--configure-script",
+        metavar="PATH",
+        section="Config",
+        parse=config_make_list_parser(delimiter=",", parse=make_path_parser()),
+        paths=("mkosi.configure",),
+        help="Configure script to run before doing anything",
+    ),
+    ConfigSetting(
         dest="distribution",
         short="-d",
         section="Distribution",
@@ -2075,15 +2084,6 @@ SETTINGS = (
         default_factory=config_default_source_date_epoch,
         default_factory_depends=("environment",),
         help="Set the $SOURCE_DATE_EPOCH timestamp",
-    ),
-    ConfigSetting(
-        dest="configure_scripts",
-        long="--configure-script",
-        metavar="PATH",
-        section="Content",
-        parse=config_make_list_parser(delimiter=",", parse=make_path_parser()),
-        paths=("mkosi.configure",),
-        help="Configure script to run before doing anything",
     ),
     ConfigSetting(
         dest="sync_scripts",
@@ -3697,6 +3697,7 @@ def summary(config: Config) -> str:
                              Images: {line_join_list(config.images)}
                        Dependencies: {line_join_list(config.dependencies)}
                     Minimum Version: {none_to_none(config.minimum_version)}
+                  Configure Scripts: {line_join_list(config.configure_scripts)}
 
     {bold("DISTRIBUTION")}:
                        Distribution: {bold(config.distribution)}
@@ -3744,7 +3745,6 @@ def summary(config: Config) -> str:
      Clean Package Manager Metadata: {config.clean_package_metadata}
                   Source Date Epoch: {none_to_none(config.source_date_epoch)}
 
-                  Configure Scripts: {line_join_list(config.configure_scripts)}
                        Sync Scripts: {line_join_list(config.sync_scripts)}
                     Prepare Scripts: {line_join_list(config.prepare_scripts)}
                       Build Scripts: {line_join_list(config.build_scripts)}

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -690,12 +690,11 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 `Output=`, `--output=`, `-o`
 
-: Name to use for the generated output image file or directory. All
-  outputs will be prefixed with the given name. Defaults to `image` or,
-  if `ImageId=` is specified, it is used as the default output name,
-  optionally suffixed with the version set with `ImageVersion=`. Note
-  that this option does not allow configuring the output directory, use
-  `OutputDirectory=` for that.
+: Name to use for the generated output image file or directory. Defaults
+  to `image` or, if `ImageId=` is specified, it is used as the default
+  output name, optionally suffixed with the version set with
+  `ImageVersion=`. Note that this option does not allow configuring the
+  output directory, use `OutputDirectory=` for that.
 
 : Note that this only specifies the output prefix, depending on the
   specific output format, compression and image version used, the full
@@ -869,6 +868,12 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
   This is useful to make builds reproducible. See
   [SOURCE_DATE_EPOCH](https://reproducible-builds.org/specs/source-date-epoch/)
   for more information.
+
+`CleanScripts=`, `--clean-script=`
+
+: Takes a comma-separated list of paths to executables that are used as
+  the clean scripts for this image. See the **Scripts** section for
+  more information.
 
 ### [Content] Section
 
@@ -2005,6 +2010,12 @@ current working directory. The following scripts are supported:
 * If **`mkosi.finalize`** (`FinalizeScripts=`) exists, it is executed as
   the last step of preparing an image.
 
+* If **`mkosi.clean`** (`CleanScripts=`) exists, it is executed right
+  after the outputs of a previous build have been cleaned up. A clean
+  script can clean up any outputs that mkosi does not know about (e.g.
+  RPMs built in a build script). Note that this script does not use the
+  tools tree even if one is configured.
+
 If a script uses the `.chroot` extension, mkosi will chroot into the
 image using `mkosi-chroot` (see below) before executing the script. For
 example, if `mkosi.postinst.chroot` exists, mkosi will chroot into the
@@ -2092,30 +2103,30 @@ Scripts executed by mkosi receive the following environment variables:
 
 Consult this table for which script receives which environment variables:
 
-| Variable            | `mkosi.configure` | `mkosi.sync` | `mkosi.prepare` | `mkosi.build` | `mkosi.postinst` | `mkosi.finalize` |
-|---------------------|-------------------|--------------|-----------------|---------------|------------------|------------------|
-| `ARCHITECTURE`      | X                 | X            | X               | X             | X                | X                |
-| `DISTRIBUTION`      | X                 | X            | X               | X             | X                | X                |
-| `RELEASE`           | X                 | X            | X               | X             | X                | X                |
-| `PROFILE`           | X                 | X            | X               | X             | X                | X                |
-| `CACHED`            |                   | X            |                 |               |                  |                  |
-| `CHROOT_SCRIPT`     |                   |              | X               | X             | X                | X                |
-| `SRCDIR`            | X                 | X            | X               | X             | X                | X                |
-| `CHROOT_SRCDIR`     |                   |              | X               | X             | X                | X                |
-| `BUILDDIR`          |                   |              |                 | X             |                  |                  |
-| `CHROOT_BUILDDIR`   |                   |              |                 | X             |                  |                  |
-| `DESTDIR`           |                   |              |                 | X             |                  |                  |
-| `CHROOT_DESTDIR`    |                   |              |                 | X             |                  |                  |
-| `OUTPUTDIR`         |                   |              |                 | X             | X                | X                |
-| `CHROOT_OUTPUTDIR`  |                   |              |                 | X             | X                | X                |
-| `BUILDROOT`         |                   |              | X               | X             | X                | X                |
-| `WITH_DOCS`         |                   |              | X               | X             |                  |                  |
-| `WITH_TESTS`        |                   |              | X               | X             |                  |                  |
-| `WITH_NETWORK`      |                   |              | X               | X             |                  |                  |
-| `SOURCE_DATE_EPOCH` |                   |              | X               | X             | X                | X                |
-| `MKOSI_UID`         | X                 | X            | X               | X             | X                | X                |
-| `MKOSI_GID`         | X                 | X            | X               | X             | X                | X                |
-| `MKOSI_CONFIG`      |                   | X            | X               | X             | X                | X                |
+| Variable            | `mkosi.configure` | `mkosi.sync` | `mkosi.prepare` | `mkosi.build` | `mkosi.postinst` | `mkosi.finalize` | `mkosi.clean` |
+|---------------------|-------------------|--------------|-----------------|---------------|------------------|------------------|---------------|
+| `ARCHITECTURE`      | X                 | X            | X               | X             | X                | X                | X             |
+| `DISTRIBUTION`      | X                 | X            | X               | X             | X                | X                | X             |
+| `RELEASE`           | X                 | X            | X               | X             | X                | X                | X             |
+| `PROFILE`           | X                 | X            | X               | X             | X                | X                | X             |
+| `CACHED`            |                   | X            |                 |               |                  |                  |               |
+| `CHROOT_SCRIPT`     |                   |              | X               | X             | X                | X                |               |
+| `SRCDIR`            | X                 | X            | X               | X             | X                | X                | X             |
+| `CHROOT_SRCDIR`     |                   |              | X               | X             | X                | X                |               |
+| `BUILDDIR`          |                   |              |                 | X             |                  |                  |               |
+| `CHROOT_BUILDDIR`   |                   |              |                 | X             |                  |                  |               |
+| `DESTDIR`           |                   |              |                 | X             |                  |                  |               |
+| `CHROOT_DESTDIR`    |                   |              |                 | X             |                  |                  |               |
+| `OUTPUTDIR`         |                   |              |                 | X             | X                | X                | X             |
+| `CHROOT_OUTPUTDIR`  |                   |              |                 | X             | X                | X                |               |
+| `BUILDROOT`         |                   |              | X               | X             | X                | X                |               |
+| `WITH_DOCS`         |                   |              | X               | X             |                  |                  |               |
+| `WITH_TESTS`        |                   |              | X               | X             |                  |                  |               |
+| `WITH_NETWORK`      |                   |              | X               | X             |                  |                  |               |
+| `SOURCE_DATE_EPOCH` |                   |              | X               | X             | X                | X                | X             |
+| `MKOSI_UID`         | X                 | X            | X               | X             | X                | X                | X             |
+| `MKOSI_GID`         | X                 | X            | X               | X             | X                | X                | X             |
+| `MKOSI_CONFIG`      |                   | X            | X               | X             | X                | X                | X             |
 
 Additionally, when a script is executed, a few scripts are made
 available via `$PATH` to simplify common usecases.

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -543,6 +543,12 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 : The minimum mkosi version required to build this configuration. If
   specified multiple times, the highest specified version is used.
 
+`ConfigureScripts=`, `--configure-script=`
+
+: Takes a comma-separated list of paths to executables that are used as
+  the configure scripts for this image. See the **Scripts** section for
+  more information.
+
 ### [Distribution] Section
 
 `Distribution=`, `--distribution=`, `-d`
@@ -1025,12 +1031,6 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
   databases and repository metadata will be removed if the respective
   package manager executable is *not* present at the end of the
   installation.
-
-`ConfigureScripts=`, `--configure-script=`
-
-: Takes a comma-separated list of paths to executables that are used as
-  the configure scripts for this image. See the **Scripts** section for
-  more information.
 
 `SyncScripts=`, `--sync-script=`
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -112,6 +112,9 @@ def test_config() -> None:
             "CacheOnly": "always",
             "Checksum": false,
             "CleanPackageMetadata": "auto",
+            "CleanScripts": [
+                "/clean"
+            ],
             "CompressLevel": 3,
             "CompressOutput": "bz2",
             "ConfigureScripts": [
@@ -350,6 +353,7 @@ def test_config() -> None:
         cacheonly = Cacheonly.always,
         checksum =  False,
         clean_package_metadata = ConfigFeature.auto,
+        clean_scripts = [Path("/clean")],
         compress_level = 3,
         compress_output = Compression.bz2,
         configure_scripts = [Path("/configure")],


### PR DESCRIPTION
Clean scripts can be used to remove any outputs that mkosi doesn't
know about, e.g. packages built in mkosi build scripts and copied
to the output directory.