### PR TITLE
Mount BuildDirectory= RW during mkosi.prepare

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -706,9 +706,6 @@ def run_prepare_scripts(context: Context, build: bool) -> None:
     if context.config.profiles:
         env["PROFILES"] = " ".join(context.config.profiles)
 
-    if context.config.build_dir is not None:
-        env |= dict(BUILDDIR="/work/build")
-
     env |= context.config.environment
 
     with (
@@ -730,11 +727,6 @@ def run_prepare_scripts(context: Context, build: bool) -> None:
                     "--ro-bind", json, "/work/config.json",
                     "--bind", context.artifacts, "/work/artifacts",
                     "--bind", context.package_dir, "/work/packages",
-                    *(
-                        ["--ro-bind", str(context.config.build_dir), "/work/build"]
-                        if context.config.build_dir
-                        else []
-                    ),
                     *sources,
                 ]  # fmt: skip
 

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -2404,7 +2404,7 @@ Consult this table for which script receives which environment variables:
 | `CHROOT_SCRIPT`             |             |        | ✓         | ✓       | ✓          | ✓          |              |         |
 | `SRCDIR`                    | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |
 | `CHROOT_SRCDIR`             |             |        | ✓         | ✓       | ✓          | ✓          |              |         |
-| `BUILDDIR`                  |             |        | ✓         | ✓       | ✓          | ✓          |              |         |
+| `BUILDDIR`                  |             |        |           | ✓       | ✓          | ✓          |              |         |
 | `CHROOT_BUILDDIR`           |             |        |           | ✓       |            |            |              |         |
 | `DESTDIR`                   |             |        |           | ✓       |            |            |              |         |
 | `CHROOT_DESTDIR`            |             |        |           | ✓       |            |            |              |         |

--- a/mkosi/resources/man/mkosi.news.7.md
+++ b/mkosi/resources/man/mkosi.news.7.md
@@ -78,6 +78,10 @@
   from the build directory into the output directory, copy them from the build directory
   to the output directory in a post-installation script which does have access to the build
   directory and the output directory.
+- `BuildDirectory=` is no longer available in `PrepareScripts=`. If you
+  need to acquire some files for the build process place them somewhere
+  sensible within `$BUILDROOT` so that they can be cached when building
+  incrementally.
 
 ## v24
 


### PR DESCRIPTION
This is to allow aquiring external resources which are not part of local sources (e.g. `makepkg --verifysource`) for use during a later build step in which internet connect is disabled.