### PR TITLE
Don't explicitly bind mount in keyrings from host into sandbox

### DIFF
--- a/mkosi/mounts.py
+++ b/mkosi/mounts.py
@@ -92,17 +92,18 @@ def finalize_crypto_mounts(config: Config) -> list[PathString]:
     mounts = [
         (root / subdir, Path("/") / subdir)
         for subdir in (
-            Path("usr/share/keyrings"),
-            Path("usr/share/distribution-gpg-keys"),
             Path("etc/pki"),
             Path("etc/ssl"),
             Path("etc/ca-certificates"),
-            Path("etc/pacman.d/gnupg"),
             Path("etc/static"),
             Path("var/lib/ca-certificates"),
         )
         if (root / subdir).exists()
     ]
+
+    # This contains the Arch Linux keyring, which isn't certificates so ToolsTreeCertificates= doesn't apply.
+    if (config.tools() / "etc/pacman.d/gnupg").exists():
+        mounts += [(config.tools() / "etc/pacman.d/gnupg", Path("/etc/pacman.d/gnupg"))]
 
     return flatten(
         ("--symlink", src.readlink(), target) if src.is_symlink() else ("--ro-bind", src, target)

--- a/mkosi/resources/man/mkosi.md
+++ b/mkosi/resources/man/mkosi.md
@@ -1302,11 +1302,11 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     multiple times in which case the specified package lists are combined.
 
 `ToolsTreeCertificates=`, `--tools-tree-certificates=`
-:   Specify whether to use certificates and keys from the tools tree. If
-    enabled, `/usr/share/keyrings`, `/usr/share/distribution-gpg-keys`,
-    `/etc/pki`, `/etc/ssl`, `/etc/ca-certificates`, `/etc/pacman.d/gnupg`
-    and `/var/lib/ca-certificates` from the tools tree are used.
-    Otherwise, these directories are picked up from the host.
+:   Specify whether to use certificates and keys from the tools tree.
+    Enabled by default. If enabled, `/etc/pki`, `/etc/ssl`,
+    `/etc/ca-certificates`, and `/var/lib/ca-certificates` from the
+    tools tree are used. Otherwise, these directories are picked up from
+    the host.
 
 `Incremental=`, `--incremental=`, `-i`
 :   Takes either `strict` or a boolean value as its argument. Enables


### PR DESCRIPTION
These are automatically mounted in as part of the tools tree. This change means they'll always be picked up from the tools tree and won't take ToolsTreeCertificates= into account anymore, but then keyrings weren't exactly certificates in the first place, and can still be picked up from the host by using SandboxTrees=.

This allows users to provide their own keyrings using sandbox trees. Currently we just overmount the user provided ones with the ones from the host.