### PR TITLE
Configure journal-remote limits properly

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3697,10 +3697,11 @@ def load_credentials(args: argparse.Namespace) -> dict[str, str]:
 
 
 def finalize_term() -> str:
-    if not (term := os.getenv("TERM")) or term == "unknown":
+    term = os.getenv("TERM", "unknown")
+    if term == "unknown":
         term = "vt220" if sys.stderr.isatty() else "dumb"
 
-    return term
+    return term if sys.stderr.isatty() else "dumb"
 
 
 def load_kernel_command_line_extra(args: argparse.Namespace) -> list[str]:

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -1916,6 +1916,11 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 : Note that systemd v256 or newer is required in the virtual machine for
   log forwarding to work.
 
+: Note that if a path with the `.journal` extension is given, the
+  journal size is limited to `4G`. Configure an output directory instead
+  of file if your workload produces more than `4G` worth of journal
+  data.
+
 ## Specifiers
 
 The current value of various settings can be accessed when parsing


### PR DESCRIPTION
Let's make sure the limits are configured so we can always write at least 4G of logs. We also enable compact mode again in all cases to reduce the size used by journal files as for example Github Actions machines aren't exactly swimming in free space.

(We pick 4G because that's the max journal file size when the compact mode is used)

(We'll probably have to revisit this again at some point but for now this should do the trick)