### PR TITLE
Use resource_path() to access files in our own module

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -139,6 +139,7 @@ from mkosi.util import (
     make_executable,
     one_zero,
     read_env_file,
+    resource_path,
     scopedenv,
 )
 from mkosi.versioncomp import GenericVersion
@@ -3902,12 +3903,11 @@ def run_sandbox(args: Args, config: Config) -> None:
             # trying to run a zipapp created from a packaged version of mkosi. While zipapp.create_archive()
             # supports a filter= argument, trying to use this within a site-packages directory is rather slow
             # so we copy the mkosi package to a temporary directory instead which is much faster.
-            with tempfile.TemporaryDirectory(prefix="mkosi-zipapp-") as tmp:
-                copy_tree(
-                    Path(__file__).parent,
-                    Path(tmp) / Path(__file__).parent.name,
-                    sandbox=config.sandbox,
-                )
+            with (
+                tempfile.TemporaryDirectory(prefix="mkosi-zipapp-") as tmp,
+                resource_path(sys.modules[__package__ or __name__]) as module,
+            ):
+                copy_tree(module, Path(tmp) / module.name, sandbox=config.sandbox)
                 zipapp.create_archive(
                     source=tmp,
                     target=Path(d) / "mkosi",

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -646,8 +646,6 @@ def sandbox_cmd(
                 if p.exists():
                     cmdline += ["--ro-bind", p, p]
 
-        home = None
-
     path = finalize_path(root=tools, extra=[Path("/scripts"), *extra] if scripts else extra, relaxed=relaxed)
     cmdline += ["--setenv", "PATH", path]
 

--- a/tests/test_initrd.py
+++ b/tests/test_initrd.py
@@ -223,11 +223,11 @@ def test_initrd_size(config: ImageConfig) -> None:
 
         # The fallback value is for CentOS and related distributions.
         maxsize = 1024**2 * {
-            Distribution.fedora: 63,
+            Distribution.fedora: 67,
             Distribution.debian: 62,
             Distribution.ubuntu: 57,
             Distribution.arch: 86,
-            Distribution.opensuse: 64,
+            Distribution.opensuse: 67,
         }.get(config.distribution, 58)
 
         assert (Path(image.output_dir) / "image.initrd").stat().st_size <= maxsize


### PR DESCRIPTION
__file__ doesn't work if mkosi is packaged up as a zipapp, let's use resource_path() which is specifically intended to solve this problem and works regardless of whether we're in a zipapp or not.