### PR TITLE
cli: add back mkosi-initrd and mkosi-tools to mkosi.resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,13 @@ packages = [
 ]
 
 [tool.setuptools.package-data]
-"mkosi.resources" = ["repart/**/*", "man/*", "completion.*"]
+"mkosi.resources" = [
+    "completion.*",
+    "man/*",
+    "mkosi-initrd/**/*",
+    "mkosi-tools/**/*",
+    "repart/**/*",
+]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Otherwise these resources are not packaged and cannot be included.

E.g., `mkosi-initrd` fails because it adds `--include=mkosi-initrd`:

```
$ mkosi-initrd
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/mkosi/run.py", line 64, in uncaught_exception_handler
    yield
  File "/usr/lib64/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/mkosi/__main__.py", line 30, in main
    args, images = parse_config(sys.argv[1:], resources=resources)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/mkosi/config.py", line 3907, in parse_config
    context.parse_new_includes()
  File "/usr/lib/python3.11/site-packages/mkosi/config.py", line 3575, in parse_new_includes
    st = path.stat()
         ^^^^^^^^^^^
  File "/usr/lib64/python3.11/pathlib.py", line 1013, in stat
    return os.stat(self, follow_symlinks=follow_symlinks)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmpyqqy4ttp/resources/mkosi-initrd'
```

Fixes 9f48afa4a76b6002edc90ac976a2d1e8fd01f793