### PR TITLE
Add mirror to package cache key if one is specified

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1542,10 +1542,10 @@ class Config:
         return Path("/var/tmp")
 
     def package_cache_dir_or_default(self) -> Path:
-        return (
-            self.package_cache_dir or
-            (INVOKING_USER.cache_dir() / f"{self.distribution}~{self.release}~{self.architecture}")
-        )
+        key = f"{self.distribution}~{self.release}~{self.architecture}"
+        if self.mirror:
+            key += f"-{self.mirror}"
+        return self.package_cache_dir or (INVOKING_USER.cache_dir() / key)
 
     def tools(self) -> Path:
         return self.tools_tree or Path("/")


### PR DESCRIPTION
On Arch Linux, pacman seems to only check if the sync db on the mirror is newer than the one available locally, which breaks when using e.g. the archive where the sync db is older by definition.

Let's add any specified mirror to the default package cache dir key to make sure that a different cache is used for explicitly specified mirrors.