### PR TITLE
Add --pretty=no to suppress output from `systemd-repart` when updating

### DIFF
--- a/mkosi/sysupdate.py
+++ b/mkosi/sysupdate.py
@@ -49,6 +49,8 @@ def run_sysupdate(args: Args, config: Config) -> None:
             run(
                 [
                     "systemd-repart",
+                    "--no-pager",
+                    "--pretty=no",
                     "--split=yes",
                     *([f"--definitions={workdir(d)}" for d in config.repart_dirs]),
                     workdir(config.output_dir_or_cwd() / config.output_with_format),


### PR DESCRIPTION
Otherwise `systemd-repart` will always show partition information when running `mkosi update`.