### PR TITLE
apt: drop usr-is-merged from essential list

### DIFF
--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -142,7 +142,6 @@ class Installer(DistributionInstaller):
                     "-oDebug::pkgDPkgPm=1",
                     f"-oDPkg::Pre-Install-Pkgs::=cat >{workdir(Path(f.name))}",
                     "?essential",
-                    "?exact-name(usr-is-merged)",
                     "base-files",
                 ],
                 options=["--bind", f.name, workdir(Path(f.name))],


### PR DESCRIPTION
It is no longer required, base-files now does the work, drop it