### PR TITLE
Force ssh to use bash to run the ProxyCommand

### DIFF
--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -1625,7 +1625,7 @@ def run_ssh(args: Args, config: Config) -> None:
         cmd,
         stdin=sys.stdin,
         stdout=sys.stdout,
-        env=os.environ | config.environment,
+        env=os.environ | config.environment | {"SHELL": "/bin/bash"},
         log=False,
         sandbox=config.sandbox(
             network=True,


### PR DESCRIPTION
We only have bash installed in the tools tree and by default ssh will try to use the user's shell to execute the proxy command which might not be available so force it use bash.

Fixes #3500