### PR TITLE
Add SplitArtifacts=roothash

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3357,6 +3357,11 @@ def make_image(
             if p.split_path:
                 maybe_compress(context, context.config.compress_output, p.split_path)
 
+    if ArtifactOutput.roothash in context.config.split_artifacts and (
+        roothash := finalize_roothash(partitions)
+    ):
+        (context.staging / context.config.output_split_roothash).write_text(roothash.partition("=")[2])
+
     return partitions
 
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -572,6 +572,7 @@ class ArtifactOutput(StrEnum):
     partitions = enum.auto()
     tar = enum.auto()
     pcrs = enum.auto()
+    roothash = enum.auto()
 
     @staticmethod
     def compat_no() -> list["ArtifactOutput"]:
@@ -2050,6 +2051,10 @@ class Config:
         return f"{self.output}.pcrs"
 
     @property
+    def output_split_roothash(self) -> str:
+        return f"{self.output}.roothash"
+
+    @property
     def output_nspawn_settings(self) -> str:
         return f"{self.output}.nspawn"
 
@@ -2088,6 +2093,7 @@ class Config:
             self.output_split_kernel,
             self.output_split_initrd,
             self.output_split_pcrs,
+            self.output_split_roothash,
             self.output_nspawn_settings,
             self.output_checksum,
             self.output_signature,

--- a/mkosi/partition.py
+++ b/mkosi/partition.py
@@ -56,6 +56,10 @@ def finalize_roothash(partitions: Sequence[Partition]) -> Optional[str]:
         if not (p.type.startswith("usr") or p.type.startswith("root")):
             die(f"Found roothash property on unexpected partition type {p.type}")
 
+        # When the partition is deferred/skipped the roothash is listed as the literal 'TBD' string
+        if h == "TBD":
+            continue
+
         # When there's multiple verity enabled root or usr partitions, the first one wins.
         if p.type.startswith("usr"):
             usrhash = usrhash or h

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -603,10 +603,13 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 `SplitArtifacts=`, `--split-artifacts`
 :   The artifact types to split out of the final image. A comma-delimited
-    list consisting of `uki`, `kernel`, `initrd`, `partitions` and
+    list consisting of `uki`, `kernel`, `initrd`, `prcs`, `partitions` and
     `tar`. When building a bootable image `kernel` and `initrd`
     correspond to their artifact found in the image (or in the UKI),
-    while `uki` copies out the entire UKI.
+    while `uki` copies out the entire UKI. If `pcrs` is specified, a JSON
+    file containing the pre-calculated TPM2 digests is written out, according
+    to the [UKI specification](https://uapi-group.org/specifications/specs/unified_kernel_image/#json-format-for-pcrsig),
+    which is useful for offline signing.
 
     When building a disk image and `partitions` is specified,
     pass `--split=yes` to **systemd-repart** to have it write out split partition

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -603,8 +603,8 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 `SplitArtifacts=`, `--split-artifacts`
 :   The artifact types to split out of the final image. A comma-delimited
-    list consisting of `uki`, `kernel`, `initrd`, `prcs`, `partitions` and
-    `tar`. When building a bootable image `kernel` and `initrd`
+    list consisting of `uki`, `kernel`, `initrd`, `prcs`, `partitions`,
+    `roothash` and `tar`. When building a bootable image `kernel` and `initrd`
     correspond to their artifact found in the image (or in the UKI),
     while `uki` copies out the entire UKI. If `pcrs` is specified, a JSON
     file containing the pre-calculated TPM2 digests is written out, according
@@ -622,6 +622,9 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
     When `tar` is specified, the rootfs is additionally archived as a
     tar archive (compressed according to `CompressOutput=`).
+
+    When `roothash` is specified and a dm-verity disk image is built, the dm-verity
+    roothash is written out as a separate file, which is useful for offline signing.
 
     By default `uki`, `kernel` and `initrd` are split out.
 

--- a/mkosi/resources/mkosi-obs/mkosi.conf
+++ b/mkosi/resources/mkosi-obs/mkosi.conf
@@ -3,7 +3,7 @@
 SandboxTrees=/usr/src/packages/SOURCES:/usr/src/packages/SOURCES
 
 [Output]
-SplitArtifacts=pcrs
+SplitArtifacts=pcrs,roothash
 
 [Validation]
 SignExpectedPcrCertificate=/usr/src/packages/SOURCES/_projectcert.crt

--- a/mkosi/resources/mkosi-obs/mkosi.postoutput
+++ b/mkosi/resources/mkosi-obs/mkosi.postoutput
@@ -13,8 +13,10 @@ declare -a UKIS
 UKIS=( "$(find "$OUTPUTDIR" -type f -name "*.efi" -printf '%P\n')" )
 declare -a KERNELS
 KERNELS=( "$(find "$OUTPUTDIR" -type f -name "vmlinu*" -printf '%P\n')" )
+declare -a ROOTHASHES
+ROOTHASHES=( "$(find "$OUTPUTDIR" -type f -name "*.roothash" -printf '%P\n')" )
 
-if ((${#UKIS[@]} == 0)) && ((${#KERNELS[@]} == 0)); then
+if ((${#UKIS[@]} == 0)) && ((${#KERNELS[@]} == 0)) && ((${#ROOTHASHES[@]} == 0)); then
     echo "No unsigned files found, exiting"
     exit 0
 fi
@@ -42,6 +44,12 @@ for f in "${KERNELS[@]}"; do
     test -f "${OUTPUTDIR}/${f}" || continue
     mkdir -p hashes/kernels
     pesign --force -n sql:"$nss_db" -i "${OUTPUTDIR}/${f}" -E "hashes/kernels/$f"
+done
+
+for f in "${ROOTHASHES[@]}"; do
+    test -f "${OUTPUTDIR}/${f}" || continue
+    mkdir -p hashes/roothashes
+    cp "${OUTPUTDIR}/$f" hashes/roothashes/
 done
 
 # Pack everything into a CPIO archive and place it where OBS expects it


### PR DESCRIPTION
Reattaching the signature is still WIP, but the splitting out step is independent, so we can start with this.