### PR TITLE
mkosi-initrd: Drop some RemoveFiles= from Arch config

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-arch.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-arch.conf
@@ -38,8 +38,4 @@ RemoveFiles=
         /usr/share/i18n/*
         /usr/share/hwdata/*
         /usr/share/iana-etc/*
-        /usr/share/doc/*
-        /usr/share/man/*
         /usr/share/locale/*
-        /usr/share/info/*
-        /usr/share/gtk-doc/*


### PR DESCRIPTION
These are now handles by WithDocs=no.