### PR TITLE
debian: Fix up os-release for unstable/sid builds

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -240,7 +240,7 @@ def configure_os_release(context: Context) -> None:
     if context.config.overlay or context.config.output_format in (OutputFormat.sysext, OutputFormat.confext):
         return
 
-    for candidate in ["usr/lib/os-release", "usr/lib/initrd-release"]:
+    for candidate in ["usr/lib/os-release", "usr/lib/initrd-release", "etc/os-release"]:
         osrelease = context.root / candidate
         # at this point we know we will either change or add to the file
         newosrelease = osrelease.with_suffix(".new")


### PR DESCRIPTION
The version codename for unstable/sid builds is indistinguishable from
testing. Let's make sure we fix that up ourselves so that unstable image
builds can be properly distinguished from testing builds.