### PR TITLE
Implement linux-noinitrd firmware

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -321,12 +321,16 @@ class Cacheonly(StrEnum):
 class Firmware(StrEnum):
     auto = enum.auto()
     linux = enum.auto()
+    linux_noinitrd = enum.auto()
     uefi = enum.auto()
     uefi_secure_boot = enum.auto()
     bios = enum.auto()
 
     def is_uefi(self) -> bool:
         return self in (Firmware.uefi, Firmware.uefi_secure_boot)
+
+    def is_linux(self) -> bool:
+        return self in (Firmware.linux, Firmware.linux_noinitrd)
 
 
 class ConsoleMode(StrEnum):

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1736,14 +1736,16 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 `Firmware=`, `--firmware=`
 :   Configures the virtual machine firmware to use. Takes one of `uefi`,
-    `uefi-secure-boot`, `bios`, `linux`, or `auto`. Defaults to `auto`.
-    When set to `uefi`, the OVMF firmware without secure boot support
-    is used. When set to `uefi-secure-boot`, the OVMF firmware with
-    secure boot support is used. When set to `bios`, the default SeaBIOS
-    firmware is used. When set to `linux`, direct kernel boot is used.
-    See the `Linux=` option for more details on which kernel image is
-    used with direct kernel boot. When set to `auto`, `uefi-secure-boot`
-    is used if possible and `linux` otherwise.
+    `uefi-secure-boot`, `bios`, `linux`, `linux-noinitrd` or `auto`.
+    Defaults to `auto`. When set to `uefi`, the OVMF firmware without
+    secure boot support is used. When set to `uefi-secure-boot`, the
+    OVMF firmware with secure boot support is used. When set to `bios`,
+    the default SeaBIOS firmware is used. When set to `linux`, direct
+    kernel boot is used. See the `Linux=` option for more details on
+    which kernel image is used with direct kernel boot.
+    `linux-noinitrd` is identical to `linux` except that no initrd is
+    used. When set to `auto`, `uefi-secure-boot` is used if possible and
+    `linux` otherwise.
 
 `FirmwareVariables=`, `--firmware-variables=`
 :   Configures the path to the the virtual machine firmware variables file


### PR DESCRIPTION
Useful for direct kernel booting without an initrd even if one was built.