### PR TITLE
Implement build overlay mounting with mkosi-sandbox

### DIFF
--- a/mkosi/bootloader.py
+++ b/mkosi/bootloader.py
@@ -673,7 +673,6 @@ def install_systemd_boot(context: Context) -> None:
         "--all-architectures",
         "--no-variables",
     ]
-    options: list[PathString] = ["--bind", context.root, "/buildroot"]
 
     bootctlver = systemd_tool_version("bootctl", sandbox=context.sandbox)
 
@@ -686,7 +685,7 @@ def install_systemd_boot(context: Context) -> None:
         run_systemd_sign_tool(
             context.config,
             cmdline=cmd,
-            options=options,
+            options=context.rootoptions(),
             certificate=context.config.secure_boot_certificate if want_bootctl_auto_enroll else None,
             certificate_source=context.config.secure_boot_certificate_source,
             key=context.config.secure_boot_key if want_bootctl_auto_enroll else None,
@@ -756,7 +755,7 @@ def install_systemd_boot(context: Context) -> None:
                         "--cert", workdir(context.config.secure_boot_certificate),
                         "--output", workdir(keys / f"{db}.auth"),
                     ]  # fmt: skip
-                    options = [
+                    options: list[PathString] = [
                         "--ro-bind",
                         context.config.secure_boot_certificate,
                         workdir(context.config.secure_boot_certificate),

--- a/mkosi/context.py
+++ b/mkosi/context.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+import os
 from collections.abc import Sequence
 from contextlib import AbstractContextManager
 from pathlib import Path
@@ -41,6 +42,9 @@ class Context:
     @property
     def root(self) -> Path:
         return self.workspace / "root"
+
+    def rootoptions(self, dst: PathString = "/buildroot", *, readonly: bool = False) -> list[str]:
+        return ["--ro-bind" if readonly else "--bind", os.fspath(self.root), os.fspath(dst)]
 
     @property
     def staging(self) -> Path:

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -297,7 +297,7 @@ def fixup_os_release(context: Context) -> None:
                     f"/{candidate}.dpkg",
                     f"/{candidate}",
                 ],
-                sandbox=context.sandbox(options=["--bind", context.root, "/buildroot"]),
+                sandbox=context.sandbox(options=context.rootoptions()),
             )
 
         newosrelease.rename(osrelease)

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -116,7 +116,7 @@ class Installer(DistributionInstaller):
                     ],
                     sandbox=context.sandbox(
                         options=[
-                            "--bind", context.root, "/buildroot",
+                            *context.rootoptions(),
                             *finalize_certificate_mounts(context.config),
                         ],
                     ),

--- a/mkosi/installer/__init__.py
+++ b/mkosi/installer/__init__.py
@@ -138,7 +138,7 @@ class PackageManager:
         return context.sandbox(
             network=True,
             options=[
-                "--bind", context.root, "/buildroot",
+                *context.rootoptions(),
                 *cls.mounts(context),
                 *cls.options(root=context.root, apivfs=apivfs),
                 *options,

--- a/mkosi/kmod.py
+++ b/mkosi/kmod.py
@@ -101,9 +101,9 @@ def modinfo(context: Context, kver: str, modules: Iterable[str]) -> str:
 
     if context.config.output_format.is_extension_image() and not context.config.overlay:
         cmdline += ["--basedir", "/buildroot"]
-        sandbox = context.sandbox(options=["--ro-bind", context.root, "/buildroot"])
+        sandbox = context.sandbox(options=context.rootoptions(readonly=True))
     else:
-        sandbox = chroot_cmd(root=context.root)
+        sandbox = chroot_cmd(root=context.rootoptions)
 
     cmdline += [*modules]
 

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -637,14 +637,14 @@ def chroot_options() -> list[PathString]:
 @contextlib.contextmanager
 def chroot_cmd(
     *,
-    root: Path,
+    root: Callable[[PathString], list[str]],
     network: bool = False,
     options: Sequence[PathString] = (),
 ) -> Iterator[list[PathString]]:
     with vartmpdir() as dir, resource_path(sys.modules[__package__ or __name__]) as module:
         cmdline: list[PathString] = [
             sys.executable, "-SI", module / "sandbox.py",
-            "--bind", root, "/",
+            *root("/"),
             # We mounted a subdirectory of TMPDIR to /var/tmp so we unset TMPDIR so that /tmp or /var/tmp are
             # used instead.
             "--unsetenv", "TMPDIR",


### PR DESCRIPTION
Now that we have Context.rootoptions(), we can switch out how we set
up the root mount without having to modify code all over the place.

Let's use this to get rid of mount_build_overlay() and instead replace
it with setup_build_overlay(), which simply configures a bunch of
fields on Context that make rootoptions() set up the root mount as an
overlay instead of a bind mount.