### PR TITLE
Chroot for depmod and modinfo

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -572,7 +572,7 @@ def run_prepare_scripts(context: Context, build: bool) -> None:
             arg = "final"
 
         for script in context.config.prepare_scripts:
-            chroot = chroot_cmd(resolve=True)
+            chroot = chroot_cmd(resolve=True, work=True)
 
             helpers = {
                 "mkosi-chroot": chroot,
@@ -649,7 +649,7 @@ def run_build_scripts(context: Context) -> None:
         finalize_source_mounts(context.config, ephemeral=context.config.build_sources_ephemeral) as sources,
     ):
         for script in context.config.build_scripts:
-            chroot = chroot_cmd(resolve=context.config.with_network)
+            chroot = chroot_cmd(resolve=context.config.with_network, work=True)
 
             helpers = {
                 "mkosi-chroot": chroot,
@@ -727,7 +727,7 @@ def run_postinst_scripts(context: Context) -> None:
         finalize_source_mounts(context.config, ephemeral=context.config.build_sources_ephemeral) as sources,
     ):
         for script in context.config.postinst_scripts:
-            chroot = chroot_cmd(resolve=context.config.with_network)
+            chroot = chroot_cmd(resolve=context.config.with_network, work=True)
 
             helpers = {
                 "mkosi-chroot": chroot,
@@ -791,7 +791,7 @@ def run_finalize_scripts(context: Context) -> None:
 
     with finalize_source_mounts(context.config, ephemeral=context.config.build_sources_ephemeral) as sources:
         for script in context.config.finalize_scripts:
-            chroot = chroot_cmd(resolve=context.config.with_network)
+            chroot = chroot_cmd(resolve=context.config.with_network, work=True)
 
             helpers = {
                 "mkosi-chroot": chroot,

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3635,8 +3635,9 @@ def copy_repository_metadata(context: Context) -> None:
                     *,
                     binary: Optional[PathString],
                     mounts: Sequence[Mount] = (),
+                    extra: Sequence[PathString] = (),
                 ) -> AbstractContextManager[list[PathString]]:
-                    return context.sandbox(binary=binary, mounts=[*mounts, *exclude])
+                    return context.sandbox(binary=binary, mounts=[*mounts, *exclude], extra=extra)
 
                 copy_tree(
                     src, dst,

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2890,8 +2890,14 @@ def run_depmod(context: Context, *, cache: bool = False) -> None:
             )
 
         with complete_step(f"Running depmod for {kver}"):
-            run(["depmod", "--all", "--basedir", "/buildroot", kver],
-                sandbox=context.sandbox(binary="depmod", mounts=[Mount(context.root, "/buildroot")]))
+            run(
+                ["depmod", "--all", kver],
+                sandbox=context.sandbox(
+                    binary=None,
+                    mounts=[Mount(context.root, "/buildroot")],
+                    extra=chroot_cmd(),
+                )
+            )
 
 
 def run_sysusers(context: Context) -> None:

--- a/mkosi/kmod.py
+++ b/mkosi/kmod.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from mkosi.log import complete_step, log_step
 from mkosi.run import run
-from mkosi.sandbox import Mount, SandboxProtocol, nosandbox
+from mkosi.sandbox import Mount, SandboxProtocol, chroot_cmd, nosandbox
 from mkosi.util import parents_below
 
 
@@ -94,9 +94,9 @@ def resolve_module_dependencies(
     for i in range(0, len(nametofile.keys()), 8500):
         chunk = list(nametofile.keys())[i:i+8500]
         info += run(
-            ["modinfo", "--basedir", "/buildroot", "--set-version", kver, "--null", *chunk],
+            ["modinfo", "--set-version", kver, "--null", *chunk],
             stdout=subprocess.PIPE,
-            sandbox=sandbox(binary="modinfo", mounts=[Mount(root, "/buildroot", ro=True)]),
+            sandbox=sandbox(binary="modinfo", mounts=[Mount(root, "/buildroot", ro=True)], extra=chroot_cmd()),
         ).stdout.strip()
 
     log_step("Calculating required kernel modules and firmware")

--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -47,7 +47,8 @@ class SandboxProtocol(Protocol):
         self,
         *,
         binary: Optional[PathString],
-        mounts: Sequence[Mount] = ()
+        mounts: Sequence[Mount] = (),
+        extra: Sequence[PathString] = (),
     ) -> AbstractContextManager[list[PathString]]: ...
 
 
@@ -55,6 +56,7 @@ def nosandbox(
     *,
     binary: Optional[PathString],
     mounts: Sequence[Mount] = (),
+    extra: Sequence[PathString] = (),
 ) -> AbstractContextManager[list[PathString]]:
     return contextlib.nullcontext([])
 

--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -275,7 +275,7 @@ def apivfs_cmd() -> list[PathString]:
 
 
 def chroot_cmd(*, resolve: bool = False, work: bool = False) -> list[PathString]:
-    workdir = '/buildroot/work' if work else ''
+    workdir = "/buildroot/work" if work else ""
 
     return apivfs_cmd() + [
         "sh", "-c",


### PR DESCRIPTION
modinfo cannot always work with output from newer or different depmod.

Specifically, this fixes the case where modinfo sch_fq_codel fails with
"module not found" on CentOS Stream 9 images built from Fedora 40. When
depmod from Fedora 40 is used, modinfo in the image fails with "module
not found". When depmod from inside the image is used, modinfo succeeds
as expected.

We'd rather not do this but in this case there's no other option.
