### PR TITLE
Make sure policy-rc.d parent directory exists

### DIFF
--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -196,6 +196,8 @@ class Installer(DistributionInstaller):
         # Note: despite writing in /usr/sbin, this file is not shipped by the OS and instead should be managed by
         # the admin.
         policyrcd = context.root / "usr/sbin/policy-rc.d"
+        with umask(~0o755):
+            policyrcd.parent.mkdir(parents=True, exist_ok=True)
         with umask(~0o644):
             policyrcd.write_text("#!/bin/sh\nexit 101\n")
 


### PR DESCRIPTION
If BaseTrees= is used /usr/sbin might not exist so let's make sure it does to avoid failing with an incomprehensible exception.