### PR TITLE
Switch to reprepro for generating local apt repositories

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-arch.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-arch.conf
@@ -23,6 +23,7 @@ Packages=
         pesign
         python-cryptography
         qemu-base
+        reprepro
         sbsigntools
         shadow
         squashfs-tools

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu.conf
@@ -30,6 +30,7 @@ Packages=
         python3-cryptography
         python3-pefile
         qemu-system
+        reprepro
         sbsigntool
         squashfs-tools
         swtpm-tools

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-fedora/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-fedora/mkosi.conf
@@ -14,5 +14,6 @@ Packages=
         qemu-system-aarch64-core
         qemu-system-ppc-core
         qemu-system-s390x-core
+        reprepro
         systemd-ukify
         zypper

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-opensuse.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-opensuse.conf
@@ -22,6 +22,7 @@ Packages=
         policycoreutils
         python3-pefile
         qemu-headless
+        reprepro
         sbsigntools
         shadow
         squashfs


### PR DESCRIPTION
We don't install dpkg-dev in tools trees anymore to avoid pulling in perl, which means we don't have access to dpkg-scanpackages in tools trees anymore.

Instead of adding back dpkg-dev, let's instead switch to reprepro for generating our local apt repository. It's written in C, packaged everywhere and has hardly any dependencies.