### PR TITLE
selinux: Fix using setfiles from tools tree

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3032,13 +3032,13 @@ def run_selinux_relabel(context: Context) -> None:
     if not (selinux := want_selinux_relabel(context.config, context.root)):
         return
 
-    policy, fc, binpolicy = selinux
+    setfiles, policy, fc, binpolicy = selinux
     fc = Path("/buildroot") / fc.relative_to(context.root)
     binpolicy = Path("/buildroot") / binpolicy.relative_to(context.root)
 
     with complete_step(f"Relabeling files using {policy} policy"):
-        run(["setfiles", "-mFr", "/buildroot", "-c", binpolicy, fc, "/buildroot"],
-            sandbox=context.sandbox(binary="setfiles", mounts=[Mount(context.root, "/buildroot")]),
+        run([setfiles, "-mFr", "/buildroot", "-c", binpolicy, fc, "/buildroot"],
+            sandbox=context.sandbox(binary=setfiles, mounts=[Mount(context.root, "/buildroot")]),
             check=context.config.selinux_relabel == ConfigFeature.enabled)
 
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -4217,7 +4217,7 @@ def json_type_transformer(refcls: Union[type[Args], type[Config]]) -> Callable[[
     return json_transformer
 
 
-def want_selinux_relabel(config: Config, root: Path, fatal: bool = True) -> Optional[tuple[str, Path, Path]]:
+def want_selinux_relabel(config: Config, root: Path, fatal: bool = True) -> Optional[tuple[Path, str, Path, Path]]:
     if config.selinux_relabel == ConfigFeature.disabled:
         return None
 
@@ -4235,7 +4235,7 @@ def want_selinux_relabel(config: Config, root: Path, fatal: bool = True) -> Opti
             die("SELinux relabel is requested but no selinux policy is configured in /etc/selinux/config")
         return None
 
-    if not config.find_binary("setfiles"):
+    if not (setfiles := config.find_binary("setfiles")):
         if fatal and config.selinux_relabel == ConfigFeature.enabled:
             die("SELinux relabel is requested but setfiles is not installed")
         return None
@@ -4259,7 +4259,7 @@ def want_selinux_relabel(config: Config, root: Path, fatal: bool = True) -> Opti
 
     binpolicy = sorted(policies, key=lambda p: GenericVersion(p.name), reverse=True)[0]
 
-    return policy, fc, binpolicy
+    return setfiles, policy, fc, binpolicy
 
 
 def systemd_tool_version(config: Config, tool: PathString) -> GenericVersion:


### PR DESCRIPTION
After the change to support tools from ExtraSearchPaths or the ToolsTree the sandbox needs the found file path to be passed in.

The setfiles command needed to relabel trees was missed in this change.