### PR TITLE
Allow multilib and multilib-testing repositories for arch distribution

### DIFF
--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -73,6 +73,8 @@ class Installer(DistributionInstaller):
                     "extra-testing-debug",
                     "core-debug",
                     "extra-debug",
+                    "multilib-testing",
+                    "multilib",
                 ) if repo in context.config.repositories
             ] + ["core", "extra"]
 


### PR DESCRIPTION
I also noticed setting random values as repositories makes mkosi silently ignore them. Wouldn’t it be nice to have a small warning when a repository name is not expected for a given distribution? Helps debug typos.