### PR TITLE
Use fstab.extra instead of kernel command line for extra mounts

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3760,6 +3760,7 @@ def load_kernel_command_line_extra(args: argparse.Namespace) -> list[str]:
     term = finalize_term()
 
     cmdline = [
+        "rw",
         # Make sure we set up networking in the VM/container.
         "systemd.wants=network.target",
         # Make sure we don't load vmw_vmci which messes with virtio vsock.

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -1048,7 +1048,7 @@ def run_qemu(args: Args, config: Config) -> None:
             if credentials["fstab.extra"] and not credentials["fstab.extra"][-1] == "\n":
                 credentials["fstab.extra"] += "\n"
 
-            credentials["fstab.extra"] += f"{tag} {dst} virtiofs\n"
+            credentials["fstab.extra"] += f"{tag} {dst} virtiofs x-initrd.mount\n"
 
         if config.runtime_build_sources:
             with finalize_source_mounts(config, ephemeral=False) as mounts:

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -1026,7 +1026,7 @@ def run_qemu(args: Args, config: Config) -> None:
                     "-chardev", f"socket,id={sock.name},path={sock}",
                     "-device", f"vhost-user-fs-pci,queue-size=1024,chardev={sock.name},tag=root",
                 ]
-                kcl += ["root=root", "rootfstype=virtiofs", "rw"]
+                kcl += ["root=root", "rootfstype=virtiofs"]
 
         def add_virtiofs_mount(
             sock: Path,


### PR DESCRIPTION
Kernel command line space is very limited, so let's use credentials
where we can instead.
