### PR TITLE
Drop --cache=always for virtiofsd

### DIFF
--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -314,7 +314,6 @@ def start_virtiofsd(config: Config, directory: PathString, *, name: str, selinux
         # qemu's client doesn't seem to support announcing submounts so disable the feature to avoid the warning.
         "--no-announce-submounts",
         "--sandbox=chroot",
-        "--cache=always",
         f"--inode-file-handles={'prefer' if os.getuid() == 0 and not uidmap else 'never'}",
     ]
 


### PR DESCRIPTION
We want to support users writing to these directories from the host so --cache=always is not an option as that assumes virtiofsd has exclusive write access.