### PR TITLE
apt: avoid ?exact-name for systemd packages

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
@@ -10,8 +10,6 @@ Packages=
         kmod     # Not pulled in as a dependency on Debian/Ubuntu
         dmsetup  # Not pulled in as a dependency on Debian/Ubuntu
 
-        ?exact-name(systemd-cryptsetup)
-        ?exact-name(systemd-repart)
         libcryptsetup12
 
         # xfsprogs pulls in python on Debian (???) and XFS generally

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf.d/10-systemd-cryptsetup.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf.d/10-systemd-cryptsetup.conf
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[TriggerMatch]
+Distribution=debian
+Release=!bullseye
+Release=!bookworm
+
+[TriggerMatch]
+Distribution=ubuntu
+Release=!jammy
+Release=!noble
+
+[TriggerMatch]
+Distribution=kali
+
+[Content]
+Packages=systemd-cryptsetup

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf.d/10-systemd-repart.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf.d/10-systemd-repart.conf
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[TriggerMatch]
+Distribution=debian
+Release=!bullseye
+Release=!bookworm
+
+[TriggerMatch]
+Distribution=ubuntu
+
+[TriggerMatch]
+Distribution=kali
+
+[Content]
+Packages=systemd-repart

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
@@ -10,9 +10,6 @@ Packages=
         ?exact-name(distribution-gpg-keys)
         ?exact-name(grub-pc-bin)
         ?exact-name(kali-archive-keyring)
-        ?exact-name(systemd-boot)
-        ?exact-name(systemd-repart)
-        ?exact-name(systemd-ukify)
         ?exact-name(virtiofsd)
         apt
         archlinux-keyring

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf.d/systemd-boot.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf.d/systemd-boot.conf
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[TriggerMatch]
+Distribution=debian
+Release=!bullseye
+
+[TriggerMatch]
+Distribution=ubuntu
+Release=!jammy
+
+[TriggerMatch]
+Distribution=kali
+
+[Content]
+Packages=systemd-boot

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf.d/systemd-repart.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf.d/systemd-repart.conf
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[TriggerMatch]
+Distribution=debian
+Release=!bullseye
+Release=!bookworm
+
+[TriggerMatch]
+Distribution=ubuntu
+
+[TriggerMatch]
+Distribution=kali
+
+[Content]
+Packages=systemd-repart

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf.d/systemd-ukify.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf.d/systemd-ukify.conf
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[TriggerMatch]
+Distribution=debian
+Release=!bullseye
+Release=!bookworm
+
+[TriggerMatch]
+Distribution=ubuntu
+Release=!jammy
+
+[TriggerMatch]
+Distribution=kali
+
+[Content]
+Packages=systemd-ukify

--- a/mkosi/resources/mkosi-vm/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-vm/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
@@ -7,8 +7,6 @@ Distribution=|ubuntu
 
 [Content]
 Packages=
-        ?exact-name(systemd-boot)
-        ?exact-name(systemd-resolved)
         bash
         dbus-broker
         iproute2

--- a/mkosi/resources/mkosi-vm/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/systemd-boot.conf
+++ b/mkosi/resources/mkosi-vm/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/systemd-boot.conf
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[TriggerMatch]
+Distribution=debian
+Release=!bullseye
+
+[TriggerMatch]
+Distribution=ubuntu
+Release=!jammy
+
+[TriggerMatch]
+Distribution=kali
+
+[Content]
+Packages=systemd-boot

--- a/mkosi/resources/mkosi-vm/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/systemd-resolved.conf
+++ b/mkosi/resources/mkosi-vm/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/systemd-resolved.conf
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[TriggerMatch]
+Distribution=debian
+Release=!bullseye
+
+[TriggerMatch]
+Distribution=ubuntu
+Release=!jammy
+
+[TriggerMatch]
+Distribution=kali
+
+[Content]
+Packages=systemd-resolved


### PR DESCRIPTION
There is a strange interaction between ?exact-name, apt repositories generated by OBS and multiple architectures, that breaks installing packages:

```
$ apt install --dry-run '?exact-name(systemd-cryptsetup)' NOTE: This is only a simulation!
      apt needs root privileges for real execution.
      Keep also in mind that locking is deactivated,
      so don't depend on the relevance to the real current situation!

systemd-cryptsetup is already the newest version (257.999+731+g8c5b35957-0). Some packages could not be installed. This may mean that you have requested an impossible situation or if you are using the unstable distribution that some required packages have not yet been created or been moved out of Incoming.
The following information may help to resolve the situation:

Unsatisfied dependencies:
 systemd-cryptsetup : Conflicts: systemd-cryptsetup:i386 but 257.999+731+g8c5b35957-0 is to be installed
                      Conflicts: systemd-cryptsetup:arm64 but 257.999+731+g8c5b35957-0 is to be installed
 systemd-cryptsetup:i386 : Conflicts: systemd-cryptsetup but 257.999+731+g8c5b35957-0 is to be installed
                           Conflicts: systemd-cryptsetup:arm64 but 257.999+731+g8c5b35957-0 is to be installed
 systemd-cryptsetup:arm64 : Depends: libc6:arm64 (>= 2.38) but it is not installable
                            Depends: libcryptsetup12:arm64 (>= 2:2.7) but it is not installable
                            Depends: libssl3t64:arm64 (>= 3.0.0) but it is not installable
                            Depends: libsystemd-shared:arm64 (= 257.999+731+g8c5b35957-0) but it is not going to be installed
                            Conflicts: systemd-cryptsetup but 257.999+731+g8c5b35957-0 is to be installed
                            Conflicts: systemd-cryptsetup:i386 but 257.999+731+g8c5b35957-0 is to be installed
Error: Unable to correct problems, you have held broken packages.
```

It seems ?exact-name selects _all_ available packages, unless an architecture is specified:

```
$ apt install --dry-run '?exact-name(systemd-cryptsetup:amd64)' NOTE: This is only a simulation!
      apt needs root privileges for real execution.
      Keep also in mind that locking is deactivated,
      so don't depend on the relevance to the real current situation!

Summary:
  Upgrading: 0, Installing: 0, Removing: 0, Not Upgrading: 0
```

But this only happens with the repository metadata format generated on OBS. There are multiple formats, apparently.

https://download.opensuse.org/repositories/home:/bluca:/systemd/Debian_Testing/

So either we set the specific architecture in the common mkosi.conf, or we need a separate mkosi.conf with a trigger to filter out releases where the packages are not available.
I chose the latter as it the filters are fixed, while adding by architecture means every time a new arch is added, it needs to be duplicated.

This is only necessary for packages that are hosted on OBS, ie: the systemd ones.