### PR TITLE
Set --pretty=no in run_shell() when calling repart

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3932,6 +3932,7 @@ def run_shell(args: Args, config: Config) -> None:
                     "--no-pager",
                     "--dry-run=no",
                     "--offline=no",
+                    "--pretty=no",
                     fname,
                 ],
                 stdin=sys.stdin,


### PR DESCRIPTION
We do the same in apply_runtime_size() as it makes repart output a lot less noisy.