### PR TITLE
doc: distribution-gpg-keys is available in Arch Linux

### DIFF
--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -1481,7 +1481,7 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     | `curl`                  | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `debian-keyring`        | ✓      | ✓      | ✓      | ✓      | ✓    |          |
     | `diffutils`             | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
-    | `distribution-gpg-keys` | ✓      | ✓      |        |        |      | ✓        |
+    | `distribution-gpg-keys` | ✓      | ✓      |        |        | ✓    | ✓        |
     | `dnf`                   | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `dnf-plugins-core`      | ✓      | ✓      |        |        |      | ✓        |
     | `dnf5`                  | ✓      |        |        |        |      |          |


### PR DESCRIPTION
This package is available in the Arch Linux repositories since 2024-06-19.