### PR TITLE
Add codespell to detect spelling mistakes as early as possible

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+skip = ./.git,./docs/style.css

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install pandoc python3-pytest
           python3 -m pip install --break-system-packages --upgrade setuptools wheel pip
-          python3 -m pip install --break-system-packages mypy ruff
+          python3 -m pip install --break-system-packages codespell mypy ruff
           npm install -g pyright
 
       - name: Run ruff
@@ -34,6 +34,11 @@ jobs:
 
       - name: Check that tabs are not used in code
         run: sh -c '! git grep -P "\\t" "*.py"'
+
+      - name: Spell Checking (codespell)
+        run: |
+          codespell --version
+          codespell
 
       - name: Type Checking (mypy)
         run: |

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
   running unprivileged instead of using newuidmap/newgidmap. When
   running unprivileged, all files and directories in the image will be
   owned by the invoking user (and by root inside any produced archives).
-  Any attemp to chown files to other users in scripts will fail unless
+  Any attempt to chown files to other users in scripts will fail unless
   the new environment variable `$MKOSI_CHROOT_SUPPRESS_CHOWN` is set to
   a true value.
 - `mkosi` does not drop privileges anymore to the invoking user when

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1244,7 +1244,7 @@ def build_default_initrd(context: Context) -> Path:
                 config,
                 workspace=workspace,
                 resources=context.resources,
-                # Re-use the repository metadata snapshot from the main image for the initrd.
+                # Reuse the repository metadata snapshot from the main image for the initrd.
                 metadata_dir=context.metadata_dir,
                 package_dir=context.package_dir,
             )
