### PR TITLE
opensuse: remove sysuser-shadow from initrd

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-opensuse.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-opensuse.conf
@@ -34,6 +34,7 @@ Packages=
 RemovePackages=
         # Various packages pull in shadow to create users, we can remove it afterwards
         shadow
+        sysuser-shadow
 
 RemoveFiles=
         /usr/share/locale/*


### PR DESCRIPTION
SUSE-ish utility pulled by some rpm scriptlets that calls systemd-sysusers or shadow tools to create users and groups during installation.