### PR TITLE
Check for CAP_SYS_ADMIN instead of root

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -114,6 +114,7 @@ from mkosi.run import (
     workdir,
 )
 from mkosi.sandbox import (
+    CAP_SYS_ADMIN,
     CLONE_NEWNS,
     MOUNT_ATTR_NODEV,
     MOUNT_ATTR_NOEXEC,
@@ -123,6 +124,7 @@ from mkosi.sandbox import (
     MS_SLAVE,
     __version__,
     acquire_privileges,
+    have_effective_cap,
     join_new_session_keyring,
     mount,
     mount_rbind,
@@ -4888,12 +4890,11 @@ def run_build(
     metadata_dir: Path,
     package_dir: Optional[Path] = None,
 ) -> None:
-    if os.getuid() != 0:
+    if not have_effective_cap(CAP_SYS_ADMIN):
         acquire_privileges()
-
-    unshare(CLONE_NEWNS)
-
-    if os.getuid() == 0:
+        unshare(CLONE_NEWNS)
+    else:
+        unshare(CLONE_NEWNS)
         mount("", "/", "", MS_SLAVE | MS_REC, "")
 
     # For extra safety when running as root, remount a bunch of directories read-only unless the output

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -87,7 +87,12 @@ from mkosi.installer import clean_package_manager_metadata
 from mkosi.kmod import gen_required_kernel_modules, loaded_modules, process_kernel_modules
 from mkosi.log import ARG_DEBUG, complete_step, die, log_notice, log_step
 from mkosi.manifest import Manifest
-from mkosi.mounts import finalize_certificate_mounts, finalize_source_mounts, mount_overlay
+from mkosi.mounts import (
+    finalize_certificate_mounts,
+    finalize_source_mounts,
+    finalize_volatile_tmpdir,
+    mount_overlay,
+)
 from mkosi.pager import page
 from mkosi.partition import Partition, finalize_root, finalize_roothash
 from mkosi.qemu import (
@@ -501,7 +506,12 @@ def setup_build_overlay(context: Context, volatile: bool = False) -> Iterator[No
         if volatile:
             context.lowerdirs = [d]
             context.upperdir = Path(
-                stack.enter_context(tempfile.TemporaryDirectory(prefix="volatile-overlay"))
+                stack.enter_context(
+                    tempfile.TemporaryDirectory(
+                        prefix="volatile-overlay.",
+                        dir=finalize_volatile_tmpdir(),
+                    )
+                )
             )
             os.chmod(context.upperdir, d.stat().st_mode)
         else:

--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -452,7 +452,7 @@ def become_user(uid: int, gid: int) -> None:
 
 
 def acquire_privileges(*, become_root: bool = False) -> bool:
-    if os.getuid() == 0 or (not become_root and have_effective_cap(CAP_SYS_ADMIN)):
+    if have_effective_cap(CAP_SYS_ADMIN) and (os.getuid() == 0 or not become_root):
         return False
 
     if become_root:


### PR DESCRIPTION
Even if we're running as root, we might not have CAP_SYS_ADMIN, so let's always check for CAP_SYS_ADMIN.