### PR TITLE
Have coredumpctl and journalctl operate on forwarded journal if available

### DIFF
--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -105,10 +105,17 @@ The following command line verbs are known:
     Any arguments specified after the `journalctl` verb are appended to the
     `journalctl` invocation.
 
+    If `ForwardJournal=` is specified, this verb will operate on the
+    forwarded journal instead of the journal inside the image.
+
 `coredumpctl`
 :   Uses `coredumpctl` to look for coredumps inside the image.
     Any arguments specified after the `coredumpctl` verb are appended to the
     `coredumpctl` invocation.
+
+    If `ForwardJournal=` is specified, this verb will operate on the
+    forwarded journal instead of the image. Note that this requires
+    configuring systemd-coredump to store coredumps in the journal.
 
 `clean`
 :   Remove build artifacts generated on a previous build. If combined


### PR DESCRIPTION
If ForwardJournal= is configured, have coredumpctl and journalctl operate on it instead of on the image itself. While this doesn't handle the edge case where the journal is forwarded but the coredumps are stored in the image, let's assume that users that enable ForwardJournal= will also configure coredumps to be stored in the journal.