### PR TITLE
mkosi-initrd: Add extra kernel modules

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -57,6 +57,7 @@ KernelModulesInclude=
                     /dm-verity.ko
                     /dmi-sysfs.ko
                     /drm_buddy.ko
+                    /drm_display_helper.ko
                     /efi-pstore.ko
                     /efivarfs.ko
                     /erofs.ko
@@ -64,6 +65,7 @@ KernelModulesInclude=
                     /i2c-algo-bit.ko
                     /i2c-mux.ko
                     /i2c-smbus.ko
+                    /intel-gtt.ko
                     /intel-uncore-frequency-common.ko
                     /intel[-_]vsec.ko
                     /kvm.ko
@@ -86,8 +88,13 @@ KernelModulesInclude=
                     /snd-intel-dspcfg.ko
                     /snd-soc-hda-codec.ko
                     /squashfs.ko
+                    /ttm.ko
                     /usb-storage.ko
+                    /uvc.ko
                     /vfat.ko
+                    /video.ko
+                    /videobuf2-v4l2.ko
+                    /videobuf2-vmalloc.ko
                     /virtio_balloon.ko
                     /virtio_blk.ko
                     /virtio_console.ko


### PR DESCRIPTION
All this stuff gets loaded by udev on my laptop, isn't huge, and doesn't pull in any firmware, so let's add these to the list of kernel modules.