### PR TITLE
Search for underscores in `systemd-stub`

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1849,7 +1849,7 @@ def systemd_stub_version(context: Context, stub: Path) -> Optional[GenericVersio
 
     if not (
         version := re.match(
-            r"#### LoaderInfo: systemd-stub (?P<version>[.~^a-zA-Z0-9-+]+) ####", sdmagic_text
+            r"#### LoaderInfo: systemd-stub (?P<version>[.~^a-zA-Z0-9-+_]+) ####", sdmagic_text
         )
     ):
         die(f"Unable to determine systemd-stub version, found {sdmagic_text!r}")


### PR DESCRIPTION
We're hitting problems building x86-64 raw disk images of RHEL 95.

```
...‣ Unable to determine systemd-stub version, found '#### LoaderInfo: systemd-stub 252-46.el9_5.2 ####'
```

RHEL 95 arm64 raw disk images are not encountering this.

This PR modifies the regex for `systemd-stub` to include underscores for RHEL95, which has allowed us to bypass the error.

Here is the `mkosi` config (using `v25.2`):

```ini
### IMAGE: default
# mkosi.conf
[Config]
MinimumVersion=v25.2

[Output]
ManifestFormat=json,changelog

[Build]
ToolsTree=default

[Content]

# "hashed:" with no hash produces a blank password.
RootPassword=hashed:

WithRecommends=0
WithDocs=0

# mkosi.conf.d/10-bootable.conf
[Match]
Format=disk

[Content]
Bootable=true

# mkosi.conf.d/20-centos/mkosi.conf
[Match]
Distribution=|rhel
Distribution=|rocky

[Content]
Packages=
    NetworkManager
    bash
    coreutils
    kernel-core
    kernel-modules
    linux-firmware
    systemd
    systemd-boot
    systemd-udev
    util-linux

# mkosi.conf.d/20-centos/mkosi.conf.d/20-rhel/mkosi.conf
[Match]
Distribution=rhel

[Distribution]
Release=9

# mkosi.conf.d/20-centos/mkosi.conf.d/20-rhel/mkosi.conf.d/10-x86-64.conf
[Match]
Architecture=x86-64

[Build]
ToolsTreeCertificates=false

[Distribution]
LocalMirror=https://preserve.eag.rdlabs.hpecorp.net/mirrors/netinst/rhel/9.5/x86_64/latest/BaseOS?ssl_verify=no

# mkosi.conf.d/20-centos/mkosi.conf.d/20-rhel/mkosi.conf.d/20-selinux.conf
[Match]
Format=disk

[Content]

# Ignore SELinux (breaks boots, at least for VMs).
KernelCommandLine=
        enforcing=0

# mkosi.conf.d/40-tools/mkosi.conf.d/30-debian.conf
[Match]
ToolsTreeDistribution=debian

[Build]
ToolsTreePackages=
    coreutils
    qemu-user
    qemu-user-static
    squashfs-tools

# mkosi.conf.d/90-output.conf
[Output]
OutputDirectory=build-%d-%r-%a
ImageId=%d-%r-%a
```
