### PR TITLE
Add option to skip passing --seed to systemd-repart

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3192,7 +3192,6 @@ def make_image(
         "--json=pretty",
         "--no-pager",
         f"--offline={yes_no(context.config.repart_offline)}",
-        "--seed", str(context.config.seed),
         context.staging / context.config.output_with_format,
     ]
     mounts = [Mount(context.staging, context.staging)]
@@ -3227,6 +3226,8 @@ def make_image(
             "--generate-fstab=/etc/fstab",
             "--generate-crypttab=/etc/crypttab",
         ]
+    if context.config.seed:
+        cmdline += ["--seed", str(context.config.seed)]
 
     for d in definitions:
         cmdline += ["--definitions", d]
@@ -3480,7 +3481,6 @@ def make_extension_image(context: Context, output: Path) -> None:
         "--dry-run=no",
         "--no-pager",
         f"--offline={yes_no(context.config.repart_offline)}",
-        "--seed", str(context.config.seed) if context.config.seed else "random",
         "--empty=create",
         "--size=auto",
         "--definitions", r,
@@ -3510,6 +3510,8 @@ def make_extension_image(context: Context, output: Path) -> None:
         cmdline += ["--sector-size", str(context.config.sector_size)]
     if context.config.split_artifacts:
         cmdline += ["--split=yes"]
