### PR TITLE
man/mkosi-initrd: fix description of --output option

### DIFF
--- a/mkosi/resources/man/mkosi-initrd.1.md
+++ b/mkosi/resources/man/mkosi-initrd.1.md
@@ -31,10 +31,6 @@ initrds and Unified Kernel Images for the current running system.
 :   Name to use for the generated output image file or directory. Defaults
     to `initrd`.
 
-    Note that this only specifies the output prefix, depending on the
-    specific output format and compression used, the full output name might be
-    `initrd.cpio.zst`.
-
 `--output-dir=`, `-O`
 :   Path to a directory where to place all generated artifacts. Defaults to the
     current working directory.


### PR DESCRIPTION
Follow-up for 6b0dfe58f3f04264f1df5cb90b7091195913562f