### PR TITLE
Check if systemd is actually running before using run0

### DIFF
--- a/mkosi/user.py
+++ b/mkosi/user.py
@@ -189,4 +189,4 @@ def become_root_cmd() -> list[str]:
     if os.getuid() == 0:
         return []
 
-    return ["run0"] if find_binary("run0") else ["sudo"]
+    return ["run0"] if find_binary("run0") and Path("/run/systemd/system").exists() else ["sudo"]


### PR DESCRIPTION
If we're not running systemd, we can't use run0 either, so use sudo in that case.