### PR TITLE
Reorder configs again after running configure scripts

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -71,6 +71,7 @@ from mkosi.config import (
     format_bytes,
     parse_boolean,
     parse_config,
+    resolve_deps,
     summary,
     systemd_tool_version,
     want_selinux_relabel,
@@ -4701,7 +4702,9 @@ def run_verb(args: Args, images: Sequence[Config], *, resources: Path) -> None:
             images[i] = config = run_configure_scripts(config)
 
     # The images array has been modified so we need to reevaluate last again.
+    # Also ensure that all other images are reordered in case their dependencies were modified.
     last = images[-1]
+    images = resolve_deps(images[:-1], last.dependencies) + [last]
 
     if not (last.output_dir_or_cwd() / last.output).exists() or last.output_format == OutputFormat.none:
         ensure_directories_exist(last)

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3788,7 +3788,7 @@ def create_argument_parser(chdir: bool = True) -> argparse.ArgumentParser:
     return parser
 
 
-def resolve_deps(images: Sequence[argparse.Namespace], include: Sequence[str]) -> list[argparse.Namespace]:
+def resolve_deps(images: Sequence[Config], include: Sequence[str]) -> list[Config]:
     graph = {config.image: config.dependencies for config in images}
 
     if any((missing := i) not in graph for i in include):
@@ -4395,9 +4395,12 @@ def parse_config(
     if dependencies is not None:
         setattr(config, "dependencies", dependencies)
 
-    images = resolve_deps(images, config.dependencies)
+    main = load_config(config)
 
-    return args, tuple([load_config(ns) for ns in images] + [load_config(config)])
+    subimages = [load_config(ns) for ns in images]
+    subimages = resolve_deps(subimages, main.dependencies)
+
+    return args, tuple(subimages + [main])
 
 
 def finalize_term() -> str:


### PR DESCRIPTION
I am looking to shoe horn PKGBUILDs dependency representation into mkosi subimages, for that I populate the `Dependencies=` in a configure script, so just ensure that we reevaluate the dependency tree after the configure scripts have run.