### PR TITLE
Look for $USER for the username before reading /etc/passwd

### DIFF
--- a/mkosi/user.py
+++ b/mkosi/user.py
@@ -39,7 +39,7 @@ class INVOKING_USER:
     @classmethod
     @functools.lru_cache(maxsize=1)
     def name(cls) -> str:
-        return pwd.getpwuid(cls.uid).pw_name
+        return os.getenv("USER", pwd.getpwuid(cls.uid).pw_name)
 
     @classmethod
     @functools.lru_cache(maxsize=1)


### PR DESCRIPTION
Let's take $USER into account if set before reading /etc/passwd for the username. This gives a way out for environments where the uid of the user does not have an entry in /etc/passwd.