### PR TITLE
mypy: enable scripts_are_modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ show_error_codes = true
 show_column_numbers = true
 warn_unreachable = true
 strict_equality = true
+scripts_are_modules = true
 
 [tool.ruff]
 target-version = "py39"


### PR DESCRIPTION
Otherwise mypy errors on type checking multiple kernel-install scripts in kernel-install/.