### PR TITLE
mkosi-tools: Install distribution-gpg-keys in Arch Linux default tools tree

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-arch.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-arch.conf
@@ -13,6 +13,7 @@ Packages=
         dbus-broker
         dbus-broker-units
         debian-archive-keyring
+        distribution-gpg-keys
         dpkg
         edk2-ovmf
         erofs-utils


### PR DESCRIPTION
It was recently packaged in the extra repository.