### PR TITLE
mkosi-initrd: also take input from /etc/kernel/cmdline

### DIFF
--- a/mkosi/initrd.py
+++ b/mkosi/initrd.py
@@ -197,6 +197,9 @@ def main() -> None:
                     f.write("\n".join(crypttab))
                 cmdline += ["--extra-tree", f"{staging_dir}/crypttab:/etc/crypttab"]
 
+        if Path("/etc/kernel/cmdline").exists():
+            cmdline += ["--kernel-command-line", Path("/etc/kernel/cmdline").read_text()]
+
         # Prefer dnf as dnf5 has not yet officially replaced it and there's a much bigger chance that there
         # will be a populated dnf cache directory.
         run(


### PR DESCRIPTION
Other kernel-install plugins (for Type 1) already take /etc/kernel/cmdline into account when generating the local cmdline entry, so do the same in mkosi-initrd for the UKI