### PR TITLE
Add `UnifiedKernelImageFormat=` (attempt 2)

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2300,7 +2300,9 @@ def install_type1(
 
 
 def install_uki(context: Context, kver: str, kimg: Path, token: str, partitions: Sequence[Partition]) -> None:
-    roothash = finalize_roothash(partitions)
+    roothash_value = ""
+    if roothash := finalize_roothash(partitions):
+        roothash_value = f"-{roothash.partition("=")[2]}"
 
     boot_count = ""
     if (context.root / "etc/kernel/tries").exists():
@@ -2312,11 +2314,7 @@ def install_uki(context: Context, kver: str, kimg: Path, token: str, partitions:
         else:
             boot_binary = context.root / efi_boot_binary(context)
     else:
-        if roothash:
-            _, _, h = roothash.partition("=")
-            boot_binary = context.root / f"boot/EFI/Linux/{token}-{kver}-{h}{boot_count}.efi"
-        else:
-            boot_binary = context.root / f"boot/EFI/Linux/{token}-{kver}{boot_count}.efi"
+        boot_binary = context.root / f"boot/EFI/Linux/{token}-{kver}{roothash_value}{boot_count}.efi"
 
     # Make sure the parent directory where we'll be writing the UKI exists.
     with umask(~0o700):

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3985,6 +3985,7 @@ def summary(config: Config) -> str:
                          Bootloader: {config.bootloader}
                     BIOS Bootloader: {config.bios_bootloader}
                     Shim Bootloader: {config.shim_bootloader}
+              Unified Kernel Images: {config.unified_kernel_images}
                             Initrds: {line_join_list(config.initrds)}
                     Initrd Packages: {line_join_list(config.initrd_packages)}
            Initrd Volatile Packages: {line_join_list(config.initrd_volatile_packages)}

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -950,16 +950,17 @@ def is_valid_filename(s: str) -> bool:
     return not (s == "." or s == ".." or "/" in s)
 
 
-def config_parse_output(value: Optional[str], old: Optional[str]) -> Optional[str]:
-    if not value:
-        return None
+def config_make_filename_parser(hint: str) -> ConfigParseCallback:
+    def config_parse_filename(value: Optional[str], old: Optional[str]) -> Optional[str]:
+        if not value:
+            return None
 
-    if not is_valid_filename(value):
-        die(f"{value!r} is not a valid filename.",
-            hint="Output= or --output= requires a filename with no path components. "
-                 "Use OutputDirectory= or --output-dir= to configure the output directory.")
+        if not is_valid_filename(value):
+            die(f"{value!r} is not a valid filename.", hint=hint)
 
-    return value
+        return value
+
+    return config_parse_filename
 
 
 def match_path_exists(value: str) -> bool:
@@ -1431,6 +1432,7 @@ class Config:
     bios_bootloader: BiosBootloader
     shim_bootloader: ShimBootloader
     unified_kernel_images: ConfigFeature
+    unified_kernel_image_format: str
     initrds: list[Path]
     initrd_packages: list[str]
     initrd_volatile_packages: list[str]
@@ -1971,7 +1973,10 @@ SETTINGS = (
         metavar="NAME",
         section="Output",
         specifier="o",
-        parse=config_parse_output,
+        parse=config_make_filename_parser(
+            "Output= or --output= requires a filename with no path components. "
+            "Use OutputDirectory= or --output-dir= to configure the output directory."
+        ),
         default_factory=config_default_output,
         default_factory_depends=("image_id", "image_version"),
         help="Output name",
@@ -2380,6 +2385,19 @@ SETTINGS = (
         section="Content",
         parse=config_parse_feature,
         help="Specify whether to use UKIs with grub/systemd-boot in UEFI mode",
+    ),
+    ConfigSetting(
+        dest="unified_kernel_image_format",
+        section="Content",
+        parse=config_make_filename_parser(
+            "UnifiedKernelImageFormat= or --unified-kernel-image-format= "
+            "requires a filename with no path components."
+        ),
+        # The default value is set in `__init__.py` in `install_uki`.
+        # `None` is used to determin if the roothash and boot count format
+        # should be appended to the filename if they are found.
+        #default=
+        help="Specify the format used for the UKI filename",
     ),
     ConfigSetting(
         dest="initrds",
@@ -3986,6 +4004,7 @@ def summary(config: Config) -> str:
                     BIOS Bootloader: {config.bios_bootloader}
                     Shim Bootloader: {config.shim_bootloader}
               Unified Kernel Images: {config.unified_kernel_images}
+        Unified Kernel Image Format: {config.unified_kernel_image_format}
                             Initrds: {line_join_list(config.initrds)}
                     Initrd Packages: {line_join_list(config.initrd_packages)}
            Initrd Volatile Packages: {line_join_list(config.initrd_volatile_packages)}

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -997,6 +997,25 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     Otherwise Type 1 entries as defined by the Boot Loader Specification
     will be used instead. If disabled, Type 1 entries will always be used.
 
+`UnifiedKernelImageFormat=`, `--unified-kernel-image-format=`
+:   Takes a filename without any path components to specify the format that
+    unified kernel images should be installed as. This may include both the
+    regular specifiers (see **Specifiers**) and special delayed specifiers, that
+    are expanded during the installation of the files, which are described below.
+    The default format for this parameter is `&e-&k` with `-&h` being appended
+    if `roothash=` or `usrhash=` is found on the kernel command line and `+&c`
+    if `/etc/kernel/tries` is found in the image.
+
+    The following specifiers may be used:
+
+    | Specifier | Value                                              |
+    |-----------|----------------------------------------------------|
+    | `&&`      | `&` character                                      |
+    | `&e`      | Entry Token                                        |
+    | `&k`      | Kernel version                                     |
+    | `&h`      | `roothash=` or `usrhash=` value of kernel argument |
+    | `&c`      | Number of tries used for boot attempt counting     |
+
 `Initrds=`, `--initrd`
 :   Use user-provided initrd(s). Takes a comma separated list of paths to initrd
     files. This option may be used multiple times in which case the initrd lists

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -332,6 +332,7 @@ def test_config() -> None:
             "ToolsTreeRepositories": [
                 "abc"
             ],
+            "UnifiedKernelImageFormat": "myuki",
             "UnifiedKernelImages": "auto",
             "UnitProperties": [
                 "PROPERTY=VALUE"
@@ -495,6 +496,7 @@ def test_config() -> None:
         tools_tree_packages=[],
         tools_tree_release=None,
         tools_tree_repositories=["abc"],
+        unified_kernel_image_format="myuki",
         unified_kernel_images=ConfigFeature.auto,
         unit_properties=["PROPERTY=VALUE"],
         use_subvolumes=ConfigFeature.auto,


### PR DESCRIPTION
~~This is currently incomplete as it doesn't handle the Type1 entry case as~~ I'm unsure how the nested directories should be handled as allowing nesting doesn't work with UKI auto discovery, see https://github.com/systemd/mkosi/pull/2731#issuecomment-2139669076. Provisionally `-` is replaced by `/` for Type1 entries.

I'd love some input on how to better formulate the documentation because it seems very superficial right now.

Tested UKI cases:
- `BootloaderEntryFormat=` -> `/boot/EFI/Linux/<entry-token>-<kver>-<usrhash>.efi` ✅ (have no tries file set)
- `BootloaderEntryFormat=%i_%v` -> `/boot/EFI/Linux/<image-id>_<image-version>.efi` ✅
- `BootloaderEntryFormat=hello~&c+&h-&k-&e` -> `/boot/EFI/Linux/hello~+<usrhash>-<kver>-<entry-token>.efi` - `&c` ignored, expected ✅
- `BootloaderEntryFormat=&e/&k` -> config parse error, expected ✅
- `BootloaderEntryFormat=&&` -> `/boot/EFI/Linux/&.efi` ✅