### PR TITLE
mkosi-initrd: Include extra modules

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -45,6 +45,8 @@ KernelModulesInclude=
                     /autofs4.ko
                     /binfmt_misc.ko
                     /btrfs.ko
+                    /cdrom.ko
+                    /cfg80211.ko
                     /configfs.ko
                     /dm-crypt.ko
                     /dm-integrity.ko
@@ -53,18 +55,31 @@ KernelModulesInclude=
                     /dm-raid.ko
                     /dm-verity.ko
                     /dmi-sysfs.ko
+                    /drm_buddy.ko
                     /efi-pstore.ko
                     /efivarfs.ko
                     /erofs.ko
                     /ext4.ko
+                    /i2c-algo-bit.ko
+                    /i2c-mux.ko
+                    /i2c-smbus.ko
+                    /intel_vsec.ko
+                    /kvm.ko
+                    /libphy.ko
                     /loop.ko
+                    /mdio_devres.ko
+                    /mei.ko
                     /nvme.ko
                     /overlay.ko
+                    /pmt_telemetry.ko
                     /qemu_fw_cfg.ko
                     /raid[0-9]*.ko
                     /scsi_mod.ko
                     /sd_mod.ko
+                    /serio.ko
                     /sg.ko
+                    /snd-intel-dspcfg.ko
+                    /snd-soc-hda-codec.ko
                     /squashfs.ko
                     /vfat.ko
                     /virtio_balloon.ko
@@ -78,7 +93,9 @@ KernelModulesInclude=
                     /virtiofs.ko
                     /vmw_vsock_virtio_transport.ko
                     /vsock.ko
+                    /wmi.ko
                     /x_tables.ko
                     /xfs.ko
+                    /xhci-pci-renesas.ko
                     ^fs/nls/
                     crypto/

--- a/tests/test_initrd.py
+++ b/tests/test_initrd.py
@@ -223,11 +223,11 @@ def test_initrd_size(config: ImageConfig) -> None:
 
         # The fallback value is for CentOS and related distributions.
         maxsize = 1024**2 * {
-            Distribution.fedora: 59,
-            Distribution.debian: 58,
-            Distribution.ubuntu: 54,
-            Distribution.arch: 80,
-            Distribution.opensuse: 62,
-        }.get(config.distribution, 55)
+            Distribution.fedora: 61,
+            Distribution.debian: 60,
+            Distribution.ubuntu: 55,
+            Distribution.arch: 81,
+            Distribution.opensuse: 63,
+        }.get(config.distribution, 56)
 
         assert (Path(image.output_dir) / "image.initrd").stat().st_size <= maxsize


### PR DESCRIPTION
These are all modules that the kernel tries to load while in the initrd on my laptop. All of these seem generic enough to include by default.