### PR TITLE
Always specify _sourcedir as an absolute path

### DIFF
--- a/docs/building-rpms-from-source.md
+++ b/docs/building-rpms-from-source.md
@@ -71,7 +71,7 @@ mkosi-chroot \
     --query \
     --buildrequires \
     --define "_topdir /var/tmp" \
-    --define "_sourcedir rpm" \
+    --define "_sourcedir $PWD/mkosi/rpm" \
     rpm/mkosi.spec |
         sort --unique |
         tee /tmp/buildrequires |
@@ -83,7 +83,7 @@ until mkosi-chroot \
     -bd \
     --build-in-place \
     --define "_topdir /var/tmp" \
-    --define "_sourcedir rpm" \
+    --define "_sourcedir $PWD/mkosi/rpm" \
     --define "_build_name_fmt %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm" \
     rpm/mkosi.spec
 do
@@ -157,7 +157,7 @@ env --chdir=mkosi \
     --build-in-place \
     $([ "$WITH_TESTS" = "0" ] && echo --nocheck) \
     --define "_topdir /var/tmp" \
-    --define "_sourcedir rpm" \
+    --define "_sourcedir $PWD/mkosi/rpm" \
     --define "_rpmdir $OUTPUTDIR" \
     ${BUILDDIR:+--define} \
     ${BUILDDIR:+"_vpath_builddir $BUILDDIR"} \

--- a/mkosi.conf.d/30-rpm/mkosi.build.chroot
+++ b/mkosi.conf.d/30-rpm/mkosi.build.chroot
@@ -7,7 +7,7 @@ rpmbuild \
     --build-in-place \
     $([ "$WITH_TESTS" = "0" ] && echo --nocheck) \
     --define "_topdir /var/tmp" \
-    --define "_sourcedir rpm" \
+    --define "_sourcedir $PWD/rpm" \
     --define "_rpmdir $PACKAGEDIR" \
     --define "_build_name_fmt %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm" \
     rpm/mkosi.spec


### PR DESCRIPTION
Relative _sourcedir was never supported by rpm:
https://github.com/rpm-software-management/rpm/issues/3208#issuecomment-2283520243