### PR TITLE
Add 'login' to Debian/Ubuntu/Kali package list

### DIFF
--- a/docs/bootable.md
+++ b/docs/bootable.md
@@ -62,6 +62,7 @@ Distribution=debian
 [Content]
 Bootable=yes
 Packages=linux-image-generic
+         login
          systemd
          systemd-boot
          systemd-sysv
@@ -78,6 +79,7 @@ Distribution=kali
 [Content]
 Bootable=yes
 Packages=linux-image-generic
+         login
          systemd
          systemd-boot
          systemd-sysv
@@ -95,6 +97,7 @@ Repositories=main,universe
 [Content]
 Bootable=yes
 Packages=linux-image-generic
+         login
          systemd
          systemd-sysv
          udev

--- a/mkosi.conf.d/30-debian-kali-ubuntu/mkosi.conf
+++ b/mkosi.conf.d/30-debian-kali-ubuntu/mkosi.conf
@@ -17,6 +17,7 @@ Packages=
         iputils-ping
         libtss2-rc0
         libtss2-tcti-device0
+        login
         openssh-client
         openssh-server
         polkitd


### PR DESCRIPTION
The login package as provided by util-linux is 'Protected' but no longer 'Essential' and that's intentional, so it will not be pulled in by default. Add it to the list.