### PR TITLE
mkosi-initrd: Add two more modules

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -71,8 +71,10 @@ KernelModulesInclude=
                     /loop.ko
                     /mdio_devres.ko
                     /mei.ko
+                    /mxm-wmi.ko
                     /nvme.ko
                     /overlay.ko
+                    /parport.ko
                     /pmt_telemetry.ko
                     /qemu_fw_cfg.ko
                     /raid[0-9]*.ko
@@ -84,6 +86,7 @@ KernelModulesInclude=
                     /snd-intel-dspcfg.ko
                     /snd-soc-hda-codec.ko
                     /squashfs.ko
+                    /usb-storage.ko
                     /vfat.ko
                     /virtio_balloon.ko
                     /virtio_blk.ko


### PR DESCRIPTION
Three more generic modules that are needed in the initrd.

- mxm-wmi is a standard for switchable laptop graphics
- usb-storage is obviously for USB storage devices
- partport (https://docs.kernel.org/admin-guide/parport.html) seems generic enough that we should include it in the initrd.