### PR TITLE
fixup: GitHub Action: Install all required mkosi dependencies

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -68,7 +68,7 @@ runs:
         # For archlinux-keyring and pacman
         sudo add-apt-repository ppa:michel-slm/kernel-utils
         sudo apt-get update
-        mkosi dependencies | xargs -d '\n' sudo apt-get install
+        mkosi dependencies | xargs -d '\n' sudo apt-get install --assume-yes --no-install-recommends
 
         sudo pacman-key --init
         sudo pacman-key --populate archlinux


### PR DESCRIPTION
8505a5303bb0c65991faf59a45409330e0c16a92 lost the --assume-yes --no-install-recommends. While the former seems to be implicit in the GitHub runner environment, the latter isn't, and it seems best to leave both in place.