### PR TITLE
Make Check-Valid-Until=false a default flag for apt-get

### DIFF
--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -169,6 +169,7 @@ class Apt(PackageManager):
             "-o", "APT::Get::Allow-Remove-Essential=true",
             "-o", "APT::Sandbox::User=root",
             "-o", "Acquire::AllowReleaseInfoChange=true",
+            "-o", "Acquire::Check-Valid-Until=false",
             "-o", "Dir::Cache=/var/cache/apt",
             "-o", "Dir::State=/var/lib/apt",
             "-o", "Dir::Log=/var/log/apt",


### PR DESCRIPTION
Building a Debian image from an older snapshot mirror (e.g., `Mirror=https://snapshot.debian.org/archive/debian/20240926T203024Z/`) causes an error:
```
Release file for https://snapshot.debian.org/archive/debian/20240926T203024Z/dists/testing-updates/InRelease is expired (invalid since 41d 20h 0min 32s). Updates for this repository will not be applied.
```
Debian snapshot's [readme page](https://snapshot.debian.org/) suggests using `Acquire::Check-Valid-Until=false` APT flag to prevent it from disregarding snapshot entries.

Making this a default parameter will not have impact on pulling from the up-to-date mirrors.