### PR TITLE
Introduce --append argument

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3052,6 +3052,11 @@ def create_argument_parser(action: type[argparse.Action]) -> argparse.ArgumentPa
         action="store_true",
         default=False,
     )
+    parser.add_argument(
+        "--append",
+        help="All settings passed after this argument will be parsed after all configuration files are parsed",
+        action="store_true",
+    )
     # These can be removed once mkosi v15 is available in LTS distros and compatibility with <= v14
     # is no longer needed in build infrastructure (e.g.: OBS).
     parser.add_argument(
@@ -3150,6 +3155,7 @@ def parse_config(argv: Sequence[str] = (), *, resources: Path = Path("/")) -> tu
     defaults = argparse.Namespace()
     parsed_includes: set[tuple[int, int]] = set()
     immutable_settings: set[str] = set()
+    append = False
 
     def expand_specifiers(text: str, path: Path) -> str:
         percent = False
@@ -3226,6 +3232,9 @@ def parse_config(argv: Sequence[str] = (), *, resources: Path = Path("/")) -> tu
             option_string: Optional[str] = None
         ) -> None:
             assert option_string is not None
+
+            if getattr(namespace, "append", False) != append:
+                return
 
             if values is None and self.nargs == "?":
                 values = self.const or "yes"
@@ -3501,6 +3510,11 @@ def parse_config(argv: Sequence[str] = (), *, resources: Path = Path("/")) -> tu
         setattr(namespace, "image", None)
         finalize_defaults()
         images = [namespace]
+
+    append = True
+
+    for ns in images:
+        argparser.parse_args(argv, ns)
 
     for s in vars(cli_ns):
         if s not in SETTINGS_LOOKUP_BY_DEST:

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -255,6 +255,15 @@ Those settings cannot be configured in the configuration files.
 
 : Show the summary output as JSON-SEQ.
 
+`--append`
+
+: All settings passed after this argument will be parsed after all
+  configuration files have been parsed.
+
+: Note that any setting passed this way will not have any affect on
+  `[Match]` sections as they will only be parsed after all `[Match]`
+  sections have already been evaluated.
+
 ## Supported output formats
 
 The following output formats are supported:


### PR DESCRIPTION
In systemd, we want to have a default set of kernel command line arguments and override a few of them via the command line. Introduce --append so that we can specify settings via the command line that are parsed after all configuration have files have been parsed to make this possible.