### PR TITLE
Fix wrongly-quoted string

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2779,7 +2779,7 @@ def have_cache(config: Config) -> bool:
             logging.info("Cache manifest mismatch, not reusing cached images")
             if ARG_DEBUG.get():
                 run(
-                    ["diff", "-u", "manifest", "-"],
+                    ["diff", "--unified", manifest, "-"],
                     input=new,
                     check=False,
                     sandbox=config.sandbox(binary="diff", options=["--bind", manifest, manifest]),


### PR DESCRIPTION
Fixes: 0a1e8f26d16ac64040da7d03ef4711e706775f3a