### PR TITLE
Modules and firmware includes

### DIFF
--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1016,10 +1016,10 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 `KernelModulesInclude=`, `--kernel-modules-include=`
 :   Takes a list of regex patterns that specify kernel modules to include in the image. Patterns should be
-    relative to the `/usr/lib/modules/<kver>/kernel` directory. mkosi checks for a match anywhere in the module
-    path (e.g. `i915` will match against `drivers/gpu/drm/i915.ko`). All modules that match any of the
-    specified patterns are included in the image. All module and firmware dependencies of the matched modules
-    are included in the image as well.
+    relative to `/usr/lib/modules/<kver>/<subdir>` paths. mkosi checks for a match anywhere in the module path
+    (e.g. `i915` will match against `drivers/gpu/drm/i915.ko`). All modules that match any of the specified
+    patterns are included in the image. All module and firmware dependencies of the matched modules are included
+    in the image as well.
 
     If the special value `default` is used, the default kernel modules
     defined in the `mkosi-initrd` configuration are included as well.

--- a/tests/test_initrd.py
+++ b/tests/test_initrd.py
@@ -225,9 +225,9 @@ def test_initrd_size(config: ImageConfig) -> None:
         maxsize = 1024**2 * {
             Distribution.fedora: 63,
             Distribution.debian: 62,
-            Distribution.ubuntu: 56,
+            Distribution.ubuntu: 57,
             Distribution.arch: 83,
             Distribution.opensuse: 64,
-        }.get(config.distribution, 57)
+        }.get(config.distribution, 58)
 
         assert (Path(image.output_dir) / "image.initrd").stat().st_size <= maxsize


### PR DESCRIPTION
In order to include out-of-tree modules (and their required firmware) installed in an `updates` subfolder, a special case is added when a file is found below that folder.

Furthermore, a firmware file required by a module might be a symbolic link to the real firmware file. Add handling of this case too.