### PR TITLE
Parse profiles after mkosi.conf.d

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 /mkosi.output
 /mkosi.nspawn
 /mkosi.rootpw
+mkosi.local
 mkosi.local.conf
 /mkosi.key
 /mkosi.crt

--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,10 @@
   when running a command that boots the image
 - More directories aside from `/etc` and `/usr` are now picked up from
   sandbox trees (formerly known as package manager trees).
+- Profile configuration from `mkosi.profiles` is now parsed after
+  `mkosi.conf.d` instead of before it. To set defaults for use in `mkosi.conf.d`
+  based on the configured profile, use an early dropin in `mkosi.conf.d` that
+  matches on the configured profile instead.
 
 ## v24
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,9 @@
   `mkosi.conf.d` instead of before it. To set defaults for use in `mkosi.conf.d`
   based on the configured profile, use an early dropin in `mkosi.conf.d` that
   matches on the configured profile instead.
+- `Profile=` is renamed to `Profiles=` and takes a comma separated list of
+  profiles now. Scripts now receive `$PROFILES` with a comma separated lists
+  of profiles instead of `$PROFILE`.
 
 ## v24
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -517,8 +517,8 @@ def run_configure_scripts(config: Config) -> Config:
         MKOSI_GID=str(os.getgid()),
     )
 
-    if config.profile:
-        env["PROFILE"] = config.profile
+    if config.profiles:
+        env["PROFILES"] = ",".join(config.profiles)
 
     with finalize_source_mounts(config, ephemeral=False) as sources:
         for script in config.configure_scripts:
@@ -560,8 +560,8 @@ def run_sync_scripts(config: Config) -> None:
         CACHED=one_zero(have_cache(config)),
     )
 
-    if config.profile:
-        env["PROFILE"] = config.profile
+    if config.profiles:
+        env["PROFILES"] = ",".join(config.profiles)
 
     # We make sure to mount everything in to make ssh work since syncing might involve git which
     # could invoke ssh.
@@ -690,8 +690,8 @@ def run_prepare_scripts(context: Context, build: bool) -> None:
         **GIT_ENV,
     )
 
-    if context.config.profile:
-        env["PROFILE"] = context.config.profile
+    if context.config.profiles:
+        env["PROFILES"] = ",".join(context.config.profiles)
 
     if context.config.build_dir is not None:
         env |= dict(BUILDDIR="/work/build")
@@ -767,8 +767,8 @@ def run_build_scripts(context: Context) -> None:
         **GIT_ENV,
     )
 
-    if context.config.profile:
-        env["PROFILE"] = context.config.profile
+    if context.config.profiles:
+        env["PROFILES"] = ",".join(context.config.profiles)
 
     if context.config.build_dir is not None:
         env |= dict(
@@ -840,8 +840,8 @@ def run_postinst_scripts(context: Context) -> None:
         **GIT_ENV,
     )
 
-    if context.config.profile:
-        env["PROFILE"] = context.config.profile
+    if context.config.profiles:
+        env["PROFILES"] = ",".join(context.config.profiles)
 
     if context.config.build_dir is not None:
         env |= dict(BUILDDIR="/work/build")
@@ -906,8 +906,8 @@ def run_finalize_scripts(context: Context) -> None:
         **GIT_ENV,
     )
 
-    if context.config.profile:
-        env["PROFILE"] = context.config.profile
+    if context.config.profiles:
+        env["PROFILES"] = ",".join(context.config.profiles)
 
     if context.config.build_dir is not None:
         env |= dict(BUILDDIR="/work/build")
@@ -963,8 +963,8 @@ def run_postoutput_scripts(context: Context) -> None:
         MKOSI_CONFIG="/work/config.json",
     )
 
-    if context.config.profile:
-        env["PROFILE"] = context.config.profile
+    if context.config.profiles:
+        env["PROFILES"] = ",".join(context.config.profiles)
 
     with (
         finalize_source_mounts(context.config, ephemeral=context.config.build_sources_ephemeral) as sources,
@@ -3858,8 +3858,8 @@ def run_clean_scripts(config: Config) -> None:
         MKOSI_CONFIG="/work/config.json",
     )
 
