### PR TITLE
Relax read-only mounts even more

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4302,7 +4302,15 @@ def run_build(
             if not Path(d).exists():
                 continue
 
-            if config.output_dir_or_cwd().is_relative_to(d):
+            if any(
+                p and p.is_relative_to(d)
+                for p in (
+                    config.workspace_dir_or_default(),
+                    config.package_cache_dir_or_default(),
+                    config.cache_dir,
+                    config.output_dir_or_cwd(),
+                )
+            ):
                 continue
 
             attrs = MOUNT_ATTR_RDONLY

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -33,7 +33,7 @@ from typing import Any, Callable, Optional, TypeVar, Union, cast
 from mkosi.distributions import Distribution, detect_distribution
 from mkosi.log import ARG_DEBUG, ARG_DEBUG_SHELL, Style, die
 from mkosi.pager import page
-from mkosi.run import SandboxProtocol, find_binary, nosandbox, run, sandbox_cmd
+from mkosi.run import SandboxProtocol, find_binary, nosandbox, run, sandbox_cmd, workdir
 from mkosi.sandbox import __version__
 from mkosi.types import PathString, SupportsRead
 from mkosi.user import INVOKING_USER
@@ -4732,8 +4732,8 @@ def want_selinux_relabel(
         return None
 
     policy = run(
-        ["sh", "-c", f". {selinux} && echo $SELINUXTYPE"],
-        sandbox=config.sandbox(binary="sh", options=["--ro-bind", selinux, selinux]),
+        ["sh", "-c", f". {workdir(selinux)} && echo $SELINUXTYPE"],
+        sandbox=config.sandbox(binary="sh", options=["--ro-bind", selinux, workdir(selinux)]),
         stdout=subprocess.PIPE,
     ).stdout.strip()
     if not policy:

--- a/mkosi/curl.py
+++ b/mkosi/curl.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from mkosi.config import Config
 from mkosi.mounts import finalize_crypto_mounts
-from mkosi.run import run
+from mkosi.run import run, workdir
 
 
 def curl(config: Config, url: str, output_dir: Path) -> None:
@@ -12,7 +12,7 @@ def curl(config: Config, url: str, output_dir: Path) -> None:
         [
             "curl",
             "--location",
-            "--output-dir", output_dir,
+            "--output-dir", workdir(output_dir),
             "--remote-name",
             "--no-progress-meter",
             "--fail",
@@ -26,6 +26,6 @@ def curl(config: Config, url: str, output_dir: Path) -> None:
         sandbox=config.sandbox(
             binary="curl",
             network=True,
-            options=["--bind", output_dir, output_dir, *finalize_crypto_mounts(config)],
+            options=["--bind", output_dir, workdir(output_dir), *finalize_crypto_mounts(config)],
         ),
     )  # fmt: skip

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -11,7 +11,7 @@ from mkosi.distributions import DistributionInstaller, PackageType
 from mkosi.installer import PackageManager
 from mkosi.installer.apt import Apt, AptRepository
 from mkosi.log import die
-from mkosi.run import run
+from mkosi.run import run, workdir
 from mkosi.sandbox import umask
 
 
@@ -140,12 +140,12 @@ class Installer(DistributionInstaller):
                 "install",
                 [
                     "-oDebug::pkgDPkgPm=1",
-                    f"-oDPkg::Pre-Install-Pkgs::=cat >{f.name}",
+                    f"-oDPkg::Pre-Install-Pkgs::=cat >{workdir(Path(f.name))}",
                     "?essential",
                     "?exact-name(usr-is-merged)",
                     "base-files",
                 ],
-                options=["--bind", f.name, f.name],
+                options=["--bind", f.name, workdir(Path(f.name))],
             )
 
             essential = f.read().strip().splitlines()

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -10,7 +10,7 @@ from mkosi.config import PACKAGE_GLOBS, Config, ConfigFeature
 from mkosi.context import Context
 from mkosi.installer import PackageManager
 from mkosi.log import die
-from mkosi.run import run
+from mkosi.run import run, workdir
 from mkosi.sandbox import umask
 from mkosi.types import _FILE, CompletedProcess, PathString
 
@@ -256,9 +256,12 @@ class Apt(PackageManager):
             ],
             sandbox=context.sandbox(
                 binary="reprepro",
-                options=["--bind", context.repository, context.repository, "--chdir", context.repository],
+                options=[
+                    "--bind", context.repository, workdir(context.repository),
+                    "--chdir", workdir(context.repository),
+                ],
             ),
