### PR TITLE
Look up qemu and virt-fw-vars in extra search paths

### DIFF
--- a/mkosi/kmod.py
+++ b/mkosi/kmod.py
@@ -29,7 +29,6 @@ def filter_kernel_modules(root: Path, kver: str, *, include: Iterable[str], excl
         for m in modules:
             rel = os.fspath(Path(*m.parts[1:]))
             if regex.search(rel):
-                logging.debug(f"Including module {rel}")
                 keep.add(rel)
 
     if exclude:
@@ -38,7 +37,6 @@ def filter_kernel_modules(root: Path, kver: str, *, include: Iterable[str], excl
         for m in modules:
             rel = os.fspath(Path(*m.parts[1:]))
             if rel not in keep and regex.search(rel):
-                logging.debug(f"Excluding module {rel}")
                 remove.add(m)
 
         modules -= remove
@@ -221,7 +219,6 @@ def process_kernel_modules(
 
             p = root / m
             if p.is_file() or p.is_symlink():
-                logging.debug(f"Removing module {m}")
                 p.unlink()
             else:
                 p.rmdir()
@@ -235,7 +232,6 @@ def process_kernel_modules(
 
             p = root / fw
             if p.is_file() or p.is_symlink():
-                logging.debug(f"Removing firmware {fw}")
                 p.unlink()
             else:
                 p.rmdir()

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -80,8 +80,8 @@ def uncaught_exception_handler(exit: Callable[[int], NoReturn] = sys.exit) -> It
         if (
             ARG_DEBUG.get() and
             e.cmd and
-            e.cmd[0] not in ("self", "ssh", "systemd-nspawn") and
-            not e.cmd[0].startswith("qemu")
+            str(e.cmd[0]) not in ("self", "ssh", "systemd-nspawn") and
+            "qemu-system" not in str(e.cmd[0])
         ):
             sys.excepthook(*ensure_exc_info())
     except BaseException:

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -59,18 +59,21 @@ def uncaught_exception_handler(exit: Callable[[int], NoReturn] = sys.exit) -> It
     try:
         yield
     except SystemExit as e:
+        rc = e.code if isinstance(e.code, int) else 1
+
         if ARG_DEBUG.get():
             sys.excepthook(*ensure_exc_info())
-
-        rc = e.code if isinstance(e.code, int) else 1
     except KeyboardInterrupt:
+        rc = 1
+
         if ARG_DEBUG.get():
             sys.excepthook(*ensure_exc_info())
         else:
             logging.error("Interrupted")
-
-        rc = 1
     except subprocess.CalledProcessError as e:
+        # We always log when subprocess.CalledProcessError is raised, so we don't log again here.
+        rc = e.returncode
+
         # Failures from qemu, ssh and systemd-nspawn are expected and we won't log stacktraces for those.
         # Failures from self come from the forks we spawn to build images in a user namespace. We've already done all
         # the logging for those failures so we don't log stacktraces for those either.
@@ -81,9 +84,6 @@ def uncaught_exception_handler(exit: Callable[[int], NoReturn] = sys.exit) -> It
             not e.cmd[0].startswith("qemu")
         ):
             sys.excepthook(*ensure_exc_info())
-
-        # We always log when subprocess.CalledProcessError is raised, so we don't log again here.
-        rc = e.returncode
     except BaseException:
         sys.excepthook(*ensure_exc_info())
         rc = 1


### PR DESCRIPTION
Because qemu uses OVMF firmware descriptions from /usr, we look those up in the same root that we'll be invoking qemu from. Because virt-fw-vars operates on the same files, we also invoke it in the same root that we find qemu in.