### PR TITLE
Add option to control whether to register with machined

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3803,6 +3803,8 @@ def run_shell(args: Args, config: Config) -> None:
     for k, v in finalize_credentials(config).items():
         cmdline += [f"--set-credential={k}:{v}"]
 
+    cmdline += ["--register", yes_no(config.register)]
+
     with contextlib.ExitStack() as stack:
         # Make sure the latest nspawn settings are always used.
         if config.nspawn_settings:

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1862,6 +1862,7 @@ class Config:
     ephemeral: bool
     credentials: dict[str, str]
     kernel_command_line_extra: list[str]
+    register: bool
     runtime_trees: list[ConfigTree]
     runtime_size: Optional[int]
     runtime_scratch: ConfigFeature
@@ -3648,6 +3649,14 @@ SETTINGS: list[ConfigSetting[Any]] = [
         # arguments.
         help=argparse.SUPPRESS,
     ),
+    ConfigSetting(
+        dest="register",
+        metavar="BOOL",
+        section="Runtime",
+        parse=config_parse_boolean,
+        default=True,
+        help="Register booted vm/container with systemd-machined",
+    ),
 ]
 SETTINGS_LOOKUP_BY_NAME = {name: s for s in SETTINGS for name in [s.name, *s.compat_names]}
 SETTINGS_LOOKUP_BY_DEST = {s.dest: s for s in SETTINGS}
@@ -4887,6 +4896,7 @@ def summary(config: Config) -> str:
                     SSH Certificate: {none_to_none(config.ssh_certificate)}
                             Machine: {config.machine_or_name()}
                     Forward Journal: {none_to_none(config.forward_journal)}
+       Register guest with machined: {yes_no(config.register)}
 
             Virtual Machine Monitor: {config.vmm}
                            QEMU GUI: {yes_no(config.qemu_gui)}

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -918,8 +918,10 @@ def scope_cmd(
 
 
 def register_machine(config: Config, pid: int, fname: Path) -> None:
-    if os.getuid() != 0 or (
-        "DBUS_SYSTEM_ADDRESS" not in os.environ and not Path("/run/dbus/system_bus_socket").exists()
+    if (
+        not config.register
+        or os.getuid() != 0
+        or ("DBUS_SYSTEM_ADDRESS" not in os.environ and not Path("/run/dbus/system_bus_socket").exists())
     ):
         return
 

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1801,6 +1801,10 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     Note that `Ephemeral=` has to be enabled to start multiple instances
     of the same image.
 
+`Register=`, `--register=`
+:   Takes a boolean value. Enabled by default. Specifies whether to register
+    the vm/container with systemd-machined.
+
 `ForwardJournal=`, `--forward-journal=`
 :   Specify the path to which journal logs from containers and virtual
     machines should be forwarded. If the path has the `.journal`

--- a/mkosi/vmspawn.py
+++ b/mkosi/vmspawn.py
@@ -59,6 +59,7 @@ def run_vmspawn(args: Args, config: Config) -> None:
         "--vsock", config.qemu_vsock.to_tristate(),
         "--tpm", config.qemu_swtpm.to_tristate(),
         "--secure-boot", yes_no(config.secure_boot),
+        "--register", yes_no(config.register),
     ]  # fmt: skip
 
     if config.runtime_network == Network.user:

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -262,6 +262,7 @@ def test_config() -> None:
             "QemuSwtpm": "auto",
             "QemuVsock": "enabled",
             "QemuVsockConnectionId": -2,
+            "Register": true,
             "Release": "53",
             "RemoveFiles": [],
             "RemovePackages": [
@@ -512,6 +513,7 @@ def test_config() -> None:
         qemu_swtpm=ConfigFeature.auto,
         qemu_vsock=ConfigFeature.enabled,
         qemu_vsock_cid=QemuVsockCID.hash,
+        register=True,
         release="53",
         remove_files=[],
         remove_packages=["all"],


### PR DESCRIPTION
On an ephemeral test runner it is useless churn to register the guest, and can trigger nasty bugs like the one where machined kills the user session. Add a config knob, enabled by default, so that it can be disabled where it's not useful.