### PR TITLE
centos: Handle major/minor releases in derivatives properly

### DIFF
--- a/kernel-install/50-mkosi.install
+++ b/kernel-install/50-mkosi.install
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import logging
+import os
 import sys
 import tempfile
 from pathlib import Path
@@ -91,7 +92,7 @@ def main() -> None:
 
     logging.info(f"Building {output}")
 
-    run(cmdline, stdin=sys.stdin, stdout=sys.stdout)
+    run(cmdline, stdin=sys.stdin, stdout=sys.stdout, env=os.environ)
 
     if format == OutputFormat.cpio:
         build_microcode_initrd(context.staging_area / "microcode")

--- a/kernel-install/51-mkosi-addon.install
+++ b/kernel-install/51-mkosi-addon.install
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import logging
+import os
 import sys
 from pathlib import Path
 
@@ -44,7 +45,7 @@ def main() -> None:
 
     logging.info("Building mkosi-local.addon.efi")
 
-    run(cmdline, stdin=sys.stdin, stdout=sys.stdout)
+    run(cmdline, stdin=sys.stdin, stdout=sys.stdout, env=os.environ)
 
 
 if __name__ == "__main__":

--- a/mkosi/distributions/alma.py
+++ b/mkosi/distributions/alma.py
@@ -10,13 +10,14 @@ class Installer(centos.Installer):
     def pretty_name(cls) -> str:
         return "AlmaLinux"
 
-    @staticmethod
-    def gpgurls(context: Context) -> tuple[str, ...]:
+    @classmethod
+    def gpgurls(cls, context: Context) -> tuple[str, ...]:
+        major = cls.major_release(context.config)
         return (
             find_rpm_gpgkey(
                 context,
-                f"RPM-GPG-KEY-AlmaLinux-{context.config.release}",
-                f"https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux-{context.config.release}",
+                f"RPM-GPG-KEY-AlmaLinux-{major}",
+                f"https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux-{major}",
             ),
         )
 

--- a/mkosi/distributions/rhel.py
+++ b/mkosi/distributions/rhel.py
@@ -15,14 +15,12 @@ class Installer(centos.Installer):
     def pretty_name(cls) -> str:
         return "RHEL"
 
-    @staticmethod
-    def gpgurls(context: Context) -> tuple[str, ...]:
-        major = int(float(context.config.release))
-
+    @classmethod
+    def gpgurls(cls, context: Context) -> tuple[str, ...]:
         return (
             find_rpm_gpgkey(
                 context,
-                f"RPM-GPG-KEY-redhat{major}-release",
+                f"RPM-GPG-KEY-redhat{cls.major_release(context.config)}-release",
                 "https://access.redhat.com/security/data/fd431d51.txt",
             ),
         )
@@ -87,7 +85,7 @@ class Installer(centos.Installer):
             )
 
             v = context.config.release
-            major = int(float(v))
+            major = cls.major_release(context.config)
             yield RpmRepository(
                 f"rhel-{v}-{repo}-rpms",
                 f"baseurl={join_mirror(mirror, f'rhel{major}/{v}/$basearch/{repo}/os')}",

--- a/mkosi/distributions/rhel_ubi.py
+++ b/mkosi/distributions/rhel_ubi.py
@@ -12,14 +12,12 @@ class Installer(centos.Installer):
     def pretty_name(cls) -> str:
         return "RHEL UBI"
 
-    @staticmethod
-    def gpgurls(context: Context) -> tuple[str, ...]:
-        major = int(float(context.config.release))
-
+    @classmethod
+    def gpgurls(cls, context: Context) -> tuple[str, ...]:
         return (
             find_rpm_gpgkey(
                 context,
-                f"RPM-GPG-KEY-redhat{major}-release",
+                f"RPM-GPG-KEY-redhat{cls.major_release(context.config)}-release",
                 "https://access.redhat.com/security/data/fd431d51.txt",
             ),
         )

--- a/mkosi/distributions/rocky.py
+++ b/mkosi/distributions/rocky.py
@@ -10,13 +10,14 @@ class Installer(centos.Installer):
     def pretty_name(cls) -> str:
         return "Rocky Linux"
 
-    @staticmethod
-    def gpgurls(context: Context) -> tuple[str, ...]:
+    @classmethod
+    def gpgurls(cls, context: Context) -> tuple[str, ...]:
+        major = cls.major_release(context.config)
         return (
             find_rpm_gpgkey(
                 context,
-                f"RPM-GPG-KEY-Rocky-{context.config.release}",
-                f"https://download.rockylinux.org/pub/rocky/RPM-GPG-KEY-Rocky-{context.config.release}",
+                f"RPM-GPG-KEY-Rocky-{major}",
+                f"https://download.rockylinux.org/pub/rocky/RPM-GPG-KEY-Rocky-{major}",
             ),
         )
 

--- a/mkosi/initrd.py
+++ b/mkosi/initrd.py
@@ -345,7 +345,7 @@ def main() -> None:
             cmdline,
             stdin=sys.stdin,
             stdout=sys.stdout,
-            env={"MKOSI_DNF": dnf.resolve().name} if (dnf := find_binary("dnf")) else {},
+            env=os.environ | ({"MKOSI_DNF": dnf.resolve().name} if (dnf := find_binary("dnf")) else {}),
         )
 
         initrd_finalize(staging_dir, args.output, args.output_dir)


### PR DESCRIPTION
While centos doesn't have major/minor releases, rocky, alma and rhel do, so let's make sure we handle those cases properly.

Additionally, we also fix EPEL to use the proper major/minor release when we're doing EPEL 10, as since EPEL 10 there's major/minor releases for EPEL as well.