### PR TITLE
Fix mirror paths for centos/fedora family of distributions.

### DIFF
--- a/mkosi/distributions/alma.py
+++ b/mkosi/distributions/alma.py
@@ -22,7 +22,7 @@ class Installer(centos.Installer):
     @classmethod
     def repository_variants(cls, context: Context, repo: str) -> list[RpmRepository]:
         if context.config.mirror:
-            url = f"baseurl={join_mirror(context.config.mirror, f'almalinux/$releasever/{repo}/$basearch/os')}"
+            url = f"baseurl={join_mirror(context.config.mirror, f'$releasever/{repo}/$basearch/os')}"
         else:
             url = f"mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/{repo.lower()}"
 

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -117,12 +117,12 @@ class Installer(DistributionInstaller):
             if repo == "extras":
                 yield RpmRepository(
                     repo.lower(),
-                    f"baseurl={join_mirror(mirror, f'centos-stream/SIGs/$stream/{repo}/$basearch/extras-common')}",
+                    f"baseurl={join_mirror(mirror, f'SIGs/$stream/{repo}/$basearch/extras-common')}",
                     cls.gpgurls(context),
                 )
                 yield RpmRepository(
                     f"{repo.lower()}-source",
-                    f"baseurl={join_mirror(mirror, f'centos-stream/SIGs/$stream/{repo}/source/extras-common')}",
+                    f"baseurl={join_mirror(mirror, f'SIGs/$stream/{repo}/source/extras-common')}",
                     cls.gpgurls(context),
                     enabled=False,
                 )
@@ -130,18 +130,18 @@ class Installer(DistributionInstaller):
             else:
                 yield RpmRepository(
                     repo.lower(),
-                    f"baseurl={join_mirror(mirror, f'centos-stream/$stream/{repo}/$basearch/os')}",
+                    f"baseurl={join_mirror(mirror, f'$stream/{repo}/$basearch/os')}",
                     cls.gpgurls(context),
                 )
                 yield RpmRepository(
                     f"{repo.lower()}-debuginfo",
-                    f"baseurl={join_mirror(mirror, f'centos-stream/$stream/{repo}/$basearch/debug/tree')}",
+                    f"baseurl={join_mirror(mirror, f'$stream/{repo}/$basearch/debug/tree')}",
                     cls.gpgurls(context),
                     enabled=False,
                 )
                 yield RpmRepository(
                     f"{repo.lower()}-source",
-                    f"baseurl={join_mirror(mirror, f'centos-stream/$stream/{repo}/source/tree')}",
+                    f"baseurl={join_mirror(mirror, f'$stream/{repo}/source/tree')}",
                     cls.gpgurls(context),
                     enabled=False,
                 )
@@ -213,21 +213,25 @@ class Installer(DistributionInstaller):
                 ("epel-testing", "epel/testing"),
                 ("epel-next-testing", "epel/testing/next")
             ):
+                # For EPEL we make the assumption that epel is mirrored in the parent directory of the mirror URL and
+                # path we were given. Since this doesn't work for all scenarios, we also allow overriding the mirror
+                # via ane environment variable.
+                url = context.config.environment.get("EPEL_MIRROR", join_mirror(mirror, "../fedora"))
                 yield RpmRepository(
                     repo,
-                    f"baseurl={join_mirror(mirror, f'fedora/{dir}/$releasever/Everything/$basearch')}",
+                    f"baseurl={url}/{dir}/$releasever/Everything/$basearch",
                     gpgurls,
                     enabled=False,
                 )
                 yield RpmRepository(
                     f"{repo}-debuginfo",
-                    f"baseurl={join_mirror(mirror, f'fedora/{dir}/$releasever/Everything/$basearch/debug')}",
+                    f"baseurl={url}/{dir}/$releasever/Everything/$basearch/debug",
                     gpgurls,
                     enabled=False,
                 )
                 yield RpmRepository(
                     f"{repo}-source",
-                    f"baseurl={join_mirror(mirror, f'fedora/{dir}/$releasever/Everything/source/tree')}",
+                    f"baseurl={url}/{dir}/$releasever/Everything/source/tree",
                     gpgurls,
                     enabled=False,
                 )
