### PR TITLE
opensuse: Add support for aarch64

### DIFF
--- a/mkosi.conf.d/15-x86-64.conf
+++ b/mkosi.conf.d/15-x86-64.conf
@@ -2,6 +2,10 @@
 
 [Match]
 Architecture=x86-64
+# We cannot install the grub tools in the OpenSUSE tools tree due to
+# https://bugzilla.opensuse.org/show_bug.cgi?id=1227464.
+# TODO: Remove this again when the above bug is resolved.
+ToolsTreeDistribution=!opensuse
 
 [Content]
 @BiosBootloader=grub

--- a/mkosi.conf.d/20-opensuse/mkosi.conf
+++ b/mkosi.conf.d/20-opensuse/mkosi.conf
@@ -12,9 +12,6 @@ Distribution=opensuse
 Packages=
         bash
         diffutils
-        grub2-efi
-        grub2-i386-pc
-        grub2-x86_64-efi
         iproute
         iputils
         kernel-kvmsmall
@@ -31,6 +28,3 @@ Packages=
         shim
         strace
         systemd-boot
-        systemd-coredump
-        ucode-amd
-        ucode-intel

--- a/mkosi.conf.d/20-opensuse/mkosi.conf.d/x86-64.conf
+++ b/mkosi.conf.d/20-opensuse/mkosi.conf.d/x86-64.conf
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Architecture=x86-64
+
+[Content]
+Packages=
+        grub2-efi
+        grub2-i386-pc
+        grub2-x86_64-efi
+        ucode-amd
+        ucode-intel

--- a/mkosi.conf.d/30-debian-ubuntu/mkosi.conf
+++ b/mkosi.conf.d/30-debian-ubuntu/mkosi.conf
@@ -22,6 +22,4 @@ Packages=
         strace
         systemd-coredump
         systemd-sysv
-        systemd-boot
-        systemd-resolved
         tzdata

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1277,7 +1277,11 @@ def find_grub_directory(context: Context, *, target: str) -> Optional[Path]:
 
 def find_grub_binary(config: Config, binary: str) -> Optional[Path]:
     assert "grub" not in binary
-    return config.find_binary(f"grub-{binary}", f"grub2-{binary}")
+
+    # Debian has a bespoke setup where if only grub-pc-bin is installed, grub-bios-setup is installed in
+    # /usr/lib/i386-pc instead of in /usr/bin. Let's take that into account and look for binaries in
+    # /usr/lib/grub/i386-pc as well.
+    return config.find_binary(f"grub-{binary}", f"grub2-{binary}", f"/usr/lib/grub/i386-pc/grub-{binary}")
 
 
 def want_grub_efi(context: Context) -> bool:

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos-fedora/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos-fedora/mkosi.conf
@@ -12,6 +12,7 @@ Packages=
         createrepo_c
         dnf-plugins-core
         git-core
+        grub2-tools
         openssh-clients
         policycoreutils
         python3-cryptography

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu/mkosi.conf
@@ -15,7 +15,7 @@ Packages=
         debian-archive-keyring
         erofs-utils
         git-core
-        grub2
+        grub-common
         libarchive-tools
         libcryptsetup12
         libtss2-dev

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu/mkosi.conf
@@ -27,6 +27,7 @@ Packages=
         policycoreutils
         python3-cryptography
         python3-pefile
+        qemu-efi-aarch64
         qemu-system
         reprepro
         sbsigntool

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu/mkosi.conf.d/grub.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-ubuntu/mkosi.conf.d/grub.conf
@@ -5,4 +5,4 @@ Architecture=x86-64
 
 [Content]
 Packages=
-        grub2-tools
+        grub-pc-bin

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-opensuse.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-opensuse.conf
@@ -16,7 +16,6 @@ Packages=
         git-core
         glibc-gconv-modules-extra
         grep
-        grub2
         openssh-clients
         ovmf
         patterns-base-minimal_base

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-opensuse.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-opensuse.conf
@@ -24,6 +24,8 @@ Packages=
         python3-pefile
         qemu-headless
         qemu-ipxe
+        qemu-ovmf-x86_64
+        qemu-uefi-aarch64
         reprepro
         sbsigntools
         shadow

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-opensuse.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-opensuse.conf
@@ -23,6 +23,7 @@ Packages=
         policycoreutils
         python3-pefile
         qemu-headless
