### PR TITLE
Fix partition identification for mount.usr=PARTUUID

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2296,7 +2296,8 @@ def finalize_cmdline(context: Context, partitions: Sequence[Partition], roothash
 
     if not roothash:
         for name in ("root", "mount.usr"):
-            if not (root := next((p.uuid for p in partitions if p.type.startswith(name)), None)):
+            type_prefix = name.removeprefix("mount.")
+            if not (root := next((p.uuid for p in partitions if p.type.startswith(type_prefix)), None)):
                 continue
 
             cmdline = [f"{name}=PARTUUID={root}" if c == f"{name}=PARTUUID" else c for c in cmdline]


### PR DESCRIPTION
This PR fixes #2858: The logic to automatically populate PARTUUID for the `root` and `mount.usr` kernel parameters (#2835) doesn't work for `mount.usr`, since the partition types are matched against the parameter name and the relevant partition types start with `'usr'`, not `'mount.usr'`.

Use the following configuration in an empty directory to reproduce the issue on main and see it work on this branch.

```bash
mkdir -p mkosi.{repart,extra/usr/lib/repart.d}
cat <<'EOF' >mkosi.extra/usr/lib/repart.d/02-root.conf
[Partition]
Type=root
Format=ext4
FactoryReset=yes
EOF
cat <<'EOF' >mkosi.repart/00-esp.conf
[Partition]
Type=esp
Format=vfat
Minimize=guess
CopyFiles=/boot:/
CopyFiles=/efi:/
EOF
cat <<'EOF' >mkosi.repart/01-usr.conf
[Partition]
Type=usr
Format=erofs
Minimize=best
CopyFiles=/usr:/
EOF
cat <<'EOF' >mkosi.conf
[Distribution]
Distribution=arch

[Content]
Bootable=yes
KernelCommandLine=mount.usr=PARTUUID
Packages=systemd,udev,linux

[Output]
Format=disk

[Host]
RuntimeSize=8G
EOF
mkosi -f build
ukify inspect image.efi | grep -a 'mount\.usr'
# => mount.usr=PARTUUID on main
# => mount.usr=PARTUUID=<UUID> on this branch
mkosi qemu
# => fails to mount /sysusr/usr on main
# => boots successfully on this branch
```