### PR TITLE
ci: remove packages.microsoft.com

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
 
     - name: Install
       run: |
+        # This is added by default, and it is often broken, but we don't need anything from it
+        sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get update
         sudo apt-get install pandoc python3-pytest
         python3 -m pip install --upgrade setuptools wheel pip

--- a/action.yaml
+++ b/action.yaml
@@ -35,6 +35,8 @@ runs:
   - name: Dependencies
     shell: bash
     run: |
+      # This is added by default, and it is often broken, but we don't need anything from it
+      sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
       # For archlinux-keyring and pacman
       sudo add-apt-repository ppa:michel-slm/kernel-utils
       sudo apt-get update


### PR DESCRIPTION
It is not needed, it publishes things like dotnet, and it is often broken, so just remove the sources