### PR TITLE
Use host model cpu

### DIFF
--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -1093,6 +1093,7 @@ def run_qemu(args: Args, config: Config) -> None:
             accel += ",device=/dev/fdset/1"
     else:
         accel = "tcg"
+        cmdline += ["-cpu", "max"]
 
     cmdline += ["-accel", accel]
 
@@ -1114,8 +1115,6 @@ def run_qemu(args: Args, config: Config) -> None:
 
         index = list(qemu_device_fds.keys()).index(QemuDeviceNode.vhost_vsock)
         cmdline += ["-device", f"vhost-vsock-pci,guest-cid={cid},vhostfd={SD_LISTEN_FDS_START + index}"]
-
-    cmdline += ["-cpu", "max"]
 
     if config.qemu_gui:
         if config.architecture.is_arm_variant():


### PR DESCRIPTION
mkosi currently calls qemu with `-cpu max`. This enables all features supported by the accelerator, which could be less than the ones supported by the host.

Switch to the default `-cpu host` and keep max only when using binary translation.