### PR TITLE
Add optional file ID for qemu drives

### DIFF
--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -1477,15 +1477,18 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 `QemuDrives=`, `--qemu-drive=`
 
 : Add a qemu drive. Takes a colon-delimited string of format
-  `<id>:<size>[:<directory>[:<options>]]`. `id` specifies the qemu id we
-  assign to the drive. This can be used as the `drive=` property in
-  various qemu devices. `size` specifies the size of the drive. This
-  takes a size in bytes. Additionally, the suffixes `K`, `M` and `G` can
-  be used to specify a size in kilobytes, megabytes and gigabytes
-  respectively. `directory` optionally specifies the directory in which
-  to create the file backing the drive. `options` optionally specifies
-  extra comma-delimited properties which are passed verbatim to qemu's
-  `-drive` option.
+  `<id>:<size>[:<directory>[:<options>[:<file-id>]]]`. `id` specifies
+  the qemu ID assigned to the drive. This can be used as the `drive=`
+  property in various qemu devices. `size` specifies the size of the
+  drive. This takes a size in bytes. Additionally, the suffixes `K`, `M`
+  and `G` can be used to specify a size in kilobytes, megabytes and
+  gigabytes respectively. `directory` optionally specifies the directory
+  in which to create the file backing the drive. `options` optionally
+  specifies extra comma-delimited properties which are passed verbatim
+  to qemu's `-drive` option. `file-id` specifies the ID of the file
+  backing the drive. Drives with the same file ID will share the
+  backing file. The directory and size of the file will be determined
+  from the first drive with a given file ID.
 
 : Example usage:
 

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -17,7 +17,7 @@ import re
 import resource
 import stat
 import tempfile
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Hashable, Iterable, Iterator, Mapping, Sequence
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Callable, Optional, TypeVar, no_type_check
@@ -27,6 +27,7 @@ from mkosi.types import PathString
 
 T = TypeVar("T")
 V = TypeVar("V")
+S = TypeVar("S", bound=Hashable)
 
 
 def dictify(f: Callable[..., Iterator[tuple[T, V]]]) -> Callable[..., dict[T, V]]:
@@ -319,3 +320,17 @@ def try_or(fn: Callable[..., T], exception: type[Exception], default: T) -> T:
         return fn()
     except exception:
         return default
+
+
+def groupby(seq: Sequence[T], key: Callable[[T], S]) -> list[tuple[S, list[T]]]:
+    grouped: dict[S, list[T]] = {}
+
+    for i in seq:
+        k = key(i)
+
+        if k not in grouped:
+            grouped[k] = []
+
+        grouped[k].append(i)
+
+    return [(key, group) for key, group in grouped.items()]

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -232,12 +232,14 @@ def test_config() -> None:
             "QemuDrives": [
                 {
                     "Directory": "/foo/bar",
+                    "FileId": "red",
                     "Id": "abc",
                     "Options": "abc,qed",
                     "Size": 200
                 },
                 {
                     "Directory": null,
+                    "FileId": "wcd",
                     "Id": "abc",
                     "Options": "",
                     "Size": 200
@@ -437,7 +439,10 @@ def test_config() -> None:
         proxy_url="https://my/proxy",
         qemu_args=[],
         qemu_cdrom=False,
-        qemu_drives=[QemuDrive("abc", 200, Path("/foo/bar"), "abc,qed"), QemuDrive("abc", 200, None, "")],
+        qemu_drives=[
+            QemuDrive("abc", 200, Path("/foo/bar"), "abc,qed", "red"),
+            QemuDrive("abc", 200, None, "", "wcd"),
+        ],
         qemu_firmware=QemuFirmware.linux,
         qemu_firmware_variables=Path("/foo/bar"),
         qemu_gui=True,


### PR DESCRIPTION
For testing multipath in systemd's integration tests, we need multiple qemu drives backed by the same file. Let's allow specifying an additional file ID to make this possible with QemuDrive=.