### PR TITLE
Add support for FirmwareVariables=microsoft-mok

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3699,7 +3699,7 @@ SETTINGS: list[ConfigSetting[Any]] = [
         dest="firmware_variables",
         metavar="PATH",
         section="Runtime",
-        parse=config_make_path_parser(constants=("custom", "microsoft")),
+        parse=config_make_path_parser(constants=("custom", "microsoft", "microsoft-mok")),
         help="Set the path to the firmware variables file to use",
         compat_longs=("--qemu-firmware-variables",),
         compat_names=("QemuFirmwareVariables",),

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1637,6 +1637,13 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     When set to `microsoft`, a firmware variables file with the Microsoft
     secure boot certificates already enrolled will be used.
 
+    When set to `microsoft-mok`, a firmware variables file with the
+    Microsoft secure boot certificates already enrolled will be extended
+    with a `MokList` variable containing the secure boot certificate
+    from `SecureBootCertificate=`. This is intended to be used together
+    with shim binaries signed by the distribution and locally signed EFI
+    binaries.
+
     When set to `custom`, the secure boot certificate from
     `SecureBootCertificate=` will be enrolled into the default firmware
     variables file.


### PR DESCRIPTION
This new setting will use firmware variables with enrolled microsoft
keys and extend them with the required MOK variables to trust the
user's secure boot key/certificate.

Co-authored-by: Luca Boccassi <luca.boccassi@gmail.com>

Replaces #3018 