### PR TITLE
Beef up DNS resolution a little

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3442,7 +3442,10 @@ def make_extension_or_portable_image(context: Context, output: Path) -> None:
 
 
 def finalize_staging(context: Context) -> None:
-    rmtree(*(context.config.output_dir_or_cwd() / f.name for f in context.staging.iterdir()))
+    rmtree(
+        *(context.config.output_dir_or_cwd() / f.name for f in context.staging.iterdir()),
+        sandbox=context.sandbox,
+    )
 
     for f in context.staging.iterdir():
         if f.is_symlink():
@@ -3624,7 +3627,7 @@ def build_image(context: Context) -> None:
 
         if context.config.output_format == OutputFormat.none:
             finalize_staging(context)
-            rmtree(context.root)
+            rmtree(context.root, sandbox=context.sandbox)
             return
 
         if wantrepo:
@@ -3731,7 +3734,7 @@ def build_image(context: Context) -> None:
     finalize_staging(context)
 
     if not context.args.debug_workspace:
-        rmtree(context.root)
+        rmtree(context.root, sandbox=context.sandbox)
 
     print_output_size(context.config.output_dir_or_cwd() / context.config.output_with_compression)
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1077,6 +1077,29 @@ def install_sandbox_trees(config: Config, dst: Path) -> None:
     Path(dst / "etc/resolv.conf").unlink(missing_ok=True)
     Path(dst / "etc/resolv.conf").touch()
 
+    if not (dst / "etc/nsswitch.conf").exists():
+        (dst / "etc/nsswitch.conf").write_text(
+            textwrap.dedent(
+                """\
+                passwd:     files
+                shadow:     files
+                group:      files
+                hosts:      files myhostname resolve [!UNAVAIL=return] dns
+                services:   files
+                netgroup:   files
+                automount:  files
+
+                aliases:    files
+                ethers:     files
+                gshadow:    files
+                networks:   files dns
+                protocols:  files
+                publickey:  files
+                rpc:        files
+                """
+            )
+        )
+
     Path(dst / "etc/static").unlink(missing_ok=True)
     if (config.tools() / "etc/static").is_symlink():
         (dst / "etc/static").symlink_to((config.tools() / "etc/static").readlink())

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
@@ -27,6 +27,8 @@ Packages=
         libcryptsetup12
         libseccomp2
         libtss2-dev
+        libnss-resolve
+        libnss-myhostname
         makepkg
         openssh-client
         ovmf

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -609,8 +609,10 @@ def sandbox_cmd(
         else:
             cmdline += ["--dev", "/dev"]
 
-        if network and Path("/etc/resolv.conf").exists():
-            cmdline += ["--ro-bind", "/etc/resolv.conf", "/etc/resolv.conf"]
+        if network:
+            for p in (Path("/etc/resolv.conf"), Path("/run/systemd/resolve")):
+                if p.exists():
+                    cmdline += ["--ro-bind", p, p]
 
         home = None
 
@@ -734,8 +736,10 @@ def chroot_cmd(
         *chroot_options(),
     ]  # fmt: skip
 
-    if network and Path("/etc/resolv.conf").exists():
-        cmdline += ["--ro-bind", "/etc/resolv.conf", "/etc/resolv.conf"]
+    if network:
+        for p in (Path("/etc/resolv.conf"), Path("/run/systemd/resolve")):
+            if p.exists():
+                cmdline += ["--ro-bind", p, p]
 
     with vartmpdir() as dir:
         yield [*cmdline, "--bind", dir, "/var/tmp", *options]


### PR DESCRIPTION
Let's write a basic nsswitch.conf that makes use of libnss-resolve and bind mount the systemd-resolved socket into the sandbox if available.