### PR TITLE
Fix grub.cfg install path on almalinux

### DIFF
--- a/mkosi/bootloader.py
+++ b/mkosi/bootloader.py
@@ -160,6 +160,8 @@ def prepare_grub_config(context: Context) -> Optional[Path]:
         # file.
         if context.config.distribution == Distribution.opensuse:
             earlyconfig = context.root / "efi/EFI/BOOT/grub.cfg"
+        elif context.config.distribution == Distribution.alma:
+            earlyconfig = context.root / "efi/EFI/almalinux/grub.cfg"
         else:
             earlyconfig = context.root / "efi/EFI" / context.config.distribution.name / "grub.cfg"
 


### PR DESCRIPTION
grub-signed on AlmaLinux is hardcoded to look for grub.cfg in EFI/almalinux/grub.cfg

Fixes #3608 