### PR TITLE
fedora: Install basesystem package instead of filesystem

### DIFF
--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -80,7 +80,7 @@ class Installer(DistributionInstaller):
     @classmethod
     def install(cls, context: Context) -> None:
         # Make sure glibc-minimal-langpack is installed instead of glibc-all-langpacks.
-        cls.install_packages(context, ["filesystem", "glibc-minimal-langpack"], apivfs=False)
+        cls.install_packages(context, ["basesystem", "glibc-minimal-langpack"], apivfs=False)
 
     @classmethod
     def install_packages(cls, context: Context, packages: Sequence[str], apivfs: bool = True) -> None:

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -79,8 +79,7 @@ class Installer(DistributionInstaller):
 
     @classmethod
     def install(cls, context: Context) -> None:
-        # Make sure glibc-minimal-langpack is installed instead of glibc-all-langpacks.
-        cls.install_packages(context, ["basesystem", "glibc-minimal-langpack"], apivfs=False)
+        cls.install_packages(context, ["basesystem"], apivfs=False)
 
     @classmethod
     def install_packages(cls, context: Context, packages: Sequence[str], apivfs: bool = True) -> None:

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -85,7 +85,7 @@ class Installer(DistributionInstaller):
 
     @classmethod
     def install(cls, context: Context) -> None:
-        cls.install_packages(context, ["filesystem"], apivfs=False)
+        cls.install_packages(context, ["basesystem"], apivfs=False)
 
     @classmethod
     def install_packages(cls, context: Context, packages: Sequence[str], apivfs: bool = True) -> None:

--- a/mkosi/distributions/mageia.py
+++ b/mkosi/distributions/mageia.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 from mkosi.config import Architecture
 from mkosi.context import Context
@@ -28,8 +28,8 @@ class Installer(fedora.Installer):
         return Distribution.mageia
 
     @classmethod
-    def install_packages(cls, context: Context, packages: Sequence[str], apivfs: bool = True) -> None:
-        super().install_packages(context, packages, apivfs)
+    def install(cls, context: Context) -> None:
+        cls.install_packages(context, ["filesystem"], apivfs=False)
 
     @classmethod
     @listify

--- a/mkosi/distributions/openmandriva.py
+++ b/mkosi/distributions/openmandriva.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 from mkosi.config import Architecture
 from mkosi.context import Context
@@ -28,8 +28,8 @@ class Installer(fedora.Installer):
         return Distribution.openmandriva
 
     @classmethod
-    def install_packages(cls, context: Context, packages: Sequence[str], apivfs: bool = True) -> None:
-        super().install_packages(context, packages, apivfs)
+    def install(cls, context: Context) -> None:
+        cls.install_packages(context, ["filesystem"], apivfs=False)
 
     @classmethod
     @listify


### PR DESCRIPTION
basesystem pulls in filesystem and setup. The latter defines some common groups and directories that are expected to be available on every system.

Fedora/CentOS also define basesystem as a package that's expected to be installed everywhere, so let's make sure our images satisfy that requirement.