### PR TITLE
Put .profile section values in quotes if not alphanumeric

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2011,6 +2011,9 @@ def build_uki_profiles(context: Context, cmdline: Sequence[str]) -> list[Path]:
 
         with profile_section.open("w") as f:
             for k, v in profile.profile.items():
+                if not all(c.isalnum() for c in v):
+                    v = f'"{v}"'
+
                 f.write(f"{k}={v}\n")
 
         with complete_step(f"Generating UKI profile '{id}'"):


### PR DESCRIPTION
This is supposed to be sourcable by shells so make sure we use quotes in case values with whitespace are used.