### PR TITLE
Move package installation and removal to PackageManager interface

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -239,7 +239,9 @@ def install_distribution(context: Context) -> None:
             return
 
         with complete_step(f"Installing extra packages for {context.config.distribution.pretty_name()}"):
-            context.config.distribution.install_packages(context, context.config.packages)
+            context.config.distribution.package_manager(context.config).install(
+                context, context.config.packages
+            )
     else:
         if context.config.overlay or context.config.output_format.is_extension_image():
             if context.config.packages:
@@ -278,7 +280,9 @@ def install_distribution(context: Context) -> None:
                 (context.root / "boot/loader/entries.srel").write_text("type1\n")
 
             if context.config.packages:
-                context.config.distribution.install_packages(context, context.config.packages)
+                context.config.distribution.package_manager(context.config).install(
+                    context, context.config.packages
+                )
 
     for f in (
         "var/lib/systemd/random-seed",
@@ -300,7 +304,9 @@ def install_build_packages(context: Context) -> None:
         complete_step(f"Installing build packages for {context.config.distribution.pretty_name()}"),
         setup_build_overlay(context),
     ):
-        context.config.distribution.install_packages(context, context.config.build_packages)
+        context.config.distribution.package_manager(context.config).install(
+            context, context.config.build_packages
+        )
 
 
 def install_volatile_packages(context: Context) -> None:
@@ -308,7 +314,9 @@ def install_volatile_packages(context: Context) -> None:
         return
 
     with complete_step(f"Installing volatile packages for {context.config.distribution.pretty_name()}"):
-        context.config.distribution.install_packages(context, context.config.volatile_packages)
+        context.config.distribution.package_manager(context.config).install(
+            context, context.config.volatile_packages
+        )
 
 
 def remove_packages(context: Context) -> None:
@@ -319,7 +327,9 @@ def remove_packages(context: Context) -> None:
 
     with complete_step(f"Removing {len(context.config.remove_packages)} packages…"):
         try:
-            context.config.distribution.remove_packages(context, context.config.remove_packages)
+            context.config.distribution.package_manager(context.config).remove(
+                context, context.config.remove_packages
+            )
         except NotImplementedError:
             die(f"Removing packages is not supported for {context.config.distribution}")
 

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -3,7 +3,6 @@
 import enum
 import importlib
 import urllib.parse
-from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, cast
 
@@ -41,14 +40,6 @@ class DistributionInstaller:
 
     @classmethod
     def install(cls, context: "Context") -> None:
-        raise NotImplementedError
-
-    @classmethod
-    def install_packages(cls, context: "Context", packages: Sequence[str]) -> None:
-        raise NotImplementedError
-
-    @classmethod
-    def remove_packages(cls, context: "Context", packages: Sequence[str]) -> None:
         raise NotImplementedError
 
     @classmethod
@@ -135,12 +126,6 @@ class Distribution(StrEnum):
 
     def install(self, context: "Context") -> None:
         return self.installer().install(context)
-
-    def install_packages(self, context: "Context", packages: Sequence[str]) -> None:
-        return self.installer().install_packages(context, packages)
-
-    def remove_packages(self, context: "Context", packages: Sequence[str]) -> None:
-        return self.installer().remove_packages(context, packages)
 
     def filesystem(self) -> str:
         return self.installer().filesystem()

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -12,7 +12,6 @@ from mkosi.distributions import DistributionInstaller, PackageType
 from mkosi.installer import PackageManager
 from mkosi.installer.pacman import Pacman, PacmanRepository
 from mkosi.log import complete_step, die
-from mkosi.util import sort_packages
 
 
 class Installer(DistributionInstaller):
@@ -70,7 +69,7 @@ class Installer(DistributionInstaller):
         Pacman.invoke(
             context,
             "--sync",
-            ["--needed", "--assume-installed", "initramfs", *sort_packages(packages)],
+            ["--needed", "--assume-installed", "initramfs", *packages],
             apivfs=apivfs,
         )
 

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import tempfile
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from pathlib import Path
 
 from mkosi.archive import extract_tar
