### PR TITLE
Use Config.finalize_environment() in Installer.finalize_environment()

### DIFF
--- a/mkosi/installer/__init__.py
+++ b/mkosi/installer/__init__.py
@@ -58,7 +58,7 @@ class PackageManager:
                 "hostonly_l": "no",
             }
 
-        return context.config.environment | env
+        return context.config.finalize_environment() | env
 
     @classmethod
     def env_cmd(cls, context: Context) -> list[PathString]:


### PR DESCRIPTION
Otherwise we don't get the required proxy environment variables.