### PR TITLE
Update mkosi apt sources location in kernel-install plugin

### DIFF
--- a/kernel-install/50-mkosi.install
+++ b/kernel-install/50-mkosi.install
@@ -155,7 +155,7 @@ def main() -> None:
         # Make sure we don't use any of mkosi's default repositories.
         for p in (
             "yum.repos.d/mkosi.repo",
-            "apt/sources.list",
+            "apt/sources.list.d/mkosi.sources",
             "zypp/repos.d/mkosi.repo",
             "pacman.conf",
         ):


### PR DESCRIPTION
This was changed in cffddd87776178f19d9a7a633aa597cc9e49722f so let's accomodate for that in the kernel-install plugin.