### PR TITLE
Add %I specifier for subimages

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -4420,6 +4420,8 @@ def load_environment(args: argparse.Namespace) -> dict[str, str]:
         "TERM": finalize_term(),
     }
 
+    if args.image is not None:
+        env["SUBIMAGE"] = args.image
     if args.image_id is not None:
         env["IMAGE_ID"] = args.image_id
     if args.image_version is not None:

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3595,6 +3595,10 @@ SPECIFIERS = (
         callback=lambda ns, config: ns.distribution.filesystem(),
         depends=("distribution",),
     ),
+    Specifier(
+        char="I",
+        callback=lambda ns, config: ns.image or "",
+    ),
 )
 
 SPECIFIERS_LOOKUP_BY_CHAR = {s.char: s for s in SPECIFIERS}

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -2031,11 +2031,12 @@ use `%%`. The following specifiers are understood:
 
 There are also specifiers that are independent of settings:
 
-| Specifier | Value                                   |
-|-----------|-----------------------------------------|
-| `%C`      | Parent directory of current config file |
-| `%P`      | Current working directory               |
-| `%D`      | Directory that mkosi was invoked in     |
+| Specifier | Value                                          |
+|-----------|------------------------------------------------|
+| `%C`      | Parent directory of current config file        |
+| `%P`      | Current working directory                      |
+| `%D`      | Directory that mkosi was invoked in            |
+| `%I`      | Name of the current subimage in `mkosi.images` |
 
 Finally, there are specifiers that are derived from a setting:
 

--- a/mkosi/resources/man/mkosi.news.7.md
+++ b/mkosi/resources/man/mkosi.news.7.md
@@ -86,6 +86,10 @@
   (qemu, nspawn, ...), we now keep $PATH entries inside the user's home
   intact. Note that this may cause issues if a PATH entry in your home contains
   binaries linked against libraries in `/usr` from the host.
+- Introduced new specifier `%I` which resolves to the name of the current
+  subimage when used in a config under `mkosi.images/`. This differs to `%o`
+  as it is always the name of the config file without extension (or the name
+  of the directory).
 
 ## v24
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1104,6 +1104,7 @@ def test_specifiers(tmp_path: Path) -> None:
         Environment=Distribution=%d
                     Release=%r
                     Architecture=%a
+                    Image=%I
                     ImageId=%i
                     ImageVersion=%v
                     OutputDirectory=%O
@@ -1134,13 +1135,22 @@ def test_specifiers(tmp_path: Path) -> None:
         """
     )
 
+    (d / "mkosi.images").mkdir()
+    (d / "mkosi.images/subimage.conf").write_text(
+        """
+        [Build]
+        Environment=Image=%I
+        """
+    )
+
     with chdir(d):
-        _, [config] = parse_config()
+        _, [subimage, config] = parse_config()
 
         expected = {
             "Distribution": "ubuntu",
             "Release": "lunar",
             "Architecture": "arm64",
+            "Image": "",
             "ImageId": "my-image-id",
             "ImageVersion": "1.2.3",
             "OutputDirectory": str(Path.cwd() / "abcde"),
@@ -1158,6 +1168,8 @@ def test_specifiers(tmp_path: Path) -> None:
         }
 
         assert {k: v for k, v in config.environment.items() if k in expected} == expected
+
+        assert subimage.environment["Image"] == "subimage"
 
 
 def test_kernel_specifiers(tmp_path: Path) -> None:


### PR DESCRIPTION
This expands to the name of the subimage (and an empty string for the main image) and is the same value that is used for `Dependencies=`. Also exports it as an env var to scripts for easier access.

Fixes: #2566