### PR TITLE
Replace conf tag with ini in markdown

### DIFF
--- a/blog/content/a-reintroduction-to-mkosi.md
+++ b/blog/content/a-reintroduction-to-mkosi.md
@@ -112,7 +112,7 @@ written down.
 For example, the command we used above can be written down in a
 configuration file `mkosi.conf`:
 
-```conf
+```ini
 [Distribution]
 Distribution=arch
 
@@ -132,7 +132,7 @@ also be conditionalized using the `[Match]` section. For example, to
 only install a specific package on Arch Linux, you can write the
 following to `mkosi.conf.d/10-arch.conf`:
 
-```conf
+```ini
 [Match]
 Distribution=arch
 
@@ -311,7 +311,7 @@ extension in one go.
 We start by creating a temporary directory with a base configuration
 file `mkosi.conf` with some shared settings:
 
-```conf
+```ini
 [Output]
 OutputDirectory=mkosi.output
 CacheDirectory=mkosi.cache
@@ -320,7 +320,7 @@ CacheDirectory=mkosi.cache
 Now let's continue with the base image definition by writing the
 following to `mkosi.images/base/mkosi.conf`:
 
-```conf
+```ini
 [Output]
 Format=directory
 
@@ -336,7 +336,7 @@ so that we can build our extension without needing root privileges.
 Now that we have our base image, we can define a sysext that builds on
 top of it by writing the following to `mkosi.images/btrfs/mkosi.conf`:
 
-```conf
+```ini
 [Config]
 Dependencies=base
 

--- a/docs/building-rpms-from-source.md
+++ b/docs/building-rpms-from-source.md
@@ -28,7 +28,7 @@ related files. These can be mounted into the current working directory
 when running mkosi scripts by using the `BuildSources=` setting. For
 example, in `mkosi.local.conf`, we could have the following settings:
 
-```conf
+```ini
 [Build]
 BuildSources=../mkosi:mkosi
              ../fedora/mkosi:mkosi/rpm
@@ -48,7 +48,7 @@ from outside of the image that the RPM is being built in, so we have to
 make sure they're available inside the image by adding the following to
 `mkosi.conf`:
 
-```conf
+```ini
 [Content]
 Packages=rpm-build
 # If you don't want rpm-build in the final image.

--- a/docs/initrd.md
+++ b/docs/initrd.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 Building an image with a mkosi-built initrd is a two step process, because you will build two images - the initrd and your distribution image.
 1. Build an initrd image using the `cpio` output format with the same target distributions as you want to use for your distribution image. mkosi compresses the `cpio` output format by default.
 
-```conf
+```ini
 [Output]
 Format=cpio
 

--- a/docs/root-verity.md
+++ b/docs/root-verity.md
@@ -3,7 +3,7 @@
 First of all, to build a disk image with a verity protected root
 partition, put the following in mkosi.repart:
 
-```conf
+```ini
 # mkosi.repart/00-esp.conf
 [Partition]
 Type=esp
@@ -49,7 +49,7 @@ it runs after the root partition has been mounted, so let's create an
 initrd with `mkosi.images` where we customize systemd-repart to behave
 like this:
 
-```conf
+```ini
 # mkosi.images/initrd/mkosi.conf
 [Include]
 Include=mkosi-initrd
@@ -63,7 +63,7 @@ ConditionDirectoryNotEmpty=|/sysroot/usr/lib/repart.d
 To use the initrd in the top level image, add the following to
 mkosi.conf:
 
-```conf
+```ini
 [Content]
 Initrds=%O/initrd
 ```
@@ -73,7 +73,7 @@ create an A/B update setup and an encrypted `/var`. This includes the
 definitions from mkosi.repart in a reduced form solely for matching the
 existing partitions:
 
-```conf
+```ini
 # mkosi.extra/usr/lib/repart.d/00-esp.conf
 [Partition]
 Type=esp
@@ -143,7 +143,7 @@ will differ depending on how the image is updated but we list some
 example definitions here. These are all missing a `[Source]` section
 whose contents will depend on how updates are deployed:
 
-```conf
+```ini
 # /usr/lib/sysupdate.d/10-root-verity-sig.conf
 [Transfer]
 ProtectVersion=%A

--- a/docs/sysext.md
+++ b/docs/sysext.md
@@ -21,7 +21,7 @@ in one go.
 Start by creating a temporary directory with a base configuration file
 `mkosi.conf` with some shared settings:
 
-```conf
+```ini
 [Output]
 OutputDirectory=mkosi.output
 CacheDirectory=mkosi.cache
@@ -33,7 +33,7 @@ directory.
 Now let's continue with the base image definition by writing the
 following to `mkosi.images/base/mkosi.conf`:
 
-```conf
+```ini
 [Output]
 Format=directory
 
@@ -49,7 +49,7 @@ so that we can build our extension without needing root privileges.
 Now that we have our base image, we can define a sysext that builds on
 top of it by writing the following to `mkosi.images/btrfs/mkosi.conf`:
 
-```conf
+```ini
 [Config]
 Dependencies=base
 
@@ -81,7 +81,7 @@ What we can do now is package up the base image as the main image, but
 in another format, for example an initrd, we can do that by adding the
 following to `mkosi.conf`:
 
-```conf
+```ini
 [Output]
 Format=cpio
 Output=initrd


### PR DESCRIPTION
No markdown renderer has any clue which highlighting to use for conf files whereas INI is well defined and results in proper highlighting.