### PR TITLE
Reduce the number of filesystems we remount noexec/nosuid/nodev when root

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4894,7 +4894,7 @@ def run_build(
                 continue
 
             attrs = MOUNT_ATTR_RDONLY
-            if d not in ("/usr", "/opt"):
+            if d in ("/boot", "/efi"):
                 attrs |= MOUNT_ATTR_NOSUID | MOUNT_ATTR_NODEV | MOUNT_ATTR_NOEXEC
 
             mount_rbind(d, d, attrs)


### PR DESCRIPTION
For mkosi-initrd, /etc might very well contain executable scripts which we should allow to run, so let's only mount /boot and /efi nodev/nosuid/noexec.