### PR TITLE
Make user provided command line take preference over roothash=

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1946,18 +1946,20 @@ def finalize_cmdline(
     else:
         cmdline = []
 
-    if roothash:
-        cmdline += [roothash]
-
     cmdline += context.config.kernel_command_line
 
-    if not roothash:
-        for name in ("root", "mount.usr"):
-            type_prefix = name.removeprefix("mount.")
-            if not (root := next((p.uuid for p in partitions if p.type.startswith(type_prefix)), None)):
-                continue
+    for name in ("root", "mount.usr"):
+        type_prefix = name.removeprefix("mount.")
+        if not (root := next((p.uuid for p in partitions if p.type.startswith(type_prefix)), None)):
+            continue
 
-            cmdline = [f"{name}=PARTUUID={root}" if c == f"{name}=PARTUUID" else c for c in cmdline]
+        cmdline = [f"{name}=PARTUUID={root}" if c == f"{name}=PARTUUID" else c for c in cmdline]
+
+    if roothash and (
+        (roothash.startswith("roothash=") and not any(c.startswith("root=") for c in cmdline))
+        or (roothash.startswith("usrhash=") and not any(c.startswith("mount.usr") for c in cmdline))
+    ):
+        cmdline += [roothash]
 
     return cmdline
 


### PR DESCRIPTION
If the user provides their own root= or mount.usr= configuration, let's always have that take preference over the partition roothash= or usrhash=

This is preparation for adding support for root=dissect in which case we don't need roothash= or usrhash= on the kernel command line.