### PR TITLE
Make sure "mkosi -C build" works

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3555,6 +3555,10 @@ def parse_config(argv: Sequence[str] = (), *, resources: Path = Path("/")) -> tu
         except ValueError:
             continue
 
+        # Hack to make sure mkosi -C build works.
+        if argv[v_i - 1] in ("-C", "--directory"):
+            continue
+
         if v_i > 0 and argv[v_i - 1] != "--":
             argv.insert(v_i, "--")
         break


### PR DESCRIPTION
In systemd we want to (optionally) make sure all mkosi output is written to the meson build directory. To make this work, we want to write a mkosi.conf to the meson build directory so that developers can do "mkosi -C build". Currently this doesn't work because "build" is interpreted as a verb. Let's make sure that doesn't happen.

We need a better solution for this hack but for now this is the best I can come up with.