### PR TITLE
Parse profiles in subimages as well

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -417,6 +417,20 @@ def test_profiles(tmp_path: Path) -> None:
     assert config.profiles == ["profile", "abc"]
     assert config.distribution == Distribution.opensuse
 
+    # Check that mkosi.profiles/ is parsed in subimages as well.
+    (d / "mkosi.images/subimage/mkosi.profiles").mkdir(parents=True)
+    (d / "mkosi.images/subimage/mkosi.profiles/abc.conf").write_text(
+        """
+        [Build]
+        Environment=Image=%I
+        """
+    )
+
+    with chdir(d):
+        _, [subimage, config] = parse_config()
+
+    assert subimage.environment["Image"] == "subimage"
+
 
 def test_override_default(tmp_path: Path) -> None:
     d = tmp_path


### PR DESCRIPTION
Let's parse from mkosi.profiles in subimages as well. We'll still insist that the profiles used are set in the main image though. To make this work we have to remove the check to see if a profile exists or not, since it might not exist in every mkosi.profiles/ directory that we parse. At the same time we remove the restriction that profiles are set before we parse mkosi.conf.d/ since this isn't really useful anymore now that we parse profiles last and not first anymore. This allows us to get rid of the concept of immutable settings.

Fixes #3307