### PR TITLE
Stop always setting autologin credentials

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3832,8 +3832,6 @@ def parse_config(argv: Sequence[str] = (), *, resources: Path = Path("/")) -> tu
 
 def load_credentials(args: argparse.Namespace) -> dict[str, str]:
     creds = {
-        "agetty.autologin": "root",
-        "login.noauth": "yes",
         "firstboot.locale": "C.UTF-8",
         **args.credentials,
     }


### PR DESCRIPTION
Let's require users to set these automatically if they want to have autologin without enabling the Autologin= setting. This gives more flexibility after https://github.com/systemd/systemd/pull/33873 is merged in systemd as users can choose to enable the settings globally or per tty depending on what they need.