### PR TITLE
mkosi-initrd: Don't remove sanitizer libraries from initrd

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-arch.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-arch.conf
@@ -24,11 +24,6 @@ RemoveFiles=
         /usr/lib/libgomp.so*
         /usr/lib/libgphobos.so*
         /usr/lib/libobjc.so*
-        /usr/lib/libasan.so*
-        /usr/lib/libtsan.so*
-        /usr/lib/liblsan.so*
-        /usr/lib/libubsan.so*
-        /usr/lib/libstdc++.so*
         /usr/lib/libgdruntime.so*
 
         # Remove all files that are only required for development.

--- a/tests/test_initrd.py
+++ b/tests/test_initrd.py
@@ -263,7 +263,7 @@ def test_initrd_size(initrd: Image) -> None:
         Distribution.fedora: 46,
         Distribution.debian: 40,
         Distribution.ubuntu: 36,
-        Distribution.arch: 47,
+        Distribution.arch: 67,
         Distribution.opensuse: 39,
     }.get(initrd.config.distribution, 48)
 


### PR DESCRIPTION
Let's not unconditionally remove sanitizer libraries and their dependencies from the initrd as it turns out running software with sanitizers in the initrd isn't that far fetched.