### PR TITLE
opensuse: fix package name: btrfs-progs -> btrfsprogs

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-opensuse.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-opensuse.conf
@@ -22,7 +22,7 @@ Packages=
         libtss2-tcti-device0
 
         # File system checkers for supported root file systems
-        btrfs-progs
+        btrfsprogs
         e2fsprogs
         xfsprogs
         erofs-utils

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/10-opensuse.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/10-opensuse.conf
@@ -5,7 +5,7 @@ Distribution=opensuse
 
 [Content]
 Packages=
-        btrfs-progs
+        btrfsprogs
         ca-certificates-mozilla
         createrepo_c
         distribution-gpg-keys


### PR DESCRIPTION
This error was not visible enough because zypper can find it anyway:

```
'btrfs-progs' not found in package names. Trying capabilities.
```