### PR TITLE
action: Use aa-teardown to disable apparmor

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -44,8 +44,9 @@ runs:
   - name: Disable and mask apparmor service
     shell: bash
     run: |
-        sudo systemctl disable --now apparmor
-        sudo systemctl mask apparmor
+        # This command fails with a non-zero error code even though it unloads the apparmor profiles.
+        # https://gitlab.com/apparmor/apparmor/-/issues/403
+        sudo aa-teardown || true
         sudo apt-get remove apparmor
 
   - name: Dependencies


### PR DESCRIPTION
systemctl stop apparmor doesn't seem to be sufficient, aa-teardown on the other hand seems to do the trick.