### PR TITLE
Don't mount stuff twice from different sources in sandbox

### DIFF
--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -470,6 +470,9 @@ def sandbox_cmd(
     else:
         cmdline += ["--ro-bind", tools / "usr", "/usr"]
 
+    if (tools / "etc/ld.so.cache").exists():
+        cmdline += ["--ro-bind", tools / "etc/ld.so.cache", "/etc/ld.so.cache"]
+
     if relaxed:
         cmdline += ["--bind", "/tmp", "/tmp"]
     else:


### PR DESCRIPTION
We were mounting /var/tmp and /etc/resolv.conf twice in chroot_cmd(), let's make sure we avoid doing that by moving the CLI options into the respective _script_cmd() functions.