### PR TITLE
Switch to linux-virtual on Ubuntu

### DIFF
--- a/mkosi.conf.d/20-ubuntu/mkosi.conf
+++ b/mkosi.conf.d/20-ubuntu/mkosi.conf
@@ -9,5 +9,5 @@ Repositories=universe
 
 [Content]
 Packages=
-        linux-image-generic # TODO: Switch to linux-virtual once it supports reading credentials from SMBIOS.
-        linux-tools-generic
+        linux-image-virtual
+        linux-tools-virtual


### PR DESCRIPTION
linux-virtual finally supports credentials so we don't need to use linux-generic anymore.