-    if config.profile:
-        env["PROFILE"] = config.profile
+    if config.profiles:
+        env["PROFILES"] = ",".join(config.profiles)
 
     with (
         finalize_source_mounts(config, ephemeral=False) as sources,

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3782,21 +3782,26 @@ class ParseContext:
         extras = path.is_dir()
 
         if path.is_dir():
-            path = path / "mkosi.conf"
+            path /= "mkosi.conf"
 
         if not self.match_config(path):
             return False
 
         if extras:
-            if local and (path.parent / "mkosi.local.conf").exists():
-                self.parse_config_one(path.parent / "mkosi.local.conf")
+            if local:
+                if (
+                    (localpath := path.parent / "mkosi.local/mkosi.conf").exists()
+                    or (localpath := path.parent / "mkosi.local.conf").exists()
+                ):  # fmt: skip
+                    self.parse_config_one(localpath)
 
-                # Configuration from mkosi.local.conf should override other file based configuration but not
-                # the CLI itself so move the finalized values to the CLI namespace.
-                for s in SETTINGS:
-                    if hasattr(self.config, s.dest):
-                        setattr(self.cli, s.dest, self.finalize_value(s))
-                        delattr(self.config, s.dest)
+                    # Local configuration should override other file based
+                    # configuration but not the CLI itself so move the finalized
+                    # values to the CLI namespace.
+                    for s in SETTINGS:
+                        if hasattr(self.config, s.dest):
+                            setattr(self.cli, s.dest, self.finalize_value(s))
+                            delattr(self.config, s.dest)
 
             for s in SETTINGS:
                 if (

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3866,28 +3866,30 @@ class ParseContext:
                 setattr(self.config, s.dest, s.parse(v, getattr(self.config, s.dest, None)))
                 self.parse_new_includes()
 
+        profilepath = None
         if profiles:
             profile = self.finalize_value(SETTINGS_LOOKUP_BY_DEST["profile"])
             self.immutable.add("Profile")
 
             if profile:
-                for p in (profile, f"{profile}.conf"):
-                    p = Path("mkosi.profiles") / p
-                    if p.exists():
+                for p in (Path(profile), Path(f"{profile}.conf")):
+                    profilepath = Path("mkosi.profiles") / p
+                    if profilepath.exists():
                         break
                 else:
                     die(f"Profile '{profile}' not found in mkosi.profiles/")
 
                 setattr(self.config, "profile", profile)
 
-                with chdir(p if p.is_dir() else Path.cwd()):
-                    self.parse_config_one(p if p.is_file() else Path("."))
-
         if extras and (path.parent / "mkosi.conf.d").exists():
             for p in sorted((path.parent / "mkosi.conf.d").iterdir()):
                 if p.is_dir() or p.suffix == ".conf":
                     with chdir(p if p.is_dir() else Path.cwd()):
                         self.parse_config_one(p if p.is_file() else Path("."))
+
+        if profilepath:
+            with chdir(profilepath if profilepath.is_dir() else Path.cwd()):
+                self.parse_config_one(profilepath if profilepath.is_file() else Path("."))
 
         return True
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -48,6 +48,8 @@ from mkosi.util import (
 )
 from mkosi.versioncomp import GenericVersion
 
+T = TypeVar("T")
+
 ConfigParseCallback = Callable[[Optional[str], Optional[Any]], Any]
 ConfigMatchCallback = Callable[[str, Any], bool]
 ConfigDefaultCallback = Callable[[argparse.Namespace], Any]
@@ -577,8 +579,11 @@ def config_match_build_sources(match: str, value: list[ConfigTree]) -> bool:
     return Path(match.lstrip("/")) in [tree.target for tree in value if tree.target]
 
 
-def config_match_repositories(match: str, value: list[str]) -> bool:
-    return match in value
+def config_make_list_matcher(parse: Callable[[str], T]) -> ConfigMatchCallback:
+    def config_match_list(match: str, value: list[T]) -> bool:
+        return parse(match) in value
+
+    return config_match_list
 
 
 def config_parse_string(value: Optional[str], old: Optional[str]) -> Optional[str]:
@@ -1107,10 +1112,7 @@ def config_parse_number(value: Optional[str], old: Optional[int] = None) -> Opti
         die(f"{value!r} is not a valid number")
 
 
-def config_parse_profile(value: Optional[str], old: Optional[int] = None) -> Optional[str]:
-    if not value:
-        return None
-
+def parse_profile(value: str) -> str:
     if not is_valid_filename(value):
         die(
             f"{value!r} is not a valid profile",
@@ -1477,7 +1479,7 @@ class Config:
     access the value from context.
     """
 
-    profile: Optional[str]
+    profiles: list[str]
     files: list[Path]
     dependencies: list[str]
     minimum_version: Optional[GenericVersion]
@@ -1952,13 +1954,15 @@ SETTINGS = (
     ),
     # Config section
     ConfigSetting(
-        dest="profile",
+        dest="profiles",
+        long="--profile",
         section="Config",
         specifier="p",
-        help="Build the specified profile",
-        parse=config_parse_profile,
-        match=config_make_string_matcher(),
+        help="Build the specified profiles",
+        parse=config_make_list_parser(delimiter=",", parse=parse_profile),
+        match=config_make_list_matcher(parse=parse_profile),
         scope=SettingScope.universal,
+        compat_names=("Profile",),
     ),
     ConfigSetting(
         dest="dependencies",
@@ -2064,7 +2068,7 @@ SETTINGS = (
         metavar="REPOS",
         section="Distribution",
         parse=config_make_list_parser(delimiter=","),
-        match=config_match_repositories,
+        match=config_make_list_matcher(parse=str),
         help="Repositories to use",
         scope=SettingScope.universal,
     ),
@@ -3777,7 +3781,7 @@ class ParseContext:
 
         return match_triggered is not False
 
-    def parse_config_one(self, path: Path, profiles: bool = False, local: bool = False) -> bool:
+    def parse_config_one(self, path: Path, parse_profiles: bool = False, parse_local: bool = False) -> bool:
         s: Optional[ConfigSetting]  # Make mypy happy
         extras = path.is_dir()
 
@@ -3788,7 +3792,7 @@ class ParseContext:
             return False
 
         if extras:
-            if local:
+            if parse_local:
                 if (
                     (localpath := path.parent / "mkosi.local/mkosi.conf").exists()
                     or (localpath := path.parent / "mkosi.local.conf").exists()
@@ -3871,20 +3875,20 @@ class ParseContext:
                 setattr(self.config, s.dest, s.parse(v, getattr(self.config, s.dest, None)))
                 self.parse_new_includes()
 
-        profilepath = None
-        if profiles:
-            profile = self.finalize_value(SETTINGS_LOOKUP_BY_DEST["profile"])
-            self.immutable.add("Profile")
+        profilepaths = []
+        if parse_profiles:
+            profiles = self.finalize_value(SETTINGS_LOOKUP_BY_DEST["profiles"])
+            self.immutable.add("Profiles")
 
-            if profile:
+            for profile in profiles or []:
                 for p in (Path(profile), Path(f"{profile}.conf")):
-                    profilepath = Path("mkosi.profiles") / p
-                    if profilepath.exists():
+                    p = Path("mkosi.profiles") / p
+                    if p.exists():
                         break
                 else:
                     die(f"Profile '{profile}' not found in mkosi.profiles/")
 
-                setattr(self.config, "profile", profile)
+                profilepaths += [p]
 
         if extras and (path.parent / "mkosi.conf.d").exists():
             for p in sorted((path.parent / "mkosi.conf.d").iterdir()):
@@ -3892,9 +3896,9 @@ class ParseContext:
                     with chdir(p if p.is_dir() else Path.cwd()):
                         self.parse_config_one(p if p.is_file() else Path("."))
 
-        if profilepath:
-            with chdir(profilepath if profilepath.is_dir() else Path.cwd()):
-                self.parse_config_one(profilepath if profilepath.is_file() else Path("."))
+        for p in profilepaths:
+            with chdir(p if p.is_dir() else Path.cwd()):
+                self.parse_config_one(p if p.is_file() else Path("."))
 
         return True
 
@@ -3982,7 +3986,7 @@ def parse_config(
 
     # Parse the global configuration unless the user explicitly asked us not to.
     if args.directory is not None:
-        context.parse_config_one(Path("."), profiles=True, local=True)
+        context.parse_config_one(Path("."), parse_profiles=True, parse_local=True)
 
     config = copy.deepcopy(context.config)
 
@@ -4054,7 +4058,7 @@ def parse_config(
             context.defaults = argparse.Namespace()
 
             with chdir(p if p.is_dir() else Path.cwd()):
-                if not context.parse_config_one(p if p.is_file() else Path("."), local=True):
+                if not context.parse_config_one(p if p.is_file() else Path("."), parse_local=True):
                     continue
 
             # Consolidate all settings into one namespace again.
@@ -4335,7 +4339,7 @@ def summary(config: Config) -> str:
 {bold(f"IMAGE: {config.image or 'default'}")}
 
     {bold("CONFIG")}:
-                            Profile: {none_to_none(config.profile)}
+                           Profiles: {line_join_list(config.profiles)}
                        Dependencies: {line_join_list(config.dependencies)}
                     Minimum Version: {none_to_none(config.minimum_version)}
                   Configure Scripts: {line_join_list(config.configure_scripts)}

--- a/mkosi/resources/man/mkosi.md
+++ b/mkosi/resources/man/mkosi.md
@@ -1743,7 +1743,7 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 ### [Match] Section.
 
 `Profile=`
-:   Matches against the configured profile.
+:   Matches against the configured profiles.
 
 `Distribution=`
 :   Matches against the configured distribution.
@@ -1864,11 +1864,11 @@ config file is read:
 
 ### [Config] Section
 
-`Profile=`, `--profile=`
-:   Select the given profile. A profile is a configuration file or
-    directory in the `mkosi.profiles/` directory. When selected, this
-    configuration file or directory is included after parsing the
-    `mkosi.conf.d/*.conf` drop in configuration files.
+`Profiles=`, `--profile=`
+:   Select the given profiles. A profile is a configuration file or
+    directory in the `mkosi.profiles/` directory. The configuration files
+    and directories of each profile are included after parsing the
+    `mkosi.conf.d/*.conf` drop in configuration.
 
 `Dependencies=`, `--dependency=`
 :   The images that this image depends on specified as a comma-separated
@@ -2169,7 +2169,8 @@ Scripts executed by mkosi receive the following environment variables:
 * `$DISTRIBUTION_ARCHITECTURE` contains the architecture from
   `$ARCHITECTURE` in the format used by the configured distribution.
 
-* `$PROFILE` contains the profile from the `Profile=` setting.
+* `$PROFILES` contains the profiles from the `Profiles=` setting as a
+  comma-delimited string.
 
 * `$CACHED=` is set to `1` if a cached image is available, `0` otherwise.
 
@@ -2268,7 +2269,7 @@ Consult this table for which script receives which environment variables:
 | `DISTRIBUTION`              | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |
 | `DISTRIBUTION_ARCHITECTURE` | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |
 | `RELEASE`                   | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |
-| `PROFILE`                   | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          |              | ✓       |
+| `PROFILES`                  | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          |              | ✓       |
 | `CACHED`                    |             | ✓      |           |         |            |            |              |         |
 | `CHROOT_SCRIPT`             |             |        | ✓         | ✓       | ✓          | ✓          |              |         |
 | `SRCDIR`                    | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |

--- a/mkosi/resources/man/mkosi.md
+++ b/mkosi/resources/man/mkosi.md
@@ -306,12 +306,12 @@ Configuration is parsed in the following order:
 * `mkosi.conf` is parsed if it exists in the directory configured with
   `--directory=` or the current working directory if `--directory=` is
   not used.
-* If a profile is defined, its configuration is parsed from the
-  `mkosi.profiles/` directory.
 * `mkosi.conf.d/` is parsed in the same directory if it exists. Each
   directory and each file with the `.conf` extension in `mkosi.conf.d/`
   is parsed. Any directory in `mkosi.conf.d` is parsed as if it were
   a regular top level directory.
+* If any profiles are configured, their configuration is parsed from the
+  `mkosi.profiles/` directory.
 * Subimages are parsed from the `mkosi.images` directory if it exists.
 
 Note that settings configured via the command line always override
@@ -1867,8 +1867,7 @@ config file is read:
 :   Select the given profile. A profile is a configuration file or
     directory in the `mkosi.profiles/` directory. When selected, this
     configuration file or directory is included after parsing the
-    `mkosi.conf` file, but before any `mkosi.conf.d/*.conf` drop in
-    configuration.
+    `mkosi.conf.d/*.conf` drop in configuration files.
 
 `Dependencies=`, `--dependency=`
 :   The images that this image depends on specified as a comma-separated

--- a/mkosi/resources/man/mkosi.md
+++ b/mkosi/resources/man/mkosi.md
@@ -299,8 +299,9 @@ grouped by section below.
 Configuration is parsed in the following order:
 
 * The command line arguments are parsed.
-* `mkosi.local.conf` is parsed if it exists. This file should be in
-  `.gitignore` (or equivalent) and is intended for local configuration.
+* `mkosi.local.conf` or `mkosi.local` is parsed if it exists. This file or
+  directory should be in `.gitignore` (or equivalent) and is intended for local
+  configuration.
 * Any default paths (depending on the option) are configured if the
   corresponding path exists.
 * `mkosi.conf` is parsed if it exists in the directory configured with
@@ -318,9 +319,9 @@ Note that settings configured via the command line always override
 settings configured via configuration files. If the same setting is
 configured more than once via configuration files, later assignments
 override earlier assignments except for settings that take a collection
-of values. Also, settings read from `mkosi.local.conf` will override
-settings from configuration files that are parsed later, but not settings
-specified on the CLI.
+of values. Also, settings read from `mkosi.local` or `mkosi.local.conf` will
+override settings from configuration files that are parsed later, but not
+settings specified on the CLI.
 
 For settings that take a single value, the empty assignment (`SomeSetting=` or
 `--some-setting=`) can be used to override a previous setting and reset to the

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -377,8 +377,8 @@ def test_profiles(tmp_path: Path) -> None:
         _, [config] = parse_config()
 
     assert config.profile == "profile"
-    # mkosi.conf.d/ should override the profile
-    assert config.distribution == Distribution.debian
+    # The profile should override mkosi.conf.d/
+    assert config.distribution == Distribution.fedora
     assert config.qemu_kvm == ConfigFeature.enabled
 
     (d / "mkosi.conf").unlink()
@@ -387,8 +387,8 @@ def test_profiles(tmp_path: Path) -> None:
         _, [config] = parse_config(["--profile", "profile"])
 
     assert config.profile == "profile"
-    # mkosi.conf.d/ should override the profile
-    assert config.distribution == Distribution.debian
+    # The profile should override mkosi.conf.d/
+    assert config.distribution == Distribution.fedora
     assert config.qemu_kvm == ConfigFeature.enabled
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -361,7 +361,7 @@ def test_profiles(tmp_path: Path) -> None:
     (d / "mkosi.conf").write_text(
         """\
         [Config]
-        Profile=profile
+        Profiles=profile
         """
     )
 
@@ -376,7 +376,7 @@ def test_profiles(tmp_path: Path) -> None:
     with chdir(d):
         _, [config] = parse_config()
 
-    assert config.profile == "profile"
+    assert config.profiles == ["profile"]
     # The profile should override mkosi.conf.d/
     assert config.distribution == Distribution.fedora
     assert config.qemu_kvm == ConfigFeature.enabled
@@ -386,10 +386,33 @@ def test_profiles(tmp_path: Path) -> None:
     with chdir(d):
         _, [config] = parse_config(["--profile", "profile"])
 
-    assert config.profile == "profile"
+    assert config.profiles == ["profile"]
     # The profile should override mkosi.conf.d/
     assert config.distribution == Distribution.fedora
     assert config.qemu_kvm == ConfigFeature.enabled
+
+    (d / "mkosi.conf").write_text(
+        """\
+        [Config]
+        Profiles=profile,abc
+        """
+    )
+
+    (d / "mkosi.profiles/abc.conf").write_text(
+        """\
+        [Match]
+        Profile=abc
+
+        [Distribution]
+        Distribution=opensuse
+        """
+    )
+
+    with chdir(d):
+        _, [config] = parse_config()
+
+    assert config.profiles == ["profile", "abc"]
+    assert config.distribution == Distribution.opensuse
 
 
 def test_override_default(tmp_path: Path) -> None:

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -215,7 +215,9 @@ def test_config() -> None:
             "PrepareScripts": [
                 "/run/foo"
             ],
-            "Profile": "profile",
+            "Profiles": [
+                "profile"
+            ],
             "ProxyClientCertificate": "/my/client/cert",
             "ProxyClientKey": "/my/client/key",
             "ProxyExclude": [
@@ -442,7 +444,7 @@ def test_config() -> None:
         postinst_scripts=[Path("/bar/qux")],
         postoutput_scripts=[Path("/foo/src")],
         prepare_scripts=[Path("/run/foo")],
-        profile="profile",
+        profiles=["profile"],
         proxy_client_certificate=Path("/my/client/cert"),
         proxy_client_key=Path("/my/client/key"),
         proxy_exclude=["www.example.com"],


### PR DESCRIPTION
Currently profiles can't depend on any of the configuration set in mkosi.conf.d as they are parsed before mkosi.conf.d is parsed. Let's parse the profile related configuration last instead so it can match on all the configuration set in mkosi.conf.d.

To set the distribution and release and such based on the profile, a dropin in mkosi.conf.d can match on the configured profile instead.