### PR TITLE
qemu: Enable hyper-v enlightenments on x86

### DIFF
--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -896,7 +896,7 @@ def run_qemu(args: Args, config: Config) -> None:
             f"vhost-vsock-pci,guest-cid={cid},vhostfd={SD_LISTEN_FDS_START + index}"
         ]
 
-    cmdline += ["-cpu", "max"]
+    cmdline += ["-cpu", "max" + (",hv_relaxed,hv-vapic,hv-time" if config.architecture.is_x86_variant() else "")]
 
     if config.qemu_gui:
         cmdline += ["-vga", "virtio"]


### PR DESCRIPTION
Mirrors the same change in vmspawn:
https://github.com/systemd/systemd/pull/32359/commits/77290bc83fe9fc3eeba1354e7635a2aa0a1caa2d