### PR TITLE
Make diff debug output in have_cache universal

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2779,7 +2779,7 @@ def have_cache(config: Config) -> bool:
             logging.info("Cache manifest mismatch, not reusing cached images")
             if ARG_DEBUG.get():
                 run(
-                    ["diff", manifest, "-"],
+                    ["diff", "-u", "manifest", "-"],
                     input=new,
                     check=False,
                     sandbox=config.sandbox(binary="diff", options=["--bind", manifest, manifest]),


### PR DESCRIPTION
universal diffs are just easier to look at.