### PR TITLE
use virtio console in x86

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -429,6 +429,8 @@ class Architecture(StrEnum):
             Architecture.ppc      : "hvc0",
             Architecture.ppc64    : "hvc0",
             Architecture.ppc64_le : "hvc0",
+            Architecture.x86      : "hvc0",
+            Architecture.x86_64   : "hvc0",
         }.get(self, "ttyS0")
 
     def supports_smbios(self, firmware: QemuFirmware) -> bool:

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -937,9 +937,18 @@ def run_qemu(args: Args, config: Config) -> None:
             "-nographic",
             "-nodefaults",
             "-chardev", "stdio,mux=on,id=console,signal=off",
-            "-serial", "chardev:console",
             "-mon", "console",
         ]
+        if ((config.architecture.to_qemu() == "i386" or config.architecture.to_qemu() == "x86_64")
+            and config.architecture.default_serial_tty() == "hvc0"):
+            cmdline += [
+                "-device", "virtio-serial-pci,id=virtio-serial0",
+                "-device", "virtconsole,bus=virtio-serial0.0,chardev=console",
+            ]
+        else:
+            cmdline += [
+                "-serial", "chardev:console",
+            ]
 
     # QEMU has built-in logic to look for the BIOS firmware so we don't need to do anything special for that.
     if firmware.is_uefi():


### PR DESCRIPTION
Use the VirtIO console device instead of the emulated one on x86. The console output is ~16x faster, and it's very noticeable with scrolling output or interactive tools like `htop`

Emulated device:
```
time hexdump -vC -n200000 /dev/zero

real	0m6.756s
user	0m0.035s
sys	0m6.714s
```

VirtIO console
```
time hexdump -vC -n200000 /dev/zero

real	0m0.421s
user	0m0.040s
sys	0m0.376s
```