### PR TITLE
ci: Don't run on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
We're not exactly swimming in capacity, and this hasn't ever caught anything, so let's stop running CI on pushes to main.