### PR TITLE
burn: Fail if no arguments are provided

### DIFF
--- a/mkosi/burn.py
+++ b/mkosi/burn.py
@@ -12,6 +12,9 @@ def run_burn(args: Args, config: Config) -> None:
     if config.output_format not in (OutputFormat.disk, OutputFormat.esp):
         die(f"{config.output_format} images cannot be burned to disk")
 
+    if not args.cmdline:
+        die("Please specify a device to burn the image to", hint="For example /dev/disk/by-id/usb-foobar")
+
     fname = config.output_dir_or_cwd() / config.output
 
     if len(args.cmdline) != 1:


### PR DESCRIPTION
If no arguments are provided systemd-repart will operate on the device backing the rootfs which in the case of burn we definitely don't want to do most of the time so let's fail unless a device is explicitly provided.