### PR TITLE
Recommend PackageDirectories= to install local packages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,12 @@
 - Support for installing local packages located in directories in
   `BuildSources=` was dropped. Instead, the packages can be made
   available for installation via `PackageManagerTrees=`.
+- Configuration parsing was reworked to remove the need for the `@`
+  specifier and to streamline building multiple images with
+  `mkosi.images/`. If you were building multiple images with
+  `mkosi.images/`, you'll need to adapt your configuration to the
+  rework. Read the **Building multiple images** section in the
+  documentation for more information.
 
 ## v23.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
   other architectures) has been removed. The required `console=`
   argument to have the kernel output to the serial console has to be
   added manually from `v24` onwards.
+- Support for installing local packages located in directories in
+  `BuildSources=` was dropped. Instead, the packages can be made
+  available for installation via `PackageManagerTrees=`.
 
 ## v23.1
 

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import dataclasses
-import os
 import shutil
 import textwrap
 from collections.abc import Iterable, Sequence
@@ -10,7 +9,6 @@ from pathlib import Path
 from mkosi.config import Config
 from mkosi.context import Context
 from mkosi.installer import PackageManager
-from mkosi.mounts import finalize_source_mounts
 from mkosi.run import run
 from mkosi.sandbox import Mount, apivfs_cmd
 from mkosi.types import _FILE, CompletedProcess, PathString
@@ -162,25 +160,20 @@ class Pacman(PackageManager):
         apivfs: bool = False,
         stdout: _FILE = None,
     ) -> CompletedProcess:
-        with finalize_source_mounts(
-            context.config,
-            ephemeral=os.getuid() == 0 and context.config.build_sources_ephemeral,
-        ) as sources:
-            return run(
-                cls.cmd(context) + [operation, *arguments],
-                sandbox=(
-                    context.sandbox(
-                        binary="pacman",
-                        network=True,
-                        vartmp=True,
-                        mounts=[Mount(context.root, "/buildroot"), *cls.mounts(context), *sources],
-                        options=["--dir", "/work/src", "--chdir", "/work/src"],
-                        extra=apivfs_cmd() if apivfs else [],
-                    )
-                ),
-                env=context.config.environment | cls.finalize_environment(context),
-                stdout=stdout,
-            )
+        return run(
+            cls.cmd(context) + [operation, *arguments],
+            sandbox=(
+                context.sandbox(
+                    binary="pacman",
+                    network=True,
+                    vartmp=True,
+                    mounts=[Mount(context.root, "/buildroot"), *cls.mounts(context)],
+                    extra=apivfs_cmd() if apivfs else [],
+                )
+            ),
+            env=context.config.environment | cls.finalize_environment(context),
+            stdout=stdout,
+        )
 
     @classmethod
     def sync(cls, context: Context, force: bool) -> None:

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -736,17 +736,6 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
              python3dist(mypy)
     ```
 
-    Note that since mkosi runs in a sandbox with most of the host files
-    unavailable, any local packages have to be mounted into the sandbox
-    explicitly using `BuildSources=`. For example, let's say we have a
-    local package located at `../my-packages/abc.rpm` relative to the mkosi
-    working directory, then we'd be able to install it as follows:
-
-    ```ini
-    BuildSources=../my-packages:my-packages-in-sandbox
-    Packages=my-packages-in-sandbox/abc.rpm
-    ```
-
 `BuildPackages=`, `--build-package=`
 :   Similar to `Packages=`, but configures packages to install only in an
     overlay that is made available on top of the image to the prepare

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -714,9 +714,11 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     The types and syntax of *package specifications* that are allowed
     depend on the package installer (e.g. `dnf` for `rpm`-based distros or
     `apt` for `deb`-based distros), but may include package names, package
-    names with version and/or architecture, package name globs, paths to
-    packages in the file system, package groups, and virtual provides,
-    including file paths.
+    names with version and/or architecture, package name globs, package
+    groups, and virtual provides, including file paths.
+
+    See `PackageDirectories=` for information on how to make local
+    packages available for installation with `Packages=`.
 
     **Example**: when using a distro that uses `dnf`, the following configuration
     would install the `meson` package (in the latest version), the 32-bit version
@@ -729,7 +731,6 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     Packages=meson
              libfdisk-devel.i686
              git-*
-             prebuilt/rpms/systemd-249-rc1.local.rpm
              /usr/bin/ld
              @development-tools
              python3dist(mypy)


### PR DESCRIPTION
apt-get requires absolute paths to be specified and doesn't work
with relative paths. Let's instead recommend PackageDirectories=
which we know works the same for all distributions.

Fixes #2890 