### PR TITLE
config: don't skip dependency parsing when using history

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -4458,9 +4458,6 @@ def parse_config(
     for s in SETTINGS:
         setattr(config, s.dest, context.finalize_value(s))
 
-    if prev:
-        return args, (load_config(config),)
-
     images = []
 
     # If Dependencies= was not explicitly specified on the CLI or in the configuration,


### PR DESCRIPTION
Without this even for images with dependencies the images passed to run_verb will only have a single element (the one loaded from history), which breaks resolve_deps, which is then not passed images to look dependencies up in.

Fixes: #3238