### PR TITLE
Define virt as default QEMU machine for riscv64

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -475,6 +475,7 @@ class Architecture(StrEnum):
             Architecture.ppc:      "pseries",
             Architecture.ppc64:    "pseries",
             Architecture.ppc64_le: "pseries",
+            Architecture.riscv64:  "virt",
         }  # fmt: skip
 
         if self not in m:


### PR DESCRIPTION
The documentation says:
> It is the recommended board type if you simply want to run a guest
> such as Linux and do not care about reproducing the idiosyncrasies and
> limitations of a particular bit of real-world hardware.
https://qemu.readthedocs.io/en/v9.1.0/system/riscv/virt.html