+    if context.config.seed:
+        cmdline += ["--seed", str(context.config.seed)]
 
     with complete_step(f"Building {context.config.output_format} extension image"):
         j = json.loads(

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -4119,7 +4119,9 @@ def json_type_transformer(refcls: Union[type[Args], type[Config]]) -> Callable[[
     def path_list_transformer(pathlist: list[str], fieldtype: type[list[Path]]) -> list[Path]:
         return [Path(p) for p in pathlist]
 
-    def uuid_or_false_transformer(uuid_or_false_str: str, fieldtype: type[Union[uuid.UUID, Literal[False]]]) -> Union[uuid.UUID | Literal[False]]:
+    def uuid_or_false_transformer(
+        uuid_or_false_str: str, fieldtype: type[Union[uuid.UUID, Literal[False]]],
+    ) -> Union[uuid.UUID | Literal[False]]:
         if uuid_or_false_str in {"0", "false", "no", "n", "f", "off", "never"}:
             return False
         return uuid.UUID(uuid_or_false_str)

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -4119,8 +4119,10 @@ def json_type_transformer(refcls: Union[type[Args], type[Config]]) -> Callable[[
     def path_list_transformer(pathlist: list[str], fieldtype: type[list[Path]]) -> list[Path]:
         return [Path(p) for p in pathlist]
 
-    def uuid_transformer(uuidstr: str, fieldtype: type[uuid.UUID]) -> uuid.UUID:
-        return uuid.UUID(uuidstr)
+    def uuid_or_false_transformer(uuid_or_false_str: str, fieldtype: type[Union[uuid.UUID, Literal[False]]]) -> Union[uuid.UUID | Literal[False]]:
+        if uuid_or_false_str in {"0", "false", "no", "n", "f", "off", "never"}:
+            return False
+        return uuid.UUID(uuid_or_false_str)
 
     def root_password_transformer(
         rootpw: Optional[list[Union[str, bool]]], fieldtype: type[Optional[tuple[str, bool]]]
@@ -4189,7 +4191,7 @@ def json_type_transformer(refcls: Union[type[Args], type[Config]]) -> Callable[[
         Path: path_transformer,
         Optional[Path]: optional_path_transformer,
         list[Path]: path_list_transformer,
-        uuid.UUID: uuid_transformer,
+        Union[uuid.UUID, Literal[False]]: uuid_or_false_transformer,
         Optional[tuple[str, bool]]: root_password_transformer,
         list[ConfigTree]: config_tree_transformer,
         tuple[str, ...]: str_tuple_transformer,

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -29,7 +29,7 @@ import uuid
 from collections.abc import Collection, Iterable, Iterator, Sequence
 from contextlib import AbstractContextManager
 from pathlib import Path
-from typing import Any, Callable, Optional, TypeVar, Union, cast
+from typing import Any, Callable, Literal, Optional, TypeVar, Union, cast
 
 from mkosi.distributions import Distribution, detect_distribution
 from mkosi.log import ARG_DEBUG, ARG_DEBUG_SHELL, Style, die
@@ -633,7 +633,9 @@ def config_parse_compression(value: Optional[str], old: Optional[Compression]) -
         return Compression.zstd if parse_boolean(value) else Compression.none
 
 
-def config_parse_seed(value: Optional[str], old: Optional[str]) -> Optional[uuid.UUID]:
+def config_parse_seed(value: Optional[str], old: Optional[str]) -> Optional[uuid.UUID | Literal[False]]:
+    if value in {"0", "false", "no", "n", "f", "off", "never"}:
+        return False
     if not value or value == "random":
         return None
 
@@ -1394,7 +1396,7 @@ class Config:
     repart_offline: bool
     overlay: bool
     use_subvolumes: ConfigFeature
-    seed: uuid.UUID
+    seed: uuid.UUID | Literal[False]
 
     packages: list[str]
     build_packages: list[str]

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -633,7 +633,7 @@ def config_parse_compression(value: Optional[str], old: Optional[Compression]) -
         return Compression.zstd if parse_boolean(value) else Compression.none
 
 
-def config_parse_seed(value: Optional[str], old: Optional[str]) -> Optional[uuid.UUID | Literal[False]]:
+def config_parse_seed(value: Optional[str], old: Optional[str]) -> Optional[Union[uuid.UUID, Literal[False]]]:
     if value in {"0", "false", "no", "n", "f", "off", "never"}:
         return False
     if not value or value == "random":
@@ -1396,7 +1396,7 @@ class Config:
     repart_offline: bool
     overlay: bool
     use_subvolumes: ConfigFeature
-    seed: uuid.UUID | Literal[False]
+    seed: Union[uuid.UUID, Literal[False]]
 
     packages: list[str]
     build_packages: list[str]

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -651,11 +651,13 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     create subvolumes are ignored.
 
 `Seed=`, `--seed=`
-:   Takes a UUID as argument or the special value `random`.
-    Overrides the seed that [`systemd-repart(8)`](https://www.freedesktop.org/software/systemd/man/systemd-repart.service.html)
+:   Takes a UUID as argument, the special value `random` or a boolean false.
+    If not false, overrides the seed that
+    [`systemd-repart(8)`](https://www.freedesktop.org/software/systemd/man/systemd-repart.service.html)
     uses when building a disk image. This is useful to achieve reproducible
     builds, where deterministic UUIDs and other partition metadata should be
-    derived on each build.
+    derived on each build. If `random`, a UUID is generated and passed to
+    `systemd-repart`. Set to `random` by default.
 
 `SourceDateEpoch=`, `--source-date-epoch=`
 :   Takes a timestamp in seconds since the UNIX epoch as argument.


### PR DESCRIPTION
The use case here is if we've already set `/etc/machine-id` in our image, for example if `/` is meant to be read-only. At the moment it's not possible to use the DDI with `SD_GPT_VAR`, because the partition UUID generated by `systemd-repart` won't match `/etc/machine-id`, `--seed` is always passed and overrides it. This PR allows setting `Seed=no` and adding a `mkosi.repart/var.conf` like:

```
[Partition]
Type=var
CopyFiles=/var:/
SizeMinBytes=1G
```

so that the generated image will auto mount that partition to `/var`.
The current default, where `mkosi` itself generates a UUID and passes it via `--seed`, is left as the default.

Unfortunately this only works with an already set `/etc/machine-id` because of [ordering between `gpt-auto-generator` and `systemd-repart` at start up](https://github.com/systemd/systemd/issues/31071). Also relevant: https://github.com/systemd/mkosi/discussions/2304