### PR TITLE
Check in spawn() whether the command we're trying to run is available

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1462,7 +1462,6 @@ def grub_bios_setup(context: Context, partitions: Sequence[Partition]) -> None:
         # be able to do the mount and we don't know the pid beforehand.
         run(
             [
-                "sh", "-c", f"mount --bind {mountinfo.name} /proc/$$/mountinfo && exec $0 \"$@\"",
                 setup,
                 "--directory", "/grub",
                 context.staging / context.config.output_with_format,
@@ -1473,7 +1472,7 @@ def grub_bios_setup(context: Context, partitions: Sequence[Partition]) -> None:
                     Mount(context.staging, context.staging),
                     Mount(mountinfo.name, mountinfo.name),
                 ],
-            ),
+            ) + ["sh", "-c", f"mount --bind {mountinfo.name} /proc/$$/mountinfo && exec $0 \"$@\""],
         )
 
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2661,6 +2661,9 @@ def check_systemd_tool(
 
 def check_tools(config: Config, verb: Verb) -> None:
     if verb == Verb.build:
+        if config.bootable != ConfigFeature.disabled:
+            check_tool(config, "depmod", reason="generate kernel module dependencies")
+
         if want_efi(config) and config.unified_kernel_images == ConfigFeature.enabled:
             check_systemd_tool(
                 config,

--- a/mkosi/installer/__init__.py
+++ b/mkosi/installer/__init__.py
@@ -46,6 +46,10 @@ class PackageManager:
         return env
 
     @classmethod
+    def env_cmd(cls, context: Context) -> list[PathString]:
+        return ["env", *([f"{k}={v}" for k, v in cls.finalize_environment(context).items()])]
+
+    @classmethod
     def mounts(cls, context: Context) -> list[Mount]:
         mounts = [
             *finalize_crypto_mounts(tools=context.config.tools()),

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -52,7 +52,7 @@ class Apt(PackageManager):
     def scripts(cls, context: Context) -> dict[str, list[PathString]]:
         return {
             **{
-                command: apivfs_cmd() + cls.cmd(context, command) for command in (
+                command: apivfs_cmd() + cls.env_cmd(context) + cls.cmd(context, command) for command in (
                     "apt",
                     "apt-cache",
                     "apt-cdrom",
@@ -128,8 +128,6 @@ class Apt(PackageManager):
         debarch = context.config.distribution.architecture(context.config.architecture)
 
         cmdline: list[PathString] = [
-            "env",
-            *([f"{k}={v}" for k, v in cls.finalize_environment(context).items()]),
             command,
             "-o", f"APT::Architecture={debarch}",
             "-o", f"APT::Architectures={debarch}",
@@ -204,7 +202,7 @@ class Apt(PackageManager):
                         options=["--dir", "/work/src", "--chdir", "/work/src"],
                     ) + (apivfs_cmd() if apivfs else [])
                 ),
-                env=context.config.environment,
+                env=context.config.environment | cls.finalize_environment(context),
                 stdout=stdout,
             )
 

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -39,7 +39,7 @@ class Dnf(PackageManager):
     @classmethod
     def scripts(cls, context: Context) -> dict[str, list[PathString]]:
         return {
-            "dnf": apivfs_cmd() + cls.cmd(context),
+            "dnf": apivfs_cmd() + cls.env_cmd(context) + cls.cmd(context),
             "rpm": apivfs_cmd() + rpm_cmd(),
             "mkosi-install"  : ["dnf", "install"],
             "mkosi-upgrade"  : ["dnf", "upgrade"],
@@ -99,8 +99,6 @@ class Dnf(PackageManager):
         dnf = cls.executable(context.config)
 
         cmdline: list[PathString] = [
-            "env",
-            *([f"{k}={v}" for k, v in cls.finalize_environment(context).items()]),
             dnf,
             "--assumeyes",
             "--best",
@@ -183,7 +181,7 @@ class Dnf(PackageManager):
                             options=["--dir", "/work/src", "--chdir", "/work/src"],
                         ) + (apivfs_cmd() if apivfs else [])
                     ),
-                    env=context.config.environment,
+                    env=context.config.environment | cls.finalize_environment(context),
                     stdout=stdout,
                 )
         finally:

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -37,7 +37,7 @@ class Pacman(PackageManager):
     @classmethod
     def scripts(cls, context: Context) -> dict[str, list[PathString]]:
         return {
-            "pacman": apivfs_cmd() + cls.cmd(context),
+            "pacman": apivfs_cmd() + cls.env_cmd(context) + cls.cmd(context),
             "mkosi-install"  : ["pacman", "--sync", "--needed"],
             "mkosi-upgrade"  : ["pacman", "--sync", "--sysupgrade", "--needed"],
             "mkosi-remove"   : ["pacman", "--remove", "--recursive", "--nosave"],
@@ -127,8 +127,6 @@ class Pacman(PackageManager):
     @classmethod
     def cmd(cls, context: Context) -> list[PathString]:
         return [
-            "env",
-            *([f"{k}={v}" for k, v in cls.finalize_environment(context).items()]),
             "pacman",
             "--root=/buildroot",
             "--logfile=/dev/null",
@@ -166,7 +164,7 @@ class Pacman(PackageManager):
                         options=["--dir", "/work/src", "--chdir", "/work/src"],
                     ) + (apivfs_cmd() if apivfs else [])
                 ),
-                env=context.config.environment,
+                env=context.config.environment | cls.finalize_environment(context),
                 stdout=stdout,
             )
 

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -38,7 +38,7 @@ class Zypper(PackageManager):
         ]
 
         return {
-            "zypper": apivfs_cmd() + cls.cmd(context),
+            "zypper": apivfs_cmd() + cls.env_cmd(context) + cls.cmd(context),
             "rpm"   : apivfs_cmd() + rpm_cmd(),
             "mkosi-install"  : install,
             "mkosi-upgrade"  : ["zypper", "update"],
@@ -105,8 +105,6 @@ class Zypper(PackageManager):
     @classmethod
     def cmd(cls, context: Context) -> list[PathString]:
         return [
-            "env",
-            *([f"{k}={v}" for k, v in cls.finalize_environment(context).items()]),
             "zypper",
             "--installroot=/buildroot",
             "--cache-dir=/var/cache/zypp",
@@ -138,7 +136,7 @@ class Zypper(PackageManager):
                         options=["--dir", "/work/src", "--chdir", "/work/src"],
                     ) + (apivfs_cmd() if apivfs else [])
                 ),
-                env=context.config.environment,
+                env=context.config.environment | cls.finalize_environment(context),
                 stdout=stdout,
             )
 

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -244,6 +244,14 @@ def spawn(
             # expect it to pick.
             assert nfd == SD_LISTEN_FDS_START + i
 
+    # First, check if the sandbox works at all before executing the command.
+    if sandbox and (rc := subprocess.run(sandbox + ["true"]).returncode) != 0:
+        log_process_failure(sandbox, cmdline, rc)
+        raise subprocess.CalledProcessError(rc, sandbox + cmdline)
+
+    if subprocess.run(sandbox + ["sh", "-c", f"command -v {cmdline[0]}"], stdout=subprocess.DEVNULL).returncode != 0:
+        die(f"{cmdline[0]} not found.", hint=f"Is {cmdline[0]} installed on the host system?")
+
     if (
         foreground and
         sandbox and


### PR DESCRIPTION
Currently, if we try to run a command within a sandbox, we fail with
an unclear error if the program is not installed. This is because our
FileNotFoundError exception handler is never triggered as the program
we run via subprocess is almost always "sh" or "bwrap". Let's make sure
we also check for the actual program we're going to run in the sandbox
and show a clear error if it's not available.

Fixes #2584 