### PR TITLE
tests: Build with --incremental=strict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,12 +211,11 @@ jobs:
       - name: Build tools tree
         run: |
           # TODO: Remove grub2 hack when https://bugzilla.opensuse.org/show_bug.cgi?id=1227464 is resolved.
-          sudo --preserve-env \
-              mkosi \
-              --directory "" \
-              --distribution ${{ matrix.tools }} \
-              --include mkosi-tools \
-              $( [[ ${{ matrix.tools }} == opensuse ]] && echo --package=grub2)
+          mkosi \
+            --directory "" \
+            --distribution ${{ matrix.tools }} \
+            --include mkosi-tools \
+            $( [[ ${{ matrix.tools }} == opensuse ]] && echo --package=grub2)
 
       - name: Run integration tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,9 @@ jobs:
             --include mkosi-tools \
             $( [[ ${{ matrix.tools }} == opensuse ]] && echo --package=grub2)
 
+      - name: Build image
+        run: mkosi --distribution ${{ matrix.distro }} -f
+
       - name: Run integration tests
         run: |
           sudo --preserve-env \

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -13,6 +13,7 @@ Format=directory
 OutputDirectory=mkosi.output
 
 [Build]
+Incremental=yes
 BuildSources=.
 BuildSourcesEphemeral=yes
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1996,7 +1996,6 @@ class Config:
             "release": self.release,
             "mirror": self.mirror,
             "architecture": self.architecture,
-            "package_manager": self.distribution.package_manager(self).executable(self),
             "packages": sorted(self.packages),
             "build_packages": sorted(self.build_packages),
             "package_directories": [

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -102,7 +102,7 @@ class Image:
             "--release", self.config.release,
             *(f"--kernel-command-line={i}" for i in kcl),
             "--force",
-            "--incremental",
+            "--incremental=strict",
             "--output-directory", self.output_dir,
             *(["--debug-shell"] if self.config.debug_shell else []),
             *options,


### PR DESCRIPTION
Let's require cached images to be present before running the
integration tests. This makes sure the tests only need to build the
output that they're testing and it also opens up the road for running
tests in parallel in the future.