### PR TITLE
mkosi-initrd: Add more default kernel modules

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -39,21 +39,31 @@ WithDocs=no
 
 # Make sure various core modules are always included in the initrd.
 KernelModulesInclude=
+                    /ahci.ko
                     /btrfs.ko
+                    /configfs.ko
+                    /dm-mod.ko
                     /dm-crypt.ko
                     /dm-integrity.ko
                     /dm-verity.ko
                     /dmi-sysfs.ko
+                    /efi-pstore.ko
                     /erofs.ko
                     /ext4.ko
                     /loop.ko
+                    /nvme.ko
                     /overlay.ko
                     /qemu_fw_cfg.ko
+                    /scsi_mod.ko
+                    /sd_mod.ko
+                    /sg.ko
                     /squashfs.ko
                     /vfat.ko
                     /virtio_balloon.ko
                     /virtio_net.ko
                     /virtio_scsi.ko
+                    /virtio-rng.ko
+                    /virtiofs.ko
                     /vmw_vsock_virtio_transport.ko
                     /vsock.ko
                     /xfs.ko


### PR DESCRIPTION
More virtualization modules required to boot an opensuse image in qemu (opensuse has much more modules compared to Fedora which has more builtin).