### PR TITLE
Track local packages in cache manifest

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -591,6 +591,7 @@ def run_prepare_scripts(context: Context, build: bool) -> None:
                             Mount(json, "/work/config.json", ro=True),
                             Mount(context.root, "/buildroot"),
                             Mount(context.artifacts, "/work/artifacts"),
+                            Mount(context.repository, "/work/packages"),
                             *context.config.distribution.package_manager(context.config).mounts(context),
                         ],
                         options=["--dir", "/work/src", "--chdir", "/work/src"],
@@ -673,6 +674,7 @@ def run_build_scripts(context: Context) -> None:
                             Mount(context.install_dir, "/work/dest"),
                             Mount(context.staging, "/work/out"),
                             Mount(context.artifacts, "/work/artifacts"),
+                            Mount(context.repository, "/work/packages"),
                             *(
                                 [Mount(context.config.build_dir, "/work/build")]
                                 if context.config.build_dir
@@ -750,6 +752,7 @@ def run_postinst_scripts(context: Context) -> None:
                             Mount(context.root, "/buildroot"),
                             Mount(context.staging, "/work/out"),
                             Mount(context.artifacts, "/work/artifacts"),
+                            Mount(context.repository, "/work/packages"),
                             *context.config.distribution.package_manager(context.config).mounts(context),
                         ],
                         options=["--dir", "/work/src", "--chdir", "/work/src"],
@@ -816,6 +819,7 @@ def run_finalize_scripts(context: Context) -> None:
                             Mount(context.root, "/buildroot"),
                             Mount(context.staging, "/work/out"),
                             Mount(context.artifacts, "/work/artifacts"),
+                            Mount(context.repository, "/work/packages"),
                             *context.config.distribution.package_manager(context.config).mounts(context),
                         ],
                         options=["--dir", "/work/src", "--chdir", "/work/src"],
@@ -1655,7 +1659,7 @@ def install_package_directories(context: Context) -> None:
     with complete_step("Copying in extra packages…"):
         for d in context.config.package_directories:
             for p in itertools.chain(*(d.glob(glob) for glob in PACKAGE_GLOBS)):
-                shutil.copy(p, context.packages, follow_symlinks=True)
+                shutil.copy(p, context.repository, follow_symlinks=True)
 
     if context.want_local_repo():
         with complete_step("Building local package repository"):
@@ -1830,7 +1834,7 @@ def build_default_initrd(context: Context) -> Path:
         context.config,
         resources=context.resources,
         output_dir=context.workspace,
