### PR TITLE
Wait until sandbox exec()'s specified command before continuing

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -642,7 +642,6 @@ def script_maybe_chroot_sandbox(
             "--chdir", "/work/src",
             *(["--ro-bind-try", "/etc/resolv.conf", "/etc/resolv.conf"] if network else []),
             *(["--suppress-chown"] if suppress_chown else []),
-            "--",
         ],
         "mkosi-as-caller": mkosi_as_caller(),
         **context.config.distribution.package_manager(context.config).scripts(context),

--- a/mkosi/installer/__init__.py
+++ b/mkosi/installer/__init__.py
@@ -123,7 +123,6 @@ class PackageManager:
             "--bind", "/var/tmp", "/buildroot/var/tmp",
             *apivfs_options(),
             *cls.options(root="/buildroot"),
-            "--",
         ]  # fmt: skip
 
     @classmethod

--- a/mkosi/resources/man/mkosi-sandbox.1.md
+++ b/mkosi/resources/man/mkosi-sandbox.1.md
@@ -112,6 +112,11 @@ host system.
 `--unshare-ipc`
 :   Specifying this option makes `mkosi-sandbox` unshare an IPC namespace if possible.
 
+`--exec-fd FD`
+:   The specified `FD` will be closed when `mkosi-sandbox` calls `execvp()`. This is useful
+    to wait until all setup logic has completed before continuing execution in the parent
+    process invoking `mkosi-sandbox`.
+
 `--version`
 :   Show package version.
 

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -261,6 +261,9 @@ def spawn(
     with sandbox as sbx:
         prefix = [os.fspath(x) for x in sbx]
 
+        if prefix:
+            prefix += ["--"]
+
         try:
             with subprocess.Popen(
                 [*prefix, *cmdline],
@@ -605,7 +608,7 @@ def sandbox_cmd(
 
         if not overlay and not relaxed:
             tmp = stack.enter_context(vartmpdir())
-            yield [*cmdline, "--bind", tmp, "/var/tmp", "--dir", "/tmp", "--dir", "/run", *options, "--"]
+            yield [*cmdline, "--bind", tmp, "/var/tmp", "--dir", "/tmp", "--dir", "/run", *options]
             return
 
         for d in ("etc", "opt"):
@@ -645,7 +648,7 @@ def sandbox_cmd(
             tmp = stack.enter_context(vartmpdir())
             cmdline += ["--bind", tmp, "/var/tmp"]
 
-        yield [*cmdline, *options, "--"]
+        yield [*cmdline, *options]
 
 
 def apivfs_options(*, root: Path = Path("/buildroot")) -> list[PathString]:
@@ -700,7 +703,7 @@ def chroot_cmd(
         cmdline += ["--ro-bind", "/etc/resolv.conf", "/etc/resolv.conf"]
 
     with vartmpdir() as dir:
-        yield [*cmdline, "--bind", dir, "/var/tmp", *options, "--"]
+        yield [*cmdline, "--bind", dir, "/var/tmp", *options]
 
 
 def finalize_interpreter(tools: bool) -> str:


### PR DESCRIPTION
Let's wait in spawn() until all setup logic has completed before
continuing if a sandbox is used. When using spawn() without run(),
this helps us fail early if the setup logic fails instead of later
on if we're not checking the result of the spawn() command immediately
afterwards.

As a side effect, this also acts as a synchronization point when using
systemd-run --scope where when spawn() returns, we can be 100% sure that
the scope has been created, which is important when calling RegisterMachine
from systemd-machined which does the wrong thing if the scope for the specified
machine does not yet exist and ends up killing the parent unit (often the user
session) instead of just the virtual machine.