### PR TITLE
Use verity repart definitions for extension/portable with hash and defer

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3532,7 +3532,7 @@ def make_esp(context: Context, uki: Path) -> list[Partition]:
 
 
 def make_extension_or_portable_image(context: Context, output: Path) -> None:
-    if want_verity(context.config) or context.config.verity == Verity.signed:
+    if want_verity(context.config) or context.config.verity in (Verity.signed, Verity.hash, Verity.defer):
         unsigned = ""
     else:
         unsigned = "-unsigned"


### PR DESCRIPTION
The --exlude-partitions and --defer-partitions options to systemd-repart makes no difference if none of the excluded or deferred partitions are defined. So make dure the verity definitions are used when Verity=hash or Verity=defer is configured.