-        )
+        )  # fmt: skip
 
         (context.sandbox_tree / "etc/apt/sources.list.d").mkdir(parents=True, exist_ok=True)
         (context.sandbox_tree / "etc/apt/sources.list.d/mkosi-local.sources").write_text(

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -8,7 +8,7 @@ from mkosi.context import Context
 from mkosi.installer import PackageManager
 from mkosi.installer.rpm import RpmRepository, rpm_cmd
 from mkosi.log import ARG_DEBUG
-from mkosi.run import run
+from mkosi.run import run, workdir
 from mkosi.types import _FILE, CompletedProcess, PathString
 
 
@@ -217,9 +217,9 @@ class Dnf(PackageManager):
     @classmethod
     def createrepo(cls, context: Context) -> None:
         run(
-            ["createrepo_c", context.repository],
+            ["createrepo_c", workdir(context.repository)],
             sandbox=context.sandbox(
-                binary="createrepo_c", options=["--bind", context.repository, context.repository]
+                binary="createrepo_c", options=["--bind", context.repository, workdir(context.repository)]
             ),
         )
 

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from mkosi.config import Config
 from mkosi.context import Context
 from mkosi.installer import PackageManager
-from mkosi.run import run
+from mkosi.run import run, workdir
 from mkosi.sandbox import umask
 from mkosi.types import _FILE, CompletedProcess, PathString
 from mkosi.versioncomp import GenericVersion
@@ -181,11 +181,15 @@ class Pacman(PackageManager):
             [
                 "repo-add",
                 "--quiet",
-                context.repository / "mkosi.db.tar",
-                *sorted(context.repository.glob("*.pkg.tar*"), key=lambda p: GenericVersion(Path(p).name)),
+                workdir(context.repository / "mkosi.db.tar"),
+                *sorted(
+                    (workdir(p) for p in context.repository.glob("*.pkg.tar*")),
+                    key=lambda p: GenericVersion(Path(p).name),
+                ),
             ],
             sandbox=context.sandbox(
-                binary="repo-add", options=["--bind", context.repository, context.repository]
+                binary="repo-add",
+                options=["--bind", context.repository, workdir(context.repository)],
             ),
         )
 

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -8,7 +8,7 @@ from mkosi.config import Config, yes_no
 from mkosi.context import Context
 from mkosi.installer import PackageManager
 from mkosi.installer.rpm import RpmRepository, rpm_cmd
-from mkosi.run import run
+from mkosi.run import run, workdir
 from mkosi.types import _FILE, CompletedProcess, PathString
 
 
@@ -138,9 +138,10 @@ class Zypper(PackageManager):
     @classmethod
     def createrepo(cls, context: Context) -> None:
         run(
-            ["createrepo_c", context.repository],
+            ["createrepo_c", workdir(context.repository)],
             sandbox=context.sandbox(
-                binary="createrepo_c", options=["--bind", context.repository, context.repository]
+                binary="createrepo_c",
+                options=["--bind", context.repository, workdir(context.repository)],
             ),
         )
 

--- a/mkosi/partition.py
+++ b/mkosi/partition.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Final, Optional
 
 from mkosi.log import die
-from mkosi.run import SandboxProtocol, nosandbox, run
+from mkosi.run import SandboxProtocol, nosandbox, run, workdir
 
 
 @dataclasses.dataclass(frozen=True)
