### PR TITLE
tests: don't fail directory CI if lvm2-monitor.service fails

### DIFF
--- a/mkosi.postinst
+++ b/mkosi.postinst
@@ -16,3 +16,5 @@ mkosi-chroot \
     --groups "$SUDO_GROUP",systemd-journal \
     --shell /bin/bash \
     mkosi
+
+systemctl --root="$BUILDROOT" mask lvm2-monitor.service


### PR DESCRIPTION
This service sometimes fails in CI for the arch:directory combination, e.g.

```
2025-01-21T12:07:33.4370559Z [   14.125731] mkosi-check-and-shutdown.sh[419]: + systemctl --failed --no-legend
2025-01-21T12:07:33.4380022Z [   14.126655] mkosi-check-and-shutdown.sh[420]: + tee /failed-services
2025-01-21T12:07:33.4714973Z [   14.160448] mkosi-check-and-shutdown.sh[420]: ● lvm2-monitor.service not-found failed failed lvm2-monitor.service
2025-01-21T12:07:33.4751355Z [   14.164135] mkosi-check-and-shutdown.sh[418]: + [[ ! -s /failed-services ]]
```

This is the first time this appears in the partcular boot's logs and we always ignore it and carry on. Let's sidestep checking whether it is this particular error.