### PR TITLE
Drop ConfigureScripts=

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1861,7 +1861,6 @@ class Config:
     clean_package_metadata: ConfigFeature
     source_date_epoch: Optional[int]
 
-    configure_scripts: list[Path]
     sync_scripts: list[Path]
     prepare_scripts: list[Path]
     build_scripts: list[Path]
@@ -2449,15 +2448,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
         section="Config",
         parse=config_parse_minimum_version,
         help="Specify the minimum required mkosi version",
-    ),
-    ConfigSetting(
-        dest="configure_scripts",
-        long="--configure-script",
-        metavar="PATH",
-        section="Config",
-        parse=config_make_list_parser(delimiter=",", parse=make_path_parser()),
-        paths=("mkosi.configure",),
-        help="Configure script to run before doing anything",
     ),
     ConfigSetting(
         dest="pass_environment",
@@ -4375,7 +4365,6 @@ class ParseContext:
                     resources=self.resources,
                 )
                 make_executable(
-                    *config.configure_scripts,
                     *config.clean_scripts,
                     *config.sync_scripts,
                     *config.prepare_scripts,
@@ -4939,7 +4928,6 @@ def summary(config: Config) -> str:
                            Profiles: {line_join_list(config.profiles)}
                        Dependencies: {line_join_list(config.dependencies)}
                     Minimum Version: {none_to_none(config.minimum_version)}
-                  Configure Scripts: {line_join_list(config.configure_scripts)}
                    Pass Environment: {line_join_list(config.pass_environment)}
 
     {bold("DISTRIBUTION")}:

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -2109,11 +2109,6 @@ config file is read:
 :   The minimum **mkosi** version required to build this configuration. If
     specified multiple times, the highest specified version is used.
 
-`ConfigureScripts=`, `--configure-script=`
-:   Takes a comma-separated list of paths to executables that are used as
-    the configure scripts for this image. See the **Scripts** section for
-    more information.
-
 `PassEnvironment=`, `--pass-environment=`
 :   Takes a list of environment variable names separated by spaces. When
     building multiple images, pass the listed environment variables to
@@ -2318,17 +2313,6 @@ image. For each script, the configured build sources (`BuildSources=`)
 are mounted into the current working directory before running the script
 in the current working directory. `$SRCDIR` is set to point to the
 current working directory. The following scripts are supported:
-
-* If **`mkosi.configure`** (`ConfigureScripts=`) exists, it is executed
-  before building the image. This script may be used to dynamically
-  modify the configuration. It receives the configuration serialized as
-  JSON on stdin and should output the modified configuration serialized
-  as JSON on stdout. Note that this script only runs when building or
-  booting the image (`build`, `vm`, `boot` and `shell` verbs). If a
-  default tools tree is configured, it will be built before running the
-  configure scripts and the configure scripts will run with the tools
-  tree available. This also means that the modifications made by
-  configure scripts will not be visible in the `summary` output.
 
 * If **`mkosi.sync`** (`SyncScripts=`) exists, it is executed before the
   image is built. This script may be used to update various sources that

--- a/mkosi/resources/man/mkosi.news.7.md
+++ b/mkosi/resources/man/mkosi.news.7.md
@@ -17,6 +17,9 @@
   where `build` would be interpreted as the argument for
   `--repository-key-check` whereas now it'll be properly interpreted as
   the verb.
+- Support for configure scripts (`ConfigureScripts=`) was removed. Instead,
+  `mkosi sandbox` can be used to generate configuration based on the
+  configured tools tree.
 - Teach `--verity` a new `hash` value, which skips the verity signature
   partition for extension / portable images. To align the possible values,
   `yes` is renamed to `signed`.

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -135,9 +135,6 @@ def test_config() -> None:
             ],
             "CompressLevel": 3,
             "CompressOutput": "bz2",
-            "ConfigureScripts": [
-                "/configure"
-            ],
             "Console": "gui",
             "Credentials": {
                 "credkey": "credval"
@@ -458,7 +455,6 @@ def test_config() -> None:
         clean_scripts=[Path("/clean")],
         compress_level=3,
         compress_output=Compression.bz2,
-        configure_scripts=[Path("/configure")],
         console=ConsoleMode.gui,
         cpus=2,
         credentials={"credkey": "credval"},


### PR DESCRIPTION
These were added to allow generating configuration based on the tools tree, specifically QemuArgs= and Drives= for systemd's integration tests. Now that mkosi sandbox exists and we run meson within mkosi sandbox in systemd (https://github.com/systemd/systemd/pull/36500), there's no real need to keep these around anymore, and we don't know of any users outside of systemd, so let's drop support for them.

These were always somewhat of a hack to begin with, since we didn't do any proper validation on the JSON returned by configure scripts.