### PR TITLE
ci: Enable debug logging for systemd-repart

### DIFF
--- a/mkosi.extra/usr/lib/systemd/system/systemd-machine-id-commit.service.d/timeout.conf
+++ b/mkosi.extra/usr/lib/systemd/system/systemd-machine-id-commit.service.d/timeout.conf
@@ -1,2 +1,0 @@
-[Service]
-TimeoutSec=90s

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -64,7 +64,7 @@ class Image:
             "udev.log_level=info",
             "systemd.show_status=false",
             "systemd.journald.forward_to_console",
-            "systemd.journald.max_level_console=info",
+            "systemd.journald.max_level_console=debug",
             "systemd.firstboot=no",
             "systemd.unit=mkosi-check-and-shutdown.service",
         ]


### PR DESCRIPTION
This hopefully allows debugging the spurious opensuse CI failures.