### PR TITLE
Add QemuRemovable option

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1736,6 +1736,7 @@ class Config:
     qemu_vsock_cid: int
     qemu_swtpm: ConfigFeature
     qemu_cdrom: bool
+    qemu_removable: bool
     qemu_firmware: QemuFirmware
     qemu_firmware_variables: Optional[Path]
     qemu_kernel: Optional[Path]
@@ -3418,6 +3419,14 @@ SETTINGS = (
         section="Host",
         parse=config_parse_boolean,
         help="Attach the image as a CD-ROM to the virtual machine",
+    ),
+    ConfigSetting(
+        dest="qemu_removable",
+        metavar="BOOLEAN",
+        nargs="?",
+        section="Host",
+        parse=config_parse_boolean,
+        help="Attach the image as a removable drive to the virtual machine",
     ),
     ConfigSetting(
         dest="qemu_firmware",

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -1282,7 +1282,7 @@ def run_qemu(args: Args, config: Config) -> None:
             cache = f"cache.writeback=on,cache.direct={yes_no(direct)},cache.no-flush={yes_no(ephemeral)},aio=io_uring"  # noqa: E501
             cmdline += [
                 "-drive", f"if=none,id=mkosi,file={fname},format=raw,discard=on,{cache}",
-                "-device", f"scsi-{'cd' if config.qemu_cdrom else 'hd'},drive=mkosi,bootindex=1",
+                "-device", f"scsi-{'cd' if config.qemu_cdrom else 'hd'},drive=mkosi,bootindex=1{',removable=on' if config.qemu_removable else ''}",  # noqa: E501
             ]  # fmt: skip
 
         if config.qemu_swtpm == ConfigFeature.enabled or (

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1587,6 +1587,10 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     attach the image to the virtual machine as a CD-ROM device. Takes a
     boolean. Defaults to `no`.
 
+`QemuRemovable=`, `--qemu-removable=`
+:   When used with the `qemu` verb, this option specifies whether to attach the image to the virtual machine
+    as a removable device. Takes a boolean. Defaults to `no`.
+
 `QemuFirmware=`, `--qemu-firmware=`
 :   When used with the `qemu` verb, this option specifies which firmware
     to use. Takes one of `uefi`, `uefi-secure-boot`, `bios`, `linux`, or

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -260,6 +260,7 @@ def test_config() -> None:
             "QemuKernel": null,
             "QemuKvm": "auto",
             "QemuMem": 123,
+            "QemuRemovable": false,
             "QemuSmp": 2,
             "QemuSwtpm": "auto",
             "QemuVsock": "enabled",
@@ -481,6 +482,7 @@ def test_config() -> None:
         proxy_url="https://my/proxy",
         qemu_args=[],
         qemu_cdrom=False,
+        qemu_removable=False,
         qemu_drives=[
             QemuDrive("abc", 200, Path("/foo/bar"), "abc,qed", "red"),
             QemuDrive("abc", 200, None, "", "wcd"),


### PR DESCRIPTION
It would be nice to be able to set the `removable=on` option for the main image when using the `qemu` verb to better mimic scenarios where the image is written to removable media, e.g. a usb stick. 