### PR TITLE
run: Don't try to communicate inner pid for debug shell

### DIFF
--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -296,13 +296,14 @@ def spawn(
             os.close(w)
             w = q
             # dash doesn't support working with file descriptors higher than 9 so make sure we use bash.
-            prefix += ["bash", "-c", f"echo $$ >&{w} && exec {w}>&- && exec $0 \"$@\""]
+            innerpidcmd = ["bash", "-c", f"echo $$ >&{w} && exec {w}>&- && exec $0 \"$@\""]
         else:
+            innerpidcmd = []
             r, w = (None, None)
 
         try:
             with subprocess.Popen(
-                [*scope, *prefix, *cmdline],
+                [*scope, *prefix, *innerpidcmd, *cmdline],
                 stdin=stdin,
                 stdout=stdout,
                 stderr=stderr,


### PR DESCRIPTION
The pipe write end has already been closed by then so bash will fail with "bad file descriptor". Since there's no reason in having the inner pid in the debug shell let's make sure we don't try to communicate it there.