@@ -33,10 +33,10 @@ class Partition:
 def find_partitions(image: Path, *, sandbox: SandboxProtocol = nosandbox) -> list[Partition]:
     output = json.loads(
         run(
-            ["systemd-repart", "--json=short", image],
+            ["systemd-repart", "--json=short", workdir(image)],
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
-            sandbox=sandbox(binary="systemd-repart", options=["--ro-bind", image, image]),
+            sandbox=sandbox(binary="systemd-repart", options=["--ro-bind", image, workdir(image)]),
         ).stdout
     )
     return [Partition.from_dict(d) for d in output]

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -262,10 +262,6 @@ def start_swtpm(config: Config) -> Iterator[Path]:
             sandbox=config.sandbox(
                 binary="swtpm_setup",
                 options=["--bind", state, state],
-                setup=scope_cmd(
-                    name=f"mkosi-swtpm-{config.machine_or_name()}",
-                    description=f"swtpm for {config.machine_or_name()}",
-                ),
             ),
             stdout=None if ARG_DEBUG.get() else subprocess.DEVNULL,
         )  # fmt: skip
@@ -284,7 +280,14 @@ def start_swtpm(config: Config) -> Iterator[Path]:
             with spawn(
                 cmdline,
                 pass_fds=(sock.fileno(),),
-                sandbox=config.sandbox(binary="swtpm", options=["--bind", state, state]),
+                sandbox=config.sandbox(
+                    binary="swtpm",
+                    options=["--bind", state, state],
+                    setup=scope_cmd(
+                        name=f"mkosi-swtpm-{config.machine_or_name()}",
+                        description=f"swtpm for {config.machine_or_name()}",
+                    ),
+                ),
             ) as proc:
                 yield path
                 proc.terminate()

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -158,9 +158,9 @@ class KernelType(StrEnum):
             return KernelType.unknown
 
         type = run(
-            ["bootctl", "kernel-identify", path],
+            ["bootctl", "kernel-identify", workdir(path)],
             stdout=subprocess.PIPE,
-            sandbox=config.sandbox(binary="bootctl", options=["--ro-bind", path, path]),
+            sandbox=config.sandbox(binary="bootctl", options=["--ro-bind", path, workdir(path)]),
         ).stdout.strip()
 
         try:
@@ -253,7 +253,7 @@ def start_swtpm(config: Config) -> Iterator[Path]:
         run(
             [
                 "swtpm_setup",
-                "--tpm-state", state,
+                "--tpm-state", workdir(Path(state)),
                 "--tpm2",
                 "--pcr-banks",
                 "sha256",
@@ -261,12 +261,12 @@ def start_swtpm(config: Config) -> Iterator[Path]:
             ],
             sandbox=config.sandbox(
                 binary="swtpm_setup",
-                options=["--bind", state, state],
+                options=["--bind", state, workdir(Path(state))],
             ),
             stdout=None if ARG_DEBUG.get() else subprocess.DEVNULL,
         )  # fmt: skip
 
-        cmdline = ["swtpm", "socket", "--tpm2", "--tpmstate", f"dir={state}"]
+        cmdline = ["swtpm", "socket", "--tpm2", "--tpmstate", f"dir={workdir(Path(state))}"]
 
         # We create the socket ourselves and pass the fd to swtpm to avoid race conditions where we start
         # qemu before swtpm has had the chance to create the socket (or where we try to chown it first).
