### PR TITLE
tree: Don't copy xattrs to overlayfs

### DIFF
--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -53,6 +53,7 @@ NR_move_mount = 429
 NR_open_tree = 428
 OPEN_TREE_CLOEXEC = os.O_CLOEXEC
 OPEN_TREE_CLONE = 1
+OVERLAYFS_SUPER_MAGIC = 0x794C7630
 PR_CAP_AMBIENT = 47
 PR_CAP_AMBIENT_RAISE = 2
 # These definitions are taken from the libseccomp headers

--- a/mkosi/tree.py
+++ b/mkosi/tree.py
@@ -123,6 +123,7 @@ def copy_tree(
         use_subvolumes == ConfigFeature.disabled
         or not preserve
         or not is_subvolume(src)
+        or statfs(str(dst.parent)) != BTRFS_SUPER_MAGIC
         or (dst.exists() and (not dst.is_dir() or any(dst.iterdir())))
     ):
         with preserve_target_directories_stat(src, dst) if not preserve else contextlib.nullcontext():


### PR DESCRIPTION
Trying to copy the selinux xattrs to a directory in an overlayfs
filesystem will fail with "Operation not supported". There's no way
to instruct cp to not copy or ignore failures to copy selinux xattrs
so let's instead not try to copy xattrs at all when copying to directories
in overlayfs filesystems.