### PR TITLE
mkosi-initrd: Remove /var/cache and /var/log from the initrd

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -33,8 +33,8 @@ RemoveFiles=
         /usr/lib/modules/*/vmlinux*
         /usr/lib/modules/*/System.map
 
-        # This file is not reproducible so let's remove it to increase reproducibility of initrds.
-        /var/cache/ldconfig/aux-cache
+        /var/cache
+        /var/log
 
 # Configure locale explicitly so that all other locale data is stripped on distros whose package manager supports it.
 Locale=C.UTF-8


### PR DESCRIPTION
Fixes #3331