### PR TITLE
Always check tools for build at the same place

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4725,7 +4725,9 @@ def run_verb(args: Args, images: Sequence[Config], *, resources: Path) -> None:
 
     for i, config in enumerate(images):
         with prepend_to_environ_path(config):
-            check_tools(config, args.verb)
+            if args.verb != Verb.build:
+                check_tools(config, args.verb)
+
             images[i] = config = run_configure_scripts(config)
 
     # The images array has been modified so we need to reevaluate last again.
@@ -4775,8 +4777,7 @@ def run_verb(args: Args, images: Sequence[Config], *, resources: Path) -> None:
                     continue
 
                 with prepend_to_environ_path(config):
-                    if args.verb != Verb.build:
-                        check_tools(config, Verb.build)
+                    check_tools(config, Verb.build)
 
                     check_inputs(config)
                     ensure_directories_exist(config)


### PR DESCRIPTION
Let's only check non-build verb tools early and check build verb tools at the same place regardless of whether the verb is build or not to keep things more consistent.

As a side effect this allows building tools from source to do the build in sync scripts which is done in
https://github.com/davide125/arcadeos/blob/main/mkosi.sync.