### PR TITLE
Prefer `config.image` over `config.image_id`

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -689,7 +689,7 @@ def config_default_compression(namespace: argparse.Namespace) -> Compression:
 
 
 def config_default_output(namespace: argparse.Namespace) -> str:
-    output = namespace.image_id or namespace.image or "image"
+    output = namespace.image or namespace.image_id or "image"
 
     if namespace.image_version:
         output += f"_{namespace.image_version}"
@@ -1523,7 +1523,7 @@ class Config:
     image: Optional[str]
 
     def name(self) -> str:
-        return self.image_id or self.image or "default"
+        return self.image or self.image_id or "default"
 
     def machine_or_name(self) -> str:
         return self.machine or self.name()


### PR DESCRIPTION
As it currently stands, when using multiple images via `mkosi.images` all the images have the same (output) name if `ImageId=` is set, which results in all images needing to override the output name as to not clash.

This changes the default output name and the display name of those images to prefer their actual "sub-image" name, while still falling back to the `ImageId=` for the root image case.

This also somewhat has the sideeffect that it solves the original issue I had in https://github.com/systemd/mkosi/issues/2566 (but the requested specifier might still be useful, so I'll keep it open for now).