### PR TITLE
Define our own config for PE addons and UKI profiles

### DIFF
--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -942,19 +942,25 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 `UnifiedKernelImageProfiles=`, `--uki-profile=`
 :   Build additional UKI profiles. Takes a comma separated list of paths
-    to `ukify` config files. This option may be used multiple times in
+    to UKI profile config files. This option may be used multiple times in
     which case each config gets built into a corresponding UKI profile.
     Config files in the `mkosi.uki-profiles/` directory are
     automatically picked up. All configured UKI profiles are added as
     additional UKI profiles to each UKI built by mkosi.
 
+    See the documentation for the `UKIProfile` section for information
+    on which settings can be configured in UKI profile config files.
+
 `PeAddons=`, `--pe-addon`
 :   Build additional PE addons. Takes a comma separated list of paths to
-    `ukify` config files. This option may be used multiple times in which case
+    PE addon config files. This option may be used multiple times in which case
     each config gets built into a corresponding addon. Each addon has the name
     of the config file, with the extension replaced with `.addon.efi`.
     Config files in the `mkosi.pe-addons/` directory are automatically picked
     up.
+
+    See the documentation for the `PEAddon` section for information on
+    which settings can be configured in PE addon config files.
 
 `Initrds=`, `--initrd`
 :   Use user-provided initrd(s). Takes a comma separated list of paths to initrd
@@ -1931,6 +1937,41 @@ config file is read:
     building multiple images, pass the listed environment variables to
     each individual subimage as if they were "universal" settings. See
     the **Building multiple images** section for more information.
+
+### [PEAddon] Section
+
+The `PEAddon` section can be used in UKI profile config files which are
+passed to the `PEAddons=` setting. The following settings can be
+specified in the `PEAddon` section:
+
+`Output=`
+:   The name the addon should have in the addons directory in the ESP.
+    The final name is the name specified here suffixed with
+    `.addon.efi`.
+
+`Cmdline=`
+:   The kernel command line arguments to store in the `.cmdline` section
+    of the addon. Takes a space delimited list of extra kernel command
+    line arguments.
+
+### [UKIProfile] Section
+
+The `UKIProfile` section can be used in UKI profile config files which
+are passed to the `UnifiedKernelImageProfiles=` setting. The following
+settings can be specified in the `UKIProfile` section:
+
+`Profile=`
+:   The contents of the `.profile` section of the UKI profile. Takes a
+    list of key/value pairs separated by `=`. The `ID=` key must be
+    specified. See the UKI [specification](https://uapi-group.org/specifications/specs/unified_kernel_image/#multi-profile-ukis)
+    for a full list of possible keys.
+
+`Cmdline=`
+:   Extra kernel command line options for the UKI profile. Takes a space
+    delimited list of extra kernel command line arguments. Note that
+    the final `.cmdline` section will the combination of the base
+    `.cmdline` section and the extra kernel command line arguments
+    specified with this setting.
 
 ## Specifiers
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -25,11 +25,13 @@ from mkosi.config import (
     ManifestFormat,
     Network,
     OutputFormat,
+    PEAddon,
     QemuDrive,
     QemuFirmware,
     QemuVsockCID,
     SecureBootSignTool,
     ShimBootloader,
+    UKIProfile,
     Verb,
     Vmm,
 )
@@ -208,7 +210,12 @@ def test_config() -> None:
             ],
             "Passphrase": null,
             "PeAddons": [
-                "/my-addon.conf"
+                {
+                    "Cmdline": [
+                        "key=value"
+                    ],
+                    "Output": "abc"
+                }
             ],
             "PostInstallationScripts": [
                 "/bar/qux"
@@ -351,7 +358,14 @@ def test_config() -> None:
             ],
             "UnifiedKernelImageFormat": "myuki",
             "UnifiedKernelImageProfiles": [
-                "/profile"
+                {
+                    "Cmdline": [
+                        "key=value"
+                    ],
+                    "Profile": {
+                        "key": "value"
+                    }
+                }
             ],
             "UnifiedKernelImages": "auto",
             "UnitProperties": [
@@ -454,7 +468,7 @@ def test_config() -> None:
         packages=[],
         pass_environment=["abc"],
         passphrase=None,
-        pe_addons=[Path("/my-addon.conf")],
+        pe_addons=[PEAddon(output="abc", cmdline=["key=value"])],
         postinst_scripts=[Path("/bar/qux")],
         postoutput_scripts=[Path("/foo/src")],
         prepare_scripts=[Path("/run/foo")],
@@ -532,7 +546,7 @@ def test_config() -> None:
         tools_tree_release=None,
         tools_tree_repositories=["abc"],
         unified_kernel_image_format="myuki",
-        unified_kernel_image_profiles=[Path("/profile")],
+        unified_kernel_image_profiles=[UKIProfile(profile={"key": "value"}, cmdline=["key=value"])],
         unified_kernel_images=ConfigFeature.auto,
         unit_properties=["PROPERTY=VALUE"],
         use_subvolumes=ConfigFeature.auto,


### PR DESCRIPTION
ukify's config parser uses python's configparser module and as such
suffers from all its issues just like we used to in mkosi. Having ukify
parse the config file also means that we have to make sure any paths
configured in the profile are available in the sandbox.

Instead, let's define our own configs for the PE addons and UKI profiles
so we get to take advantage of our own config file parser and have full
knowledge of all the configured settings so we can mount extra stuff into
the sandbox if needed.

It also gets rid of the hack where we parse ukify's config file to figure
out the command line.

cc @NekkoDroid 