### PR TITLE
apt: Allow release info change

### DIFF
--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -140,6 +140,7 @@ class Apt(PackageManager):
             "-o", "APT::Get::Allow-Change-Held-Packages=true",
             "-o", "APT::Get::Allow-Remove-Essential=true",
             "-o", "APT::Sandbox::User=root",
+            "-o", "Acquire::AllowReleaseInfoChange=true",
             "-o", "Dir::Cache=/var/cache/apt",
             "-o", "Dir::State=/var/lib/apt",
             "-o", "Dir::Log=/var/log/apt",


### PR DESCRIPTION
Allow the update command to continue downloading data from a repository which changed its information of the release contained in the repository indicating e.g a new major release. APT will fail at the update command for such repositories until the change is confirmed to ensure the user is prepared for the change.

I'm experiencing this after I changed my private APT repository `label` and `origin`. If APT fail, then mkosi also fail. I think it's okay to automatically allow this.