### PR TITLE
qemu: Make sure qemu/VM exit status take priority

### DIFF
--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -1100,8 +1100,8 @@ def run_qemu(args: Args, config: Config) -> None:
             )
             register_machine(config, qemu.pid, fname)
 
-    if status := int(notifications.get("EXIT_STATUS", 0)):
-        raise subprocess.CalledProcessError(status, cmdline)
+            if qemu.wait() == 0 and (status := int(notifications.get("EXIT_STATUS", 0))):
+                raise subprocess.CalledProcessError(status, cmdline)
 
 
 def run_ssh(args: Args, config: Config) -> None:


### PR DESCRIPTION
In spawn(), if an exception is raised by the context manager block, we'll let it take priority over any exception we raise in spawn() itself. Let's make use of this to make sure the qemu/VM exit code always takes priority by raising the CalledProcessError from within the qemu spawn() block.

We also let any qemu error take precedence over any EXIT_STATUS error.