### PR TITLE
Specify --renumber-inodes when calling cpio

### DIFF
--- a/mkosi/archive.py
+++ b/mkosi/archive.py
@@ -116,6 +116,7 @@ def make_cpio(
                 "cpio",
                 "--create",
                 "--reproducible",
+                "--renumber-inodes",
                 "--null",
                 "--format=newc",
                 "--quiet",


### PR DESCRIPTION
This helps with making initrds reproducible as the sequence of inodes will always be stable starting from 1.