### PR TITLE
Install git-core where possible

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -22,7 +22,6 @@ Packages=
         gcc
         gdb
         gettext
-        git
         jq
         less
         libtool

--- a/mkosi.conf.d/20-arch.conf
+++ b/mkosi.conf.d/20-arch.conf
@@ -23,6 +23,7 @@ Packages=
         e2fsprogs
         edk2-ovmf
         erofs-utils
+        git
         grub
         iproute
         iputils

--- a/mkosi.conf.d/20-opensuse.conf
+++ b/mkosi.conf.d/20-opensuse.conf
@@ -22,6 +22,7 @@ Packages=
         dosfstools
         e2fsprogs
         erofs-utils
+        git-core
         grep
         grub2-efi
         grub2-i386-pc

--- a/mkosi.conf.d/30-centos-fedora/mkosi.conf
+++ b/mkosi.conf.d/30-centos-fedora/mkosi.conf
@@ -25,6 +25,7 @@ Packages=
         erofs-utils
         fedora-packager
         fedora-packager-kerberos
+        git-core
         iproute
         iputils
         kernel-core

--- a/mkosi.conf.d/30-debian-ubuntu/mkosi.conf
+++ b/mkosi.conf.d/30-debian-ubuntu/mkosi.conf
@@ -19,6 +19,7 @@ Packages=
         dosfstools
         e2fsprogs
         erofs-utils
+        git-core
         iproute2
         iputils-ping
         libtss2-dev

--- a/mkosi/resources/mkosi-tools/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf
@@ -19,7 +19,6 @@ Packages=
         dosfstools
         e2fsprogs
         findutils
-        git
         grep
         jq
         kmod

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-arch.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-arch.conf
@@ -16,6 +16,7 @@ Packages=
         dpkg
         edk2-ovmf
         erofs-utils
+        git
         grub
         openssh
         pacman

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos-fedora/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos-fedora/mkosi.conf
@@ -16,6 +16,7 @@ Packages=
         distribution-gpg-keys
         dnf-plugins-core
         dpkg-dev
+        git-core
         openssh-clients
         policycoreutils
         python3-cryptography

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu.conf
@@ -15,6 +15,7 @@ Packages=
         debian-archive-keyring
         dpkg-dev
         erofs-utils
+        git-core
         grub2
         libarchive-tools
         libtss2-dev

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-opensuse.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-opensuse.conf
@@ -12,6 +12,7 @@ Packages=
         distribution-gpg-keys
         dnf-plugins-core
         erofs-utils
+        git-core
         grep
         grub2
         openssh-clients


### PR DESCRIPTION
Let's not pull in hundreds of perl modules if we can avoid it.