### PR TITLE
Clarify explanation of `Verity=` option

### DIFF
--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1136,9 +1136,9 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     certificate must be present and the build will fail if we don't
     detect any verity partitions in the disk image produced by
     systemd-repart. If disabled, verity partitions will be excluded from
-    disk images produced by systemd-repart even if the partition
-    definitions contain verity partitions. If set to `auto`, the verity
-    key and certificate will be passed to systemd-repart if available,
+    the extension images produced by systemd-repart. If set to `auto` and
+    a verity key and certificate are present, mkosi will pass them to systemd-repart
+    and expects the generated disk image to contain verity partitions,
     but the build won't fail if no verity partitions are found in the
     disk image produced by systemd-repart.
 


### PR DESCRIPTION
This clarifies that the "auto" value for the verity option only really makes sense for extension images.

Alternative solution: Implement `Verity=` as an enum option which accepts off/no, hash, and signature (similar to the repart option - or off/verity/signed, similar to systemd.image-policy). If set to "off", no checking is performed and unsigned extension images are build. If set to "hash", mkosi asserts that the generated image contains a verity partition (and creates extension images with a verity partition? - not sure how useful). If set to "signature", mkosi asserts that key+certificate are present and checks that the resulting image contains a verity-sig partition.

I actually like the alternative solution a bit more but won't have time until next week to work on it so I wanted to get this quick clarification out there for now.