### PR TITLE
centos: Fix GPG key search logic

### DIFF
--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -102,8 +102,11 @@ class Installer(DistributionInstaller):
 
     @staticmethod
     def gpgurls(context: Context) -> tuple[str, ...]:
-        keys = (f"RPM-GPG-KEY-CentOS-{context.config.release}", "RPM-GPG-KEY-CentOS-SIG-Extras")
-        return tuple(find_rpm_gpgkey(context, key) or f"https://www.centos.org/keys/{key}" for key in keys)
+        rel = "RPM-GPG-KEY-CentOS-Official" if context.config.release == "9" else "RPM-GPG-KEY-CentOS-Official-SHA256"
+        return tuple(
+            find_rpm_gpgkey(context, key) or f"https://www.centos.org/keys/{key}"
+            for key in (rel, "RPM-GPG-KEY-CentOS-SIG-Extras")
+        )
 
     @classmethod
     def repository_variants(cls, context: Context, repo: str) -> Iterable[RpmRepository]:


### PR DESCRIPTION
Let's only look for the release key of the release we're building for and add support for searching for the SHA256 key which is used by centos stream 10.

We can't use the symlinked names because those don't exist on centos.org/keys.