### PR TITLE
Translate paths to SELinux policy files to /buildroot

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2974,6 +2974,8 @@ def run_selinux_relabel(context: Context) -> None:
         return
 
     policy, fc, binpolicy = selinux
+    fc = Path("/buildroot") / fc.relative_to(context.root)
+    binpolicy = Path("/buildroot") / binpolicy.relative_to(context.root)
 
     with complete_step(f"Relabeling files using {policy} policy"):
         run(["setfiles", "-mFr", "/buildroot", "-c", binpolicy, fc, "/buildroot"],


### PR DESCRIPTION
The setfiles call was broken by 62cee058cb116684294831c4cab20924dde93e45 because the binary policy and file context files were still using the host path in the run arguments.

Fixes the error `Error opening
/home/user/.cache/mkosi/mkosi-workspaceb5nodee6/root/etc/selinux/targeted/policy/policy.33: No such file or directory`