### PR TITLE
Make volatile packages available in local repository earlier

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3870,6 +3870,8 @@ def build_image(context: Context) -> None:
         context.config.distribution.setup(context)
         with createrepo(context):
             install_package_directories(context, context.config.package_directories)
+            install_package_directories(context, context.config.volatile_package_directories)
+            install_package_directories(context, [context.package_dir])
 
         if not cached:
             install_skeleton_trees(context)
@@ -3892,7 +3894,6 @@ def build_image(context: Context) -> None:
             return
 
         with createrepo(context):
-            install_package_directories(context, context.config.volatile_package_directories)
             install_package_directories(context, [context.package_dir])
 
         install_volatile_packages(context)

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -772,10 +772,9 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 `VolatilePackageDirectories=`, `--volatile-package-directory=`
 
-:   Like `PackageDirectories=`, but the packages in these directories
-    are only made available in the local repository just before volatile
-    packages are installed. Specifically, if `Incremental=` is enabled,
-    the packages from these directories will not be cached.
+:   Like `PackageDirectories=`, but any changes to the packages in these
+    directories will not invalidate the cached images if `Incremental=`
+    is enabled.
 
     Additionally, build scripts can add more packages to the local
     repository by placing the built packages in `$PACKAGEDIR`. The


### PR DESCRIPTION
By making the volatile packages available earlier, we can query, install and cache their dependencies in a prepare script.