### PR TITLE
Call rmtree() on context.root after finalize_staging()

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3835,6 +3835,7 @@ def build_image(context: Context) -> None:
 
         if context.config.output_format == OutputFormat.none:
             finalize_staging(context)
+            rmtree(context.root)
             return
 
         install_volatile_packages(context)
@@ -3928,6 +3929,7 @@ def build_image(context: Context) -> None:
 
     run_postoutput_scripts(context)
     finalize_staging(context)
+    rmtree(context.root)
 
     print_output_size(context.config.output_dir_or_cwd() / context.config.output_with_compression)
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -4251,10 +4251,23 @@ def json_type_transformer(refcls: Union[type[Args], type[Config]]) -> Callable[[
         if fieldtype is None:
             raise ValueError(f"{refcls} has no field {key}")
 
-        transformer = cast(Optional[Callable[[str, type], Any]], transformers.get(fieldtype.type))
+        # TODO: Remove type: ignore once we figure out the following pyright error:
+        # /home/runner/work/mkosi/mkosi/mkosi/config.py:4255:83 - error: Argument of type "Any | str" cannot be
+        #       assigned to parameter "key" of type "type[Path] | type[None] | type[list[Path]] | type[UUID] |
+        #       type[tuple[str, bool]] | type[list[ConfigTree]] | type[tuple[str, ...]] | type[Architecture] |
+        #       type[BiosBootloader] | type[ShimBootloader] | type[Bootloader] | type[Compression] |
+        #       type[ConfigFeature] | type[Distribution] | type[OutputFormat] | type[QemuFirmware] |
+        #       type[SecureBootSignTool] | type[list[ManifestFormat]] | type[Verb] | type[DocFormat] |
+        #       type[list[QemuDrive]] | type[GenericVersion] | type[Cacheonly] | type[Network] |
+        #       type[KeySource] | type[Vmm]" in function "get" (reportArgumentType)
+        #     /home/runner/work/mkosi/mkosi/mkosi/config.py:4258:41 - error: Argument of type "Any | str" cannot be
+        #        assigned to parameter of type "type"
+        #         Type "Any | str" is incompatible with type "type"
+        #         "str" is incompatible with "type" (reportArgumentType)
+        transformer = cast(Optional[Callable[[str, type], Any]], transformers.get(fieldtype.type)) # type: ignore
         if transformer is not None:
             try:
-                return transformer(val, fieldtype.type)
+                return transformer(val, fieldtype.type) # type: ignore
             except (ValueError, IndexError, AssertionError) as e:
                 raise ValueError(f"Unable to parse {val:r} for attribute {key:r} for {refcls.__name__}") from e
 

--- a/mkosi/tree.py
+++ b/mkosi/tree.py
@@ -149,7 +149,7 @@ def rmtree(*paths: Path, sandbox: SandboxProtocol = nosandbox) -> None:
     if not paths:
         return
 
-    if subvolumes := sorted({p for p in paths if is_subvolume(p, sandbox=sandbox)}):
+    if subvolumes := sorted({p for p in paths if p.exists() and is_subvolume(p, sandbox=sandbox)}):
         # Silence and ignore failures since when not running as root, this will fail with a permission error unless the
         # btrfs filesystem is mounted with user_subvol_rm_allowed.
         run(["btrfs", "subvolume", "delete", *subvolumes],


### PR DESCRIPTION
After we've finalized the staging directory, there is no more need
for the root directory in the workspace. It used to get cleaned by
the setup_workspace() context manager but this is rather slow (can
take more than a second). By calling rmtree() explicitly, if we're
on a btrfs filesystem, we'll call btrfs subvolume delete which is
much faster than rm.