### PR TITLE
action: Dump the current clock source

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -32,6 +32,10 @@ runs:
       ls -l /dev/vhost-*
       id
 
+  - name: Check clock source
+    shell: bash
+    run: cat /sys/devices/system/clocksource/clocksource0/current_clocksource
+
   - name: Enable unprivileged user namespaces
     shell: bash
     run: |


### PR DESCRIPTION
This can have a non-trivial performance impact so let's dump the clock source as extra debugging information.