### PR TITLE
nspawn: Fix uidmap for build directory

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3889,7 +3889,8 @@ def run_shell(args: Args, config: Config) -> None:
                 cmdline += ["--bind", f"{src}:{dst}:norbind,{uidmap}"]
 
             if config.build_dir:
-                cmdline += ["--bind", f"{config.build_dir}:/work/build:norbind,noidmap"]
+                uidmap = "rootidmap" if config.build_dir.stat().st_uid != 0 else "noidmap"
+                cmdline += ["--bind", f"{config.build_dir}:/work/build:norbind,{uidmap}"]
 
         for tree in config.runtime_trees:
             target = Path("/root/src") / (tree.target or "")


### PR DESCRIPTION
The build directory is now owned by the running user as well so we have to apply rootidmap just like we do with all the other mounts already.