### PR TITLE
Add missing continue if pandoc is not available

### DIFF
--- a/mkosi/documentation.py
+++ b/mkosi/documentation.py
@@ -29,7 +29,8 @@ def show_docs(
                 return
             elif form == DocFormat.pandoc:
                 if not find_binary("pandoc"):
-                    logging.error("pandoc is not available")
+                    logging.warn("pandoc is not available")
+                    continue
                 pandoc = run(
                     ["pandoc", "-t", "man", "-s", resources / f"man/{manual}.{man_chapter}.md"],
                     stdout=subprocess.PIPE,


### PR DESCRIPTION
Without the continue, the run on the next line will call die if pandoc is not available, thus breaking the fallback for subsequent formats.