### PR TITLE
mkosi-initrd: remove some unnecessary files from openSUSE initrd

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-opensuse.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-opensuse.conf
@@ -23,5 +23,57 @@ Packages=
         util-linux
 
 RemoveFiles=
-        /usr/share/locale/*
+        /etc/bash_completion.d
+        /etc/man.conf
+        /srv
+        /usr/local/man
+        /usr/share/bash-completion
+        /usr/share/bash/helpfiles
+        /usr/share/doc
+        /usr/share/fillup-templates
+        /usr/share/help
+        /usr/share/icons
+        /usr/share/info
+        /usr/share/licenses
+        /usr/share/locale
+        /usr/share/man
+        /usr/share/zsh
         /usr/etc/services
+        /var/adm
+
+        # Keep only C.utf-8 locale
+        /usr/lib/locale/*_*/
+        /usr/lib/locale/??/
+        /usr/lib/locale/???/
+
+        # RPM
+        /etc/rpm
+        /usr/bin/gendiff
+        /usr/bin/rpm*
+        /usr/lib/rpm
+        /usr/lib/sysimage
+        /usr/lib/systemd/system/rpmconfigcheck.service
+        /usr/lib64/rpm-plugins
+        /usr/sbin/rpmconfigcheck
+        /usr/src/packages
+
+        # Zypper
+        /etc/zypp
+        /usr/bin/installation_sources
+        /usr/bin/yzpper
+        /usr/bin/zypper
+        /usr/etc/logrotate.d/zypp*
+        /usr/lib/zypper
+        /usr/sbin/zypp-refresh
+        /usr/share/zypper
+        /var/log/zypp
+        /var/log/zypper.log
+
+        # YaST2
+        /etc/YaST2
+
+        # suse-module-tools scripts
+        /usr/lib/module-init-tools
+
+        # dracut modules installed by other packages
+        /usr/lib/dracut


### PR DESCRIPTION
Initial clean-up, please let me know if this is not the way to go. In my tests, this reduces the size from ~100M to ~40M.