### PR TITLE
mkosi-initrd: Include more modules

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -42,9 +42,9 @@ KernelModulesInclude=
                     /ahci.ko
                     /btrfs.ko
                     /configfs.ko
-                    /dm-mod.ko
                     /dm-crypt.ko
                     /dm-integrity.ko
+                    /dm-mod.ko
                     /dm-verity.ko
                     /dmi-sysfs.ko
                     /efi-pstore.ko
@@ -66,4 +66,6 @@ KernelModulesInclude=
                     /virtiofs.ko
                     /vmw_vsock_virtio_transport.ko
                     /vsock.ko
+                    /x_tables.ko
                     /xfs.ko
+                    ^crypto/


### PR DESCRIPTION
- systemd logs an error if x_tables.ko is missing so let's include it.
- For cryptsetup, let's make sure we include all crypto modules so it always has everything it needs