### PR TITLE
Fix relative path calculation in filter_kernel_modules()

### DIFF
--- a/mkosi/kmod.py
+++ b/mkosi/kmod.py
@@ -27,7 +27,7 @@ def filter_kernel_modules(root: Path, kver: str, *, include: Iterable[str], excl
     if include:
         regex = re.compile("|".join(include))
         for m in modules:
-            rel = os.fspath(Path(*m.parts[1:]))
+            rel = os.fspath(Path(*m.parts[5:]))
             if regex.search(rel):
                 keep.add(rel)
 
@@ -35,7 +35,7 @@ def filter_kernel_modules(root: Path, kver: str, *, include: Iterable[str], excl
         remove = set()
         regex = re.compile("|".join(exclude))
         for m in modules:
-            rel = os.fspath(Path(*m.parts[1:]))
+            rel = os.fspath(Path(*m.parts[5:]))
             if rel not in keep and regex.search(rel):
                 remove.add(m)
 


### PR DESCRIPTION
I'm not sure what possessed me when I last touched this, but to get the path relative to the kernel/ directory we have to strip of the first 5 parts, not just 1.