### PR TITLE
Specify --noprep when building rpms from source

### DIFF
--- a/docs/building-rpms-from-source.md
+++ b/docs/building-rpms-from-source.md
@@ -81,6 +81,7 @@ until mkosi-chroot \
     env --chdir=mkosi \
     rpmbuild \
     -bd \
+    --noprep \
     --build-in-place \
     --define "_topdir /var/tmp" \
     --define "_sourcedir $PWD/mkosi/rpm" \
@@ -154,6 +155,7 @@ set -e
 env --chdir=mkosi \
     rpmbuild \
     -bb \
+    --noprep \
     --build-in-place \
     $([ "$WITH_TESTS" = "0" ] && echo --nocheck) \
     --define "_topdir /var/tmp" \

--- a/mkosi.conf.d/30-rpm/mkosi.build.chroot
+++ b/mkosi.conf.d/30-rpm/mkosi.build.chroot
@@ -4,6 +4,7 @@ set -ex
 
 rpmbuild \
     -bb \
+    --noprep \
     --build-in-place \
     $([ "$WITH_TESTS" = "0" ] && echo --nocheck) \
     --define "_topdir /var/tmp" \


### PR DESCRIPTION
rpm upstream is moving in this direction as well so let's update our docs to match.