### PR TITLE
Clean up default tools tree package lists

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf
@@ -25,6 +25,5 @@ Packages=
         openssl
         systemd
         tar
-        util-linux
         xfsprogs
         zstd

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/arch.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/arch.conf
@@ -12,7 +12,6 @@ Packages=
         libseccomp
         pacman
         pkcs11-provider
-        python-cryptography
         sbsigntools
         squashfs-tools
         systemd-ukify

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/azure-centos-fedora.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/azure-centos-fedora.conf
@@ -14,7 +14,6 @@ Packages=
         grub2-tools
         libseccomp
         policycoreutils
-        python3-cryptography
         qemu-img
         squashfs-tools
         systemd-udev

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
@@ -12,12 +12,10 @@ Packages=
         btrfs-progs
         erofs-utils
         grub-common
-        libarchive-tools
         libcryptsetup12
         libseccomp2
         libtss2-dev
         policycoreutils
-        python3-cryptography
         python3-pefile
         reprepro
         sbsigntool

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/opensuse.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/opensuse.conf
@@ -10,11 +10,9 @@ Packages=
         createrepo_c
         distribution-gpg-keys
         erofs-utils
-        glibc-gconv-modules-extra
         libseccomp2
         pkcs11-provider
         policycoreutils
-        python3-cryptography
         python3-pefile
         sbsigntools
         squashfs

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/ubuntu.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/ubuntu.conf
@@ -8,4 +8,5 @@ Repositories=main,universe
 
 [Content]
 Packages=
+        python3-cryptography
         ubuntu-keyring

--- a/mkosi/resources/mkosi-tools/mkosi.profiles/package-manager/mkosi.conf.d/arch.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/package-manager/mkosi.conf.d/arch.conf
@@ -10,7 +10,6 @@ Packages=
         createrepo_c
         distribution-gpg-keys
         dnf
-        dpkg
         reprepro
         ubuntu-keyring
         zypper


### PR DESCRIPTION
- util-linux is not needed anymore since we do mounts ourselves now
- dpkg is pulled in by apt on arch and we don't list it explicitly elsewhere
- glibc-gconv-modules-extra should be pulled in by something else on opensuse by now
- python3-cryptography is only required on ubuntu, rest already has a dependency on it in systemd-ukify or is already on systemd v257 which doesn't need it anymore
- libarchive-tools seems like a leftover that isn't installed anywhere else