### PR TITLE
Set up proper environment variables for kernel-install

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -162,6 +162,14 @@ def install_distribution(context: Context) -> None:
             # should not be read from or written to.
             with umask(~0o500):
                 (context.root / "efi").mkdir(exist_ok=True)
+                (context.root / "boot").mkdir(exist_ok=True)
+
+            # Ensure /boot/loader/entries.srel exists and has type1 written to it to nudge kernel-install towards using
+            # the boot loader specification layout.
+            with umask(~0o700):
+                (context.root / "boot/loader").mkdir(exist_ok=True)
+            with umask(~0o600):
+                (context.root / "boot/loader/entries.srel").write_text("type1\n")
 
             if context.config.packages:
                 context.config.distribution.install_packages(context, context.config.packages)

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2311,7 +2311,7 @@ def find_entry_token(context: Context) -> str:
             ["kernel-install", "--root=/buildroot", "--json=pretty", "inspect"],
             sandbox=context.sandbox(binary="kernel-install", mounts=[Mount(context.root, "/buildroot", ro=True)]),
             stdout=subprocess.PIPE,
-            env={"SYSTEMD_ESP_PATH": "/efi", "SYSTEMD_XBOOTLDR_PATH": "/boot"},
+            env={"BOOT_ROOT": "/boot"},
         ).stdout
     )
 

--- a/mkosi/installer/__init__.py
+++ b/mkosi/installer/__init__.py
@@ -47,6 +47,14 @@ class PackageManager:
             context.config.bootable != ConfigFeature.disabled
         ):
             env["KERNEL_INSTALL_BYPASS"] = "1"
+        else:
+            env |= {
+                "BOOT_ROOT": "/boot",
+                # Required to make 90-loaderentry.install put the right paths into the bootloader entry.
+                "BOOT_MNT": "/boot",
+                # Hack to tell dracut to not create a hostonly initrd when it's invoked by kernel-install.
+                "hostonly_l": "no",
+            }
 
         return env
 


### PR DESCRIPTION
If we're not explicitly disabling kernel-install during package manager invocations, let's set up the environment to make it do the right thing instead.