### PR TITLE
Fix VarLink Machine.Register invocation for v257+

### DIFF
--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -1039,7 +1039,7 @@ def register_machine(config: Config, pid: int, fname: Path, cid: Optional[int]) 
                         "name": config.machine_or_name().replace("_", "-"),
                         "service": "mkosi",
                         "class": "vm",
-                        "leader": pid,
+                        "leader": {"pid": pid},
                         **({"rootDirectory": os.fspath(fname)} if fname.is_dir() else {}),
                         **({"vSockCid": cid} if cid is not None else {}),
                         **({"sshAddress": f"vsock/{cid}"} if cid is not None else {}),


### PR DESCRIPTION
Ran into a couple of issues running with QEMU after b90dc2a50cc79f70cf1c919c82857c518c77cd43, and this branch fixes them.