### PR TITLE
[RFC] mkosi-initrd: inject breakpoints into the boot process

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.extra/usr/lib/systemd/system-preset/10-mkosi-initrd.preset
+++ b/mkosi/resources/mkosi-initrd/mkosi.extra/usr/lib/systemd/system-preset/10-mkosi-initrd.preset
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+enable mkosi-initrd-pre-mount.service
+enable mkosi-initrd-pre-switch-root.service
+enable mkosi-initrd-pre-udev.service

--- a/mkosi/resources/mkosi-initrd/mkosi.extra/usr/lib/systemd/system/mkosi-initrd-pre-mount.service
+++ b/mkosi/resources/mkosi-initrd/mkosi.extra/usr/lib/systemd/system/mkosi-initrd-pre-mount.service
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Unit]
+Description=mkosi-initrd breakpoint before mount sysroot
+DefaultDependencies=no
+Conflicts=shutdown.target emergency.target
+After=mkosi-initrd-pre-udev.service sysinit.target
+Before=initrd-root-fs.target sysroot.mount systemd-fsck-root.service
+ConditionPathExists=/etc/initrd-release
+ConditionKernelCommandLine=rd.break=pre-mount
+
+[Service]
+Environment=HOME=/root
+Environment=PS1="pre-mount:$PWD# "
+WorkingDirectory=/root
+Type=oneshot
+ExecStartPre=-/bin/sh -c "/usr/bin/plymouth quit 2>/dev/null || :"
+ExecStart=-/usr/sbin/sulogin --force
+StandardInput=tty-force
+StandardOutput=inherit
+StandardError=inherit
+TasksMax=infinity
+IgnoreSIGPIPE=no
+KillMode=process
+KillSignal=SIGHUP
+
+[Install]
+WantedBy=initrd.target

--- a/mkosi/resources/mkosi-initrd/mkosi.extra/usr/lib/systemd/system/mkosi-initrd-pre-switch-root.service
+++ b/mkosi/resources/mkosi-initrd/mkosi.extra/usr/lib/systemd/system/mkosi-initrd-pre-switch-root.service
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Unit]
+Description=mkosi-initrd breakpoint before switch root
+DefaultDependencies=no
+Conflicts=shutdown.target emergency.target
+Wants=remote-fs.target
+After=initrd.target initrd-parse-etc.service sysroot.mount remote-fs.target mkosi-initrd-pre-mount.service
+Before=initrd-cleanup.service
+ConditionPathExists=/etc/initrd-release
+ConditionKernelCommandLine=rd.break=pre-switch-root
+
+[Service]
+Environment=HOME=/root
+Environment=PS1="pre-switch-root:$PWD# "
+WorkingDirectory=/root
+Type=oneshot
+ExecStartPre=-/bin/sh -c "/usr/bin/plymouth quit 2>/dev/null || :"
+ExecStart=-/usr/sbin/sulogin --force
+StandardInput=tty-force
+StandardOutput=inherit
+StandardError=inherit
+TasksMax=infinity
+IgnoreSIGPIPE=no
+KillMode=process
+KillSignal=SIGHUP
+
+[Install]
+WantedBy=initrd.target

--- a/mkosi/resources/mkosi-initrd/mkosi.extra/usr/lib/systemd/system/mkosi-initrd-pre-udev.service
+++ b/mkosi/resources/mkosi-initrd/mkosi.extra/usr/lib/systemd/system/mkosi-initrd-pre-udev.service
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Unit]
+Description=mkosi-initrd breakpoint before udev
+DefaultDependencies=no
+Conflicts=shutdown.target emergency.target
+Wants=systemd-journald.socket
+After=systemd-journald.socket
+Before=systemd-udevd.service
+ConditionPathExists=/etc/initrd-release
+ConditionKernelCommandLine=rd.break=pre-udev
+
+[Service]
+Environment=HOME=/root
+Environment=PS1="pre-udev:$PWD# "
+WorkingDirectory=/root
+Type=oneshot
+ExecStartPre=-/bin/sh -c "/usr/bin/plymouth quit 2>/dev/null || :"
+ExecStart=-/usr/sbin/sulogin --force
+StandardInput=tty-force
+StandardOutput=inherit
+StandardError=inherit
+TasksMax=infinity
+IgnoreSIGPIPE=no
+KillMode=process
+KillSignal=SIGHUP
+
+[Install]
+WantedBy=initrd.target


### PR DESCRIPTION
Added three breakpoints that can stop the boot process and open a sulogin shell by passing the `rd.break=` option on the kernel command line:

- `rd.break=pre-udev`: at the very beginning, before systemd-udevd.service starts.
- `rd.break=pre-mount`: before the real root is mounted, i.e., before sysroot.mount starts.
- `rd.break=pre-switch-root`: at the end, before switching root.

---

Before discussing whether these options are too many, too few, or their names are appropriate, here is what other initrd generators are offering:

|  | option | values |
|-|-|-|
| dracut | rd.break | cmdline, pre-udev, pre-trigger, initqueue, pre-mount, mount, pre-pivot/cleanup (default) |
| initramfs-tools | break | top, modules, premount (default), mount, mountroot, bottom, init |
| mkinitcpio | break | premount (default), postmount |