### PR TITLE
mkosi-initrd: Include various virtualization modules by default

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -43,11 +43,17 @@ KernelModulesInclude=
                     /dm-crypt.ko
                     /dm-integrity.ko
                     /dm-verity.ko
+                    /dmi-sysfs.ko
                     /erofs.ko
                     /ext4.ko
                     /loop.ko
                     /overlay.ko
+                    /qemu_fw_cfg.ko
                     /squashfs.ko
                     /vfat.ko
+                    /virtio_balloon.ko
+                    /virtio_net.ko
+                    /virtio_scsi.ko
+                    /vmw_vsock_virtio_transport.ko
                     /vsock.ko
                     /xfs.ko


### PR DESCRIPTION
Let's make sure our initrds include all necessary modules to boot in a virtualized environment.