### PR TITLE
mkosi-initrd: Remove /var/cache/ldconfig/aux-cache

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -33,6 +33,9 @@ RemoveFiles=
         /usr/lib/modules/*/vmlinux*
         /usr/lib/modules/*/System.map
 
+        # This file is not reproducible so let's remove it to increase reproducibility of initrds.
+        /var/cache/ldconfig/aux-cache
+
 # Configure locale explicitly so that all other locale data is stripped on distros whose package manager supports it.
 Locale=C.UTF-8
 WithDocs=no


### PR DESCRIPTION
The file is not reproducible so let's remove it so that reproducible initrds can be built by default.

Fixes #2957