### PR TITLE
Log error when qemu itself fails

### DIFF
--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -1250,7 +1250,6 @@ def run_qemu(args: Args, config: Config) -> None:
             stderr=stderr,
             pass_fds=qemu_device_fds.values(),
             env=os.environ | config.environment,
-            log=False,
             foreground=True,
             sandbox=config.sandbox(
                 binary=qemu,
@@ -1271,8 +1270,8 @@ def run_qemu(args: Args, config: Config) -> None:
 
             register_machine(config, proc.pid, fname)
 
-            if proc.wait() == 0 and (status := int(notifications.get("EXIT_STATUS", 0))):
-                raise subprocess.CalledProcessError(status, cmdline)
+        if status := int(notifications.get("EXIT_STATUS", 0)):
+            raise subprocess.CalledProcessError(status, cmdline)
 
 
 def run_ssh(args: Args, config: Config) -> None:


### PR DESCRIPTION
Let's log about errors from qemu itself, since those are generally unexpected and with qemu we have a way to figure out whether the error came from qemu itself or from within the virtual machine since the errors from within the virtual machine are communicated via vsock.