### PR TITLE
sandbox: Akways use O_EXCL with O_CREAT

### DIFF
--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -472,7 +472,7 @@ class BindOperation(FSOperation):
 
             with umask(~0o644 if isfile else ~0o755):
                 if isfile:
-                    os.close(os.open(dst, os.O_CREAT | os.O_CLOEXEC))
+                    os.close(os.open(dst, os.O_CREAT | os.O_CLOEXEC | os.O_EXCL))
                 else:
                     os.mkdir(dst)
 
@@ -506,7 +506,7 @@ class DevOperation(FSOperation):
 
         for node in ("null", "zero", "full", "random", "urandom", "tty"):
             ndst = joinpath(dst, node)
-            os.close(os.open(ndst, os.O_CREAT | os.O_CLOEXEC))
+            os.close(os.open(ndst, os.O_CREAT | os.O_CLOEXEC | os.O_EXCL))
 
             mount(joinpath(oldroot, "dev", node), ndst, "", MS_BIND, "")
 
@@ -526,7 +526,7 @@ class DevOperation(FSOperation):
         os.symlink("pts/ptmx", joinpath(dst, "ptmx"))
 
         if self.ttyname:
-            os.close(os.open(joinpath(dst, "console"), os.O_CREAT | os.O_CLOEXEC))
+            os.close(os.open(joinpath(dst, "console"), os.O_CREAT | os.O_CLOEXEC | os.O_EXCL))
             mount(joinpath(oldroot, self.ttyname), joinpath(dst, "console"), "", MS_BIND, "")
 
 

--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -464,11 +464,11 @@ class BindOperation(FSOperation):
         if not os.path.exists(src) and not self.required:
             return
 
-        with umask(~0o755):
-            os.makedirs(os.path.dirname(dst), exist_ok=True)
-
         if not os.path.exists(dst):
             isfile = os.path.isfile(src)
+
+            with umask(~0o755):
+                os.makedirs(os.path.dirname(dst), exist_ok=True)
 
             with umask(~0o644 if isfile else ~0o755):
                 if isfile:


### PR DESCRIPTION
In all cases we want to make sure that we're the ones creating the file so let's specify O_EXCL.