### PR TITLE
Fix Partition split_path calculation

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -58,7 +58,12 @@ runs:
 
     - name: Install
       shell: bash
-      run: sudo ln -svf ${{ github.action_path }}/bin/mkosi /usr/bin/mkosi
+      run: |
+        sudo ln -svf ${{ github.action_path }}/bin/mkosi /usr/bin/mkosi
+        # Make sure that mkosi is still found inside "mkosi sandbox" where /usr is potentially replaced with
+        # a tools tree's /usr.
+        mkdir -p $HOME/.local/bin/mkosi
+        ln -svf ${{ github.action_path }}/bin/mkosi $HOME/.local/bin/mkosi
 
     - name: Dependencies
       shell: bash

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2156,7 +2156,10 @@ def compressor_command(context: Context, compression: Compression) -> list[PathS
 
 
 def maybe_compress(
-    context: Context, compression: Compression, src: Path, dst: Optional[Path] = None
+    context: Context,
+    compression: Compression,
+    src: Path,
+    dst: Optional[Path] = None,
 ) -> None:
     if not compression or src.is_dir():
         if dst:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2576,6 +2576,9 @@ def check_ukify(
 
 def check_tools(config: Config, verb: Verb) -> None:
     if verb == Verb.build:
+        if config.output_format == OutputFormat.none:
+            return
+
         if config.bootable != ConfigFeature.disabled:
             check_tool(config, "depmod", reason="generate kernel module dependencies")
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2579,18 +2579,18 @@ def check_tools(config: Config, verb: Verb) -> None:
         if config.bootable != ConfigFeature.disabled:
             check_tool(config, "depmod", reason="generate kernel module dependencies")
 
-        if want_efi(config) and config.unified_kernel_images == ConfigFeature.enabled:
+        if want_efi(config):
             if config.unified_kernel_image_profiles:
                 check_ukify(
                     config,
-                    version="257",
+                    version="257~devel",
                     reason="build unified kernel image profiles",
                     hint=(
                         "Use ToolsTree=default to download most required tools including ukify "
                         "automatically"
                     ),
                 )
-            else:
+            elif config.unified_kernel_images == ConfigFeature.enabled:
                 check_ukify(
                     config,
                     version="254",
@@ -2623,13 +2623,6 @@ def check_tools(config: Config, verb: Verb) -> None:
                     version="256",
                     reason="sign PCR hashes with OpenSSL engine",
                 )
-
-        if config.unified_kernel_image_profiles:
-            check_ukify(
-                config,
-                version="257~devel",
-                reason="add unified kernel image profiles",
-            )
 
         if config.verity_key_source.type != KeySourceType.file:
             check_systemd_tool(

--- a/mkosi/partition.py
+++ b/mkosi/partition.py
@@ -23,7 +23,10 @@ class Partition:
             type=dict["type"],
             uuid=dict["uuid"],
             partno=int(partno) if (partno := dict.get("partno")) else None,
-            split_path=Path(p) if ((p := dict.get("split_path")) and p != "-") else None,
+            # We have to translate the sandbox path to the path on the host by removing the /work prefix.
+            split_path=(
+                Path(p.removeprefix("/work")) if ((p := dict.get("split_path")) and p != "-") else None
+            ),
             roothash=dict.get("roothash"),
         )
 


### PR DESCRIPTION
Now that we use workdir() in make_image(), we have to change the
Partition initializer to remove the path added by workdir() again
to get the proper path on the host.

Fixes https://github.com/systemd/mkosi/issues/3242.