### PR TITLE
opensuse: Add glibc-gconv-modules-extra to default tools tree

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-opensuse.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-opensuse.conf
@@ -15,6 +15,7 @@ Packages=
         dnf5-plugins
         erofs-utils
         git-core
+        glibc-gconv-modules-extra
         grep
         grub2
         openssh-clients


### PR DESCRIPTION
This package was split off from glibc but mtools does not yet have a required dependency on it (see
https://bugzilla.opensuse.org/show_bug.cgi?id=1225982) so for now let's install it ourselves.