### PR TITLE
tools: Don't use apt pattern for ubuntu-keyring

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
@@ -13,7 +13,6 @@ Packages=
         ?exact-name(systemd-boot)
         ?exact-name(systemd-repart)
         ?exact-name(systemd-ukify)
-        ?exact-name(ubuntu-keyring)
         ?exact-name(virtiofsd)
         apt
         archlinux-keyring

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf.d/ubuntu-keyring.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf.d/ubuntu-keyring.conf
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=|!debian
+Release=|!bookworm
+
+[Content]
+Packages=
+        ubuntu-keyring


### PR DESCRIPTION
Running

    mkosi --directory "" -d debian -r bookworm --include mkosi-tools --output mkosi.tools

on current Debian stable on gets an error that the package 'ubuntu-keyring' doesn't have any installable candidates. Moving the inclusion of the package out of the purview of apt and back into mkosi's fixes this issue.