### PR TITLE
Rename Profile= match to Profiles=

### DIFF
--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1767,7 +1767,7 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 ### [Match] Section.
 
-`Profile=`
+`Profiles=`
 :   Matches against the configured profiles.
 
 `Distribution=`
@@ -1854,7 +1854,7 @@ config file is read:
 
 | Matcher                  | Globs | Rich Comparisons | Default                               |
 |--------------------------|-------|------------------|---------------------------------------|
-| `Profile=`               | no    | no               | match fails                           |
+| `Profiles=`              | no    | no               | match fails                           |
 | `Distribution=`          | no    | no               | match host distribution               |
 | `Release=`               | no    | no               | match host release                    |
 | `Architecture=`          | no    | no               | match host architecture               |

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -401,7 +401,7 @@ def test_profiles(tmp_path: Path) -> None:
     (d / "mkosi.profiles/abc.conf").write_text(
         """\
         [Match]
-        Profile=abc
+        Profiles=abc
 
         [Distribution]
         Distribution=opensuse


### PR DESCRIPTION
Matches related to settings are named after their setting so this should be Profiles= similarly to the Repositories= match. The old name will still work as well but we use the new one in docs.