### PR TITLE
Use scsi-hd when QemuRemovable is enabled

### DIFF
--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -1288,9 +1288,16 @@ def run_qemu(args: Args, config: Config) -> None:
             direct = fname.stat().st_size % resource.getpagesize() == 0
             ephemeral = config.ephemeral
             cache = f"cache.writeback=on,cache.direct={yes_no(direct)},cache.no-flush={yes_no(ephemeral)},aio=io_uring"  # noqa: E501
+            device_type = "virtio-blk-pci"
+            removable_flag = ""
+            if config.qemu_cdrom:
+                device_type = "scsi-cd"
+            elif config.qemu_removable:
+                device_type = "scsi-hd"
+                removable_flag = ",removable=on"
             cmdline += [
                 "-drive", f"if=none,id=mkosi,file={fname},format=raw,discard=on,{cache}",
-                "-device", f"{'scsi-cd' if config.qemu_cdrom or config.qemu_removable else 'virtio-blk-pci'},drive=mkosi,bootindex=1{',removable=on' if config.qemu_removable else ''}",  # noqa: E501
+                "-device", f"{device_type},drive=mkosi,bootindex=1{removable_flag}",  # noqa: E501
             ]  # fmt: skip
 
         if config.qemu_swtpm == ConfigFeature.enabled or (


### PR DESCRIPTION
8abce5ac9c8a5dd45993effc72accb522dfe6c0b changed the device type from `scsi-hd` to `scsi-cd` when `QemuRemovable` is true. It appears that `scsi-cd` does not support the removable attribute though. Switch back to `scsi-hd` when `QemuRemovable` is enabled.