### PR TITLE
Remove depmod check in check_tools()

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2655,9 +2655,6 @@ def check_tools(config: Config, verb: Verb) -> None:
         if config.output_format == OutputFormat.none:
             return
 
-        if config.bootable != ConfigFeature.disabled:
-            check_tool(config, "depmod", reason="generate kernel module dependencies")
-
         if want_efi(config):
             if config.unified_kernel_image_profiles:
                 check_ukify(


### PR DESCRIPTION
We run depmod inside the image now, so drop the check for it in check_tools().