### PR TITLE
Add support for building UKI addons

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1588,6 +1588,7 @@ class Config:
     shim_bootloader: ShimBootloader
     unified_kernel_images: ConfigFeature
     unified_kernel_image_format: str
+    pe_addons: list[Path]
     initrds: list[Path]
     initrd_packages: list[str]
     initrd_volatile_packages: list[str]
@@ -2551,6 +2552,15 @@ SETTINGS = (
         # should be appended to the filename if they are found.
         # default=
         help="Specify the format used for the UKI filename",
+    ),
+    ConfigSetting(
+        dest="pe_addons",
+        long="--pe-addon",
+        metavar="PATH",
+        section="Content",
+        parse=config_make_list_parser(delimiter=",", parse=make_path_parser()),
+        recursive_paths=("mkosi.pe-addons/",),
+        help="Configuration files to generate PE addons",
     ),
     ConfigSetting(
         dest="initrds",
@@ -4479,6 +4489,7 @@ def summary(config: Config) -> str:
                     Shim Bootloader: {config.shim_bootloader}
               Unified Kernel Images: {config.unified_kernel_images}
         Unified Kernel Image Format: {config.unified_kernel_image_format}
+        Unified Kernel Image Addons: {line_join_list(config.pe_addons)}
                             Initrds: {line_join_list(config.initrds)}
                     Initrd Packages: {line_join_list(config.initrd_packages)}
            Initrd Volatile Packages: {line_join_list(config.initrd_volatile_packages)}

--- a/mkosi/resources/man/mkosi.md
+++ b/mkosi/resources/man/mkosi.md
@@ -984,6 +984,14 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     | `&h`      | `roothash=` or `usrhash=` value of kernel argument |
     | `&c`      | Number of tries used for boot attempt counting     |
 
+`PeAddons=`, `--pe-addon`
+:   Build additional PE addons. Takes a comma separated list of paths to
+    `ukify` config files. This option may be used multiple times in which case
+    each config gets built into a corresponding addon. Each addon has the name
+    of the config file, with the extension replaced with `.addon.efi`.
+    Config files in the `mkosi.pe-addons/` directory are automatically picked
+    up.
+
 `Initrds=`, `--initrd`
 :   Use user-provided initrd(s). Takes a comma separated list of paths to initrd
     files. This option may be used multiple times in which case the initrd lists

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -207,6 +207,9 @@ def test_config() -> None:
                 "abc"
             ],
             "Passphrase": null,
+            "PeAddons": [
+                "/my-addon.conf"
+            ],
             "PostInstallationScripts": [
                 "/bar/qux"
             ],
@@ -442,6 +445,7 @@ def test_config() -> None:
         packages=[],
         pass_environment=["abc"],
         passphrase=None,
+        pe_addons=[Path("/my-addon.conf")],
         postinst_scripts=[Path("/bar/qux")],
         postoutput_scripts=[Path("/foo/src")],
         prepare_scripts=[Path("/run/foo")],


### PR DESCRIPTION
Not something I personally need anymore (so feel free to close), but I already implemented it and thought this might be useful to some.

This basically just reuses `ukify`s ability to take config files in which you can configure whatever (e.g. `Cmdline=`, `DeviceTree=`, ...) and passes the output target and secure boot parameters when needed. This should allow additions to `ukify` without needing to update the code here.