### PR TITLE
Add `mkosi.pkgmngr` path to `PackageManagerTrees=`

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1955,6 +1955,7 @@ SETTINGS = (
         default_factory=lambda ns: ns.skeleton_trees,
         default_factory_depends=("skeleton_trees",),
         help="Use a package manager tree to configure the package manager",
+        paths=("mkosi.pkgmngr", "mkosi.pkgmngr.tar",),
         universal=True,
     ),
 

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -477,10 +477,16 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     the build.
 
 `PackageManagerTrees=`, `--package-manager-tree=`
-:   This option mirrors the above `SkeletonTrees=` option and defaults to the
-    same value if not configured otherwise, but installs the files to a
-    subdirectory of the workspace directory instead of the OS tree. This
-    subdirectory of the workspace is used to configure the package manager.
+:   Takes a comma separated list of colon separated path pairs. The first
+    path of each pair refers to a directory to copy into the OS tree
+    before invoking the package manager. This option is similar to the
+    `SkeletonTrees=` option, but installs the files to a subdirectory of
+    the workspace directory instead of the OS tree. This subdirectory of
+    the workspace is used to configure the package manager. If the
+    `mkosi.pkgmngr/` directory is found in the local directory it is used
+    for this purpose with the root directory as target (also see the **Files**
+    section below). If not configured in any way this value will default to
+    the same value of `SkeletonTrees=`.
 
     `mkosi` will look for the package manager configuration and related
     files in the configured package manager trees. Unless specified
@@ -2292,6 +2298,15 @@ local directory:
   what the distribution includes in its packages. They are similar to
   `mkosi.skeleton/` and `mkosi.skeleton.tar`, but the files are copied
   into the directory tree of the image *after* the OS was installed.
+
+  When using the directory, file ownership is not preserved: all files
+  copied will be owned by root. To preserve ownership, use a tar
+  archive.
+
+* The **`mkosi.pkgmngr/`** directory or **`mkosi.pkgmngr.tar`** archive
+  may be used to configure the package manager without the files being
+  inserted into the image. If the files should be included in the image
+  `mkosi.skeleton/` and `mkosi.skeleton.tar` should be used instead.
 
   When using the directory, file ownership is not preserved: all files
   copied will be owned by root. To preserve ownership, use a tar

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -977,6 +977,29 @@ def test_package_manager_tree(tmp_path: Path, skel: Optional[Path], pkgmngr: Opt
         assert conf.package_manager_trees == pkgmngr_expected
 
 
+def test_paths_with_default_factory(tmp_path: Path) -> None:
+    """
+    If both paths= and default_factory= are defined, default_factory= should not
+    be used when at least one of the files/directories from paths= has been found.
+    """
+
+    with chdir(tmp_path):
+
+        Path("mkosi.skeleton.tar").touch()
+        _, [config] = parse_config()
+
+        assert config.package_manager_trees == [
+            ConfigTree(Path.cwd() / "mkosi.skeleton.tar", None),
+        ]
+
+        Path("mkosi.pkgmngr.tar").touch()
+        _, [config] = parse_config()
+
+        assert config.package_manager_trees == [
+            ConfigTree(Path.cwd() / "mkosi.pkgmngr.tar", None),
+        ]
+
+
 @pytest.mark.parametrize(
     "sections,args,warning_count",
     [


### PR DESCRIPTION
- Reword documentation to no relying on a reference later in the doc
- Test to ensure `paths=` and `default_factory=` work as expected