@@ -282,7 +282,7 @@ def start_swtpm(config: Config) -> Iterator[Path]:
                 pass_fds=(sock.fileno(),),
                 sandbox=config.sandbox(
                     binary="swtpm",
-                    options=["--bind", state, state],
+                    options=["--bind", state, workdir(Path(state))],
                     setup=scope_cmd(
                         name=f"mkosi-swtpm-{config.machine_or_name()}",
                         description=f"swtpm for {config.machine_or_name()}",
@@ -578,16 +578,16 @@ def copy_ephemeral(config: Config, src: Path) -> Iterator[Path]:
                 become_root_in_subuid_range()
             elif config.output_format in (OutputFormat.disk, OutputFormat.esp):
                 attr = run(
-                    ["lsattr", "-l", src],
-                    sandbox=config.sandbox(binary="lsattr", options=["--ro-bind", src, src]),
+                    ["lsattr", "-l", workdir(src)],
+                    sandbox=config.sandbox(binary="lsattr", options=["--ro-bind", src, workdir(src)]),
                     stdout=subprocess.PIPE,
                 ).stdout
 
                 if "No_COW" in attr:
                     tmp.touch()
                     run(
-                        ["chattr", "+C", tmp],
-                        sandbox=config.sandbox(binary="chattr", options=["--bind", tmp, tmp]),
+                        ["chattr", "+C", workdir(tmp)],
+                        sandbox=config.sandbox(binary="chattr", options=["--bind", tmp, workdir(tmp)]),
                     )
 
             copy_tree(
@@ -638,9 +638,12 @@ def generate_scratch_fs(config: Config) -> Iterator[Path]:
         fs = config.distribution.filesystem()
         extra = config.environment.get(f"SYSTEMD_REPART_MKFS_OPTIONS_{fs.upper()}", "")
         run(
-            [f"mkfs.{fs}", "-L", "scratch", *extra.split(), scratch.name],
+            [f"mkfs.{fs}", "-L", "scratch", *extra.split(), workdir(Path(scratch.name))],
             stdout=subprocess.DEVNULL,
-            sandbox=config.sandbox(binary=f"mkfs.{fs}", options=["--bind", scratch.name, scratch.name]),
+            sandbox=config.sandbox(
+                binary=f"mkfs.{fs}",
+                options=["--bind", scratch.name, workdir(Path(scratch.name))],
+            ),
         )
         yield Path(scratch.name)
 
@@ -686,10 +689,10 @@ def finalize_firmware_variables(
         run(
             [
                 "virt-fw-vars",
-                "--input", ovmf.vars,
-                "--output", ovmf_vars.name,
-                "--enroll-cert", config.secure_boot_certificate,
-                "--add-db", "OvmfEnrollDefaultKeys", config.secure_boot_certificate,
+                "--input", workdir(ovmf.vars),
+                "--output", workdir(Path(ovmf_vars.name)),
+                "--enroll-cert", workdir(config.secure_boot_certificate),
+                "--add-db", "OvmfEnrollDefaultKeys", workdir(config.secure_boot_certificate),
                 "--no-microsoft",
                 "--secure-boot",
                 "--loglevel", "WARNING",
@@ -697,8 +700,9 @@ def finalize_firmware_variables(
             sandbox=config.sandbox(
                 binary=qemu,
                 options=[
-                    "--bind", ovmf_vars.name, ovmf_vars.name,
-                    "--ro-bind", config.secure_boot_certificate, config.secure_boot_certificate,
+                    "--bind", ovmf_vars.name, workdir(Path(ovmf_vars.name)),
+                    "--ro-bind", ovmf.vars, workdir(ovmf.vars),
+                    "--ro-bind", config.secure_boot_certificate, workdir(config.secure_boot_certificate),
                 ],
             ),
         )  # fmt: skip
@@ -729,9 +733,9 @@ def apply_runtime_size(config: Config, image: Path) -> None:
             f"--size={round_up(config.runtime_size, resource.getpagesize())}",
             "--pretty=no",
             "--offline=yes",
-            image,
+            workdir(image),
         ],
-        sandbox=config.sandbox(binary="systemd-repart", options=["--bind", image, image]),
+        sandbox=config.sandbox(binary="systemd-repart", options=["--bind", image, workdir(image)]),
     )  # fmt: skip
 
 

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -562,7 +562,7 @@ def sandbox_cmd(
 
         if not overlay and not relaxed:
             tmp = stack.enter_context(vartmpdir())
-            yield [*cmdline, "--bind", tmp, "/var/tmp", *options, "--"]
+            yield [*cmdline, "--bind", tmp, "/var/tmp", "--dir", "/tmp", "--dir", "/run", *options, "--"]
             return
 
         for d in ("etc", "opt"):


### PR DESCRIPTION
Turns out having home directories as a subdirectory of /usr is a thing. Let's relax the readonly mount requirements even more to make this use case work as well.