### PR TITLE
Use "tools" as the cache key for the default tools tree

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2409,12 +2409,15 @@ def print_output_size(path: Path) -> None:
 
 
 def cache_tree_paths(config: Config) -> tuple[Path, Path, Path]:
-    fragments = [config.distribution, config.release, config.architecture]
+    if config.image == "tools":
+        key = "tools"
+    else:
+        fragments = [config.distribution, config.release, config.architecture]
 
-    if config.image:
-        fragments += [config.image]
+        if config.image:
+            fragments += [config.image]
 
-    key = "~".join(str(s) for s in fragments)
+        key = "~".join(str(s) for s in fragments)
 
     assert config.cache_dir
     return (


### PR DESCRIPTION
Currently we still use `distribution~release~architecture`, which breaks checking if the cache is out of date, since we'll always check against the cache of the currently configured tools tree distribution, even if we used a different tools tree distribution to build the tools tree. Let's fix this by using the same cache key for all default tools trees.

This shouldn't introduce any performance regression as users are not expected to change the default tools tree distribution all the time unlike the target image distribution.