### PR TITLE
Trim default image package lists

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -16,18 +16,11 @@ BuildSourcesEphemeral=yes
 
 Packages=
         attr
-        autoconf
-        automake
         ca-certificates
-        gcc
         gdb
-        gettext
         jq
         less
-        libtool
-        make
         nano
-        pkgconf
         strace
         tmux
 

--- a/mkosi.conf.d/20-fedora/mkosi.conf
+++ b/mkosi.conf.d/20-fedora/mkosi.conf
@@ -12,7 +12,6 @@ Packages=
         btrfs-progs
         dnf5
         dnf5-plugins
-        fedora-review
         pacman
         qemu-user-static
         systemd-ukify

--- a/mkosi.conf.d/30-centos-fedora/mkosi.conf
+++ b/mkosi.conf.d/30-centos-fedora/mkosi.conf
@@ -12,7 +12,6 @@ Packages=
         bash
         bubblewrap
         ca-certificates
-        centos-packager
         coreutils
         cpio
         curl-minimal
@@ -23,15 +22,10 @@ Packages=
         dosfstools
         e2fsprogs
         erofs-utils
-        fedora-packager
-        fedora-packager-kerberos
         git-core
         iproute
         iputils
         kernel-core
-        mock
-        mock-centos-sig-configs
-        mock-core-configs
         mtools
         openssh-clients
         openssh-server
@@ -39,10 +33,6 @@ Packages=
         perf
         python3-cryptography
         qemu-kvm-core
-        rpm-build
-        rpminspect
-        rpminspect-data-centos
-        rpminspect-data-fedora
         shadow-utils
         socat
         squashfs-tools

--- a/mkosi.conf.d/30-debian-ubuntu/mkosi.conf
+++ b/mkosi.conf.d/30-debian-ubuntu/mkosi.conf
@@ -7,6 +7,8 @@ Distribution=|ubuntu
 [Content]
 Packages=
         ?exact-name(systemd-ukify)
+        ^libtss2-esys-[0-9.]+-0$
+        ^libtss2-mu[0-9.-]+$
         apt
         bash
         btrfs-progs
@@ -22,7 +24,8 @@ Packages=
         git-core
         iproute2
         iputils-ping
-        libtss2-dev
+        libtss2-rc0
+        libtss2-tcti-device0
         mtools
         openssh-client
         openssh-server


### PR DESCRIPTION
Let's remove build tools and Fedora/CentOS packaging tools as these aren't getting used and pull in the kitchen sink.