### PR TITLE
Don't check for populated OS root if Format == none

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -283,7 +283,10 @@ def remove_packages(context: Context) -> None:
 
 
 def check_root_populated(context: Context) -> None:
-    if context.config.output_format.is_extension_image():
+    if (
+        context.config.output_format == OutputFormat.none
+        or context.config.output_format.is_extension_image()
+    ):
         return
 
     """Check that the root was populated by looking for a os-release file."""


### PR DESCRIPTION
Let's skip checking if the OS root is populated if Format == none so that Format=none and Distribution=custom can be used to execute arbitrary code in a build script without actually building an image.