### PR TITLE
Cache repository metadata snapshot again

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1042,8 +1042,6 @@ def install_sandbox_trees(config: Config, dst: Path) -> None:
     if Path("/etc/static").is_symlink():
         (dst / "etc/static").symlink_to(Path("/etc/static").readlink())
 
-    (dst / "var/log").mkdir(parents=True)
-
     if Path("/etc/passwd").exists():
         shutil.copy("/etc/passwd", dst / "etc/passwd")
     if Path("/etc/group").exists():

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-arch.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-arch.conf
@@ -9,8 +9,6 @@ Packages=
         archlinux-keyring
         base
         btrfs-progs
-        dbus-broker
-        dbus-broker-units
         debian-archive-keyring
         distribution-gpg-keys
         dpkg

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -571,6 +571,13 @@ def sandbox_cmd(
                 else:
                     cmdline += ["--tmpfs", Path("/") / d]
 
+        # If we put an overlayfs on /var, and /var/tmp is not in the sandbox tree, make sure /var/tmp is a bind mount
+        # of a regular empty directory instead of the overlays so tools like systemd-repart can use the underlying
+        # filesystem features from btrfs when using /var/tmp.
+        if overlay and not (overlay / "var/tmp").exists():
+            tmp = stack.enter_context(vartmpdir())
+            cmdline += ["--bind", tmp, "/var/tmp"]
+
         yield [*cmdline, *options, "--"]
 
 

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -524,7 +524,7 @@ def sandbox_cmd(
         if path and not any(path.is_relative_to(dir) for dir in (*dirs, "/usr", "/nix", "/tmp")):
             cmdline += ["--bind", path, path]
     else:
-        cmdline += ["--dir", "/var/tmp", "--unshare-ipc"]
+        cmdline += ["--dir", "/var/tmp", "--dir", "/var/log", "--unshare-ipc"]
 
         if devices:
             cmdline += ["--bind", "/sys", "/sys", "--bind", "/dev", "/dev"]


### PR DESCRIPTION
In https://github.com/systemd/mkosi/pull/2973, we stopped putting a repository snapshot into the image. However, this also means that when rebuilding a cached image, we don't operate on the same repository metadata snapshot anymore if the shared cache was resynced in the meantime.

Let's fix this by adding a new cache directory for the top level image which stores a repository metadata snapshot. Then, if incremental mode is enabled and using the snapshot is not explicitly disabled, if we have just a single cached image that we'll be reusing, reuse the repository metadata snapshot as well. Otherwise, optionally sync and then copy the repository metadata from the shared cache.

At the same time, we merge run_sync() and sync_repository_metadata() as they don't make much sense as separate functions anymore.