### PR TITLE
Pick up GNUPGHOME from user's environment

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3830,6 +3830,8 @@ def load_environment(args: argparse.Namespace) -> dict[str, str]:
         env["GIT_PROXY_SSL_KEY"] = "/proxy.clientkey"
     if dnf := os.getenv("MKOSI_DNF"):
         env["MKOSI_DNF"] = dnf
+    if gnupghome := os.getenv("GNUPGHOME"):
+        env["GNUPGHOME"] = gnupghome
 
     env |= dict(parse_environment(line) for f in args.environment_files for line in f.read_text().strip().splitlines())
     env |= args.environment


### PR DESCRIPTION
If not set in Environment=, we default to the user's home directory. Let's instead use GNUPGHOME from the user's environment if it is set before falling back to the user's home directory.

Fixes #2815.