### PR TITLE
Support mkosi ssh for multiple running instances of the same image

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3718,7 +3718,7 @@ def run_shell(args: Args, config: Config) -> None:
         ]
 
     # Underscores are not allowed in machine names so replace them with hyphens.
-    name = config.name().replace("_", "-")
+    name = config.machine_or_name().replace("_", "-")
     cmdline += ["--machine", name]
 
     for k, v in config.credentials.items():

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -274,11 +274,8 @@ def start_swtpm(config: Config) -> Iterator[Path]:
                 pass_fds=(sock.fileno(),),
                 sandbox=config.sandbox(mounts=[Mount(state, state)]),
             ) as proc:
-                try:
-                    yield path
-                finally:
-                    proc.terminate()
-                    proc.wait()
+                yield path
+                proc.terminate()
 
 
 def find_virtiofsd(*, tools: Path = Path("/")) -> Optional[Path]:
@@ -349,11 +346,8 @@ def start_virtiofsd(config: Config, directory: Path, *, uidmap: bool) -> Iterato
                 options=["--uid", "0", "--gid", "0", "--cap-add", "all"],
             ),
         ) as proc:
-            try:
-                yield path
-            finally:
-                proc.terminate()
-                proc.wait()
+            yield path
+            proc.terminate()
 
 
 @contextlib.contextmanager
@@ -933,7 +927,6 @@ def run_qemu(args: Args, config: Config) -> None:
             for fd in qemu_device_fds.values():
                 os.close(fd)
 
-            qemu.wait()
 
     if status := int(notifications.get("EXIT_STATUS", 0)):
         raise subprocess.CalledProcessError(status, cmdline)

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -101,6 +101,11 @@ The following command line verbs are known:
   arguments to the `ssh` invocation. To connect to a container, use
   `machinectl login` or `machinectl shell`.
 
+: The `Machine=` option can be used to give the machine a custom
+  hostname when booting it which can later be used to ssh into the image
+  (e.g. `mkosi --machine=mymachine qemu` followed by
+  `mkosi --machine=mymachine ssh`).
+
 `journalctl`
 
 : Uses `journalctl` to inspect the journal inside the image.
@@ -1533,14 +1538,10 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 : When used with the `qemu` verb, this option specifies the vsock
   connection ID to use. Takes a number in the interval `[3, 0xFFFFFFFF)`
-  or `hash` or `auto`. Defaults to `hash`. When set to `hash`, the
+  or `hash` or `auto`. Defaults to `auto`. When set to `hash`, the
   connection ID will be derived from the full path to the image. When
   set to `auto`, `mkosi` will try to find a free connection ID
   automatically. Otherwise, the provided number will be used as is.
-
-: Note that when set to `auto`, `mkosi ssh` cannot be used as we cannot
-  figure out which free connection ID we found when booting the image
-  earlier.
 
 `QemuSwtpm=`, `--qemu-swtpm=`
 
@@ -1826,6 +1827,15 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
   configured and `mkosi.crt` exists in the working directory, it will
   automatically be used for this purpose. Run `mkosi genkey` to
   automatically generate a certificate in `mkosi.crt`.
+
+`Machine=`, `--machine=`
+
+: Specify the machine name to use when booting the image. Can also be
+  used to refer to a specific image when SSH-ing into an image (e.g.
+  `mkosi --image=myimage ssh`).
+
+: Note that `Ephemeral=` has to be enabled to start multiple instances
+  of the same image.
 
 ## Specifiers
 

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -145,6 +145,7 @@ def run(
     log: bool = True,
     preexec_fn: Optional[Callable[[], None]] = None,
     sandbox: Sequence[PathString] = (),
+    foreground: bool = True,
 ) -> CompletedProcess:
     sandbox = [os.fspath(x) for x in sandbox]
     cmdline = [os.fspath(x) for x in cmdline]
@@ -180,11 +181,13 @@ def run(
         stdin = subprocess.DEVNULL
 
     def preexec() -> None:
-        make_foreground_process()
+        if foreground:
+            make_foreground_process()
         if preexec_fn:
             preexec_fn()
 
     if (
+        foreground and
         sandbox and
         subprocess.run(sandbox + ["sh", "-c", "command -v setpgid"], stdout=subprocess.DEVNULL).returncode == 0
     ):
@@ -232,7 +235,8 @@ def run(
         e.cmd = cmdline
         raise
     finally:
-        make_foreground_process(new_process_group=False)
+        if foreground:
+            make_foreground_process(new_process_group=False)
 
 
 @contextlib.contextmanager

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -304,7 +304,12 @@ def spawn(
             env=env,
             preexec_fn=preexec,
         ) as proc:
-            yield proc
+            try:
+                yield proc
+            except BaseException:
+                proc.terminate()
+            finally:
+                proc.wait()
     except FileNotFoundError as e:
         die(f"{e.filename} not found.")
     except subprocess.CalledProcessError as e:

--- a/mkosi/user.py
+++ b/mkosi/user.py
@@ -70,6 +70,17 @@ class INVOKING_USER:
         return cache / "mkosi"
 
     @classmethod
+    def runtime_dir(cls) -> Path:
+        if (env := os.getenv("XDG_RUNTIME_DIR")) or (env := os.getenv("RUNTIME_DIRECTORY")):
+            d = Path(env)
+        elif cls.is_regular_user():
+            d = Path("/run/user") / str(cls.uid)
+        else:
+            d = Path("/run")
+
+        return d / "mkosi"
+
+    @classmethod
     def rchown(cls, path: Path) -> None:
         if cls.is_regular_user() and any(p.stat().st_uid == cls.uid for p in path.parents) and path.exists():
             run(["chown", "--recursive", f"{INVOKING_USER.uid}:{INVOKING_USER.gid}", path])

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -146,7 +146,8 @@ def flock_or_die(path: Path) -> Iterator[Path]:
             raise e
 
         die(f"Cannot lock {path} as it is locked by another process",
-            hint="Maybe another mkosi process is still using it?")
+            hint="Maybe another mkosi process is still using it? Use Ephemeral=yes to enable booting multiple "
+                 "instances of the same image")
 
 
 @contextlib.contextmanager

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -184,6 +184,7 @@ def test_config() -> None:
             "LocalMirror": null,
             "Locale": "en_C.UTF-8",
             "LocaleMessages": "",
+            "Machine": "machine",
             "MakeInitrd": false,
             "ManifestFormat": [
                 "json",
@@ -392,6 +393,7 @@ def test_config() -> None:
         local_mirror = None,
         locale = "en_C.UTF-8",
         locale_messages = "",
+        machine = "machine",
         make_initrd = False,
         manifest_format = [ManifestFormat.json, ManifestFormat.changelog],
         minimum_version = GenericVersion("123"),


### PR DESCRIPTION
Let's add a stopgap solution until systemd-machined supports everything we need. We maintain a super basic JSON state file in the runtime directory that is used to map a machine name to the corresponding SSH proxy command.

We also store the path to the ssh key in there so that mkosi ssh can be run from every directory.

The new Machine= option allows selecting the machine name to use. Unless set explicitly, we also use the machine name as the hostname for the machine.