### PR TITLE
 Drop redundant ukify lookup 

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2080,8 +2080,6 @@ def build_uki(
     mounts += [Mount(kimg, kimg, ro=True)]
 
     if microcodes:
-        ukify = find_binary("ukify", "/usr/lib/systemd/ukify", root=context.config.tools())
-        assert ukify is not None
         # new .ucode section support?
         if (
             systemd_tool_version(context.config, ukify) >= "256~devel" and


### PR DESCRIPTION
Otherwise the extra search paths are not taken into account.