### PR TITLE
Fail when trying to change universal settings in subimages

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3663,6 +3663,12 @@ def parse_config(argv: Sequence[str] = (), *, resources: Path = Path("/")) -> tu
 
                 if not (s := SETTINGS_LOOKUP_BY_NAME.get(name)):
                     die(f"Unknown setting {name}")
+                if (
+                    s.universal and
+                    not isinstance(s.parse(None, None), (list, set, dict)) and
+                    (image := getattr(ParseContext.config, "image", None)) is not None
+                ):
+                    die(f"Setting {name} cannot be configured in subimage {image}")
                 if name in ParseContext.immutable:
                     die(f"Setting {name} cannot be modified anymore at this point")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -255,7 +255,7 @@ def test_parse_config(tmp_path: Path) -> None:
         (d / "mkosi.images" / f"{n}.conf").write_text(
             f"""\
             [Distribution]
-            Release=bla
+            Repositories=append
 
             [Content]
             Packages={n}
@@ -263,7 +263,7 @@ def test_parse_config(tmp_path: Path) -> None:
         )
 
     with chdir(d):
-        _, [one, two, config] = parse_config(["--package", "qed", "--build-package", "def"])
+        _, [one, two, config] = parse_config(["--package", "qed", "--build-package", "def", "--repositories", "cli"])
 
     # Universal settings should always come from the main image.
     assert one.distribution == config.distribution
@@ -280,6 +280,10 @@ def test_parse_config(tmp_path: Path) -> None:
     # But should apply to the main image of course.
     assert config.packages == ["qed"]
     assert config.build_packages == ["def"]
+
+    # list based settings should be appended to in subimages
+    assert one.repositories == ["append", "epel", "epel-next", "cli"]
+    assert two.repositories == ["append", "epel", "epel-next", "cli"]
 
 
 def test_parse_includes_once(tmp_path: Path) -> None:


### PR DESCRIPTION
Let's error out when users try to configure universal settings in subimages since these will always be overridden.