### PR TITLE
qemu: enroll certificate in MOK for dm-verity and kernel mods

### DIFF
--- a/mkosi/resources/man/mkosi.md
+++ b/mkosi/resources/man/mkosi.md
@@ -1252,7 +1252,7 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     | `ubuntu-keyring`        | ✓      | ✓      | ✓      | ✓    | ✓      | ✓    |          |
     | `util-linux`            | ✓      | ✓      | ✓      | ✓    | ✓      | ✓    | ✓        |
     | `virtiofsd`             | ✓      | ✓      | ✓      | ✓    | ✓      | ✓    | ✓        |
-    | `virt-firmware`         | ✓      | ✓      |        |      |        | ✓    |          |
+    | `virt-firmware`         | ✓      | ✓      | ✓      | ✓    | ✓      | ✓    | ✓        |
     | `xfsprogs`              | ✓      | ✓      | ✓      | ✓    | ✓      | ✓    | ✓        |
     | `xz`                    | ✓      | ✓      | ✓      | ✓    | ✓      | ✓    | ✓        |
     | `zstd`                  | ✓      | ✓      | ✓      | ✓    | ✓      | ✓    | ✓        |

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
@@ -34,6 +34,7 @@ Packages=
         policycoreutils
         python3-cryptography
         python3-pefile
+        python3-virt-firmware
         qemu-efi-aarch64
         qemu-system
         reprepro

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-opensuse.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-opensuse.conf
@@ -36,5 +36,6 @@ Packages=
         systemd-experimental
         systemd-journal-remote
         virtiofsd
+        virt-firmware
         xz
         zypper


### PR DESCRIPTION
Automatically enroll the secure boot certificate in MOK, and also set the boolean so that the kernel trusts it to verify kernel modules and dm-verity volumes. This requires secure boot to be enabled to be effective, otherwise the kernel will ignore it.