### PR TITLE
Skip vmlinuz in /boot without matching dir in /usr/lib/modules

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1696,7 +1696,7 @@ def fixup_vmlinuz_location(context: Context) -> None:
     for type in ("vmlinuz", "vmlinux"):
         for d in context.root.glob(f"boot/{type}-*"):
             kver = d.name.removeprefix(f"{type}-")
-            vmlinuz = context.root / "usr/lib/modules" / kver / f"{type}"
+            vmlinuz = context.root / "usr/lib/modules" / kver / type
             if not vmlinuz.parent.exists():
                 continue
             # Some distributions (OpenMandriva) symlink /usr/lib/modules/<kver>/vmlinuz to /boot/vmlinuz-<kver>, so

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1697,6 +1697,8 @@ def fixup_vmlinuz_location(context: Context) -> None:
         for d in context.root.glob(f"boot/{type}-*"):
             kver = d.name.removeprefix(f"{type}-")
             vmlinuz = context.root / "usr/lib/modules" / kver / f"{type}"
+            if not vmlinuz.parent.exists():
+                continue
             # Some distributions (OpenMandriva) symlink /usr/lib/modules/<kver>/vmlinuz to /boot/vmlinuz-<kver>, so
             # get rid of the symlink and copy the actual vmlinuz to /usr/lib/modules/<kver>.
             if vmlinuz.is_symlink() and vmlinuz.is_relative_to("/boot"):


### PR DESCRIPTION
Fixes #2796