### PR TITLE
chdir into /proc for determining default Config

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4375,7 +4375,8 @@ def check_workspace_directory(config: Config) -> None:
     for tree in config.build_sources:
         if wd.is_relative_to(tree.source):
             die(f"The workspace directory ({wd}) cannot be a subdirectory of any source directory ({tree.source})",
-                hint="Use WorkspaceDirectory= to configure a different workspace directory")
+                hint="Set BuildSources= to the empty string or use WorkspaceDirectory= to configure a different "
+                     "workspace directory")
 
 
 def run_clean_scripts(config: Config) -> None:

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1556,7 +1556,7 @@ class Config:
 
         This prevents MkosiArgs being generated with defaults values implicitly.
         """
-        with chdir("/"):
+        with chdir("/proc"):
             _, [config] = parse_config([])
 
         return config


### PR DESCRIPTION
There are users that run mkosi from / so let's use /proc instead.

Fixes https://github.com/systemd/mkosi/issues/2786