### PR TITLE
dnf: allow whitelisting plugins through [Host] configuration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## v23
 
+- Added `DnfPlugins=` to allow configuring what DNF plugins are used
+  for builds using DNF.
 - Added `CleanScripts=` to allow running custom cleanup code whenever
   mkosi cleans up the output directory. This allows cleaning up extra
   outputs produced by e.g. a build script that mkosi doesn't know about.

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1506,6 +1506,7 @@ class Config:
     machine: Optional[str]
     forward_journal: Optional[Path]
     vmm: Vmm
+    dnf_plugins: list[str]
 
     # QEMU-specific options
     qemu_gui: bool
@@ -2936,6 +2937,13 @@ SETTINGS = (
         help="Set the path used to store forwarded machine journals",
     ),
     ConfigSetting(
+        dest="dnf_plugins",
+        metavar="BOOL",
+        section="Host",
+        parse=config_make_list_parser(delimiter=" "),
+        help="Specify DNF plugins to enable during the build",
+    ),
+    ConfigSetting(
         dest="qemu_gui",
         metavar="BOOL",
         nargs="?",
@@ -4088,6 +4096,7 @@ def summary(config: Config) -> str:
                     SSH Certificate: {none_to_none(config.ssh_certificate)}
                             Machine: {config.machine_or_name()}
                     Forward Journal: {none_to_none(config.forward_journal)}
+                        DNF Plugins: {line_join_list(config.dnf_plugins)}
 
             Virtual Machine Monitor: {config.vmm}
                            QEMU GUI: {yes_no(config.qemu_gui)}

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -116,6 +116,12 @@ class Dnf(PackageManager):
             "--enable-plugin=builddep" if dnf.endswith("dnf5") else "--enableplugin=builddep",
         ]
 
+        for plugin in context.config.dnf_plugins:
+            if dnf.endswith("dnf5"):
+                cmdline += [f"--enable-plugin={plugin}"]
+            else:
+                cmdline += [f"--enableplugin={plugin}"]
+
         if ARG_DEBUG.get():
             cmdline += ["--setopt=debuglevel=10"]
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -129,6 +129,7 @@ def test_config() -> None:
                 "dep1"
             ],
             "Distribution": "fedora",
+            "DnfPlugins": [],
             "Environment": {
                 "BAR": "BAR",
                 "Qux": "Qux",
@@ -390,6 +391,7 @@ def test_config() -> None:
         forward_journal=Path("/mkosi.journal"),
         hostname=None,
         vmm=Vmm.qemu,
+        dnf_plugins=[],
         image="default",
         image_id="myimage",
         image_version="5",


### PR DESCRIPTION
See-Also: https://github.com/systemd/mkosi/issues/700#issuecomment-2143314056

We can see that this new `dnf` argument is passed appropriately with this build command line:

```
$ mkosi -f --dnf-plugins="foo bar" --tools-tree=default --release=9 --debug
[snip]
‣  Installing Rocky
‣ + dnf5 --assumeyes --best --releasever=9 --installroot=/buildroot --setopt=keepcache=1 --setopt=logdir=/var/log --setopt=cachedir=/var/cache/libdnf5 --setopt=persistdir=/var/lib/libdnf5 --setopt=install_weak_deps=0 --setopt=check_config_file_age=0 '--disable-plugin=*' --enable-plugin=builddep --enable-plugin=foo --enable-plugin=bar --setopt=debuglevel=10 --setopt=metadata_expire=never --setopt=cacheonly=metadata --use-host-config --setopt=proxy_sslcacert=/proxy.cacert install basesystem 
```

And similarly with this configuration file:
```
$ cat mkosi.conf
[Distribution]
Release=9

[Host]
ToolsTree=default
DnfPlugins=foo
        bar
$ mkosi --debug
‣ + dnf5 --assumeyes --best --releasever=9 --installroot=/buildroot --setopt=keepcache=1 --setopt=logdir=/var/log --setopt=cachedir=/var/cache/libdnf5 --setopt=persistdir=/var/lib/libdnf5 --
setopt=install_weak_deps=0 --setopt=check_config_file_age=0 '--disable-plugin=*' --enable-plugin=builddep --enable-plugin=foo --enable-plugin=bar --setopt=debuglevel=10 --setopt=metadata_exp
ire=never --setopt=cacheonly=metadata --use-host-config --setopt=proxy_sslcacert=/proxy.cacert install basesystem
```

And an `mkosi summary` yields, with the above configuration file:
```
    HOST CONFIGURATION:
                          Proxy URL: none
[snip]
                        DNF Plugins: foo
                                     bar
```

I was able to confirm that `dnf` *was* installing the version-locked packages that I was expecting by inspecting the packages installed through the build log, but the build failed elsewhere in my Rocky 9.4 environment, tripping over the release (9.4) not being an integer even though it is set to an integer in the configuration:
```
  File "/localdisk/pbi/mkosi-test/venv/lib64/python3.9/site-packages/mkosi/config.py", line 3666, in parse_config
    finalize_defaults()
  File "/localdisk/pbi/mkosi-test/venv/lib64/python3.9/site-packages/mkosi/config.py", line 3583, in finalize_defaults
    finalize_default(s)
  File "/localdisk/pbi/mkosi-test/venv/lib64/python3.9/site-packages/mkosi/config.py", line 3417, in finalize_default
    default = setting.default_factory(namespace)
  File "/localdisk/pbi/mkosi-test/venv/lib64/python3.9/site-packages/mkosi/config.py", line 679, in config_default_compression
    (namespace.distribution.is_centos_variant() and int(namespace.release) <= 8) or
ValueError: invalid literal for int() with base 10: '9.4'
$ grep Release mkosi.conf
Release=9
```