### PR TITLE
mkosi-tools: Add qemu-img to Fedora tools tree

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos-fedora/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos-fedora/mkosi.conf
@@ -19,6 +19,7 @@ Packages=
         openssh-clients
         policycoreutils
         python3-cryptography
+        qemu-img
         qemu-kvm-core
         shadow-utils
         squashfs-tools


### PR DESCRIPTION
Required by virt-fw-vars but not explicitly declared as a dependency yet.

See https://bugzilla.redhat.com/show_bug.cgi?id=2276629