### PR TITLE
debian: use libeatmydata with dpkg

### DIFF
--- a/mkosi.conf.d/30-debian-kali-ubuntu/mkosi.conf
+++ b/mkosi.conf.d/30-debian-kali-ubuntu/mkosi.conf
@@ -8,6 +8,7 @@ Distribution=|ubuntu
 [Content]
 Packages=
         fish
+        ^libeatmydata[0-9.-]+$
         openssh-client
         openssh-server
         python3

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -135,15 +135,19 @@ class Installer(DistributionInstaller):
         # execute any dpkg commands, so all it does is download the essential debs and tell us their full in
         # the apt cache without actually installing them.
         with tempfile.NamedTemporaryFile(mode="r") as f:
+            args = [
+                "-oDebug::pkgDPkgPm=1",
+                f"-oDPkg::Pre-Install-Pkgs::=cat >{workdir(Path(f.name))}",
+                "?essential",
+                "base-files",
+            ]
+            # Disables fsync/etc to speed up installing packages
+            if "libeatmydata1" in context.config.packages or "eatmydata" in context.config.packages:
+                args.append("libeatmydata1")
             Apt.invoke(
                 context,
                 "install",
-                [
-                    "-oDebug::pkgDPkgPm=1",
-                    f"-oDPkg::Pre-Install-Pkgs::=cat >{workdir(Path(f.name))}",
-                    "?essential",
-                    "base-files",
-                ],
+                args,
                 options=["--bind", f.name, workdir(Path(f.name))],
             )
 

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -154,6 +154,9 @@ class Apt(PackageManager):
         ):
             env["INITRD"] = "No"
 
+        if "libeatmydata1" in context.config.packages or "eatmydata" in context.config.packages:
+            env["LD_PRELOAD"] = "libeatmydata.so"
+
         return super().finalize_environment(context) | env
 
     @classmethod


### PR DESCRIPTION
Even with --force-unsafe-io dpkg still does a lot of fsyncs. Pull libeatmydata1 together with the bootstrapping set, and LD_PRELOAD it. It makes all fsync and related syscalls no-ops.

Before: 2m23.104s

After: 1m8.610s

The package is ~8KB and installed is ~30KB so it should make no difference to have it installed, and it's inert unless preloaded.