### PR TITLE
fedora: do not install dnf-3

### DIFF
--- a/mkosi.conf.d/20-centos.conf
+++ b/mkosi.conf.d/20-centos.conf
@@ -11,4 +11,7 @@ Repositories=epel
              epel-next
 
 [Content]
-Packages=linux-firmware
+Packages=
+        linux-firmware
+        dnf
+        dnf-plugins-core

--- a/mkosi.conf.d/30-centos-fedora/mkosi.conf
+++ b/mkosi.conf.d/30-centos-fedora/mkosi.conf
@@ -17,8 +17,6 @@ Packages=
         curl-minimal
         debian-keyring
         distribution-gpg-keys
-        dnf
-        dnf-plugins-core
         dosfstools
         e2fsprogs
         erofs-utils


### PR DESCRIPTION
We get both dnf5 and dnf, which doesn't seem necessary. Also, in F41 dnf is Provided by dnf5, so that'd install dnf5 anyway.