### PR TITLE
Enable RepositoryKeyFetch= by default on Ubuntu without a tools tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,14 +155,6 @@ jobs:
         QemuKvm=yes
         EOF
 
-        # TODO: Drop once distribution-gpg-keys is in noble-backports.
-        if [[ "${{ matrix.tools }}" =~ opensuse|fedora|ubuntu ]]; then
-            tee --append mkosi.local.conf <<EOF
-        [Distribution]
-        RepositoryKeyFetch=yes
-        EOF
-        fi
-
         # TODO: Remove once all distros have recent enough systemd that knows systemd.default_device_timeout_sec.
         mkdir -p mkosi-initrd/mkosi.extra/usr/lib/systemd/system.conf.d
         tee mkosi-initrd/mkosi.extra/usr/lib/systemd/system.conf.d/device-timeout.conf <<EOF

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -724,6 +724,23 @@ def config_default_tools_tree_distribution(namespace: argparse.Namespace) -> Dis
     return detected.default_tools_tree_distribution()
 
 
+def config_default_repository_key_fetch(namespace: argparse.Namespace) -> bool:
+    if detect_distribution()[0] != Distribution.ubuntu:
+        return False
+
+    if namespace.tools_tree is None:
+        return cast(bool, namespace.distribution.is_rpm_distribution())
+
+    if namespace.tools_tree != Path("default"):
+        return False
+
+    return cast(
+        bool,
+        (namespace.tools_tree_distribution == Distribution.ubuntu and namespace.distribution.is_rpm_distribution()) or
+        namespace.tools_tree_distribution.is_rpm_distribution()
+    )
+
+
 def config_default_source_date_epoch(namespace: argparse.Namespace) -> Optional[int]:
     for env in namespace.environment:
         if s := startswith(env, "SOURCE_DATE_EPOCH="):
@@ -1967,7 +1984,8 @@ SETTINGS = (
         metavar="BOOL",
         nargs="?",
         section="Distribution",
-        default=False,
+        default_factory_depends=("distribution", "tools_tree", "tools_tree_distribution"),
+        default_factory=config_default_repository_key_fetch,
         parse=config_parse_boolean,
         help="Controls whether distribution GPG keys can be fetched remotely",
         universal=True,

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -101,6 +101,19 @@ class Distribution(StrEnum):
     def is_apt_distribution(self) -> bool:
         return self in (Distribution.debian, Distribution.ubuntu)
 
+    def is_rpm_distribution(self) -> bool:
+        return self in (
+            Distribution.fedora,
+            Distribution.opensuse,
+            Distribution.mageia,
+            Distribution.centos,
+            Distribution.rhel,
+            Distribution.rhel_ubi,
+            Distribution.openmandriva,
+            Distribution.rocky,
+            Distribution.alma,
+        )
+
     def pretty_name(self) -> str:
         return self.installer().pretty_name()
 

--- a/mkosi/distributions/ubuntu.py
+++ b/mkosi/distributions/ubuntu.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 from pathlib import Path
 
 from mkosi.context import Context
-from mkosi.distributions import debian
+from mkosi.distributions import Distribution, debian
 from mkosi.installer.apt import AptRepository
 from mkosi.util import listify
 
@@ -17,6 +17,10 @@ class Installer(debian.Installer):
     @classmethod
     def default_release(cls) -> str:
         return "noble"
+
+    @classmethod
+    def default_tools_tree_distribution(cls) -> Distribution:
+        return Distribution.debian
 
     @staticmethod
     @listify

--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -453,8 +453,9 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     a repository from a local filesystem.
 
 `RepositoryKeyFetch=`, `--repository-key-fetch=`
-:   Controls whether mkosi will fetch distribution GPG keys remotely. Disabled
-    by default. When disabled, the distribution GPG keys for the target distribution
+:   Controls whether mkosi will fetch distribution GPG keys remotely. Enabled by
+    default on Ubuntu when not using a tools tree, disabled by default on all
+    other distributions. When disabled, the distribution GPG keys for the target distribution
     have to be installed locally on the host system alongside the package manager for
     that distribution.
 

--- a/tests/test_sysext.py
+++ b/tests/test_sysext.py
@@ -24,7 +24,6 @@ def test_sysext(config: ImageConfig) -> None:
             options=[
                 "--directory", "",
                 "--incremental=no",
-                "--repository-key-fetch=yes",
                 "--base-tree", Path(image.output_dir) / "image",
                 "--overlay",
                 "--package=dnsmasq",


### PR DESCRIPTION
Ubuntu does not have distribution-gpg-keys yet, so let's enable
RepositoryKeyFetch= for it by default when a tools tree is not used.