### PR TITLE
Drop support for pesign secure boot signtool

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -173,7 +173,6 @@ class QemuVsockCID(enum.IntEnum):
 class SecureBootSignTool(StrEnum):
     auto = enum.auto()
     sbsign = enum.auto()
-    pesign = enum.auto()
     systemd_sbsign = enum.auto()
 
 

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1138,8 +1138,8 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     UEFI kernel image, if `SecureBoot=` is used.
 
 `SecureBootSignTool=`, `--secure-boot-sign-tool`
-:   Tool to use to sign secure boot PE binaries. Takes one of `systemd-sbsign`, `sbsign`, `pesign` or `auto`.
-    Defaults to `auto`. If set to `auto`, either `systemd-sbsign`, `sbsign` or `pesign` are used if
+:   Tool to use to sign secure boot PE binaries. Takes one of `systemd-sbsign`, `sbsign` or `auto`.
+    Defaults to `auto`. If set to `auto`, either `systemd-sbsign` or `sbsign` are used if
     available, with `systemd-sbsign` being preferred.
 
 `Verity=`, `--verity=`
@@ -1288,7 +1288,6 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     | `pkcs11-provider`       | ✓      |        | ✓      | ✓    | ✓      | ✓    | ✓        |
     | `sed`                   | ✓      | ✓      | ✓      | ✓    | ✓      | ✓    | ✓        |
     | `pacman`                | ✓      | ✓      | ✓      | ✓    | ✓      | ✓    |          |
-    | `pesign`                | ✓      | ✓      | ✓      | ✓    | ✓      | ✓    | ✓        |
     | `policycoreutils`       | ✓      | ✓      | ✓      | ✓    | ✓      |      | ✓        |
     | `qemu`                  | ✓      | ✓      | ✓      | ✓    | ✓      | ✓    | ✓        |
     | `sbsigntools`           | ✓      | ✓      | ✓      | ✓    | ✓      | ✓    | ✓        |

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-arch.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-arch.conf
@@ -21,7 +21,6 @@ Packages=
         libseccomp
         openssh
         pacman
-        pesign
         pipewire
         pipewire-audio
         pkcs11-provider

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-azure-centos-fedora/mkosi.conf.d/10-uefi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-azure-centos-fedora/mkosi.conf.d/10-uefi.conf
@@ -7,4 +7,3 @@ HostArchitecture=|arm64
 [Content]
 Packages=
         edk2-ovmf
-        pesign

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
@@ -31,7 +31,6 @@ Packages=
         openssh-client
         ovmf
         pacman-package-manager
-        pesign
         policycoreutils
         python3-cryptography
         python3-pefile

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-opensuse.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-opensuse.conf
@@ -21,7 +21,6 @@ Packages=
         openssh-clients
         ovmf
         patterns-base-minimal_base
-        pesign
         pkcs11-provider
         policycoreutils
         python3-cryptography

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -312,7 +312,7 @@ def test_config() -> None:
                 "Source": "",
                 "Type": "file"
             },
-            "SecureBootSignTool": "pesign",
+            "SecureBootSignTool": "systemd-sbsign",
             "Seed": "7496d7d8-7f08-4a2b-96c6-ec8c43791b60",
             "ShimBootloader": "none",
             "Sign": false,
@@ -538,7 +538,7 @@ def test_config() -> None:
         secure_boot_certificate_source=CertificateSource(type=CertificateSourceType.file),
         secure_boot_key=Path("/path/to/keyfile"),
         secure_boot_key_source=KeySource(type=KeySourceType.file),
-        secure_boot_sign_tool=SecureBootSignTool.pesign,
+        secure_boot_sign_tool=SecureBootSignTool.systemd_sbsign,
         seed=uuid.UUID("7496d7d8-7f08-4a2b-96c6-ec8c43791b60"),
         selinux_relabel=ConfigFeature.disabled,
         shim_bootloader=ShimBootloader.none,


### PR DESCRIPTION
sbsigntools is packaged in EPEL now and in the future we're looking to standardize solely on systemd-sbsign so let's already drop support for pesign which was only really useful on CentOS Stream because it didn't have sbsigntools which it does have now.