@@ -62,20 +62,7 @@ class Installer(DistributionInstaller):
 
     @classmethod
     def install(cls, context: Context) -> None:
-        cls.install_packages(context, ["filesystem"], apivfs=False)
-
-    @classmethod
-    def install_packages(cls, context: Context, packages: Sequence[str], apivfs: bool = True) -> None:
-        Pacman.invoke(
-            context,
-            "--sync",
-            ["--needed", "--assume-installed", "initramfs", *packages],
-            apivfs=apivfs,
-        )
-
-    @classmethod
-    def remove_packages(cls, context: Context, packages: Sequence[str]) -> None:
-        Pacman.invoke(context, "--remove", ["--nosave", "--recursive", *packages], apivfs=True)
+        Pacman.install(context, ["filesystem"], apivfs=False)
 
     @classmethod
     def repositories(cls, context: Context) -> Iterable[PacmanRepository]:

--- a/mkosi/distributions/azure.py
+++ b/mkosi/distributions/azure.py
@@ -33,7 +33,7 @@ class Installer(fedora.Installer):
 
     @classmethod
     def install(cls, context: Context) -> None:
-        cls.install_packages(context, ["filesystem", "azurelinux-release"], apivfs=False)
+        Dnf.install(context, ["filesystem", "azurelinux-release"], apivfs=False)
 
     @classmethod
     def repositories(cls, context: Context) -> Iterable[RpmRepository]:

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 from mkosi.config import Architecture, Config
 from mkosi.context import Context
@@ -78,15 +78,7 @@ class Installer(DistributionInstaller):
 
     @classmethod
     def install(cls, context: Context) -> None:
-        cls.install_packages(context, ["basesystem"], apivfs=False)
-
-    @classmethod
-    def install_packages(cls, context: Context, packages: Sequence[str], apivfs: bool = True) -> None:
-        Dnf.invoke(context, "install", packages, apivfs=apivfs)
-
-    @classmethod
-    def remove_packages(cls, context: Context, packages: Sequence[str]) -> None:
-        Dnf.invoke(context, "remove", packages, apivfs=True)
+        Dnf.install(context, ["basesystem"], apivfs=False)
 
     @classmethod
     def architecture(cls, arch: Architecture) -> str:

--- a/mkosi/distributions/custom.py
+++ b/mkosi/distributions/custom.py
@@ -1,12 +1,10 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from collections.abc import Sequence
 
 from mkosi.config import Architecture, Config
 from mkosi.context import Context
 from mkosi.distributions import DistributionInstaller
 from mkosi.installer import PackageManager
-from mkosi.log import die
 
 
 class Installer(DistributionInstaller):
@@ -29,13 +27,3 @@ class Installer(DistributionInstaller):
     @classmethod
     def install(cls, context: Context) -> None:
         pass
-
-    @classmethod
-    def install_packages(cls, context: Context, packages: Sequence[str]) -> None:
-        if packages:
-            die("Installing packages is not supported for custom distributions'")
-
-    @classmethod
-    def remove_packages(cls, context: Context, packages: Sequence[str]) -> None:
-        if packages:
-            die("Removing packages is not supported for custom distributions")

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -3,7 +3,7 @@
 import re
 import subprocess
 import tempfile
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from pathlib import Path
 
 from mkosi.config import Architecture, Config
@@ -129,15 +129,7 @@ class Installer(DistributionInstaller):
 
     @classmethod
     def install(cls, context: Context) -> None:
