### PR TITLE
opensuse: remove which from initrd

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-opensuse.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-opensuse.conf
@@ -12,7 +12,6 @@ Packages=
         diffutils
         grep
         gzip
-        which
         xz
 
         # Various libraries that are dlopen'ed by systemd


### PR DESCRIPTION
`less` had hard requirements on `which` and `file` (so also `file-magic` and `libmagic1`), reworked via packaging in Tumbleweed ( https://build.opensuse.org/request/show/1218137) and available since snapshot 20241025.