### PR TITLE
Specify --install-source=image when installing systemd-boot

### DIFF
--- a/mkosi/bootloader.py
+++ b/mkosi/bootloader.py
@@ -654,6 +654,7 @@ def install_systemd_boot(context: Context) -> None:
         "bootctl",
         "install",
         "--root=/buildroot",
+        "--install-source=image",
         "--all-architectures",
         "--no-variables",
     ]


### PR DESCRIPTION
Let's make sure we don't try to pick up EFI binaries from the host.