### PR TITLE
Add nosuid,noexec and nodev where appropriate when remounting

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4609,7 +4609,8 @@ def run_build(args: Args, config: Config, *, resources: Path) -> None:
 
     for d in remount:
         if Path(d).exists():
-            run(["mount", "--rbind", d, d, "--options", "ro"])
+            options = "ro" if d in ("/usr", "/opt") else "ro,nosuid,nodev,noexec"
+            run(["mount", "--rbind", d, d, "--options", options])
 
     with (
         complete_step(f"Building {config.name()} image"),


### PR DESCRIPTION
If not we get permission errors if the host mount uses nosuid,noexec or nodev.

Fixes #2776