### PR TITLE
Don't pass down empty lists to subimages unless explicitly configured

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3807,13 +3807,14 @@ def parse_config(argv: Sequence[str] = (), *, resources: Path = Path("/")) -> tu
     if args.directory is not None:
         context.parse_config_one(Path("."), profiles=True, local=True)
 
+    config = copy.deepcopy(context.config)
+
     # After we've finished parsing the configuration, we'll have values in both
     # namespaces (context.cli, context.config). To be able to parse the values from a
     # single namespace, we merge the final values of each setting into one namespace.
     for s in SETTINGS:
-        setattr(context.config, s.dest, context.finalize_value(s))
+        setattr(config, s.dest, context.finalize_value(s))
 
-    config = copy.deepcopy(context.config)
     images = []
 
     if args.directory is not None and Path("mkosi.images").exists():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -251,24 +251,29 @@ def test_parse_config(tmp_path: Path) -> None:
 
     (d / "mkosi.images").mkdir()
 
-    for n in ("one", "two"):
-        (d / "mkosi.images" / f"{n}.conf").write_text(
-            f"""\
-            [Distribution]
-            Repositories=append
+    (d / "mkosi.images/one.conf").write_text(
+        """\
+        [Distribution]
+        Repositories=append
 
-            [Content]
-            Packages={n}
-            """
-        )
+        [Content]
+        Packages=one
+        """
+    )
 
-    with (d / "mkosi.images" / "two.conf").open("a") as f:
-        f.write(
-            """
-            [Output]
-            ImageVersion=4.5.6
-            """
-        )
+    (d / "mkosi.images/two").mkdir()
+    (d / "mkosi.images/two/mkosi.conf").write_text(
+        """
+        [Distribution]
+        Repositories=append
+
+        [Content]
+        Packages=two
+
+        [Output]
+        ImageVersion=4.5.6
+        """
+    )
 
     with chdir(d):
         _, [one, two, config] = parse_config(["--package", "qed", "--build-package", "def", "--repositories", "cli"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -262,6 +262,7 @@ def test_parse_config(tmp_path: Path) -> None:
     )
 
     (d / "mkosi.images/two").mkdir()
+    (d / "mkosi.images/two/mkosi.skeleton").mkdir()
     (d / "mkosi.images/two/mkosi.conf").write_text(
         """
         [Distribution]
@@ -301,6 +302,10 @@ def test_parse_config(tmp_path: Path) -> None:
     # Inherited settings should be passed down to subimages but overridable by subimages.
     assert one.image_version == "1.2.3"
     assert two.image_version == "4.5.6"
+
+    # Default values from subimages should be picked up.
+    assert len(one.package_manager_trees) == 0
+    assert len(two.package_manager_trees) == 1 and two.package_manager_trees[0].source.name == "mkosi.skeleton"
 
     with chdir(d):
         _, [one, two, config] = parse_config(["--image-version", "7.8.9"])


### PR DESCRIPTION
This makes sure that subimages use default values for list based
settings unless they were explicitly configured in configuration or
on the command line or have a non-empty default value in the main
image.

Fixes https://github.com/systemd/mkosi/issues/2874