### PR TITLE
Add %F to access the default filesystem of a distribution

### DIFF
--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -1837,6 +1837,12 @@ There are also specifiers that are independent of settings:
 | `%P`      | Current working directory               |
 | `%D`      | Directory that mkosi was invoked in     |
 
+Finally, there are specifiers that are derived from a setting:
+
+| Specifier | Value                                                 |
+|-----------|-------------------------------------------------------|
+| `%F`      | The default filesystem of the configured distribution |
+
 Note that the current working directory changes as mkosi parses its
 configuration. Specifically, each time mkosi parses a directory
 containing a `mkosi.conf` file, mkosi changes its working directory to

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -966,6 +966,7 @@ def test_specifiers(tmp_path: Path) -> None:
                     ConfigRootDirectory=%D
                     ConfigRootConfdir=%C
                     ConfigRootPwd=%P
+                    Filesystem=%F
         """
     )
 
@@ -1008,6 +1009,7 @@ def test_specifiers(tmp_path: Path) -> None:
             "ConfigQedDirectory": os.fspath(d),
             "ConfigQedConfdir": os.fspath(d / "mkosi.conf.d/qed"),
             "ConfigQedPwd": os.fspath(d / "mkosi.conf.d/qed"),
+            "Filesystem": "ext4",
         }
 
         assert {k: v for k, v in config.environment.items() if k in expected} == expected


### PR DESCRIPTION
One annoyance about using mkosi.repart has always been that to keep using the default filesystem per distribution you have to write a lot of matches. Now that systemd-repart supports
$SYSTEMD_REPART_OVERRIDE_FSTYPE_ROOT, let's add a specifier to access the default filesystem so that it can be combined with the environment variable to get the same result.