+        qemu-ipxe
         reprepro
         sbsigntools
         shadow

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -1481,7 +1481,7 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     |                         | Fedora | CentOS | Debian | Ubuntu | Arch | openSUSE |
     |-------------------------|:------:|:------:|:------:|:------:|:----:|:--------:|
     | `acl`                   | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
-    | `apt`                   | ✓      | ✓      | ✓      | ✓      | ✓    |          |
+    | `apt`                   | ✓      |        | ✓      | ✓      | ✓    |          |
     | `archlinux-keyring`     | ✓      |        | ✓      | ✓      | ✓    |          |
     | `attr`                  | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `bash`                  | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
@@ -1491,9 +1491,9 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     | `coreutils`             | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `cpio`                  | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `curl`                  | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
-    | `debian-keyring`        | ✓      | ✓      | ✓      | ✓      | ✓    |          |
+    | `debian-keyring`        | ✓      |        | ✓      | ✓      | ✓    |          |
     | `diffutils`             | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
-    | `distribution-gpg-keys` | ✓      | ✓      |        |        | ✓    | ✓        |
+    | `distribution-gpg-keys` | ✓      |        |        |        | ✓    | ✓        |
     | `dnf`                   | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `dnf-plugins-core`      | ✓      | ✓      |        |        |      | ✓        |
     | `dnf5`                  | ✓      |        |        |        |      |          |
@@ -1525,7 +1525,7 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     | `systemd`               | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `ukify`                 | ✓      |        | ✓      | ✓      | ✓    | ✓        |
     | `tar`                   | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
-    | `ubuntu-keyring`        | ✓      | ✓      | ✓      | ✓      | ✓    |          |
+    | `ubuntu-keyring`        | ✓      |        | ✓      | ✓      | ✓    |          |
     | `util-linux`            | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `virtiofsd`             | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `virt-firmware`         | ✓      | ✓      |        |        | ✓    |          |

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -1505,6 +1505,7 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     | `findutils`             | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `git`                   | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `grep`                  | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
+    | `grub-tools`            | ✓      | ✓      | ✓      | ✓      | ✓    |          |
     | `jq`                    | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `kmod`                  | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `less`                  | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -68,7 +68,9 @@ def test_format(config: ImageConfig, format: OutputFormat) -> None:
         if have_vmspawn() and format in (OutputFormat.disk, OutputFormat.directory):
             image.vmspawn(options=options)
 
-        if format != OutputFormat.disk:
+        # TODO: Remove the opensuse check again when https://bugzilla.opensuse.org/show_bug.cgi?id=1227464 is resolved
+        # and we install the grub tools in the openSUSE tools tree again.
+        if format != OutputFormat.disk or config.tools_tree_distribution == Distribution.opensuse:
             return
 
         image.qemu(options=options + ["--qemu-firmware=bios"])
@@ -77,6 +79,11 @@ def test_format(config: ImageConfig, format: OutputFormat) -> None:
 @pytest.mark.parametrize("bootloader", Bootloader)
 def test_bootloader(config: ImageConfig, bootloader: Bootloader) -> None:
     if config.distribution == Distribution.rhel_ubi:
+        return
+
+    # TODO: Remove this again when https://bugzilla.opensuse.org/show_bug.cgi?id=1227464 is resolved and we install
+    # the grub tools in the openSUSE tools tree again.
+    if bootloader == Bootloader.grub and config.tools_tree_distribution == Distribution.opensuse:
         return
 
     firmware = QemuFirmware.linux if bootloader == Bootloader.none else QemuFirmware.auto


### PR DESCRIPTION
This requires another rework for the repositories() method for OpenSUSE. Whereas before we picked up all the repositories from https://download.opensuse.org/tumbleweed/repo/, it turns out that the debug and source repositories can also be found at https://download.opensuse.org/debug/tumbleweed/repo/ and https://download.opensuse.org/source/tumbleweed/repo/ respectively. Furthermore, the latter locations are the only ones that are available for ports under https://download.opensuse.org/ports/ so we switch to those instead.

Additionally, openSUSE-current is not available for ports so we disallow using current, stable and release with architectures other than x86-64.

While there are more ports than just aarch64, for now let's just add aarch64 and wait for user demand before we add any others.