### PR TITLE
ci: Drop arch tools + centos image exclude

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,10 +118,6 @@ jobs:
             tools: opensuse
           - distro: ubuntu
             tools: opensuse
-          # This combination results in rpm failing because of SIGPIPE.
-          # TODO: Try again once Arch gets a new rpm release.
-          - distro: centos
-            tools: arch
 
     steps:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b


### PR DESCRIPTION
Arch got a new version of rpm so let's see if the SIGPIPE bug has been fixed.