### PR TITLE
Add executable `mkosi.version` support for generating the version dynamically

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1275,3 +1275,23 @@ def test_environment(tmp_path: Path) -> None:
 
         assert sub.environment["PassThisEnv"] == "abc"
         assert "TestValue2" not in sub.environment
+
+
+def test_mkosi_version_executable(tmp_path: Path) -> None:
+    d = tmp_path
+
+    version = d / "mkosi.version"
+    version.write_text("#!/bin/sh\necho '1.2.3'\n")
+
+    with chdir(d):
+        with pytest.raises(SystemExit) as error:
+            _, [config] = parse_config()
+
+        assert error.type is SystemExit
+        assert error.value.code != 0
+
+    version.chmod(0o755)
+
+    with chdir(d):
+        _, [config] = parse_config()
+        assert config.image_version == "1.2.3"


### PR DESCRIPTION
The script is executed unsandboxed (not a fan of this, but unsure how this should be done before any configuration even exists) and reads `stdout` to figure out the version.

First commit allows more configurable handling of "standard config paths". Maybe this change should also be extended to `mkosi.rootpw` to allow generating it dynamically?

Closes #2915