### PR TITLE
Add back MachineId= setting

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -194,7 +194,12 @@ def install_distribution(context: Context) -> None:
         with complete_step(f"Installing {str(context.config.distribution).capitalize()}"):
             context.config.distribution.install(context)
 
-            if (context.root / "etc").exists() and not (context.root / "etc/machine-id").exists():
+            if context.config.machine_id:
+                with umask(~0o755):
+                    (context.root / "etc").mkdir(exist_ok=True)
+                with umask(~0o444):
+                    (context.root / "etc/machine-id").write_text(context.config.machine_id.hex)
+            elif (context.root / "etc").exists() and not (context.root / "etc/machine-id").exists():
                 # Uninitialized means we want it to get initialized on first boot.
                 with umask(~0o444):
                     (context.root / "etc/machine-id").write_text("uninitialized\n")

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1515,6 +1515,7 @@ class Config:
     hostname: Optional[str]
     root_password: Optional[tuple[str, bool]]
     root_shell: Optional[str]
+    machine_id: Optional[uuid.UUID]
 
     autologin: bool
     make_initrd: bool
@@ -2576,6 +2577,15 @@ SETTINGS = (
         section="Content",
         parse=config_parse_string,
         help="Set the shell for root",
+    ),
+    ConfigSetting(
+        dest="machine_id",
+        metavar="MACHINE_ID",
+        section="Content",
+        parse=config_parse_uuid,
+        paths=("mkosi.machine-id",),
+        path_read_text=True,
+        help="Set the machine ID to use",
     ),
     ConfigSetting(
         dest="autologin",
@@ -4300,6 +4310,7 @@ def summary(config: Config) -> str:
                            Hostname: {none_to_default(config.hostname)}
                       Root Password: {("(set)" if config.root_password else "(default)")}
                          Root Shell: {none_to_default(config.root_shell)}
+                         Machine ID: {none_to_none(config.machine_id)}
 
                           Autologin: {yes_no(config.autologin)}
                         Make Initrd: {yes_no(config.make_initrd)}
@@ -4427,6 +4438,9 @@ def json_type_transformer(refcls: Union[type[Args], type[Config]]) -> Callable[[
     def uuid_transformer(uuidstr: str, fieldtype: type[uuid.UUID]) -> uuid.UUID:
         return uuid.UUID(uuidstr)
 
+    def optional_uuid_transformer(uuidstr: Optional[str], fieldtype: type[Optional[uuid.UUID]]) -> Optional[uuid.UUID]:
+        return uuid.UUID(uuidstr) if uuidstr is not None else None
+
     def root_password_transformer(
         rootpw: Optional[list[Union[str, bool]]], fieldtype: type[Optional[tuple[str, bool]]]
     ) -> Optional[tuple[str, bool]]:
@@ -4499,6 +4513,7 @@ def json_type_transformer(refcls: Union[type[Args], type[Config]]) -> Callable[[
         Optional[Path]: optional_path_transformer,
         list[Path]: path_list_transformer,
         uuid.UUID: uuid_transformer,
+        Optional[uuid.UUID]: optional_uuid_transformer,
         Optional[tuple[str, bool]]: root_password_transformer,
         list[ConfigTree]: config_tree_transformer,
         Architecture: enum_transformer,

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -639,9 +639,12 @@ def config_parse_compression(value: Optional[str], old: Optional[Compression]) -
         return Compression.zstd if parse_boolean(value) else Compression.none
 
 
-def config_parse_seed(value: Optional[str], old: Optional[str]) -> Optional[uuid.UUID]:
-    if not value or value == "random":
+def config_parse_uuid(value: Optional[str], old: Optional[str]) -> Optional[uuid.UUID]:
+    if not value:
         return None
+
+    if value == "random":
+        return uuid.uuid4()
 
     try:
         return uuid.UUID(value)
@@ -2127,8 +2130,10 @@ SETTINGS = (
         dest="seed",
         metavar="UUID",
         section="Output",
-        parse=config_parse_seed,
+        parse=config_parse_uuid,
         default=uuid.uuid4(),
+        paths=("mkosi.seed",),
+        path_read_text=True,
         help="Set the seed for systemd-repart",
     ),
     ConfigSetting(

--- a/mkosi/resources/man/mkosi.md
+++ b/mkosi/resources/man/mkosi.md
@@ -1098,6 +1098,14 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     a host system with the same SELinux policy as the image you're
     building.
 
+`MachineId=`, `--machine-id=`
+
+:  Takes a UUID or the special value `random`. Sets the machine ID of the
+   image to the specified UUID. If set to `random`, a random UUID will be
+   written to `/etc/machine-id`. If not specified explicitly and the file
+   `mkosi.machine-id` exists in the local directory, the UUID to use it
+   read from it. Otherwise, `uninitialized` will be written to `/etc/machine-id`.
+
 ### [Validation] Section
 
 `SecureBoot=`, `--secure-boot`

--- a/mkosi/resources/man/mkosi.md
+++ b/mkosi/resources/man/mkosi.md
@@ -620,7 +620,9 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     Overrides the seed that [`systemd-repart(8)`](https://www.freedesktop.org/software/systemd/man/systemd-repart.service.html)
     uses when building a disk image. This is useful to achieve reproducible
     builds, where deterministic UUIDs and other partition metadata should be
-    derived on each build.
+    derived on each build. If not specified explicitly and the file `mkosi.seed`
+    exists in the local directory, the UUID to use is read from it. Otherwise,
+    a random UUID is used.
 
 `CleanScripts=`, `--clean-script=`
 :   Takes a comma-separated list of paths to executables that are used as

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -185,6 +185,7 @@ def test_config() -> None:
             "Locale": "en_C.UTF-8",
             "LocaleMessages": "",
             "Machine": "machine",
+            "MachineId": "b58253b0-cc92-4a34-8782-bcd99b20d07f",
             "MakeInitrd": false,
             "ManifestFormat": [
                 "json",
@@ -420,6 +421,7 @@ def test_config() -> None:
         locale="en_C.UTF-8",
         locale_messages="",
         machine="machine",
+        machine_id=uuid.UUID("b58253b0cc924a348782bcd99b20d07f"),
         make_initrd=False,
         manifest_format=[ManifestFormat.json, ManifestFormat.changelog],
         minimum_version=GenericVersion("123"),


### PR DESCRIPTION
To build an image with a dm-verity protected root partition that has
a persistent machine ID, the machine ID has to be embedded in the image,
so let's add back the MachineId= setting to support this use case.