### PR TITLE
Rework crypto-policies handling slightly

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1073,14 +1073,7 @@ def install_sandbox_trees(config: Config, dst: Path) -> None:
     # Ensure /etc exists in the sandbox
     (dst / "etc").mkdir(exist_ok=True)
 
-    if (p := config.tools() / "etc/crypto-policies").exists():
-        copy_tree(
-            p,
-            dst / "etc/crypto-policies",
-            preserve=False,
-            dereference=True,
-            sandbox=config.sandbox,
-        )  # fmt: skip
+    (dst / "etc/crypto-policies").mkdir(exist_ok=True)
 
     if config.sandbox_trees:
         with complete_step("Copying in sandbox trees…"):

--- a/mkosi/installer/rpm.py
+++ b/mkosi/installer/rpm.py
@@ -95,7 +95,8 @@ def setup_rpm(
     # Write an rpm sequoia policy that allows SHA1 as various distribution GPG keys (openSUSE) still use SHA1
     # for various things.
     # TODO: Remove when all rpm distribution GPG keys have stopped using SHA1.
-    if not (p := context.sandbox_tree / "etc/crypto-policies/back-ends/rpm-sequoia.config").exists():
+    if not (context.config.tools() / "etc/crypto-policies").exists():
+        p = context.sandbox_tree / "etc/crypto-policies/back-ends/rpm-sequoia.config"
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(
             textwrap.dedent(

--- a/mkosi/mounts.py
+++ b/mkosi/mounts.py
@@ -104,4 +104,7 @@ def finalize_crypto_mounts(config: Config) -> list[PathString]:
     if (config.tools() / "etc/pacman.d/gnupg").exists():
         mounts += [(config.tools() / "etc/pacman.d/gnupg", Path("/etc/pacman.d/gnupg"))]
 
+    if (config.tools() / "etc/crypto-policies").exists():
+        mounts += [(config.tools() / "etc/crypto-policies", Path("/etc/crypto-policies"))]
+
     return flatten(("--ro-bind", src, target) for src, target in sorted(set(mounts), key=lambda s: s[1]))


### PR DESCRIPTION
Let's bind mount from the tools tree if it provides crypto policies and only write our own for rpm-sequoia if the tools tree doesn't provide its own crypto policies.