### PR TITLE
Allow more granular control on which artifacts are output

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2144,6 +2144,14 @@ def maybe_compress(
                 run(cmd, stdin=i, stdout=o, sandbox=context.sandbox(binary=cmd[0]))
 
 
+def copy_nspawn_settings(context: Context) -> None:
+    if context.config.nspawn_settings is None:
+        return None
+
+    with complete_step("Copying nspawn settings file…"):
+        shutil.copy2(context.config.nspawn_settings, context.staging / context.config.output_nspawn_settings)
+
+
 def copy_uki(context: Context) -> None:
     if (context.staging / context.config.output_split_uki).exists():
         return
@@ -2187,14 +2195,6 @@ def copy_vmlinuz(context: Context) -> None:
     for _, kimg in gen_kernel_images(context):
         shutil.copy(context.root / kimg, context.staging / context.config.output_split_kernel)
         break
-
-
-def copy_nspawn_settings(context: Context) -> None:
-    if context.config.nspawn_settings is None:
-        return None
-
-    with complete_step("Copying nspawn settings file…"):
-        shutil.copy2(context.config.nspawn_settings, context.staging / context.config.output_nspawn_settings)
 
 
 def copy_initrd(context: Context) -> None:

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -499,7 +499,31 @@ class Architecture(StrEnum):
         return cls.from_uname(platform.machine())
 
 
-def parse_boolean(s: str) -> bool:
+class ArtifactOutput(StrEnum):
+    uki = enum.auto()
+    kernel = enum.auto()
+    initrd = enum.auto()
+    partitions = enum.auto()
+
+    @staticmethod
+    def compat_no() -> list["ArtifactOutput"]:
+        return [
+            ArtifactOutput.uki,
+            ArtifactOutput.kernel,
+            ArtifactOutput.initrd,
+        ]
+
+    @staticmethod
+    def compat_yes() -> list["ArtifactOutput"]:
+        return [
+            ArtifactOutput.uki,
+            ArtifactOutput.kernel,
+            ArtifactOutput.initrd,
+            ArtifactOutput.partitions,
+        ]
+
+
+def try_parse_boolean(s: str) -> Optional[bool]:
     "Parse 1/true/yes/y/t/on as true and 0/false/no/n/f/off/None as false"
 
     s_l = s.lower()
@@ -509,7 +533,16 @@ def parse_boolean(s: str) -> bool:
     if s_l in {"0", "false", "no", "n", "f", "off", "never"}:
         return False
 
-    die(f"Invalid boolean literal: {s!r}")
+    return None
+
+
+def parse_boolean(s: str) -> bool:
+    value = try_parse_boolean(s)
+
+    if value is None:
+        die(f"Invalid boolean literal: {s!r}")
+
+    return value
 
 
 def parse_path(
@@ -1291,6 +1324,21 @@ def config_parse_key_source(value: Optional[str], old: Optional[KeySource]) -> O
     return KeySource(type=type, source=source)
 
 
+def config_parse_artifact_output_list(
+    value: Optional[str], old: Optional[list[ArtifactOutput]]
+) -> Optional[list[ArtifactOutput]]:
+    if not value:
+        return None
+
+    # Keep for backwards compatibility
+    boolean_value = try_parse_boolean(value)
+    if boolean_value is not None:
+        return ArtifactOutput.compat_yes() if boolean_value else ArtifactOutput.compat_no()
+
+    list_value = config_make_list_parser(delimiter=",", parse=make_enum_parser(ArtifactOutput))(value, old)
+    return cast(list[ArtifactOutput], list_value)
+
+
 class SettingScope(StrEnum):
     # Not passed down to subimages
     local = enum.auto()
@@ -1596,7 +1644,7 @@ class Config:
     output_mode: Optional[int]
     image_id: Optional[str]
     image_version: Optional[str]
-    split_artifacts: bool
+    split_artifacts: list[ArtifactOutput]
     repart_dirs: list[Path]
     sysupdate_dir: Optional[Path]
     sector_size: Optional[int]
@@ -2292,11 +2340,11 @@ SETTINGS = (
     ),
     ConfigSetting(
         dest="split_artifacts",
-        metavar="BOOL",
         nargs="?",
         section="Output",
-        parse=config_parse_boolean,
-        help="Generate split partitions",
+        parse=config_parse_artifact_output_list,
+        default=ArtifactOutput.compat_no(),
+        help="Split artifacts out of the final image",
     ),
     ConfigSetting(
         dest="repart_dirs",
@@ -4508,7 +4556,7 @@ def summary(config: Config) -> str:
                         Output Mode: {format_octal_or_default(config.output_mode)}
                            Image ID: {config.image_id}
                       Image Version: {config.image_version}
-                    Split Artifacts: {yes_no(config.split_artifacts)}
+                    Split Artifacts: {line_join_list(config.split_artifacts)}
                  Repart Directories: {line_join_list(config.repart_dirs)}
                         Sector Size: {none_to_default(config.sector_size)}
                             Overlay: {yes_no(config.overlay)}
@@ -4824,6 +4872,7 @@ def json_type_transformer(refcls: Union[type[Args], type[Config]]) -> Callable[[
         Vmm: enum_transformer,
         list[PEAddon]: pe_addon_transformer,
         list[UKIProfile]: uki_profile_transformer,
+        list[ArtifactOutput]: enum_list_transformer,
     }
 
     def json_transformer(key: str, val: Any) -> Any:

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -596,13 +596,20 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     invoked. The image ID is automatically added to `/usr/lib/os-release`.
 
 `SplitArtifacts=`, `--split-artifacts`
-:   If specified and building a disk image, pass `--split=yes` to systemd-repart
-    to have it write out split partition files for each configured partition.
-    Read the [man](https://www.freedesktop.org/software/systemd/man/systemd-repart.html#--split=BOOL)
+:   The artifact types to split out of the final image. A comma-delimited
+    list consisting of `uki`, `kernel`, `initrd` and `partitions`. When
+    building a bootable image `kernel` and `initrd` correspond to their
+    artifact found in the image (or in the UKI), while `uki` copies out the
+    entire UKI.
+
+    When building a disk image and `partitions` is specified,
+    pass `--split=yes` to systemd-repart to have it write out split partition
+    files for each configured partition. Read the
+    [man](https://www.freedesktop.org/software/systemd/man/systemd-repart.html#--split=BOOL)
     page for more information. This is useful in A/B update scenarios where
     an existing disk image shall be augmented with a new version of a
     root or `/usr` partition along with its Verity partition and unified
-    kernel.
+    kernel. By default `uki`, `kernel` and `initrd` are split out.
 
 `RepartDirectories=`, `--repart-dir=`
 :   Paths to directories containing systemd-repart partition definition
@@ -2229,7 +2236,7 @@ current working directory. The following scripts are supported:
 * If **`mkosi.clean`** (`CleanScripts=`) exists, it is executed right
   after the outputs of a previous build have been cleaned up. A clean
   script can clean up any outputs that mkosi does not know about (e.g.
-  artifacts from `SplitArtifacts=yes` or RPMs built in a build script).
+  artifacts from `SplitArtifacts=partitions` or RPMs built in a build script).
   Note that this script does not use the tools tree even if one is configured.
 
 * If **`mkosi.version`** exists and is executable, it is run during

--- a/mkosi/sysupdate.py
+++ b/mkosi/sysupdate.py
@@ -4,15 +4,15 @@ import os
 import sys
 from pathlib import Path
 
-from mkosi.config import Args, Config
+from mkosi.config import Args, ArtifactOutput, Config
 from mkosi.log import die
 from mkosi.run import run
 from mkosi.types import PathString
 
 
 def run_sysupdate(args: Args, config: Config) -> None:
-    if not config.split_artifacts:
-        die("SplitArtifacts= must be enabled to be able to use mkosi sysupdate")
+    if ArtifactOutput.partitions not in config.split_artifacts:
+        die("SplitArtifacts=partitions must be set to be able to use mkosi sysupdate")
 
     if not config.sysupdate_dir:
         die(

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -11,6 +11,7 @@ import pytest
 from mkosi.config import (
     Architecture,
     Args,
+    ArtifactOutput,
     BiosBootloader,
     Bootloader,
     Cacheonly,
@@ -333,7 +334,10 @@ def test_config() -> None:
                 }
             ],
             "SourceDateEpoch": 12345,
-            "SplitArtifacts": true,
+            "SplitArtifacts": [
+                "uki",
+                "kernel"
+            ],
             "Ssh": false,
             "SshCertificate": "/path/to/cert",
             "SshKey": null,
@@ -533,7 +537,7 @@ def test_config() -> None:
         sign_expected_pcr_certificate=Path("/my/cert"),
         skeleton_trees=[ConfigTree(Path("/foo/bar"), Path("/")), ConfigTree(Path("/bar/baz"), Path("/qux"))],
         source_date_epoch=12345,
-        split_artifacts=True,
+        split_artifacts=[ArtifactOutput.uki, ArtifactOutput.kernel],
         ssh=False,
         ssh_certificate=Path("/path/to/cert"),
         ssh_key=None,


### PR DESCRIPTION
This PR repurposes `SplitArtifacts=` to be able to specify multiple artifact types that should be split out of the image. By specifying one or more of `uki`, `kernel`, `initrd` and `partitions` the respective components are extracted from the image. The truthy and falsy values still map to the equivalent of the old values to preserve backwards compatibility.