### PR TITLE
feat:add deepin distribution

### DIFF
--- a/mkosi.conf.d/20-deepin/mkosi.conf
+++ b/mkosi.conf.d/20-deepin/mkosi.conf
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=deepin
+
+[Distribution]
+Release=apricot
+Repositories=non-free
+
+[Content]
+Packages=
+        linux-perf
+        deepin-keyring

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -77,6 +77,7 @@ class Distribution(StrEnum):
     # of the mkosi maintainers before implementing a new distribution.
     fedora = enum.auto()
     debian = enum.auto()
+    deepin = enum.auto()
     kali = enum.auto()
     ubuntu = enum.auto()
     arch = enum.auto()
@@ -101,7 +102,12 @@ class Distribution(StrEnum):
         )
 
     def is_apt_distribution(self) -> bool:
-        return self in (Distribution.debian, Distribution.ubuntu, Distribution.kali)
+        return self in (
+            Distribution.debian,
+            Distribution.deepin,
+            Distribution.ubuntu,
+            Distribution.kali,
+        )
 
     def is_rpm_distribution(self) -> bool:
         return self in (
@@ -188,7 +194,7 @@ def detect_distribution(root: Path = Path("/")) -> tuple[Optional[Distribution],
         if d is not None:
             break
 
-    if d in {Distribution.debian, Distribution.ubuntu, Distribution.kali} and version_codename:
+    if d in {Distribution.debian, Distribution.deepin, Distribution.ubuntu, Distribution.kali} and version_codename:
         version_id = version_codename
 
     return d, version_id


### PR DESCRIPTION
Add deepin Root File System Creation with mkosi Support Starting from deepin v20 (Apricot).

Users can now utilize mkosi to build the root file systems for both deepin v20 (Apricot) and v23 (Beige). Here's how:

- For deepin in v20 (Apricot):
  ```
  mkosi -d deepin
  ```

- For deepin v23 (Beige) specifically, with the repository mirror:
  ```
  mkosi -d deepin -r beige -m https://community-packages.deepin.com/deepin/beige
  ```

**Sidenote:** In accordance with the deepin branding guidelines, the preferred usage is to start the name "deepin" with a lowercase 'd', akin to how "openSUSE" begins with a lowercase 'o'. Therefore, in this context, we have intentionally used "deepin" rather than "Deepin"—this is not a typographical error. :)