### PR TITLE
Rename "systemd" signtool to "systemd-sbsign" signtool

### DIFF
--- a/mkosi/bootloader.py
+++ b/mkosi/bootloader.py
@@ -570,13 +570,13 @@ def sign_efi_binary(context: Context, input: Path, output: Path) -> Path:
     assert context.config.secure_boot_certificate
 
     sbsign = context.config.find_binary("systemd-sbsign", "/usr/lib/systemd/systemd-sbsign")
-    if context.config.secure_boot_sign_tool == SecureBootSignTool.systemd and not sbsign:
+    if context.config.secure_boot_sign_tool == SecureBootSignTool.systemd_sbsign and not sbsign:
         die("Could not find systemd-sbsign")
 
     cmd: list[PathString]
     options: list[PathString]
 
-    if context.config.secure_boot_sign_tool == SecureBootSignTool.systemd or (
+    if context.config.secure_boot_sign_tool == SecureBootSignTool.systemd_sbsign or (
         context.config.secure_boot_sign_tool == SecureBootSignTool.auto and sbsign
     ):
         assert sbsign

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -174,7 +174,7 @@ class SecureBootSignTool(StrEnum):
     auto = enum.auto()
     sbsign = enum.auto()
     pesign = enum.auto()
-    systemd = enum.auto()
+    systemd_sbsign = enum.auto()
 
 
 class OutputFormat(StrEnum):

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1143,7 +1143,7 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     UEFI kernel image, if `SecureBoot=` is used.
 
 `SecureBootSignTool=`, `--secure-boot-sign-tool`
-:   Tool to use to sign secure boot PE binaries. Takes one of `systemd`, `sbsign`, `pesign` or `auto`.
+:   Tool to use to sign secure boot PE binaries. Takes one of `systemd-sbsign`, `sbsign`, `pesign` or `auto`.
     Defaults to `auto`. If set to `auto`, either `systemd-sbsign`, `sbsign` or `pesign` are used if
     available, with `systemd-sbsign` being preferred.
 


### PR DESCRIPTION
Matches the naming used by ukify.