### PR TITLE
Check MinimumVersion= during config parsing

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4808,9 +4808,6 @@ def run_verb(args: Args, images: Sequence[Config], *, resources: Path) -> None:
 
     last = images[-1]
 
-    if (minversion := last.minimum_version) and minversion > __version__:
-        die(f"mkosi {minversion} or newer is required by this configuration (found {__version__})")
-
     if not in_sandbox() and last.tools_tree and last.tools_tree == Path("default"):
         tools = finalize_default_tools(last, resources=resources)
     else:

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1376,12 +1376,16 @@ def config_parse_vsock_cid(value: Optional[str], old: Optional[int]) -> Optional
 
 
 def config_parse_minimum_version(
-    value: Optional[str], old: Optional[GenericVersion]
+    value: Optional[str],
+    old: Optional[GenericVersion],
 ) -> Optional[GenericVersion]:
     if not value:
         return old
 
     new = GenericVersion(value)
+
+    if new > __version__:
+        die(f"mkosi {new} or newer is required by this configuration (found {__version__})")
 
     if not old:
         return new


### PR DESCRIPTION
We fail on unknown settings, so currently if the mkosi version is too old, we fail during config parsing before we ever get to check if the current version is older than the minimum version.

Let's fix this by checking the minimum version during config parsing itself. This means it can't be overridden later on anymore with a lower version during config parsing but I doubt this will ever happen in the first place.