### PR TITLE
kmod: run proper cmdline in modinfo

### DIFF
--- a/mkosi/kmod.py
+++ b/mkosi/kmod.py
@@ -105,8 +105,10 @@ def modinfo(context: Context, kver: str, modules: Iterable[str]) -> str:
     else:
         sandbox = chroot_cmd(root=context.root)
 
+    cmdline += [*modules]
+
     return run(
-        ["modinfo", "--set-version", kver, "--null", *modules],
+        cmdline,
         stdout=subprocess.PIPE,
         sandbox=sandbox,
     ).stdout.strip()


### PR DESCRIPTION
Is a4818d7defc816c0d00322815597524597ed7818 working ok?