-        cls.install_packages(context, ["basesystem"], apivfs=False)
-
-    @classmethod
-    def install_packages(cls, context: Context, packages: Sequence[str], apivfs: bool = True) -> None:
-        Dnf.invoke(context, "install", packages, apivfs=apivfs)
-
-    @classmethod
-    def remove_packages(cls, context: Context, packages: Sequence[str]) -> None:
-        Dnf.invoke(context, "remove", packages, apivfs=True)
+        Dnf.install(context, ["basesystem"], apivfs=False)
 
     @classmethod
     def repositories(cls, context: Context) -> Iterable[RpmRepository]:

--- a/mkosi/distributions/mageia.py
+++ b/mkosi/distributions/mageia.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 from mkosi.config import Architecture
 from mkosi.context import Context
 from mkosi.distributions import fedora, join_mirror
+from mkosi.installer.dnf import Dnf
 from mkosi.installer.rpm import RpmRepository, find_rpm_gpgkey
 from mkosi.log import die
 
@@ -24,7 +25,7 @@ class Installer(fedora.Installer):
 
     @classmethod
     def install(cls, context: Context) -> None:
-        cls.install_packages(context, ["filesystem"], apivfs=False)
+        Dnf.install(context, ["filesystem"], apivfs=False)
 
     @classmethod
     def repositories(cls, context: Context) -> Iterable[RpmRepository]:

--- a/mkosi/distributions/openmandriva.py
+++ b/mkosi/distributions/openmandriva.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 from mkosi.config import Architecture
 from mkosi.context import Context
 from mkosi.distributions import fedora, join_mirror
+from mkosi.installer.dnf import Dnf
 from mkosi.installer.rpm import RpmRepository, find_rpm_gpgkey
 from mkosi.log import die
 
@@ -24,7 +25,7 @@ class Installer(fedora.Installer):
 
     @classmethod
     def install(cls, context: Context) -> None:
-        cls.install_packages(context, ["filesystem"], apivfs=False)
+        Dnf.install(context, ["filesystem"], apivfs=False)
 
     @classmethod
     def repositories(cls, context: Context) -> Iterable[RpmRepository]:

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -16,7 +16,6 @@ from mkosi.installer.zypper import Zypper
 from mkosi.log import die
 from mkosi.mounts import finalize_certificate_mounts
 from mkosi.run import run
-from mkosi.util import sort_packages
 
 
 class Installer(DistributionInstaller):
@@ -70,17 +69,17 @@ class Installer(DistributionInstaller):
                 [
                     "--download", "in-advance",
                     "--recommends" if context.config.with_recommends else "--no-recommends",
-                    *sort_packages(packages),
+                    *packages,
                 ],
                 apivfs=apivfs,
             )  # fmt: skip
         else:
-            Dnf.invoke(context, "install", sort_packages(packages), apivfs=apivfs)
+            Dnf.invoke(context, "install", packages, apivfs=apivfs)
 
     @classmethod
     def remove_packages(cls, context: Context, packages: Sequence[str]) -> None:
         if context.config.find_binary("zypper"):
-            Zypper.invoke(context, "remove", ["--clean-deps", *sort_packages(packages)], apivfs=True)
+            Zypper.invoke(context, "remove", ["--clean-deps", *packages], apivfs=True)
         else:
             Dnf.invoke(context, "remove", packages, apivfs=True)
 

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import tempfile
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from pathlib import Path
 from xml.etree import ElementTree
 
@@ -58,30 +58,7 @@ class Installer(DistributionInstaller):
 
     @classmethod
     def install(cls, context: Context) -> None:
-        cls.install_packages(context, ["filesystem"], apivfs=False)
-
-    @classmethod
-    def install_packages(cls, context: Context, packages: Sequence[str], apivfs: bool = True) -> None:
-        if context.config.find_binary("zypper"):
-            Zypper.invoke(
-                context,
-                "install",
-                [
-                    "--download", "in-advance",
-                    "--recommends" if context.config.with_recommends else "--no-recommends",
-                    *packages,
-                ],
-                apivfs=apivfs,
-            )  # fmt: skip
-        else:
-            Dnf.invoke(context, "install", packages, apivfs=apivfs)
-
-    @classmethod
-    def remove_packages(cls, context: Context, packages: Sequence[str]) -> None:
-        if context.config.find_binary("zypper"):
-            Zypper.invoke(context, "remove", ["--clean-deps", *packages], apivfs=True)
-        else:
-            Dnf.invoke(context, "remove", packages, apivfs=True)
+        cls.package_manager(context.config).install(context, ["filesystem"], apivfs=False)
 
     @classmethod
     def repositories(cls, context: Context) -> Iterable[RpmRepository]:

