### PR TITLE
Check if list matches are empty if empty string is matched against

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -738,6 +738,9 @@ def config_match_build_sources(match: str, value: list[ConfigTree]) -> bool:
 
 def config_make_list_matcher(parse: Callable[[str], T]) -> ConfigMatchCallback[list[T]]:
     def config_match_list(match: str, value: list[T]) -> bool:
+        if not match:
+            return len(value) == 0
+
         return parse(match) in value
 
     return config_match_list
@@ -4254,9 +4257,6 @@ class ParseContext:
             v = v.removeprefix("!")
 
             v = self.expand_specifiers(v, path)
-
-            if not v:
-                die("Match value cannot be empty")
 
             if s := SETTINGS_LOOKUP_BY_NAME.get(k):
                 if not s.match:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -717,7 +717,10 @@ def test_match_empty(tmp_path: Path) -> None:
         assert config.environment.get("ABC") is None
 
 
-@pytest.mark.parametrize("dist1,dist2", itertools.combinations_with_replacement(Distribution, 2))
+@pytest.mark.parametrize(
+    "dist1,dist2",
+    itertools.combinations_with_replacement([Distribution.debian, Distribution.opensuse], 2),
+)
 def test_match_distribution(tmp_path: Path, dist1: Distribution, dist2: Distribution) -> None:
     with chdir(tmp_path):
         parent = Path("mkosi.conf")
@@ -771,7 +774,7 @@ def test_match_distribution(tmp_path: Path, dist1: Distribution, dist2: Distribu
         assert "testpkg3" in conf.packages
 
 
-@pytest.mark.parametrize("release1,release2", itertools.combinations_with_replacement([36, 37, 38], 2))
+@pytest.mark.parametrize("release1,release2", itertools.combinations_with_replacement([36, 37], 2))
 def test_match_release(tmp_path: Path, release1: int, release2: int) -> None:
     with chdir(tmp_path):
         parent = Path("mkosi.conf")
@@ -865,9 +868,7 @@ def test_match_repositories(tmp_path: Path) -> None:
     assert config.output == "qed"
 
 
-@pytest.mark.parametrize(
-    "image1,image2", itertools.combinations_with_replacement(["image_a", "image_b", "image_c"], 2)
-)
+@pytest.mark.parametrize("image1,image2", itertools.combinations_with_replacement(["image_a", "image_b"], 2))
 def test_match_imageid(tmp_path: Path, image1: str, image2: str) -> None:
     with chdir(tmp_path):
         parent = Path("mkosi.conf")
@@ -939,7 +940,7 @@ def test_match_imageid(tmp_path: Path, image1: str, image2: str) -> None:
     "op,version",
     itertools.product(
         ["", "==", "<", ">", "<=", ">="],
-        [122, 123, 124],
+        [122, 123],
     ),
 )
 def test_match_imageversion(tmp_path: Path, op: str, version: str) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -696,6 +696,27 @@ def test_match_multiple(tmp_path: Path) -> None:
         assert config.image_id != "abcde"
 
 
+def test_match_empty(tmp_path: Path) -> None:
+    with chdir(tmp_path):
+        Path("mkosi.conf").write_text(
+            """\
+            [Match]
+            Profiles=
+
+            [Build]
+            Environment=ABC=QED
+            """
+        )
+
+        _, [config] = parse_config([])
+
+        assert config.environment.get("ABC") == "QED"
+
+        _, [config] = parse_config(["--profile", "profile"])
+
+        assert config.environment.get("ABC") is None
+
+
 @pytest.mark.parametrize("dist1,dist2", itertools.combinations_with_replacement(Distribution, 2))
 def test_match_distribution(tmp_path: Path, dist1: Distribution, dist2: Distribution) -> None:
     with chdir(tmp_path):


### PR DESCRIPTION
If we do something like

```
[Match]
Profiles=

...
```

It should succeed if the list of profiles is empty, so let's implement that.