### PR TITLE
Choose default tools tree distribution based on host distribution

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -707,6 +707,15 @@ def config_default_release(namespace: argparse.Namespace) -> str:
     return cast(str, namespace.distribution.default_release())
 
 
+def config_default_tools_tree_distribution(namespace: argparse.Namespace) -> Distribution:
+    detected = detect_distribution()[0]
+
+    if not detected:
+        return Distribution.custom
+
+    return detected.default_tools_tree_distribution()
+
+
 def config_default_source_date_epoch(namespace: argparse.Namespace) -> Optional[int]:
     for env in namespace.environment:
         if s := startswith(env, "SOURCE_DATE_EPOCH="):
@@ -2871,7 +2880,7 @@ SETTINGS = (
         match=config_make_enum_matcher(Distribution),
         choices=Distribution.choices(),
         default_factory_depends=("distribution",),
-        default_factory=lambda ns: ns.distribution.default_tools_tree_distribution(),
+        default_factory=config_default_tools_tree_distribution,
         help="Set the distribution to use for the default tools tree",
     ),
     ConfigSetting(

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3628,7 +3628,7 @@ class ParseContext:
 
             for s in SETTINGS:
                 for f in s.paths:
-                    p = parse_path(
+                    extra = parse_path(
                         f,
                         secret=s.path_secret,
                         required=False,
@@ -3636,12 +3636,12 @@ class ParseContext:
                         expanduser=False,
                         expandvars=False,
                     )
-                    if p.exists():
+                    if extra.exists():
                         setattr(
                             self.config,
                             s.dest,
                             s.parse(
-                                p.read_text().rstrip("\n") if s.path_read_text else f,
+                                extra.read_text().rstrip("\n") if s.path_read_text else f,
                                 getattr(self.config, s.dest, None)
                             ),
                         )

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -131,8 +131,8 @@ class Distribution(StrEnum):
     def default_release(self) -> str:
         return self.installer().default_release()
 
-    def default_tools_tree_distribution(self) -> Optional["Distribution"]:
-        return self.installer().default_tools_tree_distribution()
+    def default_tools_tree_distribution(self) -> "Distribution":
+        return self.installer().default_tools_tree_distribution() or self
 
     def grub_prefix(self) -> str:
         return self.installer().grub_prefix()

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable, Sequence
 
 from mkosi.config import Architecture, Config
 from mkosi.context import Context
-from mkosi.distributions import Distribution, DistributionInstaller, PackageType
+from mkosi.distributions import DistributionInstaller, PackageType
 from mkosi.installer import PackageManager
 from mkosi.installer.pacman import Pacman, PacmanRepository
 from mkosi.log import die
@@ -27,10 +27,6 @@ class Installer(DistributionInstaller):
     @classmethod
     def default_release(cls) -> str:
         return "rolling"
-
-    @classmethod
-    def default_tools_tree_distribution(cls) -> Distribution:
-        return Distribution.arch
 
     @classmethod
     def package_manager(cls, config: "Config") -> type[PackageManager]:

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from mkosi.archive import extract_tar
 from mkosi.config import Architecture, Config
 from mkosi.context import Context
-from mkosi.distributions import Distribution, DistributionInstaller, PackageType
+from mkosi.distributions import DistributionInstaller, PackageType
 from mkosi.installer import PackageManager
 from mkosi.installer.apt import Apt, AptRepository
 from mkosi.log import die
@@ -32,10 +32,6 @@ class Installer(DistributionInstaller):
     @classmethod
     def default_release(cls) -> str:
         return "testing"
-
-    @classmethod
-    def default_tools_tree_distribution(cls) -> Distribution:
-        return Distribution.debian
 
     @classmethod
     def package_manager(cls, config: Config) -> type[PackageManager]:

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from mkosi.config import Architecture, Config
 from mkosi.context import Context
 from mkosi.distributions import (
-    Distribution,
     DistributionInstaller,
     PackageType,
     join_mirror,
@@ -61,10 +60,6 @@ class Installer(DistributionInstaller):
     @classmethod
     def default_release(cls) -> str:
         return "40"
-
-    @classmethod
-    def default_tools_tree_distribution(cls) -> Distribution:
-        return Distribution.fedora
 
     @classmethod
     def grub_prefix(cls) -> str:

--- a/mkosi/distributions/mageia.py
+++ b/mkosi/distributions/mageia.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 
 from mkosi.config import Architecture
 from mkosi.context import Context
-from mkosi.distributions import Distribution, fedora, join_mirror
+from mkosi.distributions import fedora, join_mirror
 from mkosi.installer.rpm import RpmRepository, find_rpm_gpgkey
 from mkosi.log import die
 from mkosi.util import listify
@@ -22,10 +22,6 @@ class Installer(fedora.Installer):
     @classmethod
     def default_release(cls) -> str:
         return "cauldron"
-
-    @classmethod
-    def default_tools_tree_distribution(cls) -> Distribution:
-        return Distribution.mageia
 
     @classmethod
     def install(cls, context: Context) -> None:

--- a/mkosi/distributions/openmandriva.py
+++ b/mkosi/distributions/openmandriva.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 
 from mkosi.config import Architecture
 from mkosi.context import Context
-from mkosi.distributions import Distribution, fedora, join_mirror
+from mkosi.distributions import fedora, join_mirror
 from mkosi.installer.rpm import RpmRepository, find_rpm_gpgkey
 from mkosi.log import die
 from mkosi.util import listify
@@ -22,10 +22,6 @@ class Installer(fedora.Installer):
     @classmethod
     def default_release(cls) -> str:
         return "cooker"
-
-    @classmethod
-    def default_tools_tree_distribution(cls) -> Distribution:
-        return Distribution.openmandriva
 
     @classmethod
     def install(cls, context: Context) -> None:

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -7,7 +7,7 @@ from xml.etree import ElementTree
 
 from mkosi.config import Architecture, Config
 from mkosi.context import Context
-from mkosi.distributions import Distribution, DistributionInstaller, PackageType, join_mirror
+from mkosi.distributions import DistributionInstaller, PackageType, join_mirror
 from mkosi.installer import PackageManager
 from mkosi.installer.dnf import Dnf
 from mkosi.installer.rpm import RpmRepository, find_rpm_gpgkey, setup_rpm
@@ -35,10 +35,6 @@ class Installer(DistributionInstaller):
     @classmethod
     def default_release(cls) -> str:
         return "tumbleweed"
-
-    @classmethod
-    def default_tools_tree_distribution(cls) -> Distribution:
-        return Distribution.opensuse
 
     @classmethod
     def grub_prefix(cls) -> str:

--- a/mkosi/distributions/ubuntu.py
+++ b/mkosi/distributions/ubuntu.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 from pathlib import Path
 
 from mkosi.context import Context
-from mkosi.distributions import Distribution, debian
+from mkosi.distributions import debian
 from mkosi.installer.apt import AptRepository
 from mkosi.util import listify
 
@@ -17,10 +17,6 @@ class Installer(debian.Installer):
     @classmethod
     def default_release(cls) -> str:
         return "noble"
-
-    @classmethod
-    def default_tools_tree_distribution(cls) -> Distribution:
-        return Distribution.ubuntu
 
     @staticmethod
     @listify


### PR DESCRIPTION
Let's choose the default tools tree distribution based on the host distribution instead of the target distribution. Why? When building a Fedora image from Ubuntu, It's much more likely that apt-get will be installed to build a Debian tools tree rather than requiring dnf to be installed to build a Fedora tools tree.