### PR TITLE
Check if firmware subdirectory still exists before trying to remove it

### DIFF
--- a/mkosi/kmod.py
+++ b/mkosi/kmod.py
@@ -229,7 +229,7 @@ def process_kernel_modules(
             p = root / m
             if p.is_file() or p.is_symlink():
                 p.unlink()
-            else:
+            elif p.exists():
                 p.rmdir()
 
         for fw in firmware:
@@ -244,5 +244,5 @@ def process_kernel_modules(
                 p.unlink()
                 if p.parent != root / firmwared and not any(p.parent.iterdir()):
                     p.parent.rmdir()
-            else:
+            elif p.exists():
                 p.rmdir()


### PR DESCRIPTION
Detected with `mkosi-initrd`:

```
Calculating required kernel modules and firmware
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/mkosi/run.py", line 64, in uncaught_exception_handler
    yield
  File "/usr/lib/python3.11/site-packages/mkosi/run.py", line 105, in fork_and_wait
    target(*args, **kwargs)
  File "/usr/lib/python3.11/site-packages/mkosi/__init__.py", line 4450, in run_build
    build_image(
  File "/usr/lib/python3.11/site-packages/mkosi/__init__.py", line 3668, in build_image
    run_depmod(context)
  File "/usr/lib/python3.11/site-packages/mkosi/__init__.py", line 2721, in run_depmod
    process_kernel_modules(
  File "/usr/lib/python3.11/site-packages/mkosi/kmod.py", line 248, in process_kernel_modules
    p.rmdir()
  File "/usr/lib64/python3.11/pathlib.py", line 1156, in rmdir
    os.rmdir(self)
FileNotFoundError: [Errno 2] No such file or directory: '/var/tmp/mkosi-workspace-9r8egfmc/root/usr/lib/firmware/yamaha'
```

Fixes c0d596dbee111f4730b26045a1f4d7da68a66047