### PR TITLE
ci: Disable Azure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,6 @@ jobs:
           - fedora
           - opensuse
           - ubuntu
-          - azure
         tools:
           - arch
           - debian


### PR DESCRIPTION
They're so flaky that I don't even look at them anymore, so let's disable them until they do a new systemd stable release which includes the required vsock fix.