### PR TITLE
Don't resolve deps if we're reusing previous config

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -71,6 +71,7 @@ from mkosi.config import (
     Vmm,
     cat_config,
     format_bytes,
+    have_history,
     parse_boolean,
     parse_config,
     resolve_deps,
@@ -4725,7 +4726,9 @@ def run_verb(args: Args, images: Sequence[Config], *, resources: Path) -> None:
     # The images array has been modified so we need to reevaluate last again.
     # Also ensure that all other images are reordered in case their dependencies were modified.
     last = images[-1]
-    images = resolve_deps(images[:-1], last.dependencies) + [last]
+
+    if not have_history(args):
+        images = resolve_deps(images[:-1], last.dependencies) + [last]
 
     if not (last.output_dir_or_cwd() / last.output).exists() or last.output_format == OutputFormat.none:
         for config in images:

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -4355,6 +4355,15 @@ class ParseContext:
         return True
 
 
+def have_history(args: Args) -> bool:
+    return (
+        args.verb.needs_build()
+        and args.verb != Verb.build
+        and not args.force
+        and Path(".mkosi-private/history/latest.json").exists()
+    )
+
+
 def parse_config(
     argv: Sequence[str] = (),
     *,
@@ -4404,12 +4413,7 @@ def parse_config(
     if not args.verb.needs_config():
         return args, ()
 
-    if (
-        args.verb.needs_build()
-        and args.verb != Verb.build
-        and not args.force
-        and Path(".mkosi-private/history/latest.json").exists()
-    ):
+    if have_history(args):
         try:
             prev = Config.from_json(Path(".mkosi-private/history/latest.json").read_text())
         except ValueError:


### PR DESCRIPTION
We ignore subimages if we're reusing the previous config so let's make sure we ignore subimages as well after running configure scripts if we're reusing previous config.

Fixes #3238