### PR TITLE
mkosi-initrd: Install btrfs-progs

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-arch.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-arch.conf
@@ -7,6 +7,7 @@ Distribution=arch
 Packages=
         gzip # For compressed keymap unpacking by loadkeys
 
+        btrfs-progs
         e2fsprogs
         xfsprogs
         erofs-utils

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-azure-centos-fedora.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-azure-centos-fedora.conf
@@ -17,5 +17,3 @@ Packages=
         e2fsprogs
         xfsprogs
         dosfstools
-
-        # fsck.btrfs is a dummy, checking is done in the kernel.

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-azure.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-azure.conf
@@ -5,4 +5,5 @@ Distribution=azure
 
 [Content]
 Packages=
+        btrfs-progs
         util-linux

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-centos/mkosi.conf.d/20-epel-packages.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-centos/mkosi.conf.d/20-epel-packages.conf
@@ -5,5 +5,5 @@ Repositories=epel
 
 [Content]
 Packages=
-        # provides fsck.erofs
+        btrfs-progs
         erofs-utils

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
@@ -16,6 +16,7 @@ Packages=
 
         # xfsprogs pulls in python on Debian (???) and XFS generally
         # isn't used on Debian so we don't install xfsprogs.
+        btrfs-progs
         e2fsprogs
         erofs-utils
         dosfstools

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-fedora.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-fedora.conf
@@ -5,6 +5,7 @@ Distribution=fedora
 
 [Content]
 Packages=
+        btrfs-progs
         libfido2
         util-linux-core
         erofs-utils

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-opensuse.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-opensuse.conf
@@ -22,12 +22,11 @@ Packages=
         libtss2-tcti-device0
 
         # File system checkers for supported root file systems
+        btrfs-progs
         e2fsprogs
         xfsprogs
         erofs-utils
         dosfstools
-
-        # fsck.btrfs is a dummy, checking is done in the kernel.
 
         util-linux
 

--- a/tests/test_initrd.py
+++ b/tests/test_initrd.py
@@ -223,11 +223,11 @@ def test_initrd_size(config: ImageConfig) -> None:
 
         # The fallback value is for CentOS and related distributions.
         maxsize = 1024**2 * {
-            Distribution.fedora: 61,
-            Distribution.debian: 60,
-            Distribution.ubuntu: 55,
-            Distribution.arch: 81,
-            Distribution.opensuse: 63,
-        }.get(config.distribution, 56)
+            Distribution.fedora: 63,
+            Distribution.debian: 61,
+            Distribution.ubuntu: 56,
+            Distribution.arch: 82,
+            Distribution.opensuse: 64,
+        }.get(config.distribution, 57)
 
         assert (Path(image.output_dir) / "image.initrd").stat().st_size <= maxsize


### PR DESCRIPTION
Even if fsck.btrfs doesn't do anything particularly useful, given we install the fs tools of all the other filesystems, let's install btrfs-progs as well. This is also useful when using systemd-repart to create the root filesystem on first boot.