### PR TITLE
Share the package directory across all image builds

### DIFF
--- a/mkosi/context.py
+++ b/mkosi/context.py
@@ -23,12 +23,15 @@ class Context:
         workspace: Path,
         resources: Path,
         package_cache_dir: Optional[Path] = None,
+        package_dir: Optional[Path] = None,
     ) -> None:
         self.args = args
         self.config = config
         self.workspace = workspace
         self.resources = resources
         self.package_cache_dir = package_cache_dir or (self.root / "var")
+        self.package_dir = package_dir or (self.workspace / "packages")
+        self.package_dir.mkdir(exist_ok=True)
 
         with umask(~0o755):
             # Using a btrfs subvolume as the upperdir in an overlayfs results in EXDEV so make sure we create
@@ -45,7 +48,6 @@ class Context:
         self.staging.mkdir()
         self.pkgmngr.mkdir()
         self.repository.mkdir()
-        self.packages.mkdir()
         self.artifacts.mkdir()
         self.install_dir.mkdir()
 
@@ -64,10 +66,6 @@ class Context:
     @property
     def repository(self) -> Path:
         return self.workspace / "repository"
-
-    @property
-    def packages(self) -> Path:
-        return self.workspace / "packages"
 
     @property
     def artifacts(self) -> Path:

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -770,15 +770,18 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     running scripts. If the `mkosi.packages/` directory is found in the local
     directory it is also used for this purpose.
 
-    Build scripts can add more packages to the local repository by
-    placing the built packages in `$PACKAGEDIR`.
-
 `VolatilePackageDirectories=`, `--volatile-package-directory=`
 
 :   Like `PackageDirectories=`, but the packages in these directories
     are only made available in the local repository just before volatile
     packages are installed. Specifically, if `Incremental=` is enabled,
     the packages from these directories will not be cached.
+
+    Additionally, build scripts can add more packages to the local
+    repository by placing the built packages in `$PACKAGEDIR`. The
+    packages placed in `$PACKAGEDIR` are shared between all image builds
+    and thus available for installation in all images using
+    `VolatilePackages=`.
 
 `WithRecommends=`, `--with-recommends=`
 :   Configures whether to install recommended or weak dependencies,


### PR DESCRIPTION
This allows packages built by one image to easily be installed in another image when using mkosi.images.