### PR TITLE
Add `UnifiedKernelImageName=`

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -950,16 +950,17 @@ def is_valid_filename(s: str) -> bool:
     return not (s == "." or s == ".." or "/" in s)
 
 
-def config_parse_output(value: Optional[str], old: Optional[str]) -> Optional[str]:
-    if not value:
-        return None
+def config_make_filename_parser(hint: str) -> ConfigParseCallback:
+    def config_parse_filename(value: Optional[str], old: Optional[str]) -> Optional[str]:
+        if not value:
+            return None
 
-    if not is_valid_filename(value):
-        die(f"{value!r} is not a valid filename.",
-            hint="Output= or --output= requires a filename with no path components. "
-                 "Use OutputDirectory= or --output-dir= to configure the output directory.")
+        if not is_valid_filename(value):
+            die(f"{value!r} is not a valid filename.", hint=hint)
 
-    return value
+        return value
+
+    return config_parse_filename
 
 
 def match_path_exists(value: str) -> bool:
@@ -1431,6 +1432,7 @@ class Config:
     bios_bootloader: BiosBootloader
     shim_bootloader: ShimBootloader
     unified_kernel_images: ConfigFeature
+    unified_kernel_image_name: str
     initrds: list[Path]
     initrd_packages: list[str]
     initrd_volatile_packages: list[str]
@@ -1971,7 +1973,10 @@ SETTINGS = (
         metavar="NAME",
         section="Output",
         specifier="o",
-        parse=config_parse_output,
+        parse=config_make_filename_parser(
+            "Output= or --output= requires a filename with no path components. "
+            "Use OutputDirectory= or --output-dir= to configure the output directory."
+        ),
         default_factory=config_default_output,
         default_factory_depends=("image_id", "image_version"),
         help="Output name",
@@ -2380,6 +2385,15 @@ SETTINGS = (
         section="Content",
         parse=config_parse_feature,
         help="Specify whether to use UKIs with grub/systemd-boot in UEFI mode",
+    ),
+    ConfigSetting(
+        dest="unified_kernel_image_name",
+        section="Content",
+        parse=config_make_filename_parser(
+            "UnifiedKernelImageName= or --unified-kernel-image-name= "
+            "requires a filename with no path components."
+        ),
+        help="Specify the filename used for the UKI (only works when using a single UKI)",
     ),
     ConfigSetting(
         dest="initrds",

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -990,6 +990,12 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     Otherwise Type 1 entries as defined by the Boot Loader Specification
     will be used instead. If disabled, Type 1 entries will always be used.
 
+`UnifiedKernelImageName=`, `--unified-kernel-image-name=`
+
+: Specify the name to install the unified kernel image as. Takes a filename
+  without any path components or the `.efi` extension. This is only supported
+  when using a single unified kernel image.
+
 `Initrds=`, `--initrd`
 :   Use user-provided initrd(s). Takes a comma separated list of paths to initrd
     files. This option may be used multiple times in which case the initrd lists

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -332,6 +332,7 @@ def test_config() -> None:
             "ToolsTreeRepositories": [
                 "abc"
             ],
+            "UnifiedKernelImageName": "myuki",
             "UnifiedKernelImages": "auto",
             "UnitProperties": [
                 "PROPERTY=VALUE"
@@ -495,6 +496,7 @@ def test_config() -> None:
         tools_tree_packages=[],
         tools_tree_release=None,
         tools_tree_repositories=["abc"],
+        unified_kernel_image_name="myuki",
         unified_kernel_images=ConfigFeature.auto,
         unit_properties=["PROPERTY=VALUE"],
         use_subvolumes=ConfigFeature.auto,


### PR DESCRIPTION
This is a more scoped down version of #2727 to just be able to adjust the name of the UKI.

This possibly could be extended in the future to allow some form of templating for multiple kernels, but that effort is probably better put into adding the missing parts in kernel-install.

Fixes: #1638