### PR TITLE
Revert "action: Fix up $PATH as a workaround"

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -82,11 +82,6 @@ runs:
         mkdir -p $HOME/.local/bin
         ln -svf ${{ github.action_path }}/bin/mkosi $HOME/.local/bin/mkosi
 
-    # TODO: Remove when https://github.com/actions/runner-images/issues/11414 is fixed.
-    - name: Fix $PATH
-      shell: bash
-      run: echo "PATH=$HOME/.local/bin:$PATH" >>"$GITHUB_ENV"
-
     - name: Dependencies
       shell: bash
       run: |


### PR DESCRIPTION
Issue was fixed in a new image.

This reverts commit 49832f6c2af0f7ef0a458d1e0795ad1854ecd863.