### PR TITLE
Make --tools-tree the same as --tools-tree=default

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2793,6 +2793,8 @@ SETTINGS = (
         parse=config_make_path_parser(required=False, constants=("default",)),
         paths=("mkosi.tools",),
         help="Look up programs to execute inside the given tree",
+        nargs="?",
+        const="default",
     ),
     ConfigSetting(
         dest="tools_tree_distribution",


### PR DESCRIPTION
Saves on typing and makes it easier to use overall.