### PR TITLE
Fix conf with settings in Content instead of Build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,8 @@ jobs:
 
           [Content]
           KernelCommandLine=systemd.default_device_timeout_sec=180
+
+          [Build]
           Environment=SYSTEMD_REPART_MKFS_OPTIONS_EROFS="--quiet"
 
           [Host]

--- a/docs/building-rpms-from-source.md
+++ b/docs/building-rpms-from-source.md
@@ -29,7 +29,7 @@ when running mkosi scripts by using the `BuildSources=` setting. For
 example, in `mkosi.local.conf`, we could have the following settings:
 
 ```conf
-[Content]
+[Build]
 BuildSources=../mkosi:mkosi
              ../fedora/mkosi:mkosi/rpm
 BuildSourcesEphemeral=yes

--- a/mkosi.conf.d/30-debian-kali-ubuntu/mkosi.conf.d/20-ext4-orphan-file.conf
+++ b/mkosi.conf.d/30-debian-kali-ubuntu/mkosi.conf.d/20-ext4-orphan-file.conf
@@ -4,7 +4,7 @@
 Distribution=ubuntu
 Release=jammy
 
-[Content]
+[Build]
 # "orphan_file" is enabled by default in recent versions of mkfs.ext4 but not supported by the Jammy kernel so we
 # explicitly disable it.
 Environment=SYSTEMD_REPART_MKFS_OPTIONS_EXT4="-O ^orphan_file"

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1859,7 +1859,7 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     path. For example, if we have a `mkosi.conf` file containing:
 
     ```ini
-    [Content]
+    [Build]
     BuildSources=../abc/qed:kernel
     ```
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -101,6 +101,8 @@ def test_parse_config(tmp_path: Path) -> None:
 
         [Content]
         Packages=abc
+
+        [Build]
         Environment=MY_KEY=MY_VALUE
 
         [Output]
@@ -420,7 +422,7 @@ def test_override_default(tmp_path: Path) -> None:
 
     (d / "mkosi.conf").write_text(
         """\
-        [Content]
+        [Build]
         Environment=MY_KEY=MY_VALUE
 
         [Host]
@@ -1097,7 +1099,7 @@ def test_specifiers(tmp_path: Path) -> None:
         OutputDirectory=abcde
         Output=test
 
-        [Content]
+        [Build]
         Environment=Distribution=%d
                     Release=%r
                     Architecture=%a
@@ -1115,7 +1117,7 @@ def test_specifiers(tmp_path: Path) -> None:
     (d / "mkosi.conf.d").mkdir()
     (d / "mkosi.conf.d/abc.conf").write_text(
         """\
-        [Content]
+        [Build]
         Environment=ConfigAbcDirectory=%D
                     ConfigAbcConfdir=%C
                     ConfigAbcPwd=%P
@@ -1124,7 +1126,7 @@ def test_specifiers(tmp_path: Path) -> None:
     (d / "mkosi.conf.d/qed").mkdir()
     (d / "mkosi.conf.d/qed/mkosi.conf").write_text(
         """
-        [Content]
+        [Build]
         Environment=ConfigQedDirectory=%D
                     ConfigQedConfdir=%C
                     ConfigQedPwd=%P
@@ -1213,7 +1215,7 @@ def test_environment(tmp_path: Path) -> None:
         [Config]
         PassEnvironment=PassThisEnv
 
-        [Content]
+        [Build]
         Environment=TestValue2=300
                     TestValue3=400
                     PassThisEnv=abc


### PR DESCRIPTION
Follow-up for 6912dc0ea0c7e20900a9b5d2c43343c1c782e91c

Seen on the CI for `Environment=`, but there are more wrong settings remaining.

```
2024-10-16T08:48:32.7586608Z tests/test_initrd.py::test_initrd_luks 
2024-10-16T08:48:32.7587441Z ##[group]test_initrd_luks
2024-10-16T08:48:32.8751669Z ‣ Loading configuration file /home/runner/work/mkosi/mkosi/mkosi.local.conf
2024-10-16T08:48:32.8753483Z ‣ /home/runner/work/mkosi/mkosi/mkosi.local.conf: Setting Environment should be configured in [Build], not [Content].
```

BTW, there is something wrong with `test_config`, because it should be failing before this PR and it isn't. If the section is valid the test pass (although the specific conf setting is not under the right section).