### PR TITLE
Bind mount /dev/fuse in sandbox

### DIFF
--- a/mkosi/resources/man/mkosi.news.7.md
+++ b/mkosi/resources/man/mkosi.news.7.md
@@ -90,6 +90,8 @@
   subimage when used in a config under `mkosi.images/`. This differs to `%o`
   as it is always the name of the config file without extension (or the name
   of the directory).
+- If /dev/fuse is found in the host context, it is made available in the
+  sandbox context too.
 
 ## v24
 

--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -524,11 +524,15 @@ class DevOperation(FSOperation):
         # /dev/null fails with EACCESS for unknown reasons.
         mount("tmpfs", dst, "tmpfs", 0, "mode=0755")
 
-        for node in ("null", "zero", "full", "random", "urandom", "tty"):
+        for node in ("null", "zero", "full", "random", "urandom", "tty", "fuse"):
+            nsrc = joinpath(oldroot, "dev", node)
+            if not os.path.exists(nsrc) and node == "fuse":
+                continue
+
             ndst = joinpath(dst, node)
             os.close(os.open(ndst, os.O_CREAT | os.O_CLOEXEC | os.O_EXCL))
 
-            mount(joinpath(oldroot, "dev", node), ndst, "", MS_BIND, "")
+            mount(nsrc, ndst, "", MS_BIND, "")
 
         for i, node in enumerate(("stdin", "stdout", "stderr")):
             os.symlink(f"/proc/self/fd/{i}", joinpath(dst, node))


### PR DESCRIPTION
/dev/fuse is needed to support building container images from within the mkosi.build scripts. Make it avaiable in the sandbox just like /dev/null and its friends.

Since not all mkosi builds runs in host contexts where /dev/fuse is actually available (i.e. in a container), update the logic to skip /dev nodes if they are not present.