### PR TITLE
Fix --profile

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3666,8 +3666,7 @@ def parse_config(argv: Sequence[str] = (), *, resources: Path = Path("/")) -> tu
                     setattr(ParseContext.config, s.dest, s.parse(v, getattr(ParseContext.config, s.dest, None)))
 
         if profiles:
-            finalize_value(SETTINGS_LOOKUP_BY_DEST["profile"])
-            profile = getattr(ParseContext.config, "profile")
+            profile = finalize_value(SETTINGS_LOOKUP_BY_DEST["profile"])
             ParseContext.immutable.add("Profile")
 
             if profile:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -356,6 +356,16 @@ def test_profiles(tmp_path: Path) -> None:
     assert config.distribution == Distribution.debian
     assert config.qemu_kvm == ConfigFeature.enabled
 
+    (d / "mkosi.conf").unlink()
+
+    with chdir(d):
+        _, [config] = parse_config(["--profile", "profile"])
+
+    assert config.profile == "profile"
+    # mkosi.conf.d/ should override the profile
+    assert config.distribution == Distribution.debian
+    assert config.qemu_kvm == ConfigFeature.enabled
+
 
 def test_override_default(tmp_path: Path) -> None:
     d = tmp_path


### PR DESCRIPTION
The attribute might be set on either the cli or the config namespace so don't assume it's set on the config namespace.

Fixes #2860