### PR TITLE
Fix signing of grub boot binary

### DIFF
--- a/mkosi/bootloader.py
+++ b/mkosi/bootloader.py
@@ -358,8 +358,8 @@ def install_grub(context: Context) -> None:
             if context.config.secure_boot:
                 # sign_efi_binary() mounts input as read only, so
                 # creating temporary rw copy
-                with tempfile.NamedTemporaryFile(prefix="efi-boot-binary") as input:
-                    input = Path(input.name)
+                with tempfile.NamedTemporaryFile(prefix="efi-boot-binary") as temp_file:
+                    input = Path(temp_file.name)
                     shutil.copy2(output, input)
                     sign_efi_binary(context, input, output)
 

--- a/mkosi/bootloader.py
+++ b/mkosi/bootloader.py
@@ -356,7 +356,12 @@ def install_grub(context: Context) -> None:
                 sbat=sbat,
             )
             if context.config.secure_boot:
-                sign_efi_binary(context, output, output)
+                # sign_efi_binary() mounts input as read only, so
+                # creating temporary rw copy
+                with tempfile.NamedTemporaryFile(prefix="efi-boot-binary") as input:
+                    input = Path(input.name)
+                    shutil.copy2(output, input)
+                    sign_efi_binary(context, input, output)
 
     dst = context.root / "efi" / context.config.distribution.grub_prefix() / "fonts"
     with umask(~0o700):


### PR DESCRIPTION
When `sign_efi_binary` runs sandbox for signing, it will mount input path as read only. But in case of grub, the caller function passes input and output path to be the same. Due to this, command complains `image_write/open: Read-only file system` and exits.