### PR TITLE
Use become_root_cmd() when running systemd-repart in run_shell() as well

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4010,6 +4010,7 @@ def run_shell(args: Args, config: Config) -> None:
                     network=True,
                     devices=True,
                     options=["--bind", fname, workdir(fname)],
+                    setup=become_root_cmd(),
                 ),
             )  # fmt: skip
 


### PR DESCRIPTION
systemd-repart's --image switch requires root privileges as well, so let's use become_root_cmd() there as well.