### PR TITLE
Be more conservative in what we copy from package directories

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1609,11 +1609,14 @@ def install_package_directories(context: Context) -> None:
 
     with complete_step("Copying in extra packages…"):
         for d in context.config.package_directories:
-            copy_tree(
-                d, context.packages,
-                use_subvolumes=context.config.use_subvolumes,
-                sandbox=context.sandbox,
-            )
+            for p in itertools.chain(
+                d.glob("*.rpm*"),
+                d.glob("*.pkg.tar*"),
+                d.glob("*.deb*"),
+                d.glob("*.ddeb*"),
+                d.glob("*.udeb*"),
+            ):
+                shutil.copy(p, context.packages, follow_symlinks=True)
 
     if context.want_local_repo():
         with complete_step("Building local package repository"):


### PR DESCRIPTION
Let's make sure we only copy packages to package directories so that PackageDirectories= can be pointed at a directory containing more than just packages without copying everything.