### PR TITLE
run: Wait for child process in try block in spawn()

### DIFF
--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -227,6 +227,7 @@ def spawn(
 
         try:
             yield proc
+            proc.wait()
         except KeyboardInterrupt:
             proc.send_signal(signal.SIGINT)
             raise


### PR DESCRIPTION
If we only wait in finally block then any keyboard interrupt triggered during the wait will leave the child process alive and won't wait for it to exit. Let's make sure this doesn't happen by waiting in the try block as well.