### PR TITLE
Don't copy /var/lib/pacman/local when copying repository metadata

### DIFF
--- a/mkosi/installer/__init__.py
+++ b/mkosi/installer/__init__.py
@@ -26,6 +26,10 @@ class PackageManager:
         return []
 
     @classmethod
+    def state_subdirs(cls, state: Path) -> list[Path]:
+        return  []
+
+    @classmethod
     def scripts(cls, context: Context) -> dict[str, list[PathString]]:
         return {}
 

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -36,6 +36,10 @@ class Pacman(PackageManager):
         return [cache / "pkg"]
 
     @classmethod
+    def state_subdirs(cls, state: Path) -> list[Path]:
+        return [state / "local"]
+
+    @classmethod
     def scripts(cls, context: Context) -> dict[str, list[PathString]]:
         return {
             "pacman": apivfs_cmd() + cls.env_cmd(context) + cls.cmd(context),


### PR DESCRIPTION
/var/lib/pacman/local contains the local database of installed packages. When using "--package-cache-dir /var", we'd end up copying the local database of the host which means pacman thinks packages are already installed in the image even though they aren't.

Fix this by not copying /var/lib/pacman/local.

Fixes #2904