### PR TITLE
mkosi-tools: Only install pkcs11-provider where available

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
@@ -32,7 +32,6 @@ Packages=
         ovmf
         pacman-package-manager
         pesign
-        pkcs11-provider
         policycoreutils
         python3-cryptography
         python3-pefile

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf.d/pkcs11-provider.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf.d/pkcs11-provider.conf
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[TriggerMatch]
+Distribution=debian
+Release=!bookworm
+Release=!bullseye
+
+[TriggerMatch]
+Distribution=ubuntu
+Release=!focal
+Release=!jammy
+
+[TriggerMatch]
+Distribution=kali
+
+[Content]
+Packages=
+        pkcs11-provider


### PR DESCRIPTION
Fixes #3224