### PR TITLE
Don't create mountpoint in /var in sandbox

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1102,7 +1102,6 @@ def install_sandbox_trees(config: Config, dst: Path) -> None:
         "etc/pki",
         "etc/ssl",
         "etc/ca-certificates",
-        "var/lib/ca-certificates",
         "etc/pacman.d/gnupg",
         "etc/alternatives",
     ):


### PR DESCRIPTION
/var will always be writable in the sandbox so no need to precreate the sandbox. This also saves us from using an overlayfs mount from /var in the sandbox as it will be completely empty now.