--- a/mkosi/installer/__init__.py
+++ b/mkosi/installer/__init__.py
@@ -146,6 +146,20 @@ class PackageManager:
         )  # fmt: skip
 
     @classmethod
+    def install(
+        cls,
+        context: Context,
+        packages: Sequence[str],
+        *,
+        apivfs: bool = True,
+    ) -> None:
+        pass
+
+    @classmethod
+    def remove(cls, context: Context, packages: Sequence[str]) -> None:
+        pass
+
+    @classmethod
     def sync(cls, context: Context, force: bool) -> None:
         pass
 

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -230,6 +230,25 @@ class Apt(PackageManager):
         )
 
     @classmethod
+    def install(
+        cls,
+        context: Context,
+        packages: Sequence[str],
+        *,
+        apivfs: bool = True,
+    ) -> None:
+        cls.invoke(context, "install", packages, apivfs=apivfs)
+
+        # systemd-gpt-auto-generator is disabled by default in Ubuntu:
+        # https://git.launchpad.net/ubuntu/+source/systemd/tree/debian/systemd.links?h=ubuntu/noble-proposed.
+        # Let's make sure it is enabled by default in our images.
+        (context.root / "etc/systemd/system-generators/systemd-gpt-auto-generator").unlink(missing_ok=True)
+
+    @classmethod
+    def remove(cls, context: Context, packages: Sequence[str]) -> None:
+        cls.invoke(context, "purge", packages, apivfs=True)
+
+    @classmethod
     def sync(cls, context: Context, force: bool) -> None:
         cls.invoke(context, "update")
 

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -284,6 +284,17 @@ class Apt(PackageManager):
             )
         )
 
