### PR TITLE
qemu: run ssh client as root in sandbox

### DIFF
--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -1471,6 +1471,6 @@ def run_ssh(args: Args, config: Config) -> None:
             network=True,
             devices=True,
             relaxed=True,
-            options=["--same-dir"],
+            options=["--same-dir", "--become-root"],
         ),
     )


### PR DESCRIPTION
Not all users are configured in /etc/passwd (e.g. LDAP users from sssd), and so the ssh client fails when run as non-root user in the sandbox. Simply work around the issue by running as fake-root in the sandbox.