### PR TITLE
Deal with systemd split packages added in Debian testing

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-ubuntu/mkosi.conf
@@ -9,6 +9,10 @@ Packages=
         kmod     # Not pulled in as a dependency on Debian/Ubuntu
         dmsetup  # Not pulled in as a dependency on Debian/Ubuntu
 
+        ?exact-name(systemd-cryptsetup)
+        ?exact-name(systemd-repart)
+        libcryptsetup12
+
         # xfsprogs pulls in python on Debian (???) and XFS generally
         # isn't used on Debian so we don't install xfsprogs.
         e2fsprogs

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu.conf
@@ -6,6 +6,7 @@ Distribution=|ubuntu
 
 [Content]
 Packages=
+        ?exact-name(systemd-repart)
         ?exact-name(systemd-ukify)
         apt
         archlinux-keyring
@@ -17,6 +18,7 @@ Packages=
         git-core
         grub2
         libarchive-tools
+        libcryptsetup12
         libtss2-dev
         makepkg
         openssh-client

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu.conf
@@ -30,7 +30,6 @@ Packages=
         python3-pefile
         qemu-system
         reprepro
-        virtiofsd
         sbsigntool
         squashfs-tools
         swtpm-tools
@@ -40,5 +39,6 @@ Packages=
         systemd-journal-remote
         ubuntu-keyring
         uidmap
+        virtiofsd
         xz-utils
         zypper


### PR DESCRIPTION
systemd-repart and systemd-cryptsetup were moved to subpackages in Debian testing. Let's make sure we account for that in mkosi-tools and mkosi-initrd.