### PR TITLE
Make mkosi.packages a non-default path setting

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2128,6 +2128,7 @@ SETTINGS = (
         section="Content",
         parse=config_make_list_parser(delimiter=",", parse=make_path_parser()),
         paths=("mkosi.packages",),
+        path_default=False,
         help="Specify a directory containing extra packages",
     ),
     ConfigSetting(


### PR DESCRIPTION
If the setting is configured in the config file as well, we want it to append to mkosi.packages, not override it.