### PR TITLE
Run FinalizeScripts= when using Format=none

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3643,6 +3643,7 @@ def build_image(context: Context) -> None:
         run_build_scripts(context)
 
         if context.config.output_format == OutputFormat.none:
+            run_finalize_scripts(context)
             finalize_staging(context)
             rmtree(context.root)
             return


### PR DESCRIPTION
This is to allow copying any build files (like packages) to the output directory after the build, so that all the related logic is contained in a single image and this doesn't need to be done in a separate image.