### PR TITLE
Propagate --tools-tree-certificates to initrd build

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1256,6 +1256,7 @@ def finalize_default_initrd(
         *(["--root-password", rootpwopt] if rootpwopt else []),
         *([f"--environment={k}='{v}'" for k, v in config.environment.items()]),
         *(["--tools-tree", str(config.tools_tree)] if config.tools_tree and tools else []),
+        "--tools-tree-certificates", str(config.tools_tree_certificates),
         *([f"--extra-search-path={p}" for p in config.extra_search_paths]),
         *(["--proxy-url", config.proxy_url] if config.proxy_url else []),
         *([f"--proxy-exclude={host}" for host in config.proxy_exclude]),


### PR DESCRIPTION
The initrd build uses a config created from a "hand-crafted" command line passed to `parse_config()`. This command line includes the relevant settings (i.e. those deemed relevant for build the initrd) from the "proper" config object.

Since the --tools-tree-certificates setting wasn't added to that command line, it defaults to true regardless of any setting configured when invoking mkosi. When building behind a cooperate (transparent) proxy using a self-signed certificate, the initrd build fails when trying to download packages (unless the needed packages happened to be downloaded as part of a previous image build).

Make sure the --tools-tree-certificates setting applies to the initrd build also, by explicitly including it in the hand-crafted command line. The setting can be added unconditionally because of the default value specified in config.py.