### PR TITLE
config: add mkosi-addon

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -55,7 +55,7 @@ ConfigParseCallback = Callable[[Optional[str], Optional[T]], Optional[T]]
 ConfigMatchCallback = Callable[[str, T], bool]
 ConfigDefaultCallback = Callable[[argparse.Namespace], T]
 
-BUILTIN_CONFIGS = ("mkosi-tools", "mkosi-initrd", "mkosi-vm")
+BUILTIN_CONFIGS = ("mkosi-tools", "mkosi-initrd", "mkosi-vm", "mkosi-addon")
 
 
 class Verb(StrEnum):


### PR DESCRIPTION
Otherwise it fails:

$ mkosi --include=mkosi-addon
‣ mkosi-addon does not exist