### PR TITLE
Don't rename vmlinux to vmlinuz when copying from /boot to /usr

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1711,8 +1711,7 @@ def fixup_vmlinuz_location(context: Context) -> None:
             if vmlinuz.is_symlink() and vmlinuz.is_relative_to("/boot"):
                 vmlinuz.unlink()
             if not vmlinuz.exists():
-                # Rename vmlinux -> vmlinuz when copying
-                shutil.copy2(d, vmlinuz.with_name("vmlinuz"))
+                shutil.copy2(d, vmlinuz)
 
 
 def gen_kernel_images(context: Context) -> Iterator[tuple[str, Path]]:


### PR DESCRIPTION
We only want to rename vmlinux to vmlinuz when copying to the output directory. In the image itself we can keep using the same name.

Follow up for 6972f9efba5c8472d990be3783b7e7dbf76e109e