### PR TITLE
debian/ubuntu: Always install base-files

### DIFF
--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -152,7 +152,9 @@ class Installer(DistributionInstaller):
                 [
                     "-oDebug::pkgDPkgPm=1",
                     f"-oDPkg::Pre-Install-Pkgs::=cat >{f.name}",
-                    "?essential", "?exact-name(usr-is-merged)",
+                    "?essential",
+                    "?exact-name(usr-is-merged)",
+                    "base-files",
                 ],
                 mounts=[Mount(f.name, f.name)],
             )


### PR DESCRIPTION
In some setups, there might not be any essential packages, so make sure we always install base-files so that the base directory layout is always populated.

Fixes #2585