@@ -305,21 +309,21 @@ class Installer(DistributionInstaller):
                 if mirror := context.config.mirror:
                     yield RpmRepository(
                         f"{sig}-{c}",
-                        f"baseurl={join_mirror(mirror, f'centos-stream/SIGs/$stream/{sig}/$basearch/{c}')}",
+                        f"baseurl={join_mirror(mirror, f'SIGs/$stream/{sig}/$basearch/{c}')}",
                         gpgurls,
                         enabled=False,
                         priority=CENTOS_SIG_REPO_PRIORITY,
                     )
                     yield RpmRepository(
                         f"{sig}-{c}-debuginfo",
-                        f"baseurl={join_mirror(mirror, f'centos-stream/SIGs/$stream/{sig}/$basearch/{c}/debug')}",
+                        f"baseurl={join_mirror(mirror, f'SIGs/$stream/{sig}/$basearch/{c}/debug')}",
                         gpgurls,
                         enabled=False,
                         priority=CENTOS_SIG_REPO_PRIORITY,
                     )
                     yield RpmRepository(
                         f"{sig}-{c}-source",
-                        f"baseurl={join_mirror(mirror, f'centos-stream/SIGs/$stream/{sig}/source/{c}')}",
+                        f"baseurl={join_mirror(mirror, f'SIGs/$stream/{sig}/source/{c}')}",
                         gpgurls,
                         enabled=False,
                         priority=CENTOS_SIG_REPO_PRIORITY,

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -113,18 +113,18 @@ class Installer(DistributionInstaller):
                 yield RpmRepository(repo.lower(), f"{url}/source/tree", gpgurls, enabled=False)
         elif (m := context.config.mirror):
             directory = "development" if context.config.release == "rawhide" else "releases"
-            url = f"baseurl={join_mirror(m, f'fedora/linux/{directory}/$releasever/Everything')}"
+            url = f"baseurl={join_mirror(m, f'linux/{directory}/$releasever/Everything')}"
             yield RpmRepository("fedora", f"{url}/$basearch/os", gpgurls)
             yield RpmRepository("fedora-debuginfo", f"{url}/$basearch/debug/tree", gpgurls, enabled=False)
             yield RpmRepository("fedora-source", f"{url}/source/tree", gpgurls, enabled=False)
 
             if context.config.release != "rawhide":
-                url = f"baseurl={join_mirror(m, 'fedora/linux/updates/$releasever/Everything')}"
+                url = f"baseurl={join_mirror(m, 'linux/updates/$releasever/Everything')}"
                 yield RpmRepository("updates", f"{url}/$basearch", gpgurls)
                 yield RpmRepository("updates-debuginfo", f"{url}/$basearch/debug", gpgurls, enabled=False)
                 yield RpmRepository("updates-source", f"{url}/source/tree", gpgurls, enabled=False)
 
-                url = f"baseurl={join_mirror(m, 'fedora/linux/updates/testing/$releasever/Everything')}"
+                url = f"baseurl={join_mirror(m, 'linux/updates/testing/$releasever/Everything')}"
                 yield RpmRepository("updates-testing", f"{url}/$basearch", gpgurls, enabled=False)
                 yield RpmRepository("updates-testing-debuginfo", f"{url}/$basearch/debug", gpgurls, enabled=False)
                 yield RpmRepository("updates-testing-source", f"{url}/source/tree", gpgurls, enabled=False)

--- a/mkosi/distributions/rocky.py
+++ b/mkosi/distributions/rocky.py
@@ -22,7 +22,7 @@ class Installer(centos.Installer):
     @classmethod
     def repository_variants(cls, context: Context, repo: str) -> list[RpmRepository]:
         if context.config.mirror:
-            url = f"baseurl={join_mirror(context.config.mirror, f'rocky/$releasever/{repo}/$basearch/os')}"
+            url = f"baseurl={join_mirror(context.config.mirror, f'$releasever/{repo}/$basearch/os')}"
         else:
             url = f"mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo={repo}-$releasever"
 

--- a/mkosi/distributions/ubuntu.py
+++ b/mkosi/distributions/ubuntu.py
@@ -67,9 +67,9 @@ class Installer(debian.Installer):
 
         # Security updates repos are never mirrored. But !x86 are on the ports server.
         if context.config.architecture.is_x86_variant():
-            mirror = "http://security.ubuntu.com/ubuntu/"
+            mirror = "http://security.ubuntu.com/ubuntu"
         else:
-            mirror = "http://ports.ubuntu.com/"
+            mirror = "http://ports.ubuntu.com"
 
         yield AptRepository(
             types=types,

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -2445,6 +2445,13 @@ repository.
 * `$MKOSI_DNF` can be used to override the executable used as `dnf`.
   This is particularly useful to select between `dnf` and `dnf5`.
 
+* `$EPEL_MIRROR` can be used to override the default mirror location
+  used for the epel repositories when `Mirror=` is used. By default
+  mkosi looks for the epel repositories in the `fedora` subdirectory of
+  the parent directory of the mirror specified in `Mirror=`. For example
+  if the mirror is set to `https://mirror.net/centos-stream` mkosi will
+  look for the epel repositories in `https://mirror.net/fedora/epel`.
+
 # EXAMPLES
 
 Create and run a raw *GPT* image with *ext4*, as `image.raw`:


### PR DESCRIPTION
We assumed that fedora would always be in the fedora subdirectory of the mirror and that centos would always be in the centos-stream subdirectory of the mirror but this is not guaranteed to be true (see https://pagure.io/centos-infra/issue/1430).

Let's fix this by not always appending centos-stream/ or fedora/ to the given mirror so the user can determine whether to include this or not.

This is a breaking change but making sure all mirrors can be used regardless of layout seems more important in this case.

For EPEL we do make a bigger assumption on the mirror layout since we're forced to as we don't have a mechanism to specify more than one mirror.