@@ -2773,7 +2773,7 @@ def make_disk(
 
             if esp or bios:
                 # Even if we're doing BIOS, let's still use the ESP to store the kernels, initrds
-                # and grub modules. We cant use UKIs so we have to put each kernel and initrd on
+                # and grub modules. We can't use UKIs so we have to put each kernel and initrd on
                 # the ESP twice, so let's make the ESP twice as big in that case.
                 (defaults / "00-esp.conf").write_text(
                     textwrap.dedent(
@@ -3394,7 +3394,7 @@ def run_shell(args: Args, config: Config) -> None:
             owner = os.stat(fname).st_uid
             if owner != 0:
                 # Let's allow running a shell in a non-ephemeral image but in that case only map a
-                # single user into the image so it can't get poluted with files or directories
+                # single user into the image so it can't get polluted with files or directories
                 # owned by other users.
                 if args.verb == Verb.shell and config.output_format == OutputFormat.directory and not config.ephemeral:
                     range = 1
@@ -3458,7 +3458,7 @@ def run_shell(args: Args, config: Config) -> None:
             argv = args.cmdline
 
             # When invoked by the kernel, all unknown arguments are passed as environment variables
-            # to pid1. Let's mimick the same behavior when we invoke nspawn as a container.
+            # to pid1. Let's mimic the same behavior when we invoke nspawn as a container.
             for arg in itertools.chain(config.kernel_command_line, config.kernel_command_line_extra):
                 name, sep, value = arg.partition("=")
 
@@ -3912,7 +3912,7 @@ def sync_repository_metadata(args: Args, images: Sequence[Config], *, resources:
     for p in last.distribution.package_manager(last).cache_subdirs(src):
         p.mkdir(parents=True, exist_ok=True)
 
-    # If we're in incremental mode and caching metadata is not explicitly disabled, cache the synced repostory
+    # If we're in incremental mode and caching metadata is not explicitly disabled, cache the synced repository
     # metadata so we can reuse it later.
     if last.incremental and last.cacheonly != Cacheonly.never:
         rmtree(metadata_cache(last), sandbox=last.sandbox)

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2358,7 +2358,7 @@ SETTINGS = (
         section="Content",
         parse=config_make_list_parser(delimiter=",", parse=make_path_parser()),
         paths=("mkosi.env",),
-        help="Enviroment files to set when running scripts",
+        help="Environment files to set when running scripts",
     ),
     ConfigSetting(
         dest="with_tests",
@@ -2429,7 +2429,7 @@ SETTINGS = (
             "requires a filename with no path components."
         ),
         # The default value is set in `__init__.py` in `install_uki`.
-        # `None` is used to determin if the roothash and boot count format
+        # `None` is used to determine if the roothash and boot count format
         # should be appended to the filename if they are found.
         #default=
         help="Specify the format used for the UKI filename",
@@ -3899,9 +3899,9 @@ def parse_config(argv: Sequence[str] = (), *, resources: Path = Path("/")) -> tu
 
     # If Dependencies= was not explicitly specified on the CLI or in the configuration,
     # we want to default to all subimages. However, if a subimage has a [Match] section
-    # and does not succesfully match, we don't want to add it to the default dependencies.
+    # and does not successfully match, we don't want to add it to the default dependencies.
     # To make this work, we can't use default_factory as it is evaluated too early, so
-    # we check here to see if dependendencies were explicitly provided and if not we gather
+    # we check here to see if dependencies were explicitly provided and if not we gather
     # the list of default dependencies while we parse the subimages.
     dependencies: Optional[list[str]] = (
         None

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -210,7 +210,7 @@ class Installer(DistributionInstaller):
             ):
                 # For EPEL we make the assumption that epel is mirrored in the parent directory of the mirror URL and
                 # path we were given. Since this doesn't work for all scenarios, we also allow overriding the mirror
-                # via ane environment variable.
+                # via an environment variable.
                 url = context.config.environment.get("EPEL_MIRROR", join_mirror(mirror, "../fedora"))
                 yield RpmRepository(
                     repo,

--- a/mkosi/manifest.py
+++ b/mkosi/manifest.py
@@ -212,7 +212,7 @@ class Manifest:
                 # Yes, --quiet is specified twice, to avoid output about download stats. Note that the argument of the
                 # 'changelog' verb is the binary package name, not the source package name. We also have to set "Dir"
                 # explicitly because apt has no separate option to configure the changelog directory. Apt.invoke()
-                # sets all options that are interpreted relative to Dir to absolute paths by default so this is afe.
+                # sets all options that are interpreted relative to Dir to absolute paths by default so this is safe.
                 result = Apt.invoke(
                     self.context,
                     "changelog",

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -331,8 +331,8 @@ def find_binary(*names: PathString, root: Path = Path("/"), extra: Sequence[Path
 
 class AsyncioThread(threading.Thread):
     """
-    The default threading.Thread() is not interruptable, so we make our own version by using the concurrency
-    feature in python that is interruptable, namely asyncio.
+    The default threading.Thread() is not interruptible, so we make our own version by using the concurrency
+    feature in python that is interruptible, namely asyncio.
 
     Additionally, we store any exception that the coroutine raises and re-raise it in join() if no other
     exception was raised before.

--- a/mkosi/versioncomp.py
+++ b/mkosi/versioncomp.py
@@ -8,7 +8,7 @@ from typing import Final
 
 @functools.total_ordering
 class GenericVersion:
-    # These constants follow the convention of the return value of rpmdev-vercmp that are followe
+    # These constants follow the convention of the return value of rpmdev-vercmp that are followed
     # by systemd-analyze compare-versions when called with only two arguments (without a comparison
     # operator), recreated in the compare_versions method.
     _EQUAL: Final[int] = 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -291,7 +291,7 @@ def test_parse_config(tmp_path: Path) -> None:
     assert one.image_version == "1.2.3"
     assert two.image_version == "4.5.6"
 
-    # Default values from subimages for univeral settings should not be picked up.
+    # Default values from subimages for universal settings should not be picked up.
     assert len(one.sandbox_trees) == 0
     assert len(two.sandbox_trees) == 0
 


### PR DESCRIPTION
Fix all spelling issues and add a codespell config that ignores the .git dir and documentation stylesheet files.