### PR TITLE
Run binaries from ExtraSearchPaths= within tools tree

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -498,10 +498,7 @@ def finalize_host_scripts(
         if context.config.find_binary(binary):
             scripts[binary] = (binary, "--root", "/buildroot")
     if ukify := context.config.find_binary("ukify"):
-        # A script will always run with the tools tree mounted, so we pass binary=None to disable
-        # the conditional search logic of python_binary() depending on whether the binary is in an
-        # extra search path or not.
-        scripts["ukify"] = (python_binary(context.config, binary=None), ukify)
+        scripts["ukify"] = (python_binary(context.config), ukify)
     return finalize_scripts(context.config, scripts | dict(helpers))
 
 
@@ -542,7 +539,6 @@ def run_configure_scripts(config: Config) -> Config:
                     ["/work/configure"],
                     env=env | config.environment,
                     sandbox=config.sandbox(
-                        binary=None,
                         options=[
                             "--dir", "/work/src",
                             "--chdir", "/work/src",
@@ -617,7 +613,6 @@ def run_sync_scripts(config: Config) -> None:
                     env=env | config.environment,
                     stdin=sys.stdin,
                     sandbox=config.sandbox(
-                        binary=None,
                         network=True,
                         options=options,
                         overlay=Path(sandbox_tree),
@@ -656,7 +651,6 @@ def script_maybe_chroot_sandbox(
     with finalize_host_scripts(context, helpers) as hd:
         if script.suffix != ".chroot":
             with context.sandbox(
-                binary=None,
                 network=network,
                 options=[
                     *options,
@@ -981,7 +975,6 @@ def run_postoutput_scripts(context: Context) -> None:
                     ["/work/postoutput"],
                     env=env | context.config.environment,
                     sandbox=context.sandbox(
-                        binary=None,
                         # postoutput scripts should run as (fake) root so that file ownership is
                         # always recorded as if owned by root.
                         options=[
@@ -1034,7 +1027,6 @@ def install_tree(
             ["systemd-dissect", "--copy-from", workdir(src), "/", workdir(t)],
             env=dict(SYSTEMD_DISSECT_VERITY_EMBEDDED="no", SYSTEMD_DISSECT_VERITY_SIDECAR="no"),
             sandbox=config.sandbox(
-                binary="systemd-dissect",
                 devices=True,
                 network=True,
                 options=[
@@ -1495,7 +1487,7 @@ def run_ukify(
     (context.workspace / "cmdline").write_text(f"{' '.join(cmdline)}\x00")
 
     cmd = [
-        python_binary(context.config, binary=ukify),
+        python_binary(context.config),
         ukify,
         "build",
         *arguments,
@@ -1570,7 +1562,6 @@ def run_ukify(
         ),
         env=context.config.environment,
         sandbox=context.sandbox(
-            binary=ukify,
             options=[*opt, *options],
             devices=context.config.secure_boot_key_source.type != KeySourceType.file,
         ),
@@ -1658,7 +1649,7 @@ def build_uki(
         # new .ucode section support?
         if (
             systemd_tool_version(
-                python_binary(context.config, binary=ukify),
+                python_binary(context.config),
                 ukify,
                 sandbox=context.sandbox,
             )
@@ -1731,7 +1722,7 @@ def find_entry_token(context: Context) -> str:
             not in run(
                 ["kernel-install", "--help"],
                 stdout=subprocess.PIPE,
-                sandbox=context.sandbox(binary="kernel-install"),
+                sandbox=context.sandbox(),
             ).stdout
         )
         or systemd_tool_version("kernel-install", sandbox=context.sandbox) < "255.1"
@@ -1741,9 +1732,7 @@ def find_entry_token(context: Context) -> str:
     output = json.loads(
         run(
             ["kernel-install", "--root=/buildroot", "--json=pretty", "inspect"],
-            sandbox=context.sandbox(
-                binary="kernel-install", options=["--ro-bind", context.root, "/buildroot"]
-            ),
+            sandbox=context.sandbox(options=["--ro-bind", context.root, "/buildroot"]),
             stdout=subprocess.PIPE,
             env={"BOOT_ROOT": "/boot"},
         ).stdout
@@ -2186,7 +2175,7 @@ def maybe_compress(
             src.unlink()
 
             with dst.open("wb") as o:
-                run(cmd, stdin=i, stdout=o, sandbox=context.sandbox(binary=cmd[0]))
+                run(cmd, stdin=i, stdout=o, sandbox=context.sandbox())
 
 
 def copy_nspawn_settings(context: Context) -> None:
@@ -2336,10 +2325,7 @@ def calculate_signature_gpg(context: Context) -> None:
         run(
             cmdline,
             env=env,
-            sandbox=context.sandbox(
-                binary="gpg",
-                options=options,
-            ),
+            sandbox=context.sandbox(options=options),
         )
 
 
@@ -2358,7 +2344,6 @@ def calculate_signature_sop(context: Context) -> None:
             stdin=i,
             stdout=o,
             sandbox=context.sandbox(
-                binary=context.config.openpgp_tool,
                 options=[
                     "--bind", context.config.key, "/signing-key.pgp",
                     "--bind", context.staging, workdir(context.staging),
@@ -2563,7 +2548,7 @@ def check_ukify(
 ) -> None:
     ukify = check_tool(config, "ukify", "/usr/lib/systemd/ukify", reason=reason, hint=hint)
 
-    v = systemd_tool_version(python_binary(config, binary=ukify), ukify, sandbox=config.sandbox)
+    v = systemd_tool_version(python_binary(config), ukify, sandbox=config.sandbox)
     if v < version:
         die(
             f"Found '{ukify}' with version {v} but version {version} or newer is required to {reason}.",
@@ -2794,9 +2779,7 @@ def run_sysusers(context: Context) -> None:
     with complete_step("Generating system users"):
         run(
             ["systemd-sysusers", "--root=/buildroot"],
-            sandbox=context.sandbox(
-                binary="systemd-sysusers", options=["--bind", context.root, "/buildroot"]
-            ),
+            sandbox=context.sandbox(options=["--bind", context.root, "/buildroot"]),
         )
 
 
@@ -2827,7 +2810,6 @@ def run_tmpfiles(context: Context) -> None:
             # as success by the systemd-tmpfiles service so we handle those as success as well.
             success_exit_status=(0, 65, 73),
             sandbox=context.sandbox(
-                binary="systemd-tmpfiles",
                 options=[
                     "--bind", context.root, "/buildroot",
                     # systemd uses acl.h to parse ACLs in tmpfiles snippets which uses the host's
@@ -2853,11 +2835,11 @@ def run_preset(context: Context) -> None:
     with complete_step("Applying presets…"):
         run(
             ["systemctl", "--root=/buildroot", "preset-all"],
-            sandbox=context.sandbox(binary="systemctl", options=["--bind", context.root, "/buildroot"]),
+            sandbox=context.sandbox(options=["--bind", context.root, "/buildroot"]),
         )
         run(
             ["systemctl", "--root=/buildroot", "--global", "preset-all"],
-            sandbox=context.sandbox(binary="systemctl", options=["--bind", context.root, "/buildroot"]),
+            sandbox=context.sandbox(options=["--bind", context.root, "/buildroot"]),
         )
 
 
@@ -2872,7 +2854,7 @@ def run_hwdb(context: Context) -> None:
     with complete_step("Generating hardware database"):
         run(
             ["systemd-hwdb", "--root=/buildroot", "--usr", "--strict", "update"],
-            sandbox=context.sandbox(binary="systemd-hwdb", options=["--bind", context.root, "/buildroot"]),
+            sandbox=context.sandbox(options=["--bind", context.root, "/buildroot"]),
         )
 
     # Remove any existing hwdb in /etc in favor of the one we just put in /usr.
@@ -2891,7 +2873,7 @@ def run_firstboot(context: Context) -> None:
     if password and not hashed:
         password = run(
             ["openssl", "passwd", "-stdin", "-6"],
-            sandbox=context.sandbox(binary="openssl"),
+            sandbox=context.sandbox(),
             input=password,
             stdout=subprocess.PIPE,
         ).stdout.strip()
@@ -2925,9 +2907,7 @@ def run_firstboot(context: Context) -> None:
     with complete_step("Applying first boot settings"):
         run(
             ["systemd-firstboot", "--root=/buildroot", "--force", *options],
-            sandbox=context.sandbox(
-                binary="systemd-firstboot", options=["--bind", context.root, "/buildroot"]
-            ),
+            sandbox=context.sandbox(options=["--bind", context.root, "/buildroot"]),
         )
 
         # Initrds generally don't ship with only /usr so there's not much point in putting the
@@ -2952,7 +2932,7 @@ def run_selinux_relabel(context: Context) -> None:
     with complete_step(f"Relabeling files using {policy} policy"):
         run(
             [setfiles, "-mFr", "/buildroot", "-c", binpolicy, fc, "/buildroot"],
-            sandbox=context.sandbox(binary=setfiles, options=["--bind", context.root, "/buildroot"]),
+            sandbox=context.sandbox(options=["--bind", context.root, "/buildroot"]),
             check=context.config.selinux_relabel == ConfigFeature.enabled,
         )
 
@@ -3017,7 +2997,6 @@ def have_cache(config: Config) -> bool:
                     input=new,
                     check=False,
                     sandbox=config.sandbox(
-                        binary="diff",
                         tools=False,
                         options=["--bind", manifest, workdir(manifest)],
                     ),
@@ -3577,10 +3556,9 @@ def copy_repository_metadata(config: Config, dst: Path) -> None:
 
                 def sandbox(
                     *,
-                    binary: Optional[PathString],
                     options: Sequence[PathString] = (),
                 ) -> AbstractContextManager[list[PathString]]:
-                    return config.sandbox(binary=binary, options=[*options, *exclude])
+                    return config.sandbox(options=[*options, *exclude])
 
                 copy_tree(src, subdst, sandbox=sandbox)
 
@@ -3796,7 +3774,6 @@ def run_sandbox(args: Args, config: Config) -> None:
         env=os.environ | {"MKOSI_IN_SANDBOX": "1"},
         log=False,
         sandbox=config.sandbox(
-            binary=cmdline[0],
             devices=True,
             network=True,
             relaxed=True,
@@ -3876,7 +3853,6 @@ def run_shell(args: Args, config: Config) -> None:
                 stdin=sys.stdin,
                 env=config.environment,
                 sandbox=config.sandbox(
-                    binary="systemd-repart",
                     network=True,
                     devices=True,
                     options=["--bind", fname, workdir(fname)],
@@ -3987,7 +3963,6 @@ def run_shell(args: Args, config: Config) -> None:
             env=os.environ | config.environment,
             log=False,
             sandbox=config.sandbox(
-                binary="systemd-nspawn",
                 devices=True,
                 network=True,
                 relaxed=True,
@@ -4029,7 +4004,6 @@ def run_systemd_tool(tool: str, args: Args, config: Config) -> None:
         env=os.environ | config.environment,
         log=False,
         sandbox=config.sandbox(
-            binary=tool_path,
             network=True,
             devices=config.output_format == OutputFormat.disk,
             relaxed=True,
@@ -4050,11 +4024,10 @@ def run_serve(args: Args, config: Config) -> None:
     """Serve the output directory via a tiny HTTP server"""
 
     run(
-        [python_binary(config, binary=None), "-m", "http.server", "8081"],
+        [python_binary(config), "-m", "http.server", "8081"],
         stdin=sys.stdin,
         stdout=sys.stdout,
         sandbox=config.sandbox(
-            binary=python_binary(config, binary=None),
             network=True,
             relaxed=True,
             options=["--chdir", config.output_dir_or_cwd()],
@@ -4244,7 +4217,6 @@ def run_clean_scripts(config: Config) -> None:
                     ["/work/clean"],
                     env=env | config.environment,
                     sandbox=config.sandbox(
-                        binary=None,
                         tools=False,
                         options=[
                             "--dir", "/work/src",

--- a/mkosi/archive.py
+++ b/mkosi/archive.py
@@ -50,7 +50,6 @@ def make_tar(src: Path, dst: Path, *, sandbox: SandboxProtocol = nosandbox) -> N
             stdout=f,
             # Make sure tar uses user/group information from the root directory instead of the host.
             sandbox=sandbox(
-                binary="tar",
                 options=[
                     "--ro-bind", src, workdir(src, sandbox),
                     *finalize_passwd_symlinks(workdir(src, sandbox)),
@@ -96,7 +95,6 @@ def extract_tar(
             *options,
         ],
         sandbox=sandbox(
-            binary="tar",
             # Make sure tar uses user/group information from the root directory instead of the host.
             options=[
                 "--ro-bind", src, workdir(src, sandbox),
@@ -138,7 +136,6 @@ def make_cpio(
             input="\0".join(os.fspath(f) for f in files),
             stdout=f,
             sandbox=sandbox(
-                binary="cpio",
                 options=[
                     "--ro-bind", src, workdir(src, sandbox),
                     *finalize_passwd_symlinks(workdir(src, sandbox))

--- a/mkosi/burn.py
+++ b/mkosi/burn.py
@@ -37,7 +37,6 @@ def run_burn(args: Args, config: Config) -> None:
             env=os.environ | config.environment,
             log=False,
             sandbox=config.sandbox(
-                binary="systemd-repart",
                 devices=True,
                 network=True,
                 relaxed=True,

--- a/mkosi/context.py
+++ b/mkosi/context.py
@@ -63,14 +63,12 @@ class Context:
     def sandbox(
         self,
         *,
-        binary: Optional[PathString],
         network: bool = False,
         devices: bool = False,
         scripts: Optional[Path] = None,
         options: Sequence[PathString] = (),
     ) -> AbstractContextManager[list[PathString]]:
         return self.config.sandbox(
-            binary=binary,
             network=network,
             devices=devices,
             scripts=scripts,

--- a/mkosi/curl.py
+++ b/mkosi/curl.py
@@ -24,7 +24,6 @@ def curl(config: Config, url: str, output_dir: Path) -> None:
             url,
         ],
         sandbox=config.sandbox(
-            binary="curl",
             network=True,
             options=["--bind", output_dir, workdir(output_dir), *finalize_crypto_mounts(config)],
         ),

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -169,7 +169,7 @@ class Installer(DistributionInstaller):
                     ["dpkg-deb", "--fsys-tarfile", "/dev/stdin"],
                     stdin=i,
                     stdout=o,
-                    sandbox=context.sandbox(binary="dpkg-deb"),
+                    sandbox=context.sandbox(),
                 )
                 extract_tar(
                     Path(o.name),
@@ -298,9 +298,7 @@ def fixup_os_release(context: Context) -> None:
                     f"/{candidate}.dpkg",
                     f"/{candidate}",
                 ],
-                sandbox=context.sandbox(
-                    binary="dpkg-divert", options=["--bind", context.root, "/buildroot"]
-                ),
+                sandbox=context.sandbox(options=["--bind", context.root, "/buildroot"]),
             )
 
         newosrelease.rename(osrelease)

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -115,7 +115,6 @@ class Installer(DistributionInstaller):
                         *(key.removeprefix("file://") for key in gpgkeys),
                     ],
                     sandbox=context.sandbox(
-                        binary="rpm",
                         options=[
                             "--bind", context.root, "/buildroot",
                             *finalize_crypto_mounts(context.config),

--- a/mkosi/installer/__init__.py
+++ b/mkosi/installer/__init__.py
@@ -135,7 +135,6 @@ class PackageManager:
         options: Sequence[PathString] = (),
     ) -> AbstractContextManager[list[PathString]]:
         return context.sandbox(
-            binary=cls.executable(context.config),
             network=True,
             options=[
                 "--bind", context.root, "/buildroot",

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -256,7 +256,6 @@ class Apt(PackageManager):
                 *(d.name for glob in PACKAGE_GLOBS for d in context.repository.glob(glob) if "deb" in glob),
             ],
             sandbox=context.sandbox(
-                binary="reprepro",
                 options=[
                     "--bind", context.repository, workdir(context.repository),
                     "--chdir", workdir(context.repository),

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -218,9 +218,7 @@ class Dnf(PackageManager):
     def createrepo(cls, context: Context) -> None:
         run(
             ["createrepo_c", workdir(context.repository)],
-            sandbox=context.sandbox(
-                binary="createrepo_c", options=["--bind", context.repository, workdir(context.repository)]
-            ),
+            sandbox=context.sandbox(options=["--bind", context.repository, workdir(context.repository)]),
         )
 
         (context.sandbox_tree / "etc/yum.repos.d/mkosi-local.repo").write_text(

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -191,10 +191,7 @@ class Pacman(PackageManager):
                     key=lambda p: GenericVersion(Path(p).name),
                 ),
             ],
-            sandbox=context.sandbox(
-                binary="repo-add",
-                options=["--bind", context.repository, workdir(context.repository)],
-            ),
+            sandbox=context.sandbox(options=["--bind", context.repository, workdir(context.repository)]),
         )
 
         (context.sandbox_tree / "etc/mkosi-local.conf").write_text(

--- a/mkosi/installer/rpm.py
+++ b/mkosi/installer/rpm.py
@@ -83,7 +83,7 @@ def setup_rpm(
     plugindir = Path(
         run(
             ["rpm", "--eval", "%{__plugindir}"],
-            sandbox=context.sandbox(binary="rpm"),
+            sandbox=context.sandbox(),
             stdout=subprocess.PIPE,
         ).stdout.strip()
     )

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -139,10 +139,7 @@ class Zypper(PackageManager):
     def createrepo(cls, context: Context) -> None:
         run(
             ["createrepo_c", workdir(context.repository)],
-            sandbox=context.sandbox(
-                binary="createrepo_c",
-                options=["--bind", context.repository, workdir(context.repository)],
-            ),
+            sandbox=context.sandbox(options=["--bind", context.repository, workdir(context.repository)]),
         )
 
         (context.sandbox_tree / "etc/zypp/repos.d/mkosi-local.repo").write_text(

--- a/mkosi/manifest.py
+++ b/mkosi/manifest.py
@@ -111,7 +111,7 @@ class Manifest:
             ],
             stdout=subprocess.PIPE,
             sandbox=(
-                self.context.sandbox(binary="rpm", options=["--ro-bind", self.context.root, "/buildroot"])
+                self.context.sandbox(options=["--ro-bind", self.context.root, "/buildroot"])
             ),
         )  # fmt: skip
 
@@ -158,10 +158,7 @@ class Manifest:
                     ],
                     stdout=subprocess.PIPE,
                     stderr=subprocess.DEVNULL,
-                    sandbox=self.context.sandbox(
-                        binary="rpm",
-                        options=["--ro-bind", self.context.root, "/buildroot"],
-                    ),
+                    sandbox=self.context.sandbox(options=["--ro-bind", self.context.root, "/buildroot"]),
                 )
                 changelog = c.stdout.strip()
                 source = SourcePackageManifest(srpm, changelog)
@@ -178,10 +175,7 @@ class Manifest:
                 "--showformat", r"${Package}\t${source:Package}\t${Version}\t${Architecture}\t${Installed-Size}\t${db-fsys:Last-Modified}\n",  # noqa: E501
             ],
             stdout=subprocess.PIPE,
-            sandbox=self.context.sandbox(
-                binary="dpkg-query",
-                options=["--ro-bind", self.context.root, "/buildroot"],
-            ),
+            sandbox=self.context.sandbox(options=["--ro-bind", self.context.root, "/buildroot"]),
         )  # fmt: skip
 
         packages = sorted(c.stdout.splitlines())

--- a/mkosi/partition.py
+++ b/mkosi/partition.py
@@ -39,7 +39,7 @@ def find_partitions(image: Path, *, sandbox: SandboxProtocol = nosandbox) -> lis
             ["systemd-repart", "--json=short", workdir(image, sandbox)],
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
-            sandbox=sandbox(binary="systemd-repart", options=["--ro-bind", image, workdir(image, sandbox)]),
+            sandbox=sandbox(options=["--ro-bind", image, workdir(image, sandbox)]),
         ).stdout
     )
     return [Partition.from_dict(d) for d in output]

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1227,8 +1227,12 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     but the `mkosi.tools/` directory is found in the local directory it is
     automatically used for this purpose with the root directory as target.
 
-    Note if a binary is found in any of the paths configured with
-    `ExtraSearchPaths=`, the binary will be executed on the host.
+    Note that binaries found in any of the paths configured with
+    `ExtraSearchPaths=` will be executed with `/usr/` from the tools
+    tree instead of from the host. If the host distribution or release
+    does not match the tools tree distribution or release respectively,
+    this might result in failures when trying to execute binaries from
+    any of the extra search paths.
 
     If set to `default`, mkosi will automatically add an extra tools tree
     image and use it as the tools tree.

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -397,14 +397,12 @@ class SandboxProtocol(Protocol):
     def __call__(
         self,
         *,
-        binary: Optional[PathString],
         options: Sequence[PathString] = (),
     ) -> AbstractContextManager[list[PathString]]: ...
 
 
 def nosandbox(
     *,
-    binary: Optional[PathString],
     options: Sequence[PathString] = (),
 ) -> AbstractContextManager[list[PathString]]:
     return contextlib.nullcontext([])

--- a/mkosi/sysupdate.py
+++ b/mkosi/sysupdate.py
@@ -51,7 +51,6 @@ def run_sysupdate(args: Args, config: Config) -> None:
             env=os.environ | config.environment,
             log=False,
             sandbox=config.sandbox(
-                binary=sysupdate,
                 devices=True,
                 network=True,
                 relaxed=True,

--- a/mkosi/vmspawn.py
+++ b/mkosi/vmspawn.py
@@ -115,7 +115,6 @@ def run_vmspawn(args: Args, config: Config) -> None:
             env=os.environ | config.environment,
             log=False,
             sandbox=config.sandbox(
-                binary=cmdline[0],
                 network=True,
                 devices=True,
                 relaxed=True,


### PR DESCRIPTION
Until now, there was always the implicit assumption that any paths configured with ExtraSearchPaths= contained binaries built against the host's /usr. With that assumption, it made sense to execute binaries found in these paths outside of the tools tree as otherwise you might end up with missing or out of date libraries if these are not available within the tools tree.

However, with the introduction of "mkosi sandbox", what I want to do in systemd is to have contributors build systemd within the sandbox and then use those binaries in mkosi to build the image. This means that the build directory configured with ExtrasSearchPaths= suddenly contains binaries built against the tools tree's /usr (if one is configured) instead of the host's /usr.

Given this new use case, let's get rid of the logic to not use the tools tree for binaries in ExtraSearchPaths=, instead, users of ExtraSearchPaths= using a tools tree will have to make sure to use a tools tree that mostly matches their host's /usr.