### PR TITLE
opensuse: prevent zypper from pulling busybox in the initrd

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-opensuse.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-opensuse.conf
@@ -7,6 +7,14 @@ Distribution=opensuse
 Packages=
         patterns-base-minimal_base
 
+        # Various packages added as dependencies. If they are not explicitly installed, the zypper inner
+        # logic picks the busybox-package variant, which adds also busybox in the initrd.
+        diffutils
+        grep
+        gzip
+        which
+        xz
+
         # Various libraries that are dlopen'ed by systemd
         libfido2-1
         libtss2-esys0
@@ -23,6 +31,10 @@ Packages=
         # fsck.btrfs is a dummy, checking is done in the kernel.
 
         util-linux
+
+RemovePackages=
+        # Various packages pull in shadow to create users, we can remove it afterwards
+        shadow
 
 RemoveFiles=
         /usr/share/locale/*


### PR DESCRIPTION
zypper's internal logic selects `busybox-<package>` variants of packages that are required via dependency and not explicitly listed to install, which also causes `busybox` to be added to the initrd.

Also, remove the `shadow` package (the equivalent to the `shadow-utils` package in Fedora).