### PR TITLE
Map current user to root in subuid user namespace

### DIFF
--- a/mkosi/user.py
+++ b/mkosi/user.py
@@ -82,6 +82,9 @@ class INVOKING_USER:
 
 
 def read_subrange(path: Path) -> int:
+    if not path.exists():
+        die(f"{path} does not exist, cannot allocate subuid/subgid user namespace")
+
     uid = str(os.getuid())
     try:
         user = pwd.getpwuid(os.getuid()).pw_name


### PR DESCRIPTION
By mapping the current user to root in the subuid user namespace,
we don't have to change the ownership of all the files in the directory
tree to root in the subuid uid/gid range. This means that on btrfs
filesystems, we can do a subvolume snapshot instead of an expensive
full tree recursion to copy each file individually.