### PR TITLE
Allow resetting and freshly populating collection/list settings via CLI flags

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1341,3 +1341,27 @@ def test_split_artifacts_compat(tmp_path: Path) -> None:
     with chdir(d):
         _, [config] = parse_config()
         assert config.split_artifacts == ArtifactOutput.compat_yes()
+
+
+def test_cli_collection_reset(tmp_path: Path) -> None:
+    d = tmp_path
+
+    (d / "mkosi.conf").write_text(
+        """
+        [Content]
+        Packages=abc
+        """
+    )
+
+    with chdir(d):
+        _, [config] = parse_config(["--package", ""])
+        assert config.packages == []
+
+        _, [config] = parse_config(["--package", "", "--package", "foo"])
+        assert config.packages == ["foo"]
+
+        _, [config] = parse_config(["--package", "foo", "--package", "", "--package", "bar"])
+        assert config.packages == ["bar"]
+
+        _, [config] = parse_config(["--package", "foo", "--package", ""])
+        assert config.packages == []


### PR DESCRIPTION
Previously it was only possible to completely reset but not append, or only append but not reset to collection/list settings via command line arguments.
Now we track if a setting has ever been set to None (i.e. reset) during command line parsing.
This information is used during value finalization to decide whether to merge both collections or only keep the CLI value.

This fixes #3208