### PR TITLE
Make CDROM an upper case option

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3622,6 +3622,7 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ),
     ConfigSetting(
         dest="cdrom",
+        name="CDROM",
         metavar="BOOLEAN",
         nargs="?",
         section="Runtime",

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3589,6 +3589,7 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ),
     ConfigSetting(
         dest="vsock",
+        name="VSock",
         metavar="FEATURE",
         nargs="?",
         section="Runtime",
@@ -3599,7 +3600,7 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ),
     ConfigSetting(
         dest="vsock_cid",
-        name="VsockConnectionId",
+        name="VSockCID",
         long="--vsock-cid",
         metavar="NUMBER|auto|hash",
         section="Runtime",

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1611,7 +1611,7 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 :   Configure whether to use a virtual TPM when booting a virtual machine.
     Takes a boolean value or `auto`. Defaults to `auto`.
 
-`Cdrom=`, `--cdrom=`
+`CDROM=`, `--cdrom=`
 :   Configures whether to attach the image as a CD-ROM device when booting a
     virtual machine. Takes a boolean. Defaults to `no`.
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -118,10 +118,10 @@ def test_config() -> None:
                 }
             ],
             "BuildSourcesEphemeral": true,
+            "CDROM": false,
             "CPUs": 2,
             "CacheDirectory": "/is/this/the/cachedir",
             "CacheOnly": "always",
-            "Cdrom": false,
             "Checksum": false,
             "CleanPackageMetadata": "auto",
             "CleanScripts": [

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -384,6 +384,8 @@ def test_config() -> None:
                 "PROPERTY=VALUE"
             ],
             "UseSubvolumes": "auto",
+            "VSock": "enabled",
+            "VSockCID": -2,
             "Verity": "enabled",
             "VerityCertificate": "/path/to/cert",
             "VerityCertificateSource": {
@@ -402,8 +404,6 @@ def test_config() -> None:
             "VolatilePackages": [
                 "abc"
             ],
-            "Vsock": "enabled",
-            "VsockConnectionId": -2,
             "WithDocs": true,
             "WithNetwork": false,
             "WithRecommends": true,


### PR DESCRIPTION
It's an abbrevation so let's make it upper case similar to TPM and KVM.