### PR TITLE
Don't unconditionally enable epel for mkosi-initrd

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-centos/mkosi.conf.d/10-epel.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-centos/mkosi.conf.d/10-epel.conf
@@ -1,7 +1,0 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later
-
-[Match]
-Release=9
-
-[Distribution]
-Repositories=epel,epel-next


### PR DESCRIPTION
Whether to enable epel or not should be up to the user, not hard coded by us, so drop the config snippet that enables the epel repositories.

follow-up for 886f091a743a6ac808c20ef59e9cf7e20703376d

To enable the epel repositories for mkosi-initrd, you'd do something like the following:

"""
[Distribution]
Distribution=centos
Release=9
Repositories=epel,epel-next

[Include]
Include=mkosi-initrd
"""

We don't currently have a way to enable the epel repositories when using mkosi-initrd, because it always uses the exact same repositories as the host system. However, erofs-utils can still be installed by just including it using /usr/lib/mkosi-initrd/mkosi.conf without a match section.