### PR TITLE
Always rerun build if Format=none and don't remove previous outputs

### DIFF
--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -516,6 +516,12 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     include it in the kernel command line of every unified kernel image
     built by mkosi.
 
+    If the `none` output format is used, the outputs from a previous
+    build are not removed, but clean scripts (see `CleanScripts=`) are
+    still executed. This allows rerunning a build script
+    (see `BuildScripts=`) without removing the results of a previous
+    build.
+
 `ManifestFormat=`, `--manifest-format=`
 :   The manifest format type or types to generate. A comma-delimited
     list consisting of `json` (the standard JSON output format that


### PR DESCRIPTION
Let's always rerun the build if Format=none. Also, since we know Format=none won't touch any of the outputs we know about, let's keep the existing outputs intact. This allows using Format=none to rerun the build script without removing the existing output (e.g. directory or disk image).

We'll be able to make use of this in mkosi-kernel to rebuild the kernel modules without removing the disk image produced in a previous step.

We also simplify check_outputs() to only check the main output and not the auxiliary outputs.