### PR TITLE
fedora: Change default release to rawhide

### DIFF
--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -107,7 +107,7 @@ class Installer(DistributionInstaller):
 
     @classmethod
     def default_release(cls) -> str:
-        return "41"
+        return "rawhide"
 
     @classmethod
     def grub_prefix(cls) -> str:


### PR DESCRIPTION
Fedora releases new versions quite regularly, sometimes more regularly than we do mkosi releases. This means that users on the latest official mkosi release can end up building EOL fedora releases because the default release will be the latest fedora release at the time of the mkosi release which might be EOL already. Let's switch to rawhide as the default release so users are guaranteed to get something recent regardless of how old their mkosi version is.

This matches what we already do for debian, opensuse, arch and other distros.