### PR TITLE
Make tools tree available in tests

### DIFF
--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -302,7 +302,13 @@ def spawn(
                 make_foreground_process(new_process_group=False)
 
 
-def find_binary(*names: PathString, root: Path = Path("/"), extra: Sequence[Path] = ()) -> Optional[Path]:
+def find_binary(
+    *names: PathString,
+    root: Optional[Path] = None,
+    extra: Sequence[Path] = (),
+) -> Optional[Path]:
+    root = root or Path("/")
+
     if root != Path("/"):
         path = ":".join(
             itertools.chain(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -25,6 +25,7 @@ class ImageConfig:
     distribution: Distribution
     release: str
     debug_shell: bool
+    tools: Optional[Path]
 
 
 class Image:
@@ -64,6 +65,7 @@ class Image:
         return run(
             [
                 "python3", "-m", "mkosi",
+                *(["--tools-tree", os.fspath(self.config.tools)] if self.config.tools else []),
                 "--debug",
                 *options,
                 verb,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 from collections.abc import Iterator
+from pathlib import Path
 from typing import Any, cast
 
 import pytest
@@ -48,6 +49,7 @@ def config(request: Any) -> ImageConfig:
         distribution=distribution,
         release=release,
         debug_shell=request.config.getoption("--debug-shell"),
+        tools=p if (p := Path("mkosi.tools")).exists() else None,
     )
 
 


### PR DESCRIPTION
For use with find_binary() to check if binaries exist in the tools
tree.