### PR TITLE
Add option to save the BuildSourcesEphemeral overlay.

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -729,7 +729,10 @@ def run_prepare_scripts(context: Context, build: bool) -> None:
 
     with (
         mount_build_overlay(context) if build else contextlib.nullcontext(),
-        finalize_source_mounts(context.config, ephemeral=context.config.build_sources_ephemeral) as sources,
+        finalize_source_mounts(
+            context.config,
+            ephemeral=bool(context.config.build_sources_ephemeral),
+        ) as sources,
         finalize_config_json(context.config) as json,
     ):
         if build:
@@ -871,7 +874,10 @@ def run_postinst_scripts(context: Context) -> None:
     env |= context.config.environment
 
     with (
-        finalize_source_mounts(context.config, ephemeral=context.config.build_sources_ephemeral) as sources,
+        finalize_source_mounts(
+            context.config,
+            ephemeral=bool(context.config.build_sources_ephemeral),
+        ) as sources,
         finalize_config_json(context.config) as json,
     ):
         for script in context.config.postinst_scripts:
@@ -937,7 +943,10 @@ def run_finalize_scripts(context: Context) -> None:
     env |= context.config.environment
 
     with (
-        finalize_source_mounts(context.config, ephemeral=context.config.build_sources_ephemeral) as sources,
+        finalize_source_mounts(
+            context.config,
+            ephemeral=bool(context.config.build_sources_ephemeral),
+        ) as sources,
         finalize_config_json(context.config) as json,
     ):
         for script in context.config.finalize_scripts:
@@ -989,7 +998,10 @@ def run_postoutput_scripts(context: Context) -> None:
         env["PROFILES"] = " ".join(context.config.profiles)
 
     with (
-        finalize_source_mounts(context.config, ephemeral=context.config.build_sources_ephemeral) as sources,
+        finalize_source_mounts(
+            context.config,
+            ephemeral=bool(context.config.build_sources_ephemeral),
+        ) as sources,
         finalize_config_json(context.config) as json,
     ):
         for script in context.config.postoutput_scripts:

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1476,11 +1476,16 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     working directory is mounted to `/work/src`.
 
 `BuildSourcesEphemeral=`, `--build-sources-ephemeral=`
-:   Takes a boolean. Disabled by default. Configures whether changes to
-    source directories (the working directory and configured using
-    `BuildSources=`) are persisted. If enabled, all source directories
-    will be reset to their original state every time after running all
+:   Takes a boolean or the special value `buildcache`. Disabled by default. Configures whether changes to
+    source directories, the working directory and configured using `BuildSources=`, are persisted. If
+    enabled, all source directories will be reset to their original state every time after running all
     scripts of a specific type (except sync scripts).
+
+    💥💣💥 If set to `buildcache` the overlay is not discarded when running build scripts, but saved to the
+    build directory, configured via `BuildDirectory=`, and will be reused on subsequent runs. The overlay is
+    still discarded for all other scripts. This option can be used to implement more advanced caching of
+    builds, but can lead to unexpected states of the source directory. When using this option, a build
+    directory must be configured. 💥💣💥
 
 `Environment=`, `--environment=`
 :   Adds variables to the environment that package managers and the

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -14,6 +14,7 @@ from mkosi.config import (
     ArtifactOutput,
     BiosBootloader,
     Bootloader,
+    BuildSourcesEphemeral,
     Cacheonly,
     CertificateSource,
     CertificateSourceType,
@@ -117,7 +118,7 @@ def test_config() -> None:
                     "Target": "/frob"
                 }
             ],
-            "BuildSourcesEphemeral": true,
+            "BuildSourcesEphemeral": "yes",
             "CDROM": false,
             "CPUs": 2,
             "CacheDirectory": "/is/this/the/cachedir",
@@ -424,7 +425,7 @@ def test_config() -> None:
         build_dir=None,
         build_packages=["pkg1", "pkg2"],
         build_scripts=[Path("/path/to/buildscript")],
-        build_sources_ephemeral=True,
+        build_sources_ephemeral=BuildSourcesEphemeral.yes,
         build_sources=[ConfigTree(Path("/qux"), Path("/frob"))],
         cache_dir=Path("/is/this/the/cachedir"),
         cacheonly=Cacheonly.always,


### PR DESCRIPTION
This systematises a trick Daan showed me a while back and that I've been using most everywhere since. Having it in mkosi itself makes it easier to use for everybody.