### PR TITLE
Only install systemd-ukify on Fedora on UEFI architectures

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos-fedora/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos-fedora/mkosi.conf
@@ -24,7 +24,6 @@ Packages=
         systemd-container
         systemd-journal-remote
         systemd-udev
-        systemd-ukify
         virt-firmware
         virtiofsd
         xz

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-fedora/mkosi.conf.d/10-uefi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-fedora/mkosi.conf.d/10-uefi.conf
@@ -7,3 +7,4 @@ HostArchitecture=|arm64
 [Content]
 Packages=
         sbsigntools
+        systemd-ukify


### PR DESCRIPTION
- systemd-ukify is only available on Fedora on UEFI architectures, so let's not try to install it on other architectures.
- systemd-ukify is not in CentOS Stream 10 at the moment, so let's not try to install it on CentOS just yet.