### PR TITLE
Make /etc/ and /usr/ as updated after installation

### DIFF
--- a/mkosi.finalize
+++ b/mkosi.finalize
@@ -1,0 +1,5 @@
+#!/bin/bash
+# SPDX-License-Identifier: CC-0
+set -e
+
+touch -r "$BUILDROOT/usr" "$BUILDROOT/etc/.updated" "$BUILDROOT/var/.updated"


### PR DESCRIPTION
This implements the "conservative approach" discussed in https://github.com/systemd/mkosi/issues/3338. If we know that /etc/ and /var/ were populated during the installation, we can opt out of running early boot services, making the first boot quicker.

C.f. https://bugzilla.redhat.com/show_bug.cgi?id=2348669.