### PR TITLE
Never clean output directory when Format=none

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4242,7 +4242,7 @@ def run_clean(args: Args, config: Config, *, resources: Path) -> None:
         remove_image_cache = args.force > 0
         remove_package_cache = args.force > 1
     else:
-        remove_output_dir = config.output_format != OutputFormat.none or args.force > 0
+        remove_output_dir = config.output_format != OutputFormat.none and args.force > 0
         remove_build_cache = args.force > 1 or args.wipe_build_dir
         remove_image_cache = args.force > 1 or not have_cache(config)
         remove_package_cache = args.force > 2


### PR DESCRIPTION
If Format=none no outputs can be produced at all so let's make sure we always keep the previous outputs intact when Format=none regardless of whether -f is specified or not.