### PR TITLE
Don't die when images already exist

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2695,7 +2695,7 @@ def check_outputs(config: Config) -> None:
         config.output_nspawn_settings if config.nspawn_settings else None,
     ):
         if f and (config.output_dir_or_cwd() / f).exists():
-            die(f"Output path {f} exists already. (Consider invocation with --force.)")
+            logging.info(f"Output path {f} exists already. (Use --force to rebuild.)")
 
 
 def check_tool(config: Config, *tools: PathString, reason: str, hint: Optional[str] = None) -> Path:


### PR DESCRIPTION
We already check whether outputs exist when looping over all image configs and skip the build if the output exists. This way one can just "mkosi build" after adding a new image and the missing ones will be built.