### PR TITLE
Enable EPEL again for CentOS default tools tree

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4695,7 +4695,10 @@ def run_verb(args: Args, images: Sequence[Config], *, resources: Path) -> None:
         return bump_image_version()
 
     if args.verb == Verb.dependencies:
-        _, [deps] = parse_config(["--directory", "", "--include=mkosi-tools", "build"], resources=resources)
+        _, [deps] = parse_config(
+            ["--directory", "", "--repositories", "", "--include=mkosi-tools", "build"],
+            resources=resources,
+        )
 
         for p in deps.packages:
             print(p)

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -557,6 +557,10 @@ def config_match_build_sources(match: str, value: list[ConfigTree]) -> bool:
     return Path(match.lstrip("/")) in [tree.target for tree in value if tree.target]
 
 
+def config_match_repositories(match: str, value: list[str]) -> bool:
+    return match in value
+
+
 def config_parse_string(value: Optional[str], old: Optional[str]) -> Optional[str]:
     return value or None
 
@@ -1927,6 +1931,7 @@ SETTINGS = (
         metavar="REPOS",
         section="Distribution",
         parse=config_make_list_parser(delimiter=","),
+        match=config_match_repositories,
         help="Repositories to use",
         universal=True,
     ),

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos-fedora/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos-fedora/mkosi.conf
@@ -24,6 +24,7 @@ Packages=
         systemd-container
         systemd-journal-remote
         systemd-udev
+        systemd-ukify
         virt-firmware
         virtiofsd
         xz

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos/mkosi.conf
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=centos

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos/mkosi.conf.d/10-epel.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos/mkosi.conf.d/10-epel.conf
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Release=9
+
+[Distribution]
+Repositories=epel,epel-next

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos/mkosi.conf.d/20-epel-packages.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos/mkosi.conf.d/20-epel-packages.conf
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Repositories=epel
+
+[Content]
+Packages=
+        apt
+        archlinux-keyring
+        debian-keyring
+        distribution-gpg-keys
+        pacman
+        sbsigntools
+        ubu-keyring

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-fedora/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-fedora/mkosi.conf
@@ -18,6 +18,5 @@ Packages=
         qemu-system-ppc-core
         qemu-system-s390x-core
         reprepro
-        systemd-ukify
         ubu-keyring
         zypper

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -1483,8 +1483,8 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     |                         | Fedora | CentOS | Debian | Ubuntu | Arch | openSUSE |
     |-------------------------|:------:|:------:|:------:|:------:|:----:|:--------:|
     | `acl`                   | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
-    | `apt`                   | ✓      |        | ✓      | ✓      | ✓    |          |
-    | `archlinux-keyring`     | ✓      |        | ✓      | ✓      | ✓    |          |
+    | `apt`                   | ✓      | ✓      | ✓      | ✓      | ✓    |          |
+    | `archlinux-keyring`     | ✓      | ✓      | ✓      | ✓      | ✓    |          |
     | `attr`                  | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `bash`                  | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `btrfs-progs`           | ✓      |        | ✓      | ✓      | ✓    | ✓        |
@@ -1493,9 +1493,9 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     | `coreutils`             | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `cpio`                  | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `curl`                  | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
-    | `debian-keyring`        | ✓      |        | ✓      | ✓      | ✓    |          |
+    | `debian-keyring`        | ✓      | ✓      | ✓      | ✓      | ✓    |          |
     | `diffutils`             | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
-    | `distribution-gpg-keys` | ✓      |        |        |        | ✓    | ✓        |
+    | `distribution-gpg-keys` | ✓      | ✓      |        |        | ✓    | ✓        |
     | `dnf`                   | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `dnf-plugins-core`      | ✓      | ✓      |        |        |      | ✓        |
     | `dnf5`                  | ✓      |        |        |        |      |          |
@@ -1516,19 +1516,19 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     | `openssh`               | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `openssl`               | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `sed`                   | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
-    | `pacman`                | ✓      |        | ✓      | ✓      | ✓    |          |
+    | `pacman`                | ✓      | ✓      | ✓      | ✓      | ✓    |          |
     | `pesign`                | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `policycoreutils`       | ✓      | ✓      | ✓      | ✓      |      | ✓        |
     | `qemu`                  | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
-    | `sbsigntools`           | ✓      |        | ✓      | ✓      | ✓    | ✓        |
+    | `sbsigntools`           | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `socat`                 | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `squashfs-tools`        | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `strace`                | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `swtpm`                 | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `systemd`               | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
-    | `ukify`                 | ✓      |        | ✓      | ✓      | ✓    | ✓        |
+    | `ukify`                 | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `tar`                   | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
-    | `ubuntu-keyring`        | ✓      |        | ✓      | ✓      | ✓    |          |
+    | `ubuntu-keyring`        | ✓      | ✓      | ✓      | ✓      | ✓    |          |
     | `util-linux`            | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `virtiofsd`             | ✓      | ✓      | ✓      | ✓      | ✓    | ✓        |
     | `virt-firmware`         | ✓      | ✓      |        |        | ✓    |          |

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -1683,6 +1683,10 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     and no architecture has been explicitly configured yet, the host
     architecture is used.
 
+`Repositories=`
+:   Matches against repositories enabled with the `Repositories=` setting.
+    Takes a single repository name.
+
 `PathExists=`
 :   This condition is satisfied if the given path exists. Relative paths are interpreted relative to the parent
     directory of the config file that the condition is read from.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -753,6 +753,25 @@ def test_match_build_sources(tmp_path: Path) -> None:
     assert config.output == "abc"
 
 
+def test_match_repositories(tmp_path: Path) -> None:
+    d = tmp_path
+
+    (d / "mkosi.conf").write_text(
+        """\
+        [Match]
+        Repositories=epel
+
+        [Content]
+        Output=qed
+        """
+    )
+
+    with chdir(d):
+        _, [config] = parse_config(["--repositories", "epel,epel-next"])
+
+    assert config.output == "qed"
+
+
 @pytest.mark.parametrize(
     "image1,image2", itertools.combinations_with_replacement(
         ["image_a", "image_b", "image_c"], 2


### PR DESCRIPTION
Now that we have a Repositories= match, we can conditionally enable
EPEL for CentOS Stream 9 only and override the repositories when we
call mkosi dependencies. This means that the CentOS Stream 9 default
tools tree will have all the EPEL packages but we won't list them in
the output of mkosi dependencies.

We also add various missing packages to the CentOS Stream default tools
tree.