### PR TITLE
Stop using nargs="?" for options

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1517,7 +1517,6 @@ class ConfigSetting(Generic[T]):
     long: str = ""
     choices: Optional[list[str]] = None
     metavar: Optional[str] = None
-    nargs: Optional[str] = None
     const: Optional[Any] = None
     help: Optional[str] = None
 
@@ -2405,7 +2404,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ConfigSetting(
         dest="repository_key_check",
         metavar="BOOL",
-        nargs="?",
         section="Distribution",
         default=True,
         parse=config_parse_boolean,
@@ -2415,7 +2413,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ConfigSetting(
         dest="repository_key_fetch",
         metavar="BOOL",
-        nargs="?",
         section="Distribution",
         default_factory_depends=("distribution", "tools_tree", "tools_tree_distribution"),
         default_factory=config_default_repository_key_fetch,
@@ -2481,7 +2478,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ConfigSetting(
         dest="compress_output",
         metavar="ALG",
-        nargs="?",
         section="Output",
         parse=config_parse_compression,
         default_factory=config_default_compression,
@@ -2538,7 +2534,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ),
     ConfigSetting(
         dest="split_artifacts",
-        nargs="?",
         section="Output",
         parse=config_parse_artifact_output_list,
         default=ArtifactOutput.compat_no(),
@@ -2565,7 +2560,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ConfigSetting(
         dest="overlay",
         metavar="BOOL",
-        nargs="?",
         section="Output",
         parse=config_parse_boolean,
         help="Only output the additions on top of the given base trees",
@@ -2638,7 +2632,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ConfigSetting(
         dest="with_recommends",
         metavar="BOOL",
-        nargs="?",
         section="Content",
         parse=config_parse_boolean,
         help="Install recommended packages",
@@ -2646,7 +2639,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ConfigSetting(
         dest="with_docs",
         metavar="BOOL",
-        nargs="?",
         section="Content",
         parse=config_parse_boolean,
         default=True,
@@ -2779,7 +2771,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ConfigSetting(
         dest="bootable",
         metavar="FEATURE",
-        nargs="?",
         section="Content",
         parse=config_parse_feature,
         match=config_match_feature,
@@ -2852,7 +2843,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ConfigSetting(
         dest="microcode_host",
         metavar="BOOL",
-        nargs="?",
         section="Content",
         parse=config_parse_boolean,
         default=False,
@@ -2911,7 +2901,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ConfigSetting(
         dest="kernel_modules_initrd",
         metavar="BOOL",
-        nargs="?",
         section="Content",
         parse=config_parse_boolean,
         default=True,
@@ -3017,7 +3006,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
         dest="autologin",
         short="-a",
         metavar="BOOL",
-        nargs="?",
         section="Content",
         parse=config_parse_boolean,
         help="Enable root autologin",
@@ -3025,7 +3013,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ConfigSetting(
         dest="make_initrd",
         metavar="BOOL",
-        nargs="?",
         section="Content",
         parse=config_parse_boolean,
         help="Make sure the image can be used as an initramfs",
@@ -3033,7 +3020,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ConfigSetting(
         dest="ssh",
         metavar="BOOL",
-        nargs="?",
         section="Content",
         parse=config_parse_boolean,
         help="Set up SSH access from the host to the final image via 'mkosi ssh'",
@@ -3050,7 +3036,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ConfigSetting(
         dest="secure_boot",
         metavar="BOOL",
-        nargs="?",
         section="Validation",
         parse=config_parse_boolean,
         help="Sign the resulting kernel/initrd image for UEFI SecureBoot",
@@ -3207,7 +3192,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ConfigSetting(
         dest="checksum",
         metavar="BOOL",
-        nargs="?",
         section="Validation",
         parse=config_parse_boolean,
         help="Write SHA256SUMS file",
@@ -3215,7 +3199,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ConfigSetting(
         dest="sign",
         metavar="BOOL",
-        nargs="?",
         section="Validation",
         parse=config_parse_boolean,
         help="Write and sign SHA256SUMS file",
@@ -3240,7 +3223,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
         parse=config_make_path_parser(constants=("default",)),
         paths=("mkosi.tools",),
         help="Look up programs to execute inside the given tree",
-        nargs="?",
         const="default",
         scope=SettingScope.universal,
     ),
@@ -3339,7 +3321,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ConfigSetting(
         dest="incremental",
         short="-i",
-        nargs="?",
         section="Build",
         parse=config_make_enum_parser_with_boolean(Incremental, yes=Incremental.yes, no=Incremental.no),
         default=Incremental.no,
@@ -3425,7 +3406,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ConfigSetting(
         dest="use_subvolumes",
         metavar="FEATURE",
-        nargs="?",
         section="Build",
         parse=config_parse_feature,
         help="Use btrfs subvolumes for faster directory operations where possible",
@@ -3465,7 +3445,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ),
     ConfigSetting(
         dest="build_sources_ephemeral",
-        nargs="?",
         section="Build",
         parse=config_make_enum_parser_with_boolean(
             BuildSourcesEphemeral, yes=BuildSourcesEphemeral.yes, no=BuildSourcesEphemeral.no
@@ -3497,7 +3476,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
         dest="with_tests",
         short="-T",
         long="--without-tests",
-        nargs="?",
         const="no",
         section="Build",
         parse=config_parse_boolean,
@@ -3508,7 +3486,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ConfigSetting(
         dest="with_network",
         metavar="BOOL",
-        nargs="?",
         section="Build",
         parse=config_parse_boolean,
         help="Run build and postinst scripts with network access (instead of private network)",
@@ -3578,7 +3555,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
             "If specified, the container/VM is run with a temporary snapshot of the output "
             "image that is removed immediately when the container/VM terminates"
         ),
-        nargs="?",
     ),
     ConfigSetting(
         dest="credentials",
@@ -3700,7 +3676,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ConfigSetting(
         dest="console",
         metavar="MODE",
-        nargs="?",
         section="Runtime",
         parse=config_make_enum_parser(ConsoleMode),
         help="Configure the virtual machine console mode to use",
@@ -3732,7 +3707,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
         dest="kvm",
         name="KVM",
         metavar="FEATURE",
-        nargs="?",
         section="Runtime",
         parse=config_parse_feature,
         help="Configure whether to use KVM or not",
@@ -3743,7 +3717,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
         dest="vsock",
         name="VSock",
         metavar="FEATURE",
-        nargs="?",
         section="Runtime",
         parse=config_parse_feature,
         help="Configure whether to use vsock or not",
@@ -3766,7 +3739,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
         dest="tpm",
         name="TPM",
         metavar="FEATURE",
-        nargs="?",
         section="Runtime",
         parse=config_parse_feature,
         help="Configure whether to use a virtual tpm or not",
@@ -3777,7 +3749,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
         dest="cdrom",
         name="CDROM",
         metavar="BOOLEAN",
-        nargs="?",
         section="Runtime",
         parse=config_parse_boolean,
         help="Attach the image as a CD-ROM to the virtual machine",
@@ -3787,7 +3758,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
     ConfigSetting(
         dest="removable",
         metavar="BOOLEAN",
-        nargs="?",
         section="Runtime",
         parse=config_parse_boolean,
         help="Attach the image as a removable drive to the virtual machine",
@@ -4060,6 +4030,7 @@ def create_argument_parser(chdir: bool = True) -> argparse.ArgumentParser:
     parser.add_argument(
         "verb",
         type=Verb,
+        nargs="?",
         choices=list(Verb),
         default=Verb.build,
         help=argparse.SUPPRESS,
@@ -4092,7 +4063,6 @@ def create_argument_parser(chdir: bool = True) -> argparse.ArgumentParser:
                 dest=s.dest,
                 choices=s.choices,
                 metavar=s.metavar,
-                nargs=s.nargs,  # type: ignore
                 const=s.const,
                 help=s.help if long == s.long else argparse.SUPPRESS,
                 action=ConfigAction,
@@ -4136,9 +4106,6 @@ class ConfigAction(argparse.Action):
         option_string: Optional[str] = None,
     ) -> None:
         assert option_string is not None
-
-        if values is None and self.nargs == "?":
-            values = self.const or "yes"
 
         s = SETTINGS_LOOKUP_BY_DEST[self.dest]
 
@@ -4547,25 +4514,6 @@ def parse_config(
     only_sections: Sequence[str] = (),
 ) -> tuple[Args, tuple[Config, ...]]:
     argv = list(argv)
-
-    # Make sure the verb command gets explicitly passed. Insert a -- before the positional verb argument
-    # otherwise it might be considered as an argument of a parameter with nargs='?'. For example mkosi -i
-    # summary would be treated as -i=summary.
-    for verb in Verb:
-        try:
-            v_i = argv.index(verb.value)
-        except ValueError:
-            continue
-
-        # Hack to make sure mkosi -C build works.
-        if argv[v_i - 1] in ("-C", "--directory"):
-            continue
-
-        if v_i > 0 and argv[v_i - 1] != "--":
-            argv.insert(v_i, "--")
-        break
-    else:
-        argv += ["--", "build"]
 
     context = ParseContext(resources)
 

--- a/mkosi/resources/completion.bash
+++ b/mkosi/resources/completion.bash
@@ -11,7 +11,7 @@ _mkosi_compgen_dirs() {
 
 _mkosi_completion() {
     local -a _mkosi_options
-    local -A _mkosi_nargs _mkosi_choices _mkosi_compgen _mkosi_verbs
+    local -A _mkosi_choices _mkosi_compgen _mkosi_verbs
     local -i curword_idx verb_seen
 
 ##VARIABLEDEFINITIONS##
@@ -27,7 +27,6 @@ _mkosi_completion() {
     elif [[ "$completing_word_preceding" =~ ^- ]]  # the previous word was an option
     then
         current_option="${completing_word_preceding}"
-        current_option_nargs="${_mkosi_nargs[${current_option}]}"
         current_option_choices="${_mkosi_choices[${current_option}]}"
         current_option_compgen="${_mkosi_compgen[${current_option}]}"
 
@@ -43,11 +42,8 @@ _mkosi_completion() {
                   < <(compgen -W "${current_option_choices}" -- "${completing_word}")
 
         # if this (maybe) takes arguments, we'll just fall back to files
-        if [[ "${current_option_nargs}" == "?" ]] || ((current_option_nargs > 0))
-        then
-            readarray -t COMPREPLY -O "${#COMPREPLY[@]}" \
-                      < <(_mkosi_compgen_files "${completing_word}")
-            return
+        readarray -t COMPREPLY -O "${#COMPREPLY[@]}" \
+                    < <(_mkosi_compgen_files "${completing_word}")
         fi
     fi
 

--- a/mkosi/resources/man/mkosi.news.7.md
+++ b/mkosi/resources/man/mkosi.news.7.md
@@ -10,6 +10,13 @@
   or `mkosi shell`) should now be delimited from regular options using
   `--`. Options passed after the verb without using the `--` delimiter
   are now interpreted as regular mkosi options.
+- Boolean options specified on the command line now always expect a
+  boolean argument. For example, `--repository-key-check` needs to
+  become `--repository-key-check=yes`. The reason for this change is to
+  remove ambiguity when parsing e.g. `--repository-key-check build`
+  where `build` would be interpreted as the argument for
+  `--repository-key-check` whereas now it'll be properly interpreted as
+  the verb.
 - Teach `--verity` a new `hash` value, which skips the verity signature
   partition for extension / portable images. To align the possible values,
   `yes` is renamed to `signed`.


### PR DESCRIPTION
This allows us to get rid of the ambiguity when parsing the verb which
could be interpreted as the argument of the previous option by argparse.