### PR TITLE
Don't use overlayfs for /etc and /opt in sandbox

### DIFF
--- a/mkosi/mounts.py
+++ b/mkosi/mounts.py
@@ -95,7 +95,6 @@ def finalize_crypto_mounts(config: Config) -> list[PathString]:
             Path("etc/pki"),
             Path("etc/ssl"),
             Path("etc/ca-certificates"),
-            Path("etc/static"),
             Path("var/lib/ca-certificates"),
         )
         if (root / subdir).exists()
@@ -105,7 +104,4 @@ def finalize_crypto_mounts(config: Config) -> list[PathString]:
     if (config.tools() / "etc/pacman.d/gnupg").exists():
         mounts += [(config.tools() / "etc/pacman.d/gnupg", Path("/etc/pacman.d/gnupg"))]
 
-    return flatten(
-        ("--symlink", src.readlink(), target) if src.is_symlink() else ("--ro-bind", src, target)
-        for src, target in sorted(set(mounts), key=lambda s: s[1])
-    )
+    return flatten(("--ro-bind", src, target) for src, target in sorted(set(mounts), key=lambda s: s[1]))

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -538,7 +538,6 @@ def sandbox_cmd(
             "--dir", "/var/tmp",
             "--dir", "/var/log",
             "--unshare-ipc",
-            "--symlink", "../proc/self/mounts", "/etc/mtab",
         ]  # fmt: skip
 
         if devices:
@@ -566,7 +565,13 @@ def sandbox_cmd(
             yield [*cmdline, "--bind", tmp, "/var/tmp", *options, "--"]
             return
 
-        for d in ("etc", "opt", "srv", "media", "mnt", "var", "run", "tmp"):
+        for d in ("etc", "opt"):
+            if overlay and (overlay / d).exists():
+                cmdline += ["--ro-bind", overlay / d, Path("/") / d]
+            else:
+                cmdline += ["--dir", Path("/") / d]
+
+        for d in ("srv", "media", "mnt", "var", "run", "tmp"):
             tmp = None
             if d not in ("run", "tmp"):
                 with umask(~0o755):


### PR DESCRIPTION
Unprivileged overlayfs isn't available everywhere (see #3054). So let's try to accomodate this a little by not using overlayfs for /etc and /opt from the sandbox tree and instead mounting them read-only into the sandbox. If required, scripts can still mount an overlayfs onto these if needed, we just don't do it by default anymore.

This does mean we need to set up /etc with mountpoints and symlinks beforehand in install_sandbox_trees(), but this shouldn't be a huge problem.