### PR TITLE
kernel-install: fix move of cpio output file

### DIFF
--- a/kernel-install/50-mkosi.install
+++ b/kernel-install/50-mkosi.install
@@ -5,7 +5,6 @@ import argparse
 import dataclasses
 import logging
 import os
-import shutil
 import tempfile
 from pathlib import Path
 from typing import Optional
@@ -164,7 +163,6 @@ def main() -> None:
     (context.staging_area / output).unlink()
 
     if format == OutputFormat.cpio:
-        shutil.move(next(context.staging_area.glob("initrd*.cpio*")), context.staging_area / "initrd")
         build_microcode_initrd(context.staging_area / "microcode")
     else:
         (context.staging_area / f"{output}.vmlinuz").unlink()


### PR DESCRIPTION
Its name is already `initrd` since 6b0dfe58f3f04264f1df5cb90b7091195913562f

Otherwise:

```
‣  /tmp/tmpgpvfc6y8/initrd.cpio.zst size is 44.9M, consumes 44.9M.
‣ Copying /tmp/tmpgpvfc6y8/initrd to /tmp/kernel-install.staging.KXnXSC/initrd
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/mkosi/run.py", line 64, in uncaught_exception_handler
    yield
  File "/usr/lib64/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/kernel/install.d/50-mkosi.install", line 167, in main
    shutil.move(next(context.staging_area.glob("initrd*.cpio*")), context.staging_area / "initrd")
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
StopIteration
/usr/lib/kernel/install.d/50-mkosi.install failed with exit status 1.
```