### PR TITLE
Don't use scopes for virtiofs when using older unshare

### DIFF
--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -218,20 +218,6 @@ def spawn(
     if "TMPDIR" in os.environ:
         env["TMPDIR"] = os.environ["TMPDIR"]
 
-    if scope:
-        if not find_binary("systemd-run"):
-            scope = []
-        elif os.getuid() != 0 and "DBUS_SESSION_BUS_ADDRESS" in os.environ and "XDG_RUNTIME_DIR" in os.environ:
-            env["DBUS_SESSION_BUS_ADDRESS"] = os.environ["DBUS_SESSION_BUS_ADDRESS"]
-            env["XDG_RUNTIME_DIR"] = os.environ["XDG_RUNTIME_DIR"]
-        elif os.getuid() == 0 and "DBUS_SYSTEM_ADDRESS" in os.environ:
-            env["DBUS_SYSTEM_ADDRESS"] = os.environ["DBUS_SYSTEM_ADDRESS"]
-        else:
-            scope = []
-
-    if scope:
-        user = group = None
-
     for e in ("SYSTEMD_LOG_LEVEL", "SYSTEMD_LOG_LOCATION"):
         if e in os.environ:
             env[e] = os.environ[e]


### PR DESCRIPTION
unshare 2.37 is still shipped in Ubuntu Jammy and CentOS Stream 9 which doesn't have --map-users= and --map-groups=. In this case, let's not use scopes for virtiofsd to make sure that booting using virtiofsd still works.

Also add a missing preexec_fn to become root if we're not using a scope.

To make this work we have to move all the logic to decide whether we use a scope or not outside of run() as we need to conditionalize other arguments we provide to run() based on whether we use a scope or not.