### PR TITLE
Drop PEAddons=

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1634,12 +1634,6 @@ PACKAGE_GLOBS = (
 
 
 @dataclasses.dataclass(frozen=True)
-class PEAddon:
-    output: str
-    cmdline: list[str]
-
-
-@dataclasses.dataclass(frozen=True)
 class UKIProfile:
     profile: dict[str, str]
     cmdline: list[str]
@@ -1783,7 +1777,6 @@ class Config:
     kernel_modules_include: list[str]
     kernel_modules_exclude: list[str]
     kernel_modules_include_host: bool
-    pe_addons: list[PEAddon]
 
     kernel_modules_initrd: bool
     kernel_modules_initrd_include: list[str]
@@ -2175,21 +2168,6 @@ def parse_ini(path: Path, only_sections: Collection[str] = ()) -> Iterator[tuple
 
     if section:
         yield section, "", ""
-
-
-PE_ADDON_SETTINGS: list[ConfigSetting[Any]] = [
-    ConfigSetting(
-        dest="output",
-        section="PEAddon",
-        parse=config_make_filename_parser("Output= requires a filename with no path components."),
-        default="",
-    ),
-    ConfigSetting(
-        dest="cmdline",
-        section="PEAddon",
-        parse=config_make_list_parser(delimiter=" "),
-    ),
-]
 
 
 UKI_PROFILE_SETTINGS: list[ConfigSetting[Any]] = [
@@ -2796,18 +2774,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
         section="Content",
         parse=config_make_list_parser(delimiter=","),
         help="Exclude the specified kernel modules from the image",
-    ),
-    ConfigSetting(
-        dest="pe_addons",
-        long="--pe-addon",
-        metavar="PATH",
-        section="Content",
-        parse=config_make_list_parser(
-            delimiter=",",
-            parse=make_simple_config_parser(PE_ADDON_SETTINGS, PEAddon),
-        ),
-        recursive_paths=("mkosi.pe-addons/*.conf",),
-        help="Configuration files to generate PE addons",
     ),
     ConfigSetting(
         dest="kernel_modules_initrd",
@@ -4807,7 +4773,6 @@ def summary(config: Config) -> str:
              Kernel Modules Include: {line_join_list(config.kernel_modules_include)}
              Kernel Modules Exclude: {line_join_list(config.kernel_modules_exclude)}
         Kernel Modules Include Host: {yes_no(config.kernel_modules_include_host)}
-                          PE Addons: {line_join_list(config.pe_addons)}
 
               Kernel Modules Initrd: {yes_no(config.kernel_modules_initrd)}
       Kernel Modules Initrd Include: {line_join_list(config.kernel_modules_initrd_include)}
@@ -5042,9 +5007,6 @@ def json_type_transformer(refcls: Union[type[Args], type[Config]]) -> Callable[[
         assert "Type" in keysource
         return KeySource(type=KeySourceType(keysource["Type"]), source=keysource.get("Source", ""))
 
-    def pe_addon_transformer(addons: list[dict[str, Any]], fieldtype: type[PEAddon]) -> list[PEAddon]:
-        return [PEAddon(output=addon["Output"], cmdline=addon["Cmdline"]) for addon in addons]
-
     def uki_profile_transformer(
         profiles: list[dict[str, Any]],
         fieldtype: type[UKIProfile],
@@ -5090,7 +5052,6 @@ def json_type_transformer(refcls: Union[type[Args], type[Config]]) -> Callable[[
         Network: enum_transformer,
         KeySource: key_source_transformer,
         Vmm: enum_transformer,
-        list[PEAddon]: pe_addon_transformer,
         list[UKIProfile]: uki_profile_transformer,
         list[ArtifactOutput]: enum_list_transformer,
         CertificateSource: certificate_source_transformer,

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -978,17 +978,6 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     See the documentation for the `UKIProfile` section for information
     on which settings can be configured in UKI profile config files.
 
-`PeAddons=`, `--pe-addon`
-:   Build additional PE addons. Takes a comma separated list of paths to
-    PE addon config files. This option may be used multiple times in which case
-    each config gets built into a corresponding addon. Each addon has the name
-    of the config file, with the extension replaced with `.addon.efi`.
-    Config files in the `mkosi.pe-addons/` directory are automatically picked
-    up.
-
-    See the documentation for the `PEAddon` section for information on
-    which settings can be configured in PE addon config files.
-
 `Initrds=`, `--initrd`
 :   Use user-provided initrd(s). Takes a comma separated list of paths to initrd
     files. This option may be used multiple times in which case the initrd lists
@@ -1992,22 +1981,6 @@ config file is read:
     building multiple images, pass the listed environment variables to
     each individual subimage as if they were "universal" settings. See
     the **Building multiple images** section for more information.
-
-### [PEAddon] Section
-
-The `PEAddon` section can be used in UKI profile config files which are
-passed to the `PEAddons=` setting. The following settings can be
-specified in the `PEAddon` section:
-
-`Output=`
-:   The name the addon should have in the addons directory in the ESP.
-    The final name is the name specified here suffixed with
-    `.addon.efi`.
-
-`Cmdline=`
-:   The kernel command line arguments to store in the `.cmdline` section
-    of the addon. Takes a space delimited list of extra kernel command
-    line arguments.
 
 ### [UKIProfile] Section
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -28,7 +28,6 @@ from mkosi.config import (
     ManifestFormat,
     Network,
     OutputFormat,
-    PEAddon,
     QemuDrive,
     QemuFirmware,
     QemuVsockCID,
@@ -215,14 +214,6 @@ def test_config() -> None:
                 "abc"
             ],
             "Passphrase": null,
-            "PeAddons": [
-                {
-                    "Cmdline": [
-                        "key=value"
-                    ],
-                    "Output": "abc"
-                }
-            ],
             "PostInstallationScripts": [
                 "/bar/qux"
             ],
@@ -495,7 +486,6 @@ def test_config() -> None:
         packages=[],
         pass_environment=["abc"],
         passphrase=None,
-        pe_addons=[PEAddon(output="abc", cmdline=["key=value"])],
         postinst_scripts=[Path("/bar/qux")],
         postoutput_scripts=[Path("/foo/src")],
         prepare_scripts=[Path("/run/foo")],


### PR DESCRIPTION
Putting these inside the image isn't very useful except for the very specific use case of being able to skip copying the addon when copying the ESP to another disk to implement a "live" installer mode. For all other use cases, PE addons are either supposed to be generated locally or optionally downloaded alongside the image. For these use cases it makes much more sense to output the addons alongside the image, but not in it.

But if it makes more sense to output the addons alongside the image, then it becomes unclear whether this is something that should be implemented inside mkosi in the first place. Until we figure whether this makes sense and how to implement it, let's remove the functionality.

Addons can still be added to the image or generated alongside it by running ukify in a postinst script. The secure boot signing options will have to be passed manually but this isn't an unsolvable problem.