### PR TITLE
Improve parsing of local mkosi config

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -4561,11 +4561,10 @@ class ParseContext:
 
     def parse_config_one(self, path: Path, parse_profiles: bool = False, parse_local: bool = False) -> bool:
         s: Optional[ConfigSetting[object]]  # Hint to mypy that we might assign None
-        extras = path.is_dir()
-
         assert path.is_absolute()
 
-        if path.is_dir():
+        extras = path.is_dir()
+        if extras:
             path /= "mkosi.conf"
 
         if not self.match_config(path):
@@ -4573,10 +4572,10 @@ class ParseContext:
 
         if extras:
             if parse_local:
-                if (
-                    ((localpath := path.parent / "mkosi.local") / "mkosi.conf").exists()
-                    or (localpath := path.parent / "mkosi.local.conf").exists()
-                ):  # fmt: skip
+                for localpath in (
+                    *([p] if (p := path.parent / "mkosi.local").is_dir() else []),
+                    *([p] if (p := path.parent / "mkosi.local.conf").is_file() else []),
+                ):
                     with chdir(localpath if localpath.is_dir() else Path.cwd()):
                         self.parse_config_one(localpath if localpath.is_file() else Path.cwd())
 

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -326,9 +326,9 @@ grouped by section below.
 Configuration is parsed in the following order:
 
 * The command line arguments are parsed.
-* `mkosi.local.conf` or `mkosi.local` is parsed if it exists. This file or
-  directory should be in `.gitignore` (or equivalent) and is intended for local
-  configuration.
+* `mkosi.local.conf` and `mkosi.local/` are parsed if they exists (in that order).
+  This file or directory should be in `.gitignore` (or equivalent)
+  and is intended for local configuration.
 * Any default paths (depending on the option) are configured if the
   corresponding path exists.
 * `mkosi.conf` is parsed if it exists in the directory configured with
@@ -346,7 +346,7 @@ Note that settings configured via the command line always override
 settings configured via configuration files. If the same setting is
 configured more than once via configuration files, later assignments
 override earlier assignments except for settings that take a collection
-of values. Also, settings read from `mkosi.local` or `mkosi.local.conf` will
+of values. Also, settings read from `mkosi.local.conf` or `mkosi.local/` will
 override settings from configuration files that are parsed later, but not
 settings specified on the CLI.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -460,6 +460,8 @@ def test_local_config(tmp_path: Path) -> None:
 
         [Content]
         WithTests=yes
+        Environment=FOO=override
+        Environment=BAZ=normal
         """
     )
 
@@ -475,6 +477,8 @@ def test_local_config(tmp_path: Path) -> None:
 
         [Content]
         WithTests=no
+        Environment=FOO=normal
+        Environment=BAR=normal
         """
     )
 
@@ -490,6 +494,20 @@ def test_local_config(tmp_path: Path) -> None:
 
     assert config.distribution == Distribution.fedora
     assert not config.with_tests
+
+    (d / "mkosi.local/mkosi.conf.d").mkdir(parents=True)
+    (d / "mkosi.local/mkosi.conf.d/10-test.conf").write_text(
+        """\
+        [Content]
+        Environment=BAR=override
+        Environment=BAZ=override
+        """
+    )
+
+    with chdir(d):
+        _, [config] = parse_config()
+
+    assert config.environment == {"FOO": "override", "BAR": "override", "BAZ": "override"}
 
 
 def test_parse_load_verb(tmp_path: Path) -> None:


### PR DESCRIPTION
Clarify that mkosi.local shall be a directory with a mkosi.conf file inside of it.