+        (context.sandbox_tree / "etc/apt/preferences.d").mkdir(parents=True, exist_ok=True)
+        (context.sandbox_tree / "etc/apt/preferences.d/mkosi-local.pref").write_text(
+            textwrap.dedent(
+                """\
+                Package: *
+                Pin: origin mkosi
+                Pin-Priority: 1100
+                """
+            )
+        )
+
         cls.invoke(
             context,
             "update",

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -229,6 +229,20 @@ class Dnf(PackageManager):
                         p.unlink()
 
     @classmethod
+    def install(
+        cls,
+        context: Context,
+        packages: Sequence[str],
+        *,
+        apivfs: bool = True,
+    ) -> None:
+        cls.invoke(context, "install", packages, apivfs=apivfs)
+
+    @classmethod
+    def remove(cls, context: Context, packages: Sequence[str]) -> None:
+        cls.invoke(context, "remove", packages, apivfs=True)
+
+    @classmethod
     def sync(cls, context: Context, force: bool, arguments: Sequence[str] = ()) -> None:
         cls.invoke(
             context,

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -181,6 +181,21 @@ class Pacman(PackageManager):
         )
 
     @classmethod
+    def install(
+        cls,
+        context: Context,
+        packages: Sequence[str],
+        *,
+        apivfs: bool = True,
+    ) -> None:
+        arguments = ["--needed", "--assume-installed", "initramfs", *packages]
+        cls.invoke(context, "--sync", arguments, apivfs=apivfs)
+
+    @classmethod
+    def remove(cls, context: Context, packages: Sequence[str]) -> None:
+        cls.invoke(context, "--remove", ["--nosave", "--recursive", *packages], apivfs=True)
+
+    @classmethod
     def keyring(cls, context: Context) -> None:
         def sandbox() -> AbstractContextManager[list[PathString]]:
             return cls.sandbox(

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -133,6 +133,26 @@ class Zypper(PackageManager):
         )
 
     @classmethod
+    def install(
+        cls,
+        context: Context,
+        packages: Sequence[str],
+        *,
+        apivfs: bool = True,
+    ) -> None:
+        arguments = [
+            "--download", "in-advance",
+            "--recommends" if context.config.with_recommends else "--no-recommends",
+            *packages,
+        ]  # fmt: skip
+
+        cls.invoke(context, "install", arguments, apivfs=apivfs)
+
+    @classmethod
+    def remove(cls, context: Context, packages: Sequence[str]) -> None:
+        cls.invoke(context, "remove", ["--clean-deps", *packages], apivfs=True)
+
+    @classmethod
     def sync(cls, context: Context, force: bool, arguments: Sequence[str] = ()) -> None:
         cls.invoke(context, "refresh", [*(["--force"] if force else []), *arguments])
 

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -99,13 +99,6 @@ def format_rlimit(rlimit: int) -> str:
     return f"{soft}:{hard}"
 
 
-def sort_packages(packages: Iterable[str]) -> list[str]:
-    """Sorts packages: normal first, paths second, conditional third"""
-
-    m = {"(": 2, "/": 1}
-    return sorted(packages, key=lambda name: (m.get(name[0], 0), name))
-
-
 def flatten(lists: Iterable[Iterable[T]]) -> list[T]:
     """Flatten a sequence of sequences into a single list."""
     return list(itertools.chain.from_iterable(lists))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -100,8 +100,8 @@ def test_parse_config(tmp_path: Path) -> None:
         Architecture=arm64
         Repositories=epel,epel-next
 
-        [Content]
-        Packages=abc
+        [Config]
+        Profiles=abc
 
         [Build]
         Environment=MY_KEY=MY_VALUE
@@ -120,7 +120,7 @@ def test_parse_config(tmp_path: Path) -> None:
 
     assert config.distribution == Distribution.ubuntu
     assert config.architecture == Architecture.arm64
-    assert config.packages == ["abc"]
+    assert config.profiles == ["abc"]
     assert config.output_format == OutputFormat.cpio
     assert config.image_id == "base"
 
@@ -163,8 +163,8 @@ def test_parse_config(tmp_path: Path) -> None:
         [Distribution]
         Distribution=debian
 
-        [Content]
-        Packages=qed
+        [Config]
+        Profiles=qed
                  def
 
         [Output]
@@ -175,13 +175,13 @@ def test_parse_config(tmp_path: Path) -> None:
     )
 
     with chdir(d):
-        _, [config] = parse_config(["--package", "last"])
+        _, [config] = parse_config(["--profile", "last"])
 
     # Setting a value explicitly in a dropin should override the default from mkosi.conf.
     assert config.distribution == Distribution.debian
     # Lists should be merged by appending the new values to the existing values. Any values from the CLI
     # should be appended to the values from the configuration files.
-    assert config.packages == ["abc", "qed", "def", "last"]
+    assert config.profiles == ["abc", "qed", "def", "last"]
     assert config.output_format == OutputFormat.cpio
     assert config.image_id == "00-dropin"
     assert config.image_version == "0"
@@ -329,7 +329,7 @@ def test_parse_includes_once(tmp_path: Path) -> None:
 
     with chdir(d):
         _, [config] = parse_config(["--include", "abc.conf", "--include", "abc.conf"])
-        assert config.build_packages == ["def", "abc"]
+        assert config.build_packages == ["abc", "def"]
 
     (d / "mkosi.images").mkdir()
 


### PR DESCRIPTION
There's no need for these to be implemented by the Distribution
interface as they don't need distribution specific knowledge so let's
move them to the PackageManager interface instead.