### PR TITLE
sandbox: Make terminal background color cyan if on tty

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3786,8 +3786,18 @@ def run_sandbox(args: Args, config: Config) -> None:
     if hr:
         env |= {"MKOSI_HOST_RELEASE": hr}
 
+    cmdline = [*args.cmdline]
+
+    if sys.stdin.isatty() and config.find_binary("systemd-pty-forward"):
+        cmdline = [
+            "systemd-pty-forward",
+            "--title=mkosi-sandbox",
+            "--background=48;2;12;51;51",  # cyan
+            *cmdline,
+        ]
+
     run(
-        args.cmdline,
+        cmdline,
         stdin=sys.stdin,
         stdout=sys.stdout,
         env=os.environ | env,

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3766,6 +3766,12 @@ def in_sandbox() -> bool:
 
 
 def run_sandbox(args: Args, config: Config) -> None:
+    if in_sandbox():
+        die(
+            "mkosi sandbox cannot be invoked from within another mkosi sandbox environment",
+            hint="Exit the current sandbox environment and try again",
+        )
+
     if not args.cmdline:
         die("Please specify a command to execute in the sandbox")
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3111,13 +3111,7 @@ SETTINGS: list[ConfigSetting[Any]] = [
         dest="tools_tree",
         metavar="PATH",
         section="Build",
-        parse=(
-            # If we're running inside of mkosi sandbox, the tools tree is already in place so don't pick it
-            # up again.
-            config_make_path_parser(constants=("default",))
-            if not os.getenv("MKOSI_IN_SANDBOX")
-            else lambda value, old: None
-        ),
+        parse=config_make_path_parser(constants=("default",)),
         paths=("mkosi.tools",),
         help="Look up programs to execute inside the given tree",
         nargs="?",


### PR DESCRIPTION
Let's make the sandbox more recognizable by turning the terminal background cyan if on a tty.