### PR TITLE
ci: Make kernel-install script checks more generic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,15 +27,15 @@ jobs:
       - name: Run ruff check
         run: |
           ruff --version
-          ruff check mkosi/ tests/ kernel-install/50-mkosi.install
+          ruff check mkosi/ tests/ kernel-install/*.install
 
       - name: Run ruff format
         run: |
           ruff --version
-          if ! ruff format --check --quiet mkosi/ tests/ kernel-install/50-mkosi.install
+          if ! ruff format --check --quiet mkosi/ tests/ kernel-install/*.install
           then
               echo "Please run 'ruff format' on the above files or apply the diffs below manually"
-              ruff format --check --quiet --diff mkosi/ tests/ kernel-install/50-mkosi.install
+              ruff format --check --quiet --diff mkosi/ tests/ kernel-install/*.install
           fi
 
       - name: Check that tabs are not used in code
@@ -54,12 +54,12 @@ jobs:
       - name: Type Checking (mypy)
         run: |
           python3 -m mypy --version
-          python3 -m mypy mkosi/ tests/ kernel-install/50-mkosi.install
+          python3 -m mypy mkosi/ tests/ kernel-install/*.install
 
       - name: Type Checking (pyright)
         run: |
           pyright --version
-          pyright mkosi/ tests/ kernel-install/50-mkosi.install
+          pyright mkosi/ tests/ kernel-install/*.install
 
       - name: Unit Tests
         run: |


### PR DESCRIPTION
Let's check all .install scripts in the kernel-install directory.