### PR TITLE
Remove references of bubblewrap in docs/tools configuration

### DIFF
--- a/mkosi/resources/man/mkosi.md
+++ b/mkosi/resources/man/mkosi.md
@@ -1208,7 +1208,6 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     | `attr`                  | ✓      | ✓      | ✓      | ✓    | ✓      | ✓    | ✓        |
     | `bash`                  | ✓      | ✓      | ✓      | ✓    | ✓      | ✓    | ✓        |
     | `btrfs-progs`           | ✓      |        | ✓      | ✓    | ✓      | ✓    | ✓        |
-    | `bubblewrap`            | ✓      | ✓      | ✓      | ✓    | ✓      | ✓    | ✓        |
     | `ca-certificates`       | ✓      | ✓      | ✓      | ✓    | ✓      | ✓    | ✓        |
     | `coreutils`             | ✓      | ✓      | ✓      | ✓    | ✓      | ✓    | ✓        |
     | `cpio`                  | ✓      | ✓      | ✓      | ✓    | ✓      | ✓    | ✓        |

--- a/mkosi/resources/mkosi-tools/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf
@@ -12,7 +12,6 @@ Packages=
         acl
         attr
         bash
-        bubblewrap
         ca-certificates
         coreutils
         cpio


### PR DESCRIPTION
Since b3a3e7e7fcb2a4e8f mkosi no longer relies on bubblewrap for sandboxing.