-        package_dir=context.packages,
+        package_dir=context.repository,
     )
 
     assert config.output_dir

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -28,6 +28,7 @@ from typing import Optional, Union, cast
 from mkosi.archive import can_extract_tar, extract_tar, make_cpio, make_tar
 from mkosi.burn import run_burn
 from mkosi.config import (
+    PACKAGE_GLOBS,
     Args,
     BiosBootloader,
     Bootloader,
@@ -1653,13 +1654,7 @@ def install_package_directories(context: Context) -> None:
 
     with complete_step("Copying in extra packages…"):
         for d in context.config.package_directories:
-            for p in itertools.chain(
-                d.glob("*.rpm"),
-                d.glob("*.pkg.tar*"),
-                d.glob("*.deb*"),
-                d.glob("*.ddeb*"),
-                d.glob("*.udeb*"),
-            ):
+            for p in itertools.chain(*(d.glob(glob) for glob in PACKAGE_GLOBS)):
                 shutil.copy(p, context.packages, follow_symlinks=True)
 
     if context.want_local_repo():

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1657,6 +1657,11 @@ class Config:
             "package_manager": self.distribution.package_manager(self).executable(self),
             "packages": sorted(self.packages),
             "build_packages": sorted(self.build_packages),
+            "package_directories": [
+                (p.name, p.stat().st_mtime_ns)
+                for d in self.package_directories
+                for p in sorted(flatten(d.glob(glob) for glob in PACKAGE_GLOBS))
+            ],
             "repositories": sorted(self.repositories),
             "overlay": self.overlay,
             "prepare_scripts": sorted(

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1415,6 +1415,7 @@ class Config:
     build_packages: list[str]
     volatile_packages: list[str]
     package_directories: list[Path]
+    volatile_package_directories: list[Path]
     with_recommends: bool
     with_docs: bool
 
@@ -2188,6 +2189,15 @@ SETTINGS = (
         parse=config_make_list_parser(delimiter=",", parse=make_path_parser()),
         paths=("mkosi.packages",),
         help="Specify a directory containing extra packages",
+        universal=True,
+    ),
+    ConfigSetting(
+        dest="volatile_package_directories",
+        long="--volatile-package-directory",
+        metavar="PATH",
+        section="Content",
+        parse=config_make_list_parser(delimiter=",", parse=make_path_parser()),
+        help="Specify a directory containing extra volatile packages",
         universal=True,
     ),
     ConfigSetting(
@@ -4048,6 +4058,8 @@ def summary(config: Config) -> str:
                            Packages: {line_join_list(config.packages)}
                      Build Packages: {line_join_list(config.build_packages)}
                   Volatile Packages: {line_join_list(config.volatile_packages)}
+                Package Directories: {line_join_list(config.package_directories)}
+       Volatile Package Directories: {line_join_list(config.volatile_package_directories)}
                  With Documentation: {yes_no(config.with_docs)}
 
                          Base Trees: {line_join_list(config.base_trees)}

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1357,6 +1357,15 @@ class Args:
 CACHE_UID = os.getuid()
 CACHE_GID = os.getgid()
 
+PACKAGE_GLOBS = (
+    "*.rpm",
+    "*.pkg.tar*",
+    "*.deb*",
+    "*.ddeb*",
+    "*.udeb*",
+)
+
+
 @dataclasses.dataclass(frozen=True)
 class Config:
     """Type-hinted storage for command line arguments.

--- a/mkosi/context.py
+++ b/mkosi/context.py
@@ -45,6 +45,7 @@ class Context:
         self.staging.mkdir()
         self.pkgmngr.mkdir()
         self.repository.mkdir()
+        self.packages.mkdir()
         self.artifacts.mkdir()
         self.install_dir.mkdir()
 
@@ -63,6 +64,10 @@ class Context:
     @property
     def repository(self) -> Path:
         return self.workspace / "repository"
+
+    @property
+    def packages(self) -> Path:
+        return self.workspace / "packages"
 
     @property
     def artifacts(self) -> Path:
@@ -115,6 +120,3 @@ class Context:
             ],
             extra=extra,
         )
-
-    def want_local_repo(self) -> bool:
-        return any(self.repository.iterdir())

--- a/mkosi/context.py
+++ b/mkosi/context.py
@@ -44,7 +44,7 @@ class Context:
 
         self.staging.mkdir()
         self.pkgmngr.mkdir()
-        self.packages.mkdir()
+        self.repository.mkdir()
         self.artifacts.mkdir()
         self.install_dir.mkdir()
 
@@ -61,8 +61,8 @@ class Context:
         return self.workspace / "pkgmngr"
 
     @property
-    def packages(self) -> Path:
-        return self.workspace / "packages"
+    def repository(self) -> Path:
+        return self.workspace / "repository"
 
     @property
     def artifacts(self) -> Path:
@@ -117,4 +117,4 @@ class Context:
         )
 
     def want_local_repo(self) -> bool:
-        return any(self.packages.iterdir())
+        return any(self.repository.iterdir())

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -71,10 +71,6 @@ class DistributionInstaller:
     def grub_prefix(cls) -> str:
         return "grub"
 
-    @classmethod
-    def createrepo(cls, context: "Context") -> None:
-        raise NotImplementedError
-
 
 class Distribution(StrEnum):
     # Please consult docs/distribution-policy.md and contact one
@@ -142,7 +138,7 @@ class Distribution(StrEnum):
         return self.installer().grub_prefix()
 
     def createrepo(self, context: "Context") -> None:
-        return self.installer().createrepo(context)
+        return self.installer().package_manager(context.config).createrepo(context)
 
     def installer(self) -> type[DistributionInstaller]:
         modname = str(self).replace('-', '_')

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -37,10 +37,6 @@ class Installer(DistributionInstaller):
         return Pacman
 
     @classmethod
-    def createrepo(cls, context: Context) -> None:
-        Pacman.createrepo(context)
-
-    @classmethod
     def setup(cls, context: Context) -> None:
         Pacman.setup(context, cls.repositories(context))
 

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -50,10 +50,6 @@ class Installer(DistributionInstaller):
         return "grub2"
 
     @classmethod
-    def createrepo(cls, context: Context) -> None:
-        Dnf.createrepo(context)
-
-    @classmethod
     def dbpath(cls, context: Context) -> str:
         # The Hyperscale SIG uses /usr/lib/sysimage/rpm in its rebuild of rpm for C9S that's shipped in the
         # hyperscale-packages-experimental repository.

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -104,10 +104,6 @@ class Installer(DistributionInstaller):
         Apt.setup(context, cls.repositories(context))
 
     @classmethod
-    def createrepo(cls, context: Context) -> None:
-        Apt.createrepo(context)
-
-    @classmethod
     def install(cls, context: Context) -> None:
         # Instead of using debootstrap, we replicate its core functionality here. Because dpkg does not have
         # an option to delay running pre-install maintainer scripts when it installs a package, it's

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -161,12 +161,12 @@ class Installer(DistributionInstaller):
 
         for deb in essential:
             # If a deb path is in the form of "/var/cache/apt/<deb>", we transform it to the corresponding path in
-            # mkosi's package cache directory. If it's relative to /work/packages, we transform it to the corresponding
+            # mkosi's package cache directory. If it's relative to /repository, we transform it to the corresponding
             # path in mkosi's local package repository. Otherwise, we use the path as is.
             if Path(deb).is_relative_to("/var/cache"):
                 path = context.config.package_cache_dir_or_default() / Path(deb).relative_to("/var")
-            elif Path(deb).is_relative_to("/work/packages"):
-                path = context.packages / Path(deb).relative_to("/work/packages")
+            elif Path(deb).is_relative_to("/repository"):
+                path = context.repository / Path(deb).relative_to("/repository")
             else:
                 path = Path(deb)
 

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -75,10 +75,6 @@ class Installer(DistributionInstaller):
         return Dnf
 
     @classmethod
-    def createrepo(cls, context: Context) -> None:
-        Dnf.createrepo(context)
-
-    @classmethod
     def setup(cls, context: Context) -> None:
         Dnf.setup(context, cls.repositories(context), filelists=False)
         setup_rpm(context)

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -52,13 +52,6 @@ class Installer(DistributionInstaller):
             return Dnf
 
     @classmethod
-    def createrepo(cls, context: Context) -> None:
-        if context.config.find_binary("zypper"):
-            Zypper.createrepo(context)
-        else:
-            Dnf.createrepo(context)
-
-    @classmethod
     def setup(cls, context: Context) -> None:
         zypper = context.config.find_binary("zypper")
         if zypper:

--- a/mkosi/installer/__init__.py
+++ b/mkosi/installer/__init__.py
@@ -54,7 +54,7 @@ class PackageManager:
     def mounts(cls, context: Context) -> list[Mount]:
         mounts = [
             *finalize_crypto_mounts(context.config),
-            Mount(context.packages, "/work/packages"),
+            Mount(context.repository, "/repository"),
         ]
 
         if context.config.local_mirror and (mirror := startswith(context.config.local_mirror, "file://")):

--- a/mkosi/installer/__init__.py
+++ b/mkosi/installer/__init__.py
@@ -87,6 +87,10 @@ class PackageManager:
     def sync(cls, context: Context) -> None:
         pass
 
+    @classmethod
+    def createrepo(cls, context: Context) -> None:
+        pass
+
 
 def clean_package_manager_metadata(context: Context) -> None:
     """

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -237,7 +237,7 @@ class Apt(PackageManager):
 
     @classmethod
     def createrepo(cls, context: Context) -> None:
-        if not (conf := context.packages / "conf/distributions").exists():
+        if not (conf := context.repository / "conf/distributions").exists():
             conf.parent.mkdir(exist_ok=True)
             conf.write_text(
                 textwrap.dedent(
@@ -258,13 +258,13 @@ class Apt(PackageManager):
                 "--ignore=extension",
                 "includedeb",
                 "mkosi",
-                *(d.name for d in context.packages.glob("*.deb")),
-                *(d.name for d in context.packages.glob("*.ddeb")),
+                *(d.name for d in context.repository.glob("*.deb")),
+                *(d.name for d in context.repository.glob("*.ddeb")),
             ],
             sandbox=context.sandbox(
                 binary="reprepro",
-                mounts=[Mount(context.packages, context.packages)],
-                options=["--chdir", context.packages],
+                mounts=[Mount(context.repository, context.repository)],
+                options=["--chdir", context.repository],
             ),
         )
 
@@ -274,7 +274,7 @@ class Apt(PackageManager):
                 """\
                 Enabled: yes
                 Types: deb
-                URIs: file:///work/packages
+                URIs: file:///repository
                 Suites: mkosi
                 Components: main
                 Trusted: yes

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -229,15 +229,15 @@ class Dnf(PackageManager):
 
     @classmethod
     def createrepo(cls, context: Context) -> None:
-        run(["createrepo_c", context.packages],
-            sandbox=context.sandbox(binary="createrepo_c", mounts=[Mount(context.packages, context.packages)]))
+        run(["createrepo_c", context.repository],
+            sandbox=context.sandbox(binary="createrepo_c", mounts=[Mount(context.repository, context.repository)]))
 
         (context.pkgmngr / "etc/yum.repos.d/mkosi-local.repo").write_text(
             textwrap.dedent(
                 """\
                 [mkosi]
                 name=mkosi
-                baseurl=file:///work/packages
+                baseurl=file:///repository
                 gpgcheck=0
                 metadata_expire=never
                 priority=10

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -53,7 +53,7 @@ class Pacman(PackageManager):
             *super().mounts(context),
             # pacman writes downloaded packages to the first writable cache directory. We don't want it to write to our
             # local repository directory so we expose it as a read-only directory to pacman.
-            Mount(context.packages, "/var/cache/pacman/mkosi", ro=True),
+            Mount(context.repository, "/var/cache/pacman/mkosi", ro=True),
         ]
 
         if (context.root / "var/lib/pacman/local").exists():
@@ -198,10 +198,10 @@ class Pacman(PackageManager):
             [
                 "repo-add",
                 "--quiet",
-                context.packages / "mkosi.db.tar",
-                *sorted(context.packages.glob("*.pkg.tar*"), key=lambda p: GenericVersion(Path(p).name))
+                context.repository / "mkosi.db.tar",
+                *sorted(context.repository.glob("*.pkg.tar*"), key=lambda p: GenericVersion(Path(p).name))
             ],
-            sandbox=context.sandbox(binary="repo-add", mounts=[Mount(context.packages, context.packages)]),
+            sandbox=context.sandbox(binary="repo-add", mounts=[Mount(context.repository, context.repository)]),
         )
 
         (context.pkgmngr / "etc/mkosi-local.conf").write_text(
@@ -217,6 +217,6 @@ class Pacman(PackageManager):
 
         # pacman can't sync a single repository, so we go behind its back and do it ourselves.
         shutil.move(
-            context.packages / "mkosi.db.tar",
+            context.repository / "mkosi.db.tar",
             context.package_cache_dir / "lib/pacman/sync/mkosi.db"
         )

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -154,15 +154,15 @@ class Zypper(PackageManager):
 
     @classmethod
     def createrepo(cls, context: Context) -> None:
-        run(["createrepo_c", context.packages],
-            sandbox=context.sandbox(binary="createrepo_c", mounts=[Mount(context.packages, context.packages)]))
+        run(["createrepo_c", context.repository],
+            sandbox=context.sandbox(binary="createrepo_c", mounts=[Mount(context.repository, context.repository)]))
 
         (context.pkgmngr / "etc/zypp/repos.d/mkosi-local.repo").write_text(
             textwrap.dedent(
                 """\
                 [mkosi]
                 name=mkosi
-                baseurl=file:///work/packages
+                baseurl=file:///repository
                 gpgcheck=0
                 autorefresh=0
                 keeppackages=0

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -772,9 +772,15 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     running scripts. If the `mkosi.packages/` directory is found in the local
     directory it is also used for this purpose.
 
-    Note that this local repository is also made available when running
-    scripts. Build scripts can add more packages to the local repository
-    by placing the built packages in `$PACKAGEDIR`.
+    Build scripts can add more packages to the local repository by
+    placing the built packages in `$PACKAGEDIR`.
+
+`VolatilePackageDirectories=`, `--volatile-package-directory=`
+
+:   Like `PackageDirectories=`, but the packages in these directories
+    are only made available in the local repository just before volatile
+    packages are installed. Specifically, if `Incremental=` is enabled,
+    the packages from these directories will not be cached.
 
 `WithRecommends=`, `--with-recommends=`
 :   Configures whether to install recommended or weak dependencies,
@@ -2470,6 +2476,7 @@ overridden):
 - `RepartOffline=`
 - `UseSubvolumes=`
 - `PackageDirectories=`
+- `VolatilePackageDirectories=`
 - `SourceDateEpoch=`
 - `VerityKey=`
 - `VerityKeySource=`

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -309,12 +309,13 @@ def resource_path(mod: ModuleType) -> Iterator[Path]:
 
 def hash_file(path: Path) -> str:
     # TODO Replace with hashlib.file_digest after dropping support for Python 3.10.
-    bs = 16 * 1024**2
     h = hashlib.sha256()
+    b  = bytearray(16 * 1024**2)
+    mv = memoryview(b)
 
-    with path.open("rb") as sf:
-        while (buf := sf.read(bs)):
-            h.update(buf)
+    with path.open("rb", buffering=0) as f:
+        while n := f.readinto(mv):
+            h.update(mv[:n])
 
     return h.hexdigest()
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -342,6 +342,9 @@ def test_config() -> None:
                 "Type": "file"
             },
             "VirtualMachineMonitor": "qemu",
+            "VolatilePackageDirectories": [
+                "def"
+            ],
             "VolatilePackages": [
                 "abc"
             ],
@@ -500,6 +503,7 @@ def test_config() -> None:
         verity_certificate=Path("/path/to/cert"),
         verity_key=None,
         verity_key_source=KeySource(type=KeySource.Type.file),
+        volatile_package_directories=[Path("def")],
         volatile_packages=["abc"],
         with_docs=True,
         with_network=False,


### PR DESCRIPTION
Let's track the modification timestamps of the packages from configured
package directories so we can rebuild the image if new packages appear
or are removed or changed.