### PR TITLE
centos: epel-next does not exist anymore since CentOS Stream 10

### DIFF
--- a/mkosi.conf.d/20-centos/mkosi.conf
+++ b/mkosi.conf.d/20-centos/mkosi.conf
@@ -6,7 +6,7 @@ Distribution=|alma
 Distribution=|rocky
 
 [Distribution]
-Release=9
+Release=10
 
 [Content]
 # CentOS Stream 10 does not ship an unsigned shim

--- a/mkosi.conf.d/20-centos/mkosi.conf.d/epel.conf
+++ b/mkosi.conf.d/20-centos/mkosi.conf.d/epel.conf
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 [Match]
-Release=9
+Release=10
 
 [Distribution]
 Repositories=epel,epel-next
@@ -9,4 +9,3 @@ Repositories=epel,epel-next
 [Content]
 Packages=
         rpmautospec
-        rpmautospec-rpm-macros

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -227,12 +227,18 @@ class Installer(DistributionInstaller):
             return
 
         if mirror := context.config.mirror:
-            for repo, dir in (
+            # epel-next does not exist anymore since EPEL 10.
+            repodirs = [
                 ("epel", "epel"),
-                ("epel-next", "epel/next"),
                 ("epel-testing", "epel/testing"),
-                ("epel-next-testing", "epel/testing/next"),
-            ):
+            ]
+            if int(context.config.release) < 10:
+                repodirs += [
+                    ("epel-next", "epel/next"),
+                    ("epel-next-testing", "epel/testing/next"),
+                ]
+
+            for repo, dir in repodirs:
                 # For EPEL we make the assumption that epel is mirrored in the parent directory of the mirror
                 # URL and path we were given. Since this doesn't work for all scenarios, we also allow
                 # overriding the mirror via an environment variable.
@@ -257,7 +263,13 @@ class Installer(DistributionInstaller):
                 )
         else:
             url = "metalink=https://mirrors.fedoraproject.org/metalink?arch=$basearch"
-            for repo in ("epel", "epel-next"):
+
+            # epel-next does not exist anymore since EPEL 10.
+            repos = ["epel"]
+            if int(context.config.release) < 10:
+                repos += ["epel-next"]
+
+            for repo in repos:
                 yield RpmRepository(
                     repo,
                     f"{url}&repo={repo}-$releasever",
@@ -295,24 +307,27 @@ class Installer(DistributionInstaller):
                 gpgurls,
                 enabled=False,
             )
-            yield RpmRepository(
-                "epel-next-testing",
-                f"{url}&repo=epel-testing-next-$releasever",
-                gpgurls,
-                enabled=False,
-            )
-            yield RpmRepository(
-                "epel-next-testing-debuginfo",
-                f"{url}&repo=epel-testing-next-debug-$releasever",
-                gpgurls,
-                enabled=False,
-            )
-            yield RpmRepository(
-                "epel-next-testing-source",
-                f"{url}&repo=epel-testing-next-source-$releasever",
-                gpgurls,
-                enabled=False,
-            )
+
+            # epel-next does not exist anymore since EPEL 10.
+            if int(context.config.release) < 10:
+                yield RpmRepository(
+                    "epel-next-testing",
+                    f"{url}&repo=epel-testing-next-$releasever",
+                    gpgurls,
+                    enabled=False,
+                )
+                yield RpmRepository(
+                    "epel-next-testing-debuginfo",
+                    f"{url}&repo=epel-testing-next-debug-$releasever",
+                    gpgurls,
+                    enabled=False,
+                )
+                yield RpmRepository(
+                    "epel-next-testing-source",
+                    f"{url}&repo=epel-testing-next-source-$releasever",
+                    gpgurls,
+                    enabled=False,
+                )
 
     @classmethod
     def sig_repositories(cls, context: Context) -> Iterable[RpmRepository]:

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos/mkosi.conf
@@ -3,9 +3,6 @@
 [Match]
 Distribution=centos
 
-[Distribution]
-Repositories=epel,epel-next
-
 [Content]
 Packages=
         perf

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos/mkosi.conf.d/10-epel-10.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos/mkosi.conf.d/10-epel-10.conf
@@ -5,7 +5,3 @@ Release=10
 
 [Distribution]
 Repositories=epel
-
-[Content]
-Packages=
-        rpmautospec

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos/mkosi.conf.d/10-epel-9.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-centos/mkosi.conf.d/10-epel-9.conf
@@ -1,11 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 [Match]
-Release=10
+Release=9
 
 [Distribution]
-Repositories=epel
-
-[Content]
-Packages=
-        rpmautospec
+Repositories=epel,epel-next

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -157,9 +157,7 @@ class Image:
             check=False,
         )
 
-        rc = 0 if self.config.distribution.is_centos_variant() else 123
-
-        if result.returncode != rc:
+        if result.returncode != 123:
             raise subprocess.CalledProcessError(result.returncode, result.args, result.stdout, result.stderr)
 
         return result


### PR DESCRIPTION
Detailed in https://discussion.fedoraproject.org/t/epel-10-proposal/44304.