### PR TITLE
Stop installing dpkg-dev explicitly in tools trees

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos-fedora/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos-fedora/mkosi.conf
@@ -15,7 +15,6 @@ Packages=
         debian-keyring
         distribution-gpg-keys
         dnf-plugins-core
-        dpkg-dev
         git-core
         openssh-clients
         policycoreutils

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu.conf
@@ -13,7 +13,6 @@ Packages=
         createrepo-c
         curl
         debian-archive-keyring
-        dpkg-dev
         erofs-utils
         git-core
         grub2


### PR DESCRIPTION
apt will pull in dpkg as a dependency. dpkg-dev specifically only includes stuff required to build packages, which you generally only want to install in the image itself as the dpkg build tooling does not support operating on a chroot.

This gets rid of perl in tools trees as dpkg-dev depends on a bunch of perl scripts but dpkg doesn't.