### PR TITLE
mkosi-initrd: allow configuration from /usr/local

### DIFF
--- a/mkosi/initrd.py
+++ b/mkosi/initrd.py
@@ -112,7 +112,7 @@ def main() -> None:
             "--cache-only=metadata",
         ]
 
-    for d in ("/usr/lib/mkosi-initrd", "/run/mkosi-initrd", "/etc/mkosi-initrd"):
+    for d in ("/usr/lib/mkosi-initrd", "/usr/local/lib/mkosi-initrd", "/run/mkosi-initrd", "/etc/mkosi-initrd"):
         if Path(d).exists():
             cmdline += ["--include", d]
 


### PR DESCRIPTION
Follow up to #3015, since I was a bit too late to the game there. Let's give mkosi-initrd the full complement of search paths.