### PR TITLE
Exclude `/usr/share/gtk-doc/*` with `WithDocs=no`

### DIFF
--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -169,6 +169,7 @@ class Apt(PackageManager):
                 "-o", "DPkg::Options::=--path-include=/usr/share/doc/*/copyright",
                 "-o", "DPkg::Options::=--path-exclude=/usr/share/man/*",
                 "-o", "DPkg::Options::=--path-exclude=/usr/share/groff/*",
+                "-o", "DPkg::Options::=--path-exclude=/usr/share/gtk-doc/*",
                 "-o", "DPkg::Options::=--path-exclude=/usr/share/info/*",
             ]
 

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -102,6 +102,7 @@ class Pacman(PackageManager):
                         NoExtract = usr/share/doc/*
                         NoExtract = usr/share/man/*
                         NoExtract = usr/share/groff/*
+                        NoExtract = usr/share/gtk-doc/*
                         NoExtract = usr/share/info/*
                         """
                     )


### PR DESCRIPTION
Was unsure if this was just overlooked or if there is a specific reason this wasn't included.

Feel free to close if it doesn't make sense to exclude these files.