### PR TITLE
Add --debug-sandbox

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -31,7 +31,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional, TypeVar, Union, cast
 
 from mkosi.distributions import Distribution, detect_distribution
-from mkosi.log import ARG_DEBUG, ARG_DEBUG_SHELL, Style, die
+from mkosi.log import ARG_DEBUG, ARG_DEBUG_SANDBOX, ARG_DEBUG_SHELL, Style, die
 from mkosi.pager import page
 from mkosi.run import SandboxProtocol, find_binary, nosandbox, run, sandbox_cmd, workdir
 from mkosi.sandbox import __version__
@@ -1547,6 +1547,7 @@ class Args:
     debug: bool
     debug_shell: bool
     debug_workspace: bool
+    debug_sandbox: bool
     pager: bool
     genkey_valid_days: str
     genkey_common_name: str
@@ -3776,6 +3777,12 @@ def create_argument_parser(chdir: bool = True) -> argparse.ArgumentParser:
         default=False,
     )
     parser.add_argument(
+        "--debug-sandbox",
+        help="Run mkosi-sandbox with strace",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
         "--no-pager",
         action="store_false",
         dest="pager",
@@ -4555,6 +4562,8 @@ def load_args(args: argparse.Namespace) -> Args:
         ARG_DEBUG.set(args.debug)
     if args.debug_shell:
         ARG_DEBUG_SHELL.set(args.debug_shell)
+    if args.debug_sandbox:
+        ARG_DEBUG_SANDBOX.set(args.debug_sandbox)
 
     return Args.from_namespace(args)
 

--- a/mkosi/log.py
+++ b/mkosi/log.py
@@ -11,6 +11,7 @@ from typing import Any, Final, NoReturn, Optional
 # This global should be initialized after parsing arguments
 ARG_DEBUG = contextvars.ContextVar("debug", default=False)
 ARG_DEBUG_SHELL = contextvars.ContextVar("debug-shell", default=False)
+ARG_DEBUG_SANDBOX = contextvars.ContextVar("debug-sandbox", default=False)
 LEVEL = 0
 
 

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -234,15 +234,18 @@ Those settings cannot be configured in the configuration files.
     for in this directory, hence using this option is an effective way to
     build a project located in a specific directory.
 
-`--debug=`
+`--debug`
 :   Enable additional debugging output.
 
 `--debug-shell`
 :   When executing a command in the image fails, mkosi will start an interactive
     shell in the image allowing further debugging.
 
-`--debug-workspace=`
+`--debug-workspace`
 :   When an error occurs, the workspace directory will not be deleted.
+
+`--debug-sandbox`
+:   Run `mkosi-sandbox` with `strace`.
 
 `--version`
 :   Show package version.

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -21,7 +21,7 @@ from types import TracebackType
 from typing import Any, Callable, NoReturn, Optional, Protocol
 
 import mkosi.sandbox
-from mkosi.log import ARG_DEBUG, ARG_DEBUG_SHELL, die
+from mkosi.log import ARG_DEBUG, ARG_DEBUG_SANDBOX, ARG_DEBUG_SHELL, die
 from mkosi.sandbox import acquire_privileges, joinpath, umask
 from mkosi.types import _FILE, CompletedProcess, PathString, Popen
 from mkosi.util import current_home_dir, flatten, one_zero
@@ -485,6 +485,7 @@ def sandbox_cmd(
 
     cmdline: list[PathString] = [
         *setup,
+        *(["strace", "--detach-on=execve"] if ARG_DEBUG_SANDBOX.get() else []),
         sys.executable, "-SI", mkosi.sandbox.__file__,
         "--proc", "/proc",
         # We mounted a subdirectory of TMPDIR to /var/tmp so we unset TMPDIR so that /tmp or /var/tmp are

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -53,6 +53,7 @@ def test_args(path: Optional[Path]) -> None:
                 "bar"
             ],
             "Debug": false,
+            "DebugSandbox": false,
             "DebugShell": false,
             "DebugWorkspace": false,
             "Directory": {f'"{os.fspath(path)}"' if path is not None else 'null'},
@@ -72,6 +73,7 @@ def test_args(path: Optional[Path]) -> None:
         auto_bump=False,
         cmdline=["foo", "bar"],
         debug=False,
+        debug_sandbox=False,
         debug_shell=False,
         debug_workspace=False,
         directory=Path(path) if path is not None else None,


### PR DESCRIPTION
This will help in debugging sandbox related issues. We run the sandbox with strace and detach on execve() so we don't strace the command that we're running.