### PR TITLE
Introduce CACHE_UID/CACHE_GID for use in the cache manifest

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1331,6 +1331,8 @@ class Args:
         j = cls._load_json(s)
         return dataclasses.replace(cls.default(), **j)
 
+CACHE_UID = os.getuid()
+CACHE_GID = os.getgid()
 
 @dataclasses.dataclass(frozen=True)
 class Config:
@@ -1607,8 +1609,8 @@ class Config:
 
     def cache_manifest(self) -> dict[str, Any]:
         return {
-            "uid": INVOKING_USER.uid,
-            "gid": INVOKING_USER.gid,
+            "uid": CACHE_UID,
+            "gid": CACHE_GID,
             "distribution": self.distribution,
             "release": self.release,
             "mirror": self.mirror,


### PR DESCRIPTION
The INVOKING_USER uid and gid are potentially modified in become_root(), causing cache mismatches depending on whether have_cache() is called inside or outside of the user namespace.

Let's instead introduce two new constants resolved at module load time which won't change.