### PR TITLE
Add intel VMD to kernel modules

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -108,6 +108,7 @@ KernelModulesInclude=
                     /virtio_scsi.ko
                     /virtio-rng.ko
                     /virtiofs.ko
+                    /vmd.ko
                     /vmw_vsock_virtio_transport.ko
                     /vsock.ko
                     /wmi.ko


### PR DESCRIPTION
I can't boot on my laptop without the Intel Volume Management Device module