### PR TITLE
centos: Change local rpm GPG key location

### DIFF
--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -102,7 +102,7 @@ class Installer(DistributionInstaller):
 
     @staticmethod
     def gpgurls(context: Context) -> tuple[str, ...]:
-        keys = ("RPM-GPG-KEY-CentOS-Official", "RPM-GPG-KEY-CentOS-SIG-Extras")
+        keys = (f"RPM-GPG-KEY-CentOS-{context.config.release}", "RPM-GPG-KEY-CentOS-SIG-Extras")
         return tuple(find_rpm_gpgkey(context, key) or f"https://www.centos.org/keys/{key}" for key in keys)
 
     @classmethod


### PR DESCRIPTION
Let's look for the one suffixed with the release number. This doesn't change behavior for c9s as this is a symlink to the file we looked for previously but will fix our behavior for c10s which uses a different key.