### PR TITLE
Unset `$CONFIG` in prepare scripts

### DIFF
--- a/mkosi.prepare.chroot
+++ b/mkosi.prepare.chroot
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 set -e
 
+# Users might set $CONFIG but that influences pacman
+# so we unset it here to avoid any issues.
+unset CONFIG
+
 if [ "$1" = "final" ] && command -v pacman-key; then
     pacman-key --init
     pacman-key --populate archlinux

--- a/mkosi/resources/mkosi-tools/mkosi.prepare.chroot
+++ b/mkosi/resources/mkosi-tools/mkosi.prepare.chroot
@@ -1,5 +1,10 @@
 #!/bin/sh
 # SPDX-License-Identifier: LGPL-2.1-or-later
+set -e
+
+# Users might set $CONFIG but that influences pacman
+# so we unset it here to avoid any issues.
+unset CONFIG
 
 if [ "$1" = "final" ] && command -v pacman-key; then
     pacman-key --init


### PR DESCRIPTION
I also added `set -e` which the prepare script in the root directory has but the tools tree one does not