### PR TITLE
mkosi: support nvme-over-tcp in the initrd + thunderbolt-net

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -75,6 +75,7 @@ KernelModulesInclude=
                     /mei.ko
                     /mxm-wmi.ko
                     /nvme.ko
+                    /nvmet-tcp.ko
                     /overlay.ko
                     /parport.ko
                     /pmt_telemetry.ko
@@ -88,6 +89,7 @@ KernelModulesInclude=
                     /snd-intel-dspcfg.ko
                     /snd-soc-hda-codec.ko
                     /squashfs.ko
+                    /thunderbolt_net.ko
                     /ttm.ko
                     /usb-storage.ko
                     /uvc.ko


### PR DESCRIPTION
Let's make storage target mode a thing, and support nvme-over-tcp in the initrd, as well as thunderbolt-net.

nvme-over-tcp probably makes sense anyway for supporting the probbaly best way to do network booting these days.