### PR TITLE
Make sure we always update the local repository metadata

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4649,7 +4649,10 @@ def sync_repository_metadata(context: Context) -> None:
         complete_step(f"Syncing package manager metadata for {context.config.name()} image"),
         lock_repository_metadata(context.config),
     ):
-        context.config.distribution.package_manager(context.config).sync(context)
+        context.config.distribution.package_manager(context.config).sync(
+            context,
+            force=context.args.force > 1 or context.config.cacheonly == Cacheonly.never,
+        )
 
 
 def run_sync(args: Args, config: Config, *, resources: Path) -> None:

--- a/mkosi/installer/__init__.py
+++ b/mkosi/installer/__init__.py
@@ -84,7 +84,7 @@ class PackageManager:
         return mounts
 
     @classmethod
-    def sync(cls, context: Context) -> None:
+    def sync(cls, context: Context, force: bool) -> None:
         pass
 
     @classmethod

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -234,7 +234,7 @@ class Apt(PackageManager):
             )
 
     @classmethod
-    def sync(cls, context: Context) -> None:
+    def sync(cls, context: Context, force: bool) -> None:
         cls.invoke(context, "update")
 
     @classmethod

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -222,14 +222,11 @@ class Dnf(PackageManager):
                         p.unlink()
 
     @classmethod
-    def sync(cls, context: Context, options: Sequence[str] = ()) -> None:
+    def sync(cls, context: Context, force: bool, arguments: Sequence[str] = ()) -> None:
         cls.invoke(
             context,
             "makecache",
-            arguments=[
-                *(["--refresh"] if context.args.force > 1 or context.config.cacheonly == Cacheonly.never else []),
-                *options,
-            ],
+            arguments=[*(["--refresh"] if force else []), *arguments],
             cached_metadata=False,
         )
 
@@ -251,4 +248,4 @@ class Dnf(PackageManager):
             )
         )
 
-        cls.sync(context, options=["--disablerepo=*", "--enablerepo=mkosi"])
+        cls.sync(context, force=True, arguments=["--disablerepo=*", "--enablerepo=mkosi"])

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -7,7 +7,7 @@ import textwrap
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 
-from mkosi.config import Cacheonly, Config
+from mkosi.config import Config
 from mkosi.context import Context
 from mkosi.installer import PackageManager
 from mkosi.mounts import finalize_source_mounts
@@ -183,14 +183,8 @@ class Pacman(PackageManager):
             )
 
     @classmethod
-    def sync(cls, context: Context) -> None:
-        cls.invoke(
-            context,
-            "--sync",
-            ["--refresh"] + (
-                ["--refresh"] if context.args.force > 1 or context.config.cacheonly == Cacheonly.never else []
-            )
-        )
+    def sync(cls, context: Context, force: bool) -> None:
+        cls.invoke(context, "--sync", ["--refresh", *(["--refresh"] if force else [])])
 
     @classmethod
     def createrepo(cls, context: Context) -> None:

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -5,7 +5,7 @@ import textwrap
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 
-from mkosi.config import Cacheonly, Config, yes_no
+from mkosi.config import Config, yes_no
 from mkosi.context import Context
 from mkosi.installer import PackageManager
 from mkosi.installer.rpm import RpmRepository, rpm_cmd
@@ -148,12 +148,8 @@ class Zypper(PackageManager):
             )
 
     @classmethod
-    def sync(cls, context: Context) -> None:
-        cls.invoke(
-            context,
-            "refresh",
-            ["--force"] if context.args.force > 1 or context.config.cacheonly == Cacheonly.never else []
-        )
+    def sync(cls, context: Context, force: bool, arguments: Sequence[str] = ()) -> None:
+        cls.invoke(context, "refresh", [*(["--force"] if force else []), *arguments])
 
     @classmethod
     def createrepo(cls, context: Context) -> None:
@@ -174,4 +170,4 @@ class Zypper(PackageManager):
             )
         )
 
-        cls.invoke(context, "refresh", ["mkosi"])
+        cls.sync(context, force=True, arguments=["mkosi"])


### PR DESCRIPTION
The latest release of dnf5 introduced a change in behavior causing us to not always sync the local repository metadata. To mitigate this, let's always specify --refresh or similar for all package managers when we sync the local repository to make sure its metadata is updated.