### PR TITLE
Only run configure scripts for verbs that need a build

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4598,7 +4598,7 @@ def run_verb(args: Args, images: Sequence[Config], *, resources: Path) -> None:
 
     if not (last.output_dir_or_cwd() / last.output_with_compression).exists():
         die(f"Image '{last.name()}' has not been built yet",
-            hint="Make sure to build the image first with 'mkosi build' or use --force")
+            hint="Make sure to build the image first with 'mkosi build' or use '--force'")
 
     with prepend_to_environ_path(last):
         check_tools(last, args.verb)

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -233,11 +233,11 @@ Those settings cannot be configured in the configuration files.
 
 `--auto-bump=`, `-B`
 
-: If specified, after each successful build the the version is bumped
-  in a fashion equivalent to the `bump` verb, in preparation for the
-  next build. This is useful for simple, linear version management:
-  each build in a series will have a version number one higher then
-  the previous one.
+: If specified, after each successful build the version is bumped in a
+  fashion equivalent to the `bump` verb, in preparation for the next
+  build. This is useful for simple, linear version management: each
+  build in a series will have a version number one higher then the
+  previous one.
 
 `--doc-format`
 

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -2102,11 +2102,15 @@ in the current working directory. `$SRCDIR` is set to point to the
 current working directory. The following scripts are supported:
 
 * If **`mkosi.configure`** (`ConfigureScripts=`) exists, it is executed
-  after parsing the configuration files. This script may be used to
-  dynamically modify the configuration. It receives the configuration
-  serialized as JSON on stdin and should output the modified
-  configuration serialized as JSON on stdout. Note that this script does
-  not use the tools tree even if one is configured.
+  before building the image. This script may be used to dynamically
+  modify the configuration. It receives the configuration serialized as
+  JSON on stdin and should output the modified configuration serialized
+  as JSON on stdout. Note that this script only runs when building or
+  booting the image (`build`, `qemu`, `boot` and `shell` verbs). If a
+  default tools tree is configured, it will be built before running the
+  configure scripts and the configure scripts will run with the tools
+  tree available. This also means that the modifications made by
+  configure scripts will not be visible in the `summary` output.
 
 * If **`mkosi.sync`** (`SyncScripts=`) exists, it is executed before the
   image is built. This script may be used to update various sources that


### PR DESCRIPTION
In systemd, we want to use configure scripts to determine whether qemu was built with support for specific devices and skip running a test if it wasn't, or otherwise add the device to the qemu arguments.

To make this work, we need to run the configure scripts with the default tools tree available if one is configured.

Let's change the behavior of configure scripts to only run for verbs that need a build and run them after building the default tools tree so that they can be run with the tools tree mounted.