### PR TITLE
Only pass --expand-environment=no if we have systemd-run 254 or newer

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2200,7 +2200,11 @@ def build_uki(
     if microcodes:
         # new .ucode section support?
         if (
-            systemd_tool_version(context.config, python_binary(context.config, binary=ukify), ukify) >= "256" and
+            systemd_tool_version(
+                python_binary(context.config, binary=ukify),
+                ukify,
+                sandbox=context.sandbox,
+            ) >= "256" and
             (version := systemd_stub_version(context, stub)) and
             version >= "256"
         ):
@@ -2297,7 +2301,7 @@ def find_entry_token(context: Context) -> str:
         not context.config.find_binary("kernel-install") or
         "--version" not in run(["kernel-install", "--help"],
                                stdout=subprocess.PIPE, sandbox=context.sandbox(binary="kernel-install")).stdout or
-        systemd_tool_version(context.config, "kernel-install") < "255.1"
+        systemd_tool_version("kernel-install", sandbox=context.sandbox) < "255.1"
     ):
         return context.config.image_id or context.config.distribution.name
 
@@ -2901,7 +2905,7 @@ def check_systemd_tool(
 ) -> None:
     tool = check_tool(config, *tools, reason=reason, hint=hint)
 
-    v = systemd_tool_version(config, tool)
+    v = systemd_tool_version(tool, sandbox=config.sandbox)
     if v < version:
         die(f"Found '{tool}' with version {v} but version {version} or newer is required to {reason}.",
             hint=f"Use ToolsTree=default to get a newer version of '{tools[0]}'.")
@@ -2915,7 +2919,7 @@ def check_ukify(
 ) -> None:
     ukify = check_tool(config, "ukify", "/usr/lib/systemd/ukify", reason=reason, hint=hint)
 
-    v = systemd_tool_version(config, python_binary(config, binary=ukify), ukify)
+    v = systemd_tool_version(python_binary(config, binary=ukify), ukify, sandbox=config.sandbox)
     if v < version:
         die(f"Found '{ukify}' with version {v} but version {version} or newer is required to {reason}.",
             hint="Use ToolsTree=default to get a newer version of 'ukify'.")
@@ -3412,7 +3416,7 @@ def make_image(
         cmdline += ["--split=yes"]
     if context.config.sector_size:
         cmdline += ["--sector-size", str(context.config.sector_size)]
-    if tabs and systemd_tool_version(context.config, "systemd-repart") >= 256:
+    if tabs and systemd_tool_version("systemd-repart", sandbox=context.sandbox) >= 256:
         cmdline += [
             "--generate-fstab=/etc/fstab",
             "--generate-crypttab=/etc/crypttab",

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -35,7 +35,7 @@ from mkosi.distributions import Distribution, detect_distribution
 from mkosi.log import ARG_DEBUG, ARG_DEBUG_SHELL, Style, die
 from mkosi.pager import page
 from mkosi.run import find_binary, run
-from mkosi.sandbox import Mount, sandbox_cmd
+from mkosi.sandbox import Mount, SandboxProtocol, nosandbox, sandbox_cmd
 from mkosi.types import PathString, SupportsRead
 from mkosi.user import INVOKING_USER
 from mkosi.util import (
@@ -4427,11 +4427,11 @@ def want_selinux_relabel(config: Config, root: Path, fatal: bool = True) -> Opti
     return setfiles, policy, fc, binpolicy
 
 
-def systemd_tool_version(config: Config, *tool: PathString) -> GenericVersion:
+def systemd_tool_version(*tool: PathString, sandbox: SandboxProtocol = nosandbox) -> GenericVersion:
     return GenericVersion(
         run(
             [*tool, "--version"],
             stdout=subprocess.PIPE,
-            sandbox=config.sandbox(binary=tool[-1]),
+            sandbox=sandbox(binary=tool[-1]),
         ).stdout.split()[2].strip("()").removeprefix("v")
     )

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -153,7 +153,7 @@ class KernelType(StrEnum):
             logging.warning("bootctl is not installed, assuming 'unknown' kernel type")
             return KernelType.unknown
 
-        if (v := systemd_tool_version(config, "bootctl")) < 253:
+        if (v := systemd_tool_version("bootctl", sandbox=config.sandbox)) < 253:
             logging.warning(f"bootctl {v} doesn't know kernel-identify verb, assuming 'unknown' kernel type")
             return KernelType.unknown
 
@@ -744,7 +744,7 @@ def scope_cmd(
         "--description", description,
         "--scope",
         "--collect",
-        "--expand-environment=no",
+        *(["--expand-environment=no"] if systemd_tool_version("systemd-run") >= 254 else []),
         *(["--uid", str(user)] if user is not None else []),
         *(["--gid", str(group)] if group is not None else []),
         *([f"--property={p}" for p in properties]),


### PR DESCRIPTION
--expand-environment= was introduced in systemd v254.