### PR TITLE
Add `mkosi.packages/` for `PackageDirectories=`

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2111,6 +2111,7 @@ SETTINGS = (
         metavar="PATH",
         section="Content",
         parse=config_make_list_parser(delimiter=",", parse=make_path_parser()),
+        paths=("mkosi.packages",),
         help="Specify a directory containing extra packages",
     ),
     ConfigSetting(

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -953,7 +953,8 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 : Specify directories containing extra packages to be made available during
   the build. `mkosi` will create a local repository containing all
   packages in these directories and make it available when installing packages or
-  running scripts.
+  running scripts. If the `mkosi.packages/` directory is found in the local
+  directory it is also used for this purpose.
 
 : Note that this local repository is also made available when running
   scripts. Build scripts can add more packages to the local repository


### PR DESCRIPTION
My usecase for this is to quickly inject a locally built package for quick testing and not needing to adjust options used to build the image. Having this set as an option in the config file would require the folder to exist, but I'd like to exclude it in VCS and if a `.gitignore` is in it (exclude all, except the ignore itself) the database fails to build (on Arch).