### PR TITLE
Resolve source symlink in install_tree()

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1558,6 +1558,8 @@ def install_tree(
     target: Optional[Path] = None,
     preserve: bool = True,
 ) -> None:
+    src = src.resolve()
+
     t = dst
     if target:
         t = dst / target.relative_to("/")


### PR DESCRIPTION
We do a bunch of checks on file extension and such, and those should be done on the resolved filename and not on a symlink.