### PR TITLE
Add APK and postmarketOS support

### DIFF
--- a/mkosi.conf.d/20-alpine.conf
+++ b/mkosi.conf.d/20-alpine.conf
@@ -8,9 +8,12 @@ Distribution=postmarketos
 RepositoryKeyCheck=no
 
 [Content]
+InitrdPackages=
+    systemd-networkd # required for systemd-network-generator
 Packages=
     bash
     systemd-boot
+    systemd-networkd # required for systemd-network-generator
     linux-virt
     # stubbyboot-efistub
     # gummiboot-efistub

--- a/mkosi.conf.d/20-alpine.conf
+++ b/mkosi.conf.d/20-alpine.conf
@@ -11,8 +11,9 @@ RepositoryKeyCheck=no
 Packages=
     bash
     systemd-boot
+    linux-virt
     # stubbyboot-efistub
     # gummiboot-efistub
 
-Bootable=no
+Bootable=yes
 ShimBootloader=none

--- a/mkosi.conf.d/20-alpine.conf
+++ b/mkosi.conf.d/20-alpine.conf
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=postmarketos
+
+[Distribution]
+# keyring is only available for Arch
+RepositoryKeyCheck=no
+
+[Content]
+Packages=
+    bash
+    systemd-boot
+    # stubbyboot-efistub
+    # gummiboot-efistub
+
+Bootable=no
+ShimBootloader=none

--- a/mkosi.prepare
+++ b/mkosi.prepare
@@ -6,4 +6,4 @@ if [ "$1" = "build" ]; then
     exit 0
 fi
 
-mkosi-chroot "$SRCDIR"/bin/mkosi dependencies | xargs -d '\n' mkosi-install
+# mkosi-chroot "$SRCDIR"/bin/mkosi dependencies | xargs -d '\n' mkosi-install

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1172,7 +1172,6 @@ def _kernel_inspect(path: Path) -> str:
     return match.group(1) if match else "unknown"
 
 
-
 def fixup_vmlinuz_location(context: Context) -> None:
     # Some architectures ship an uncompressed vmlinux (ppc64el, riscv64)
     for type in ("vmlinuz", "vmlinux"):

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -396,7 +396,7 @@ def configure_autologin_service(context: Context, service: str, extra: str) -> N
                 f"""\
                 [Service]
                 ExecStart=
-                ExecStart=-agetty -o '-f -p -- \\\\u' --autologin root {extra} $TERM
+                ExecStart=-agetty -o '-f -p -- \\\\u' --autologin root {extra} /bin/ash
                 StandardInput=tty
                 StandardOutput=tty
                 """
@@ -2847,6 +2847,8 @@ def run_preset(context: Context) -> None:
     if not context.config.find_binary("systemctl"):
         logging.warning("systemctl is not installed, not applying presets")
         return
