### PR TITLE
Exit early if output format is none and there are no build scripts

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4929,6 +4929,10 @@ def run_verb(args: Args, images: Sequence[Config], *, resources: Path) -> None:
             ):
                 continue
 
+            # If the output format is "none" and there are no build scripts, there's nothing to do so exit early.
+            if config.output_format == OutputFormat.none and not config.build_scripts:
+                return
+
             check_inputs(config)
             fork_and_wait(run_sync, args, config, resources=resources)
             fork_and_wait(run_build, args, config, resources=resources, package_dir=Path(package_dir))


### PR DESCRIPTION
In systemd, the build script is part of a subimage so the build is done as part of the subimage and there's nothing to do for the main image. To speed things up a bit, exit early if there are no build scripts and the output format is none.