### PR TITLE
Only pass kernel command line to ukify if there is one

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2126,7 +2126,7 @@ def build_uki(
     cmd: list[PathString] = [
         python_binary(context.config, binary=ukify),
         ukify,
-        "--cmdline", f"@{context.workspace / 'cmdline'}",
+        *(["--cmdline", f"@{context.workspace / 'cmdline'}"] if cmdline else []),
         "--os-release", f"@{context.root / 'usr/lib/os-release'}",
         "--stub", stub,
         "--output", output,


### PR DESCRIPTION
If we don't have any kernel command line arguments, don't pass --cmdline to ukify.

Turns out systemd-stub will hang on boot when .cmdline contains only a null terminator so with this change we avoid that from happening.