### PR TITLE
fedora: Use a lower repository metadata expire time for rawhide

### DIFF
--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -101,7 +101,12 @@ class Installer(DistributionInstaller):
     @classmethod
     def setup(cls, context: Context) -> None:
         setup_rpm(context)
-        Dnf.setup(context, list(cls.repositories(context)), filelists=False)
+        Dnf.setup(
+            context,
+            list(cls.repositories(context)),
+            filelists=False,
+            metadata_expire="6h" if context.config.release == "rawhide" else None,
+        )
 
     @classmethod
     def install(cls, context: Context) -> None:

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -2,6 +2,7 @@
 import textwrap
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Optional
 
 from mkosi.config import Cacheonly, Config
 from mkosi.context import Context
@@ -41,7 +42,13 @@ class Dnf(PackageManager):
         }  # fmt: skip
 
     @classmethod
-    def setup(cls, context: Context, repositories: Sequence[RpmRepository], filelists: bool = True) -> None:
+    def setup(
+        cls,
+        context: Context,
+        repositories: Sequence[RpmRepository],
+        filelists: bool = True,
+        metadata_expire: Optional[str] = None,
+    ) -> None:
         (context.sandbox_tree / "etc/dnf/vars").mkdir(parents=True, exist_ok=True)
         (context.sandbox_tree / "etc/yum.repos.d").mkdir(parents=True, exist_ok=True)
 
@@ -95,6 +102,8 @@ class Dnf(PackageManager):
                         f.write(f"sslclientkey={repo.sslclientkey}\n")
                     if repo.priority:
                         f.write(f"priority={repo.priority}\n")
+                    if metadata_expire:
+                        f.write(f"metadata_expire={metadata_expire}\n")
 
                     for i, url in enumerate(repo.gpgurls):
                         f.write("gpgkey=" if i == 0 else len("gpgkey=") * " ")


### PR DESCRIPTION
Let's mimick Fedora's own rawhide repository configuration and use a metadata expire time of 6h when building rawhide images so that we don't end up keeping stale repository metadata around for too long which will result in dnf being unable to find certain packages as they will have been replaced by a newer version in rawhide already.