### PR TITLE
Handle failure to detect the distribution in test_parse_config()

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -151,7 +151,7 @@ def test_parse_config(tmp_path: Path) -> None:
 
     # Empty values on the CLIs resets non-collection based settings to their defaults and collection based settings to
     # empty collections.
-    assert config.distribution == detect_distribution()[0]
+    assert config.distribution == (detect_distribution()[0] or Distribution.custom)
     assert "MY_KEY" not in config.environment
     assert "my.cred" not in config.credentials
     assert config.repositories == []


### PR DESCRIPTION
If /usr/lib/os-release isn't available, we can't detect the current distribution, so let's make sure we handle that scenario as well by checking for Distribution.custom instead of None.

Fixes #2921