### PR TITLE
Run modinfo from the tools tree when building a standalone extension image

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1439,7 +1439,7 @@ def build_kernel_modules_initrd(context: Context, kver: str) -> Path:
         context.root,
         kmods,
         files=gen_required_kernel_modules(
-            context.root,
+            context,
             kver,
             include=finalize_kernel_modules_include(
                 context,
@@ -2793,7 +2793,7 @@ def run_depmod(context: Context, *, cache: bool = False) -> None:
     if not cache:
         for kver, _ in gen_kernel_images(context):
             process_kernel_modules(
-                context.root,
+                context,
                 kver,
                 include=finalize_kernel_modules_include(
                     context,

--- a/mkosi/kmod.py
+++ b/mkosi/kmod.py
@@ -23,7 +23,11 @@ def loaded_modules() -> list[str]:
 
 
 def filter_kernel_modules(
-    root: Path, kver: str, *, include: Iterable[str], exclude: Iterable[str]
+    root: Path,
+    kver: str,
+    *,
+    include: Iterable[str],
+    exclude: Iterable[str],
 ) -> list[Path]:
     modulesd = Path("usr/lib/modules") / kver
     with chdir(root):


### PR DESCRIPTION
If we're building a standalone extension image, modinfo won't be
installed in the image buildroot, so run modinfo from the host
instead.