### PR TITLE
centos: Support building centos stream 10 default images

### DIFF
--- a/mkosi.conf.d/20-centos.conf
+++ b/mkosi.conf.d/20-centos.conf
@@ -7,10 +7,10 @@ Distribution=|rocky
 
 [Distribution]
 @Release=9
-Repositories=epel
-             epel-next
 
 [Content]
+# CentOS Stream 10 does not ship an unsigned shim
+@ShimBootloader=none
 Packages=
         linux-firmware
         dnf

--- a/mkosi.conf.d/20-fedora/mkosi.conf
+++ b/mkosi.conf.d/20-fedora/mkosi.conf
@@ -8,11 +8,16 @@ Distribution=fedora
 
 [Content]
 Packages=
+        apt
         archlinux-keyring
         btrfs-progs
+        debian-keyring
+        distribution-gpg-keys
         dnf5
         dnf5-plugins
+        erofs-utils
         pacman
         qemu-user-static
+        systemd-networkd
         systemd-ukify
         zypper

--- a/mkosi.conf.d/20-fedora/mkosi.conf.d/20-uefi.conf
+++ b/mkosi.conf.d/20-fedora/mkosi.conf.d/20-uefi.conf
@@ -7,3 +7,4 @@ Architecture=|arm64
 [Content]
 Packages=
         sbsigntools
+        shim-unsigned-x64

--- a/mkosi.conf.d/30-centos-fedora/mkosi.conf
+++ b/mkosi.conf.d/30-centos-fedora/mkosi.conf
@@ -8,18 +8,14 @@ Distribution=|fedora
 
 [Content]
 Packages=
-        apt
         bash
         bubblewrap
         ca-certificates
         coreutils
         cpio
         curl-minimal
-        debian-keyring
-        distribution-gpg-keys
         dosfstools
         e2fsprogs
-        erofs-utils
         git-core
         iproute
         iputils
@@ -38,7 +34,6 @@ Packages=
         swtpm
         systemd
         systemd-container
-        systemd-networkd
         systemd-resolved
         systemd-udev
         tar

--- a/mkosi.conf.d/30-centos-fedora/mkosi.conf.d/20-uefi.conf
+++ b/mkosi.conf.d/30-centos-fedora/mkosi.conf.d/20-uefi.conf
@@ -12,5 +12,4 @@ Packages=
         kernel-uki-virt
         pesign
         shim
-        shim-unsigned-x64
         systemd-boot


### PR DESCRIPTION
Stream 10 does not have EPEL yet so we make those few packages Fedora only for now.