### PR TITLE
Fix verity signature check in case keys are configured

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3238,9 +3238,11 @@ def make_image(
     logging.debug(json.dumps(output, indent=4))
 
     partitions = [Partition.from_dict(d) for d in output]
+    arch = context.config.architecture
 
     if context.config.verity == ConfigFeature.enabled and not any(
-        p.type.startswith("usr-verity-sig") or p.type.startswith("root-verity-sig") for p in partitions
+        p.type.startswith(f"usr-{arch}-verity-sig") or p.type.startswith(f"root-{arch}-verity-sig")
+        for p in partitions
     ):
         die(
             "Verity is explicitly enabled but didn't find any verity signature partition",


### PR DESCRIPTION
The repart json output includes the architecture in the partiton type string, so the same must be included when checking for a verity signature partition.

Example repart output:
{
    "type": "usr-x86-64-verity-sig",
    "label": "image_20250127144324_verity_sig",
    "uuid": "ae4819c0-d8e8-4c11-a140-af81d63db968",
    "partno": 1,
    "file": "/home/mheb/git/os/mkosi.repart/10-usr-verity-sig.conf",
    "node": "/work/var/cache/mkosi/mkosi-workspace-igi4aky0/staging/image_20250127144324.raw2",
    "offset": 537919488,
    "old_size": 16384,
    "raw_size": 16384,
    "old_padding": 0,
    "raw_padding": 0,
    "activity": "unchanged",
    "roothash": "TBD",
    "split_path": "/work/var/cache/mkosi/mkosi-workspace-igi4aky0/staging/image_20250127144324.usr-x86-64-verity-sig.ae4819c0d8e84c11a140af81d63db968.raw"
}