### PR TITLE
initrd: Install gzip in all initrds, not just the Arch one

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -16,6 +16,7 @@ Packages=
         bash                      # for emergency logins
         less                      # this makes 'systemctl' much nicer to use ;)
         p11-kit                   # dl-opened by systemd
+        gzip                      # For compressed keymap unpacking by loadkeys
 
 RemoveFiles=
         # we don't need this after the binary catalogs have been built

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-arch.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-arch.conf
@@ -5,8 +5,6 @@ Distribution=arch
 
 [Content]
 Packages=
-        gzip # For compressed keymap unpacking by loadkeys
-
         btrfs-progs
         e2fsprogs
         xfsprogs


### PR DESCRIPTION
Fedora also has keymaps compressed with gzip and doesn't pull in gzip by default so let's just install gzip everywhere to make the problem go away.