### PR TITLE
Set default output name for `mkosi-tools` to `mkosi.tools`

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf
@@ -2,6 +2,7 @@
 
 [Output]
 Format=directory
+@Output=mkosi.tools
 ManifestFormat=
 
 [Content]


### PR DESCRIPTION
This should allow one to invoke `mkosi --directory "" --include mkosi-tools` in the project root to create a tools tree that is automatically detected and used in subsequent invocations.