+
+    return
 
     with complete_step("Applying presets…"):
         run(

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1166,6 +1166,13 @@ def gzip_binary(context: Context) -> str:
     return "pigz" if context.config.find_binary("pigz") else "gzip"
 
 
+def _kernel_inspect(path: Path) -> str:
+    r = run(["file", "-bL", path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    match = re.search("version ([^ ]*)", r.stdout)
+    return match.group(1) if match else "unknown"
+
+
+
 def fixup_vmlinuz_location(context: Context) -> None:
     # Some architectures ship an uncompressed vmlinux (ppc64el, riscv64)
     for type in ("vmlinuz", "vmlinux"):
@@ -1173,7 +1180,8 @@ def fixup_vmlinuz_location(context: Context) -> None:
             if d.is_symlink():
                 continue
 
-            kver = d.name.removeprefix(f"{type}-")
+            # kver = d.name.removeprefix(f"{type}-")
+            kver = _kernel_inspect(d)
             vmlinuz = context.root / "usr/lib/modules" / kver / type
             if not vmlinuz.parent.exists():
                 continue

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -396,7 +396,7 @@ def configure_autologin_service(context: Context, service: str, extra: str) -> N
                 f"""\
                 [Service]
                 ExecStart=
-                ExecStart=-agetty -o '-f -p -- \\\\u' --autologin root {extra} /bin/ash
+                ExecStart=-agetty -o '-f -p -- \\\\u' --autologin root {extra} $TERM
                 StandardInput=tty
                 StandardOutput=tty
                 """
@@ -2855,8 +2855,6 @@ def run_preset(context: Context) -> None:
     if not context.config.find_binary("systemctl"):
         logging.warning("systemctl is not installed, not applying presets")
         return
-
-    return
 
     with complete_step("Applying presets…"):
         run(

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -16,11 +16,11 @@ if TYPE_CHECKING:
 
 
 class PackageType(StrEnum):
-    none   = enum.auto()
-    rpm    = enum.auto()
-    deb    = enum.auto()
-    pkg    = enum.auto()
-    apk    = enum.auto()
+    none = enum.auto()
+    rpm = enum.auto()
+    deb = enum.auto()
+    pkg = enum.auto()
+    apk = enum.auto()
 
 
 class DistributionInstaller:

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -16,10 +16,11 @@ if TYPE_CHECKING:
 
 
 class PackageType(StrEnum):
-    none = enum.auto()
-    rpm = enum.auto()
-    deb = enum.auto()
-    pkg = enum.auto()
+    none   = enum.auto()
+    rpm    = enum.auto()
+    deb    = enum.auto()
+    pkg    = enum.auto()
+    apk    = enum.auto()
 
 
 class DistributionInstaller:
@@ -79,6 +80,7 @@ class Distribution(StrEnum):
     debian = enum.auto()
     kali = enum.auto()
     ubuntu = enum.auto()
+    postmarketos = enum.auto()
     arch = enum.auto()
     opensuse = enum.auto()
     mageia = enum.auto()

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -29,7 +29,7 @@ class Installer(DistributionInstaller):
         return "rolling"
 
     @classmethod
-    def package_manager(cls, config: "Config") -> type[PackageManager]:
+    def package_manager(cls, config: Config) -> type[PackageManager]:
         return Pacman
 
     @classmethod

--- a/mkosi/distributions/postmarketos.py
+++ b/mkosi/distributions/postmarketos.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 from collections.abc import Iterable, Sequence
-import os
-from sys import stdout
 
 from mkosi.config import Architecture, Config
 from mkosi.context import Context
@@ -10,10 +8,7 @@ from mkosi.distributions import Distribution, DistributionInstaller, PackageType
 from mkosi.installer import PackageManager
 from mkosi.installer.apk import Apk
 from mkosi.log import die
-from mkosi.mounts import finalize_source_mounts
-from mkosi.run import run
-from mkosi.sandbox import apivfs_cmd
-from mkosi.util import listify, sort_packages
+from mkosi.util import sort_packages
 
 
 class Installer(DistributionInstaller):
@@ -38,53 +33,22 @@ class Installer(DistributionInstaller):
         return Distribution.postmarketos
 
     @classmethod
-    def package_manager(cls, config: "Config") -> type[PackageManager]:
+    def package_manager(cls, config: Config) -> type[PackageManager]:
         return Apk
 
     @classmethod
-    def createrepo(cls, context: Context) -> None:
-        Apk.createrepo(context)
-
-    @classmethod
     def setup(cls, context: Context) -> None:
-        Apk.setup(context, cls.repositories(context))
+        Apk.setup(context, list(cls.repositories(context)))
 
     @classmethod
     def install(cls, context: Context) -> None:
-        cls.install_packages(context, ["--initdb",
-                                       "alpine-base",
-                                       "postmarketos-base",
-                                       "device-qemu-amd64",
-                                       "device-qemu-amd64-kernel-edge",
-                                       ], apivfs=False)
-        root = context.root
-        with finalize_source_mounts(
-            context.config,
-            ephemeral=os.getuid() == 0 and context.config.build_sources_ephemeral,
-        ) as sources:
-            run(
-                ["mv", (root / "etc/os-release"), (root / "usr/lib/os-release")],
-                sandbox=(
-                    context.sandbox(
-                        network=True,
-                        options=[
-                            "--bind", context.root, context.root,
-                            *sources,
-                            "--chdir", "/work/src",
-                            # pacman will fail unless invoked as root so make sure we're uid/gid 0 in the sandbox.
-                            "--uid", "0",
-                            "--gid", "0",
-                        ],
-                    ) + (apivfs_cmd(context.root))
-                ),
-                env=context.config.environment,
-                stdout=None,
-            )
-
-        cls.install_packages(context, ["--initdb",
-                                       "device-qemu-amd64",
-                                       "device-qemu-amd64-kernel-edge",
-                                       ], apivfs=False)
+        cls.install_packages(context, [
+            "--initdb",
+            "alpine-base",
+            "postmarketos-base",
+            # "device-qemu-amd64",
+            # "device-qemu-amd64-kernel-edge",
+        ], apivfs=False)
 
     @classmethod
     def install_packages(cls, context: Context, packages: Sequence[str], apivfs: bool = True) -> None:
@@ -100,11 +64,10 @@ class Installer(DistributionInstaller):
         Apk.invoke(context, "del", [*packages], apivfs=True)
 
     @classmethod
-    @listify
     def repositories(cls, context: Context) -> Iterable[str]:
         print("fetch repos")
         return iter([
-            "/home/cas/.local/var/pmbootstrap/packages/edge/",
+            "https://mirror.postmarketos.org/postmarketos/staging/systemd/master/",
             "http://mirror.postmarketos.org/postmarketos/master",
             "http://dl-cdn.alpinelinux.org/alpine/edge/main",
             "http://dl-cdn.alpinelinux.org/alpine/edge/community",
@@ -114,10 +77,10 @@ class Installer(DistributionInstaller):
     @classmethod
     def architecture(cls, arch: Architecture) -> str:
         a = {
-            Architecture.x86_64 : "x86_64",
-            Architecture.arm64  : "aarch64",
-            Architecture.arm    : "armv7h",
-        }.get(arch)
+            Architecture.x86_64: "x86_64",
+            Architecture.arm64:  "aarch64",
+            Architecture.arm:    "armv7h",
+        }.get(arch)  # fmt: skip
 
         if not a:
             die(f"Architecture {a} is not supported by Alpine Linux")

--- a/mkosi/distributions/postmarketos.py
+++ b/mkosi/distributions/postmarketos.py
@@ -42,6 +42,13 @@ class Installer(DistributionInstaller):
 
     @classmethod
     def install(cls, context: Context) -> None:
+        import logging
+        (context.root / "lib").symlink_to("usr/lib")
+        (context.root / "bin").symlink_to("usr/bin")
+        (context.root / "usr/lib").mkdir(parents=True, exist_ok=True)
+        (context.root / "usr/bin").mkdir(parents=True, exist_ok=True)
+        for p in context.root.rglob("*"):
+            logging.warning(str(p))
         cls.install_packages(context, [
             "--initdb",
             "alpine-base",

--- a/mkosi/distributions/postmarketos.py
+++ b/mkosi/distributions/postmarketos.py
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1+
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 from collections.abc import Iterable, Sequence
 

--- a/mkosi/distributions/postmarketos.py
+++ b/mkosi/distributions/postmarketos.py
@@ -46,13 +46,17 @@ class Installer(DistributionInstaller):
             (context.root / "usr" / dir).mkdir(parents=True, exist_ok=True)
             (context.root / dir).symlink_to(f"usr/{dir}")
 
-        cls.install_packages(context, [
-            "--initdb",
-            "alpine-base",
-            "postmarketos-base",
-            # "device-qemu-amd64",
-            # "device-qemu-amd64-kernel-edge",
-        ], apivfs=False)
+        cls.install_packages(
+            context,
+            [
+                "--initdb",
+                "alpine-base",
+                "postmarketos-base",
+                # "device-qemu-amd64",
+                # "device-qemu-amd64-kernel-edge",
+            ],
+            apivfs=False,
+        )
 
     @classmethod
     def install_packages(cls, context: Context, packages: Sequence[str], apivfs: bool = True) -> None:
@@ -70,13 +74,15 @@ class Installer(DistributionInstaller):
     @classmethod
     def repositories(cls, context: Context) -> Iterable[str]:
         print("fetch repos")
-        return iter([
-            "https://mirror.postmarketos.org/postmarketos/staging/systemd/master/",
-            "http://mirror.postmarketos.org/postmarketos/master",
-            "http://dl-cdn.alpinelinux.org/alpine/edge/main",
-            "http://dl-cdn.alpinelinux.org/alpine/edge/community",
-            "http://dl-cdn.alpinelinux.org/alpine/edge/testing",
-        ])
+        return iter(
+            [
+                "https://mirror.postmarketos.org/postmarketos/extra-repos/systemd/master/",
+                "https://mirror.postmarketos.org/postmarketos/master",
+                "https://dl-cdn.alpinelinux.org/alpine/edge/main",
+                "https://dl-cdn.alpinelinux.org/alpine/edge/community",
+                "https://dl-cdn.alpinelinux.org/alpine/edge/testing",
+            ]
+        )
 
     @classmethod
     def architecture(cls, arch: Architecture) -> str:

--- a/mkosi/distributions/postmarketos.py
+++ b/mkosi/distributions/postmarketos.py
@@ -42,13 +42,10 @@ class Installer(DistributionInstaller):
 
     @classmethod
     def install(cls, context: Context) -> None:
-        import logging
-        (context.root / "lib").symlink_to("usr/lib")
-        (context.root / "bin").symlink_to("usr/bin")
-        (context.root / "usr/lib").mkdir(parents=True, exist_ok=True)
-        (context.root / "usr/bin").mkdir(parents=True, exist_ok=True)
-        for p in context.root.rglob("*"):
-            logging.warning(str(p))
+        for dir in ["lib", "bin", "sbin"]:
+            (context.root / "usr" / dir).mkdir(parents=True, exist_ok=True)
+            (context.root / dir).symlink_to(f"usr/{dir}")
+
         cls.install_packages(context, [
             "--initdb",
             "alpine-base",

--- a/mkosi/distributions/postmarketos.py
+++ b/mkosi/distributions/postmarketos.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
+from collections.abc import Iterable, Sequence
+import os
+from sys import stdout
+
+from mkosi.config import Architecture, Config
+from mkosi.context import Context
+from mkosi.distributions import Distribution, DistributionInstaller, PackageType
+from mkosi.installer import PackageManager
+from mkosi.installer.apk import Apk
+from mkosi.log import die
+from mkosi.mounts import finalize_source_mounts
+from mkosi.run import run
+from mkosi.sandbox import apivfs_cmd
+from mkosi.util import listify, sort_packages
+
+
+class Installer(DistributionInstaller):
+    @classmethod
+    def pretty_name(cls) -> str:
+        return "postmarketOS"
+
+    @classmethod
+    def filesystem(cls) -> str:
+        return "ext4"
+
+    @classmethod
+    def package_type(cls) -> PackageType:
+        return PackageType.apk
+
+    @classmethod
+    def default_release(cls) -> str:
+        return "rolling"
+
+    @classmethod
+    def default_tools_tree_distribution(cls) -> Distribution:
+        return Distribution.postmarketos
+
+    @classmethod
+    def package_manager(cls, config: "Config") -> type[PackageManager]:
+        return Apk
+
+    @classmethod
+    def createrepo(cls, context: Context) -> None:
+        Apk.createrepo(context)
+
+    @classmethod
+    def setup(cls, context: Context) -> None:
+        Apk.setup(context, cls.repositories(context))
+
+    @classmethod
+    def install(cls, context: Context) -> None:
+        cls.install_packages(context, ["--initdb",
+                                       "alpine-base",
+                                       "postmarketos-base",
+                                       "device-qemu-amd64",
+                                       "device-qemu-amd64-kernel-edge",
+                                       ], apivfs=False)
+        root = context.root
+        with finalize_source_mounts(
+            context.config,
+            ephemeral=os.getuid() == 0 and context.config.build_sources_ephemeral,
+        ) as sources:
+            run(
+                ["mv", (root / "etc/os-release"), (root / "usr/lib/os-release")],
+                sandbox=(
+                    context.sandbox(
+                        network=True,
+                        options=[
+                            "--bind", context.root, context.root,
+                            *sources,
+                            "--chdir", "/work/src",
+                            # pacman will fail unless invoked as root so make sure we're uid/gid 0 in the sandbox.
+                            "--uid", "0",
+                            "--gid", "0",
+                        ],
+                    ) + (apivfs_cmd(context.root))
+                ),
+                env=context.config.environment,
+                stdout=None,
+            )
+
+        cls.install_packages(context, ["--initdb",
+                                       "device-qemu-amd64",
+                                       "device-qemu-amd64-kernel-edge",
+                                       ], apivfs=False)
+
+    @classmethod
+    def install_packages(cls, context: Context, packages: Sequence[str], apivfs: bool = True) -> None:
+        Apk.invoke(
+            context,
+            "add",
+            [*sort_packages(packages)],
+            apivfs=apivfs,
+        )
+
+    @classmethod
+    def remove_packages(cls, context: Context, packages: Sequence[str]) -> None:
+        Apk.invoke(context, "del", [*packages], apivfs=True)
+
+    @classmethod
+    @listify
+    def repositories(cls, context: Context) -> Iterable[str]:
+        print("fetch repos")
+        return iter([
+            "/home/cas/.local/var/pmbootstrap/packages/edge/",
+            "http://mirror.postmarketos.org/postmarketos/master",
+            "http://dl-cdn.alpinelinux.org/alpine/edge/main",
+            "http://dl-cdn.alpinelinux.org/alpine/edge/community",
+            "http://dl-cdn.alpinelinux.org/alpine/edge/testing",
+        ])
+
+    @classmethod
+    def architecture(cls, arch: Architecture) -> str:
+        a = {
+            Architecture.x86_64 : "x86_64",
+            Architecture.arm64  : "aarch64",
+            Architecture.arm    : "armv7h",
+        }.get(arch)
+
+        if not a:
+            die(f"Architecture {a} is not supported by Alpine Linux")
+
+        return a

--- a/mkosi/installer/apk.py
+++ b/mkosi/installer/apk.py
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-2.1+
+# SPDX-License-Identifier: LGPL-2.1-or-later
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 

--- a/mkosi/installer/apk.py
+++ b/mkosi/installer/apk.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: LGPL-2.1+
+import os
+import shutil
+import textwrap
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+from typing import NamedTuple
+
+from mkosi.config import Config
+from mkosi.context import Context
+from mkosi.installer import PackageManager
+from mkosi.mounts import finalize_source_mounts
+from mkosi.run import run
+from mkosi.sandbox import apivfs_cmd
+from mkosi.types import _FILE, CompletedProcess, PathString
+from mkosi.util import umask
+from mkosi.versioncomp import GenericVersion
+
+
+class Apk(PackageManager):
+    @classmethod
+    def executable(cls, config: Config) -> str:
+        return "apk"
+
+    @classmethod
+    def subdir(cls, config: Config) -> Path:
+        return Path("apk")
+
+    @classmethod
+    def cache_subdirs(cls, cache: Path) -> list[Path]:
+        return [cache / "apk"]
+
+    @classmethod
+    def scripts(cls, context: Context) -> dict[str, list[PathString]]:
+        return {
+            "apk": apivfs_cmd(context.root) + cls.cmd(context),
+            "mkosi-install"  : ["apk", "--update-cache", "add"],
+            "mkosi-upgrade"  : ["apk", "--update-cache", "upgrade"],
+            "mkosi-remove"   : ["apk", "--remove", "del"],
+            "mkosi-reinstall": ["apk", "--update-cache", "fix"],
+        }
+
+    @classmethod
+    def mounts(cls, context: Context) -> list[PathString]:
+        mounts: list[PathString] = [
+            *super().mounts(context),
+            # pacman writes downloaded packages to the first writable cache directory. We don't want it to write to our
+            # local repository directory so we expose it as a read-only directory to pacman.
+            "--ro-bind", context.packages, "/var/cache/apk",
+        ]
+
+        return mounts
+
+    @classmethod
+    def setup(cls, context: Context, repositories: Iterable[str]) -> None:
+        config = context.root / "etc/apk/repositories"
+        if config.exists():
+            print("apk setup() repo file exists!")
+            return
+
+        config.parent.mkdir(exist_ok=True, parents=True)
+
+        with config.open("w") as f:
+            for repo in repositories:
+                f.write(f"{repo}\n")
+
+    @classmethod
+    def cmd(cls, context: Context) -> list[PathString]:
+        _cmd = [
+            "apk",
+            "--root", context.root,
+            # Make sure pacman looks at our local repository first by putting it as the first cache directory. We mount
+            # it read-only so the second directory will still be used for writing new cache entries.
+            #"--cache-dir=" + str(context.root / "var/cache/apk/mkosi"),
+            "--arch", context.config.distribution.architecture(context.config.architecture),
+            "--no-interactive",
+            "--update-cache",
+        ]
+        #if not context.config.repository_key_check:
+        _cmd += ["--allow-untrusted"]
+        return _cmd
+
+    @classmethod
+    def invoke(
+        cls,
+        context: Context,
+        operation: str,
+        arguments: Sequence[str] = (),
+        *,
+        apivfs: bool = False,
+        stdout: _FILE = None,
+    ) -> CompletedProcess:
+        with finalize_source_mounts(
+            context.config,
+            ephemeral=os.getuid() == 0 and context.config.build_sources_ephemeral,
+        ) as sources:
+            return run(
+                cls.cmd(context) + [operation, *arguments],
+                sandbox=(
+                    context.sandbox(
+                        network=True,
+                        options=[
+                            "--bind", context.root, context.root,
+                            *cls.mounts(context),
+                            *sources,
+                            "--chdir", "/work/src",
+                            # pacman will fail unless invoked as root so make sure we're uid/gid 0 in the sandbox.
+                            "--uid", "0",
+                            "--gid", "0",
+                        ],
+                    ) + (apivfs_cmd(context.root) if apivfs else [])
+                ),
+                env=context.config.environment,
+                stdout=stdout,
+            )
+
+    @classmethod
+    def sync(cls, context: Context) -> None:
+        if (context.root / "etc/apk/world").exists():
+            cls.invoke(context, "update", [])
+
+    @classmethod
+    def createrepo(cls, context: Context) -> None:
+        print("apk createrepo() called!")
+        # run(
+        #     [
+        #         "repo-add",
+        #         "--quiet",
+        #         context.packages / "mkosi.db.tar",
+        #         *sorted(context.packages.glob("*.pkg.tar*"), key=lambda p: GenericVersion(Path(p).name))
+        #     ],
+        #     sandbox=context.sandbox(options=["--bind", context.packages, context.packages]),
+        # )
+
+        # # pacman can't sync a single repository, so we go behind its back and do it ourselves.
+        # shutil.move(
+        #     context.packages / "mkosi.db.tar",
+        #     context.package_cache_dir / "lib/pacman/sync/mkosi.db"
+        # )

--- a/mkosi/installer/apk.py
+++ b/mkosi/installer/apk.py
@@ -58,13 +58,13 @@ class Apk(PackageManager):
 
     @classmethod
     def cmd(cls, context: Context) -> list[PathString]:
-        # return ["tree", context.root, "--"]
         return [
             "apk",
             "--root", "/buildroot",
             # Make sure pacman looks at our local repository first by putting it as the first cache directory. We mount
             # it read-only so the second directory will still be used for writing new cache entries.
             #"--cache-dir=" + str(context.root / "var/cache/apk/mkosi"),
+            "--cache-dir", "/var/cache/apk",
             "--arch", context.config.distribution.architecture(context.config.architecture),
             "--no-interactive",
             "--update-cache",

--- a/mkosi/installer/apk.py
+++ b/mkosi/installer/apk.py
@@ -36,8 +36,9 @@ class Apk(PackageManager):
     def mounts(cls, context: Context) -> list[PathString]:
         mounts: list[PathString] = [
             *super().mounts(context),
-            # pacman writes downloaded packages to the first writable cache directory. We don't want it to write to our
-            # local repository directory so we expose it as a read-only directory to pacman.
+            # pacman writes downloaded packages to the first writable cache directory.
+            # We don't want it to write to our local repository directory so we expose it
+            # as a read-only directory to pacman.
             # "--ro-bind", context.packages, "/var/cache/apk",
         ]
 
@@ -61,8 +62,8 @@ class Apk(PackageManager):
         return [
             "apk",
             "--root", "/buildroot",
-            # Make sure pacman looks at our local repository first by putting it as the first cache directory. We mount
-            # it read-only so the second directory will still be used for writing new cache entries.
+            # Make sure pacman looks at our local repository first by putting it as the first cache dir.
+            # We mount it read-only so the second directory will still be used for writing new cache entries.
             #"--cache-dir=" + str(context.root / "var/cache/apk/mkosi"),
             "--cache-dir", "/var/cache/apk",
             "--arch", context.config.distribution.architecture(context.config.architecture),

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -40,6 +40,7 @@ from mkosi.config import (
     want_selinux_relabel,
     yes_no,
 )
+from mkosi.distributions import Distribution
 from mkosi.log import ARG_DEBUG, die
 from mkosi.partition import finalize_root, find_partitions
 from mkosi.run import SD_LISTEN_FDS_START, AsyncioThread, find_binary, fork_and_wait, run, spawn, workdir
@@ -1346,7 +1347,7 @@ def run_qemu(args: Args, config: Config) -> None:
 
         for k, v in credentials.items():
             payload = base64.b64encode(v.encode()).decode()
-            if config.architecture.supports_smbios(firmware):
+            if config.architecture.supports_smbios(firmware) and not config.distribution == Distribution.postmarketos:
                 cmdline += ["-smbios", f"type=11,value=io.systemd.credential.binary:{k}={payload}"]
             # qemu's fw_cfg device only supports keys up to 55 characters long.
             elif config.architecture.supports_fw_cfg() and len(k) <= 55 - len("opt/io.systemd.credentials/"):

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -40,7 +40,6 @@ from mkosi.config import (
     want_selinux_relabel,
     yes_no,
 )
-from mkosi.distributions import Distribution
 from mkosi.log import ARG_DEBUG, die
 from mkosi.partition import finalize_root, find_partitions
 from mkosi.run import SD_LISTEN_FDS_START, AsyncioThread, find_binary, fork_and_wait, run, spawn, workdir
@@ -1347,7 +1346,7 @@ def run_qemu(args: Args, config: Config) -> None:
 
         for k, v in credentials.items():
             payload = base64.b64encode(v.encode()).decode()
-            if config.architecture.supports_smbios(firmware) and not config.distribution == Distribution.postmarketos:
+            if config.architecture.supports_smbios(firmware):
                 cmdline += ["-smbios", f"type=11,value=io.systemd.credential.binary:{k}={payload}"]
             # qemu's fw_cfg device only supports keys up to 55 characters long.
             elif config.architecture.supports_fw_cfg() and len(k) <= 55 - len("opt/io.systemd.credentials/"):

--- a/mkosi/resources/mkosi-vm/mkosi.conf.d/alpine.conf
+++ b/mkosi/resources/mkosi-vm/mkosi.conf.d/alpine.conf
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=postmarketos
+
+[Content]
+Packages=systemd-boot


### PR DESCRIPTION
This PR adds support for APK and postmarketOS/Alpine (postmarketOS works like a layer atop of Alpine). It is not yet ready to be merged as it contains a few hacks to get stuff working properly. Regardless, this already works and can be used as a common playground to avoid multiple people working on this independently and duplicating the work.

Some stuff needs to be fixed in mkosi, some in postmarketOS, and some in Alpine. And some stuff needs discussion. Current TODOs/problems:

- Populate all the vm/initrd/tools presets
- mkosi assumes that vmlinuz files have their version as a suffic. This is not true for Alpine. `file` is able to extract the version though - maybe this is something which should be supported by `bootctl`: https://github.com/systemd/systemd/issues/35370
- check support for other arches
- add support for mirrors,  local repo, etc.
- check that APK cache properly works
- set up keyring for apk (but `--keys-dir` is always relative to root destination...)
- mkosi always assumes that arches which support SMBIOS also have kernels which enable `CONFIG_DMI_SYSFS`. Alpine does not
- usr-merge is currently hacked in, should be dropped once this is merged upstream

Pinging @calebccff as this is based on his prototype