### PR TITLE
Use qemu's virtconsole for the serial console

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # mkosi Changelog
 
+## v24
+
+- The default kernel command line of `console=ttyS0` (or equivalent for
+  other architectures) has been removed. The required `console=`
+  argument to have the kernel output to the serial console has to be
+  added manually from `v24` onwards.
+
 ## v23.1
 
 - Respin due to git tag mismatch

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -34,7 +34,7 @@ RemoveFiles=
         /usr/lib/kernel/install.d/50-dracut.install
 
 # Make sure that SELinux doesn't run in enforcing mode even if it's pulled in as a dependency.
-KernelCommandLine=console=ttyS0 enforcing=0
+KernelCommandLine=enforcing=0
 
 [Host]
 @QemuMem=4G

--- a/mkosi.conf.d/20-fedora/mkosi.conf
+++ b/mkosi.conf.d/20-fedora/mkosi.conf
@@ -19,5 +19,4 @@ Packages=
         pacman
         qemu-user-static
         systemd-networkd
-        systemd-ukify
         zypper

--- a/mkosi.conf.d/20-fedora/mkosi.conf.d/20-uefi.conf
+++ b/mkosi.conf.d/20-fedora/mkosi.conf.d/20-uefi.conf
@@ -7,3 +7,4 @@ Architecture=|arm64
 [Content]
 Packages=
         sbsigntools
+        systemd-ukify

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -323,13 +323,9 @@ def configure_autologin(context: Context) -> None:
                                     "--noclear --keep-baud console 115200,38400,9600")
         configure_autologin_service(context, "getty@tty1.service",
                                     "--noclear -")
-        configure_autologin_service(context, "serial-getty@ttyS0.service",
+        configure_autologin_service(context,
+                                    "serial-getty@hvc0.service",
                                     "--keep-baud 115200,57600,38400,9600 -")
-
-        if context.config.architecture.default_serial_tty() != "ttyS0":
-            configure_autologin_service(context,
-                                        f"serial-getty@{context.config.architecture.default_serial_tty()}.service",
-                                        "--keep-baud 115200,57600,38400,9600 -")
 
 
 @contextlib.contextmanager

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -420,17 +420,6 @@ class Architecture(StrEnum):
 
         return a
 
-    def default_serial_tty(self) -> str:
-        return {
-            Architecture.arm      : "ttyAMA0",
-            Architecture.arm64    : "ttyAMA0",
-            Architecture.s390     : "ttysclp0",
-            Architecture.s390x    : "ttysclp0",
-            Architecture.ppc      : "hvc0",
-            Architecture.ppc64    : "hvc0",
-            Architecture.ppc64_le : "hvc0",
-        }.get(self, "ttyS0")
-
     def supports_smbios(self, firmware: QemuFirmware) -> bool:
         if self.is_x86_variant():
             return True
@@ -3749,7 +3738,6 @@ def finalize_term() -> str:
 
 
 def load_kernel_command_line_extra(args: argparse.Namespace) -> list[str]:
-    tty = args.architecture.default_serial_tty()
     columns, lines = shutil.get_terminal_size()
     term = finalize_term()
 
@@ -3759,9 +3747,9 @@ def load_kernel_command_line_extra(args: argparse.Namespace) -> list[str]:
         "systemd.wants=network.target",
         # Make sure we don't load vmw_vmci which messes with virtio vsock.
         "module_blacklist=vmw_vmci",
-        f"systemd.tty.term.{tty}={term}",
-        f"systemd.tty.columns.{tty}={columns}",
-        f"systemd.tty.rows.{tty}={lines}",
+        f"systemd.tty.term.hvc0={term}",
+        f"systemd.tty.columns.hvc0={columns}",
+        f"systemd.tty.rows.hvc0={lines}",
     ]
 
     if not any(s.startswith("ip=") for s in args.kernel_command_line_extra):
@@ -3785,7 +3773,7 @@ def load_kernel_command_line_extra(args: argparse.Namespace) -> list[str]:
             f"systemd.tty.term.console={term}",
             f"systemd.tty.columns.console={columns}",
             f"systemd.tty.rows.console={lines}",
-            f"console={tty}",
+            "console=hvc0",
             f"TERM={term}",
         ]
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -741,10 +741,6 @@ def config_default_proxy_url(namespace: argparse.Namespace) -> Optional[str]:
     return None
 
 
-def config_default_kernel_command_line(namespace: argparse.Namespace) -> list[str]:
-    return [f"console={namespace.architecture.default_serial_tty()}"]
-
-
 def make_enum_parser(type: type[StrEnum]) -> Callable[[str], StrEnum]:
     def parse_enum(value: str) -> StrEnum:
         try:
@@ -2449,8 +2445,6 @@ SETTINGS = (
         metavar="OPTIONS",
         section="Content",
         parse=config_make_list_parser(delimiter=" "),
-        default_factory_depends=("architecture",),
-        default_factory=config_default_kernel_command_line,
         help="Set the kernel command line (only bootable images)",
     ),
     ConfigSetting(

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -937,7 +937,8 @@ def run_qemu(args: Args, config: Config) -> None:
             "-nographic",
             "-nodefaults",
             "-chardev", "stdio,mux=on,id=console,signal=off",
-            "-serial", "chardev:console",
+            "-device", "virtio-serial-pci,id=mkosi-virtio-serial-pci",
+            "-device", "virtconsole,chardev=console",
             "-mon", "console",
         ]
 

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -1065,8 +1065,6 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 `KernelCommandLine=`, `--kernel-command-line=`
 :   Use the specified kernel command line when building images.
-    Defaults to `console=ttyS0`. For `arm`, `s390` and `ppc`, `ttyS0` is replaced
-    with `ttyAMA0`, `ttysclp0` or `hvc0`, respectively.
 
 `KernelModulesInclude=`, `--kernel-modules-include=`
 :   Takes a list of regex patterns that specify kernel modules to include in the image. Patterns should be

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -1119,7 +1119,7 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 `Autologin=`, `--autologin`
 :   Enable autologin for the `root` user on `/dev/pts/0` (nspawn),
-    `/dev/tty1` and `/dev/ttyS0`.
+    `/dev/tty1` and `/dev/hvc0`.
 
 `MakeInitrd=`, `--make-initrd`
 :   Add `/etc/initrd-release` and `/init` to the image so that it can be

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,7 +13,7 @@ from typing import Any, Optional
 
 import pytest
 
-from mkosi.config import Architecture, finalize_term
+from mkosi.config import finalize_term
 from mkosi.distributions import Distribution
 from mkosi.run import run
 from mkosi.types import _FILE, CompletedProcess, PathString
@@ -58,7 +58,6 @@ class Image:
         check: bool = True,
     ) -> CompletedProcess:
         kcl = [
-            f"console={Architecture.native().default_serial_tty()}",
             f"TERM={finalize_term()}",
             "loglevel=6",
             "systemd.crash_shell",


### PR DESCRIPTION
edk2 now has a virtio serial driver so let's switch to virtconsole
for the serial console as it's significantly faster compared to the
old ISA serial console.