### PR TITLE
Check if tools tree exists before statting it in cache_manifest()

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1871,7 +1871,11 @@ class Config:
                 base64.b64encode(script.read_bytes()).decode() for script in self.prepare_scripts
             ),
             # Statting the root directory of the tools tree isn't fool proof but should be good enough.
-            "tools_tree": [self.tools_tree, self.tools_tree.stat().st_mtime_ns] if self.tools_tree else [],
+            "tools_tree": (
+                [self.tools_tree, self.tools_tree.stat().st_mtime_ns]
+                if self.tools_tree and self.tools_tree.exists()
+                else []
+            ),
         }
 
     def to_dict(self) -> dict[str, Any]:


### PR DESCRIPTION
The tools tree might have been removed because it's cache was out of date so let's make sure we check it exists in cache_manifest().