### PR TITLE
qemu: Escape commas in kernel command line SMBIOS value

### DIFF
--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -1058,9 +1058,9 @@ def run_qemu(args: Args, config: Config) -> None:
         elif config.architecture.supports_smbios(firmware):
             cmdline += [
                 "-smbios",
-                f"type=11,value=io.systemd.stub.kernel-cmdline-extra={' '.join(kcl)}",
+                f"type=11,value=io.systemd.stub.kernel-cmdline-extra={' '.join(kcl).replace(',', ',,')}",
                 "-smbios",
-                f"type=11,value=io.systemd.boot.kernel-cmdline-extra={' '.join(kcl)}",
+                f"type=11,value=io.systemd.boot.kernel-cmdline-extra={' '.join(kcl).replace(',', ',,')}",
             ]
 
         for drive in config.qemu_drives:


### PR DESCRIPTION
Commas in the command line have to be escaped by doubling them, so let's do that.