### PR TITLE
opensuse: Force rpm ndb backend

### DIFF
--- a/mkosi/distributions/azure.py
+++ b/mkosi/distributions/azure.py
@@ -28,8 +28,8 @@ class Installer(fedora.Installer):
 
     @classmethod
     def setup(cls, context: Context) -> None:
-        Dnf.setup(context, list(cls.repositories(context)), filelists=False)
         setup_rpm(context, dbpath="/var/lib/rpm")
+        Dnf.setup(context, list(cls.repositories(context)), filelists=False)
 
     @classmethod
     def install(cls, context: Context) -> None:

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -65,9 +65,10 @@ class Installer(DistributionInstaller):
         if GenericVersion(context.config.release) <= 8:
             die(f"{cls.pretty_name()} Stream 8 or earlier variants are not supported")
 
+        setup_rpm(context, dbpath=cls.dbpath(context))
+
         Dnf.setup(context, list(cls.repositories(context)))
         (context.sandbox_tree / "etc/dnf/vars/stream").write_text(f"{context.config.release}-stream\n")
-        setup_rpm(context, dbpath=cls.dbpath(context))
 
     @classmethod
     def install(cls, context: Context) -> None:

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -100,8 +100,8 @@ class Installer(DistributionInstaller):
 
     @classmethod
     def setup(cls, context: Context) -> None:
-        Dnf.setup(context, list(cls.repositories(context)), filelists=False)
         setup_rpm(context)
+        Dnf.setup(context, list(cls.repositories(context)), filelists=False)
 
     @classmethod
     def install(cls, context: Context) -> None:

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -49,13 +49,13 @@ class Installer(DistributionInstaller):
 
     @classmethod
     def setup(cls, context: Context) -> None:
+        setup_rpm(context)
+
         zypper = context.config.find_binary("zypper")
         if zypper:
             Zypper.setup(context, list(cls.repositories(context)))
         else:
             Dnf.setup(context, list(cls.repositories(context)))
-
-        setup_rpm(context)
 
     @classmethod
     def install(cls, context: Context) -> None:

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -49,7 +49,7 @@ class Installer(DistributionInstaller):
 
     @classmethod
     def setup(cls, context: Context) -> None:
-        setup_rpm(context)
+        setup_rpm(context, dbbackend="ndb")
 
         zypper = context.config.find_binary("zypper")
         if zypper:

--- a/mkosi/installer/rpm.py
+++ b/mkosi/installer/rpm.py
@@ -63,7 +63,12 @@ def find_rpm_gpgkey(
     return None
 
 
-def setup_rpm(context: Context, *, dbpath: str = "/usr/lib/sysimage/rpm") -> None:
+def setup_rpm(
+    context: Context,
+    *,
+    dbpath: str = "/usr/lib/sysimage/rpm",
+    dbbackend: Optional[str] = None,
+) -> None:
     confdir = context.sandbox_tree / "etc/rpm"
     confdir.mkdir(parents=True, exist_ok=True)
     if not (confdir / "macros.lang").exists() and context.config.locale:
@@ -71,6 +76,9 @@ def setup_rpm(context: Context, *, dbpath: str = "/usr/lib/sysimage/rpm") -> Non
 
     if not (confdir / "macros.dbpath").exists():
         (confdir / "macros.dbpath").write_text(f"%_dbpath {dbpath}")
+
+    if dbbackend:
+        (confdir / "macros.db_backend").write_text(f"%_db_backend {dbbackend}")
 
     plugindir = Path(
         run(


### PR DESCRIPTION
OpenSUSE's rpm is not built with the sqlite db backend so let's make
sure the rpm DB can be read inside the image by OpenSUSE's rpm by
forcing the ndb backend to be used.