### PR TITLE
Add --expand-environment+no to systemd-run command line

### DIFF
--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -744,6 +744,7 @@ def scope_cmd(
         "--description", description,
         "--scope",
         "--collect",
+        "--expand-environment=no",
         *(["--uid", str(user)] if user is not None else []),
         *(["--gid", str(group)] if group is not None else []),
         *([f"--property={p}" for p in properties]),


### PR DESCRIPTION
Otherwise systemd will try to expand environment variables in our command instead of the shell.