### PR TITLE
Use shutil.copy() to copy ovmf variables

### DIFF
--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -775,7 +775,7 @@ def finalize_firmware_variables(
             if config.firmware_variables == Path("microsoft") or not config.firmware_variables
             else config.firmware_variables
         )
-        shutil.copy2(vars, ovmf_vars)
+        shutil.copy(vars, ovmf_vars)
 
     return ovmf_vars, ovmf_vars_format
 


### PR DESCRIPTION
shutil.copy2() isn't required here, we only care about the contents, not the metadata of the file.