### PR TITLE
completion: fix bash completion script

### DIFF
--- a/mkosi/completion.py
+++ b/mkosi/completion.py
@@ -7,6 +7,7 @@ import io
 import shlex
 from collections.abc import Iterable, Mapping
 from pathlib import Path
+from textwrap import indent
 from typing import Optional, Union
 
 from mkosi import config
@@ -114,10 +115,8 @@ def finalize_completion_bash(options: list[CompletionItem], resources: Path) -> 
 
     options_by_key = {o.short: o for o in options if o.short} | {o.long: o for o in options if o.long}
 
+    template = completion.read_text()
     with io.StringIO() as c:
-        c.write(completion.read_text())
-        c.write("\n")
-
         c.write(to_bash_array("_mkosi_options", options_by_key.keys()))
         c.write("\n\n")
 
@@ -139,9 +138,10 @@ def finalize_completion_bash(options: list[CompletionItem], resources: Path) -> 
         c.write("\n\n")
 
         c.write(to_bash_array("_mkosi_verbs", [str(v) for v in config.Verb]))
-        c.write("\n\n\n")
 
-        return c.getvalue()
+        definitions = c.getvalue()
+
+    return template.replace("##VARIABLEDEFINITIONS##", indent(definitions, " " * 4))
 
 
 def finalize_completion_fish(options: list[CompletionItem], resources: Path) -> str:

--- a/mkosi/resources/completion.bash
+++ b/mkosi/resources/completion.bash
@@ -1,12 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 # shellcheck shell=bash
 
-declare -a _mkosi_options
-declare -A _mkosi_nargs
-declare -A _mkosi_choices
-declare -A _mkosi_compgen
-declare -a _mkosi_verbs
-
 _mkosi_compgen_files() {
     compgen -f -- "$1"
 }
@@ -16,6 +10,11 @@ _mkosi_compgen_dirs() {
 }
 
 _mkosi_completion() {
+    local -a _mkosi_options _mkosi_verbs
+    local -A _mkosi_nargs _mkosi_choices _mkosi_compgen
+
+##VARIABLEDEFINITIONS##
+
     # completing_program="$1"
     local completing_word="$2"
     local completing_word_preceding="$3"


### PR DESCRIPTION
Template the options definitions directly into the completion function, since for some weird scoping reasons even though the script is read fine and when running a shell with set -x one can see e.g. _mkosi_options being assigned the proper values, the completion function still uses '' for "${_mkosi_options[*]}".

This wasn't caught during development because the script works fine when sourced.