### PR TITLE
Revert "Force user namespace in bubblewrap if we're not running as root"

### DIFF
--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -153,11 +153,6 @@ def sandbox_cmd(
         # We mounted a subdirectory of TMPDIR to /var/tmp so we unset TMPDIR so that /tmp or /var/tmp are used instead.
         "--unsetenv", "TMPDIR",
     ]
-
-    # Make sure that bubblewrap uses a user namespace even if it's installed as setuid.
-    if os.getuid() != 0:
-        cmdline += ["--unshare-user"]
-
     mounts += [Mount(tools / "usr", "/usr", ro=True)]
 
     if relaxed:


### PR DESCRIPTION
This reverts commit 01ac080103f2bc61ecc23334b00334e421eebb8a.

We can't check the current uid in sandbox_cmd() as it might still change, for example in start_virtiofsd() where before we run bwrap we might run become_root_cmd() to become root.