### PR TITLE
Fix credential file and journal remote exit propagation

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -858,6 +858,8 @@ def config_make_dict_parser(delimiter: str,
             else:
                 die(f"{p} does not exist")
 
+            return new
+
         if unescape:
             lex = shlex.shlex(value, posix=True)
             lex.whitespace_split = True

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -435,15 +435,15 @@ def start_journal_remote(config: Config, sockfd: int) -> Iterator[None]:
             "--output", config.forward_journal,
             "--split-mode", "none" if config.forward_journal.suffix == ".journal" else "host",
         ],
+        terminate=True,
         pass_fds=(sockfd,),
         sandbox=config.sandbox(mounts=[Mount(config.forward_journal.parent, config.forward_journal.parent)]),
         user=config.forward_journal.parent.stat().st_uid,
         group=config.forward_journal.parent.stat().st_gid,
         # If all logs go into a single file, disable compact mode to allow for journal files exceeding 4G.
         env={"SYSTEMD_JOURNAL_COMPACT": "0" if config.forward_journal.suffix == ".journal" else "1"},
-    ) as proc:
+    ):
         yield
-        proc.terminate()
 
 
 @contextlib.contextmanager

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -272,6 +272,7 @@ def start_swtpm(config: Config) -> Iterator[Path]:
 
             with spawn(
                 cmdline,
+                terminate=True,
                 pass_fds=(sock.fileno(),),
                 sandbox=config.sandbox(mounts=[Mount(state, state)]),
             ) as proc:
@@ -282,7 +283,6 @@ def start_swtpm(config: Config) -> Iterator[Path]:
                     description=f"swtpm for {config.machine_or_name()}",
                 )
                 yield path
-                proc.terminate()
 
 
 def find_virtiofsd(*, tools: Path = Path("/")) -> Optional[Path]:
@@ -342,6 +342,7 @@ def start_virtiofsd(config: Config, directory: PathString, *, name: str, selinux
 
         with spawn(
             cmdline,
+            terminate=True,
             pass_fds=(sock.fileno(),),
             # When not invoked as root, bubblewrap will automatically map the current uid/gid to the requested uid/gid
             # in the user namespace it spawns, so by specifying --uid 0 --gid 0 we'll get a userns with the current
@@ -362,7 +363,6 @@ def start_virtiofsd(config: Config, directory: PathString, *, name: str, selinux
                 description=f"virtiofsd for {directory}",
             )
             yield path
-            proc.terminate()
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Getting logs out with journal-forward and using a drop-in to make the target unit exit on success or failure found a couple of bugs.

I'm not 100% on the name of the `terminate` parameter and it's possible the process could exit on its own between poll and terminate which could still propagate an exception, but that would have to be a failure we might be interested in and the fix would just be to remove check from the journal-remote call.