### PR TITLE
Include dbus and libpam-systemd in debootstrap-equivalent

### DIFF
--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -144,6 +144,8 @@ class Installer(DistributionInstaller):
                     "?essential",
                     "?exact-name(usr-is-merged)",
                     "base-files",
+                    "dbus",
+                    "libpam-systemd",
                 ],
                 options=["--bind", f.name, workdir(Path(f.name))],
             )


### PR DESCRIPTION
Fixes #3189 