### PR TITLE
Add yubico-piv-tool in tools

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf
@@ -26,4 +26,5 @@ Packages=
         systemd
         tar
         xfsprogs
+        yubico-piv-tool
         zstd

--- a/mkosi/resources/mkosi-tools/mkosi.extra/usr/share/p11-kit/modules/libyksc11.module
+++ b/mkosi/resources/mkosi-tools/mkosi.extra/usr/share/p11-kit/modules/libyksc11.module
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+module: /usr/lib64/libykcs11.so.2


### PR DESCRIPTION
OpenSC works fine when using the main signing slot of yubikeys, but doesn't work with "retired slots". Adding yubico-piv-tool allows to do it with other slots as well.

Retired slots for yubikeys can be used to store keys used for different purposes. For example, someone may use the main signing slot to sign packages or libraries, and want to use a different key for secure boot. This other key can be stored in Retired Slot 1.

I think Yubikeys are common hardware that can be used to sign images with mkosi, so it makes sense to have it in the _tools_ image.