### PR TITLE
pacman: Make sure repositories from dropins take priority

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -45,6 +45,15 @@ runs:
         sudo sysctl --ignore --write kernel.apparmor_restrict_unprivileged_unconfined=0
         sudo sysctl --ignore --write kernel.apparmor_restrict_unprivileged_userns=0
 
+    - name: Create missing mountpoints
+      shell: bash
+      run: |
+        for p in /etc/pki /etc/pacman.d/gnupg /etc/ssl /etc/ca-certificates /var/lib/ca-certificates /etc/crypto-policies; do
+          if [[ ! -e "$p" ]]; then
+            sudo mkdir -p "$p"
+          fi
+        done
+
     # Both the unix-chkpwd and swtpm profiles are broken (https://gitlab.com/apparmor/apparmor/-/issues/402) so let's
     # just disable and remove apparmor completely. It's not relevant in this context anyway.
     # TODO: Remove if https://github.com/actions/runner-images/issues/10015 is ever fixed.

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -119,6 +119,16 @@ class Pacman(PackageManager):
             # This has to go first so that our local repository always takes precedence over any other ones.
             f.write("Include = /etc/mkosi-local.conf\n")
 
+            if any((context.sandbox_tree / "etc/pacman.d/").glob("*.conf")):
+                f.write(
+                    textwrap.dedent(
+                        """\
+
+                        Include = /etc/pacman.d/*.conf
+                        """
+                    )
+                )
+
             for repo in repositories:
                 f.write(
                     textwrap.dedent(
@@ -126,16 +136,6 @@ class Pacman(PackageManager):
 
                         [{repo.id}]
                         Server = {repo.url}
-                        """
-                    )
-                )
-
-            if any((context.sandbox_tree / "etc/pacman.d/").glob("*.conf")):
-                f.write(
-                    textwrap.dedent(
-                        """\
-
-                        Include = /etc/pacman.d/*.conf
                         """
                     )
                 )


### PR DESCRIPTION
When multiple repositories ship the same package, the repository defined first in the pacman config file takes priority. Let's make sure user defined repositories take priority over the ones defined in mkosi by moving the Include= statement up a little in the config file.