### PR TITLE
Set RPM_FORCE_DEBIAN=1 for zypper and dnf

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -15,13 +15,14 @@ BuildSources=.
 BuildSourcesEphemeral=yes
 
 Packages=
+        binutils
         gdb
         less
         nano
         strace
         systemd
-        udev
         tmux
+        udev
 
 InitrdPackages=
         less

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -108,6 +108,12 @@ class Dnf(PackageManager):
                     f.write("\n")
 
     @classmethod
+    def finalize_environment(cls, context: Context) -> dict[str, str]:
+        return super().finalize_environment(context) | {
+            "RPM_FORCE_DEBIAN": "1",
+        }
+
+    @classmethod
     def cmd(
             cls,
             context: Context,

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -100,7 +100,10 @@ class Zypper(PackageManager):
 
     @classmethod
     def finalize_environment(cls, context: Context) -> dict[str, str]:
-        return super().finalize_environment(context) | {"ZYPP_CONF": "/etc/zypp/zypp.conf"}
+        return super().finalize_environment(context) | {
+            "ZYPP_CONF": "/etc/zypp/zypp.conf",
+            "RPM_FORCE_DEBIAN": "1",
+        }
 
     @classmethod
     def cmd(cls, context: Context) -> list[PathString]:


### PR DESCRIPTION
This stops rpm on Ubuntu from printing noisy warnings about aliens.