### PR TITLE
Add option to support systemd-sysupdate naming style

### DIFF
--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -649,6 +649,14 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
   root or `/usr` partition along with its Verity partition and unified
   kernel.
 
+`SysupdateNaming=`, `--sysupdate-naming`
+
+: The naming of Unified Kernel Images (UKIs) within `/boot/EFI` and the saved
+  UKI binary artifact will be in the format `ImageId_ImageVersion.efi` when
+  enabled. This is useful when used with `systemd-sysupdate` which requires the
+  version to be stored in the UKI binary name. Requires `ImageId=` and
+  `ImageVersion=` to be specified. Has no effect when a UKI is not generated.
+
 `RepartDirectories=`, `--repart-dir=`
 
 : Paths to directories containing systemd-repart partition definition

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -316,6 +316,7 @@ def test_config() -> None:
             "SyncScripts": [
                 "/sync"
             ],
+            "SysupdateNaming": false,
             "Timezone": null,
             "ToolsTree": null,
             "ToolsTreeCertificates": true,
@@ -486,6 +487,7 @@ def test_config() -> None:
         ssh_certificate=Path("/path/to/cert"),
         ssh_key=None,
         sync_scripts=[Path("/sync")],
+        sysupdate_naming=False,
         timezone=None,
         tools_tree=None,
         tools_tree_certificates=True,


### PR DESCRIPTION
When using `systemd-sysupdate` the names of output files need to contain the image version since this is the only version that is reasonable to use across all artifacts. This change makes sure the UKI stored in the ESP or XBOOTLDR partition has an appropriate name, along with the name if `SplitArtifacts=` is set.

Note: The UKI cannot contain the kernel version or other values that will change and cannot be hard-coded into a `sysupdate.d` file.

Fixes #1638.