### PR TITLE
Clarify that inherited settings take priority over CLI/main settings

### DIFF
--- a/mkosi/resources/mkosi.md
+++ b/mkosi/resources/mkosi.md
@@ -2515,8 +2515,10 @@ overridden):
 - `ToolsTreeCertificates=`
 
 There are also settings which are passed down to subimages but can
-be overridden. Currently the following settings are passed down to
-subimages but can be overridden:
+be overridden. For these settings, values configured explicitly in
+the subimage will take priority over values configured on the CLI or
+in the main image config. Currently the following settings are passed
+down to subimages but can be overridden:
 
 - `ImageId=`
 - `ImageVersion=`

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -297,6 +297,14 @@ def test_parse_config(tmp_path: Path) -> None:
     assert one.image_version == "1.2.3"
     assert two.image_version == "4.5.6"
 
+    with chdir(d):
+        _, [one, two, config] = parse_config(["--image-version", "7.8.9"])
+
+    # Inherited settings specified on the CLI should not override subimages that configure the setting explicitly.
+    assert config.image_version == "7.8.9"
+    assert one.image_version == "7.8.9"
+    assert two.image_version == "4.5.6"
+
 
 def test_parse_includes_once(tmp_path: Path) -> None:
     d = tmp_path


### PR DESCRIPTION
If "inherited" settings are configured explicitly in subimages, those
values should take priority over values configured in the main config
and CLI.