### PR TITLE
Use MKOSI_HOST_DISTRIBUTION in config_default_tools_tree_distribution()

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -893,6 +893,9 @@ def config_default_release(namespace: argparse.Namespace) -> str:
 
 
 def config_default_tools_tree_distribution(namespace: argparse.Namespace) -> Distribution:
+    if d := os.getenv("MKOSI_HOST_DISTRIBUTION"):
+        return Distribution(d).default_tools_tree_distribution()
+
     detected = detect_distribution()[0]
 
     if not detected:


### PR DESCRIPTION
It doesn't really matter since we won't use the tools tree in the sandbox anyway but this reduces the diff between mkosi summary outside and inside the sandbox.