### PR TITLE
Always cache the default tools tree

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -139,7 +139,7 @@ from mkosi.sandbox import (
 )
 from mkosi.sysupdate import run_sysupdate
 from mkosi.tree import copy_tree, make_tree, move_tree, rmtree
-from mkosi.user import INVOKING_USER, become_root_cmd
+from mkosi.user import become_root_cmd
 from mkosi.util import (
     PathString,
     current_home_dir,
@@ -2506,7 +2506,7 @@ def calculate_signature_gpg(context: Context) -> None:
         workdir(context.staging / context.config.output_checksum),
     ]
 
-    home = Path(context.config.finalize_environment().get("GNUPGHOME", INVOKING_USER.home() / ".gnupg"))
+    home = Path(context.config.finalize_environment().get("GNUPGHOME", Path.home() / ".gnupg"))
     if not home.exists():
         die(f"GPG home {home} not found")
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2096,10 +2096,10 @@ class Config:
 
         if (
             (cache := INVOKING_USER.cache_dir())
-            and cache != Path("/var/cache/mkosi")
+            and cache != Path("/var/cache")
             and os.access(cache, os.W_OK)
         ):
-            return cache
+            return cache / "mkosi"
 
         return Path("/var/tmp")
 
@@ -2107,7 +2107,7 @@ class Config:
         key = f"{self.distribution}~{self.release}~{self.architecture}"
         if self.mirror:
             key += f"-{self.mirror.replace('/', '-')}"
-        return self.package_cache_dir or (INVOKING_USER.cache_dir() / key)
+        return self.package_cache_dir or (INVOKING_USER.cache_dir() / "mkosi" / key)
 
     def tools(self) -> Path:
         return self.tools_tree or Path("/")

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -7,6 +7,7 @@ import dataclasses
 import enum
 import fnmatch
 import functools
+import getpass
 import graphlib
 import inspect
 import io
@@ -4239,7 +4240,7 @@ def create_argument_parser(chdir: bool = True) -> argparse.ArgumentParser:
         "--genkey-common-name",
         metavar="CN",
         help="Template for the CN when generating keys",
-        default=f"mkosi of {INVOKING_USER.name()}",
+        default=f"mkosi of {getpass.getuser()}",
     )
     parser.add_argument(
         "-B",

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any, Callable, NoReturn, Optional, Protocol
 
 from mkosi.log import ARG_DEBUG, ARG_DEBUG_SANDBOX, ARG_DEBUG_SHELL, die
 from mkosi.sandbox import acquire_privileges, joinpath, umask
-from mkosi.util import _FILE, PathString, current_home_dir, flatten, one_zero, resource_path, unique
+from mkosi.util import _FILE, PathString, flatten, one_zero, resource_path, unique
 
 # These types are only generic during type checking and not at runtime, leading
 # to a TypeError during compilation.
@@ -500,7 +500,6 @@ def sandbox_cmd(
         if relaxed:
             for p in Path("/").iterdir():
                 if p not in (
-                    Path("/home"),
                     Path("/proc"),
                     Path("/usr"),
                     Path("/nix"),
@@ -523,9 +522,6 @@ def sandbox_cmd(
                     and (factory := Path("/usr/share/factory")).exists()
                 ):
                     cmdline += ["--bind", factory, factory]
-
-            if home := current_home_dir():
-                cmdline += ["--bind", home, home]
         else:
             cmdline += [
                 "--dir", "/var/tmp",

--- a/mkosi/user.py
+++ b/mkosi/user.py
@@ -15,19 +15,6 @@ SUBRANGE = 65536
 
 class INVOKING_USER:
     @classmethod
-    def name(cls) -> str:
-        try:
-            return pwd.getpwuid(os.getuid()).pw_name
-        except KeyError:
-            if os.getuid() == 0:
-                return "root"
-
-            if not (user := os.getenv("USER")):
-                die(f"Could not find user name for UID {os.getuid()}")
-
-            return user
-
-    @classmethod
     def is_regular_user(cls, uid: int) -> bool:
         return uid >= 1000
 

--- a/mkosi/user.py
+++ b/mkosi/user.py
@@ -42,7 +42,7 @@ class INVOKING_USER:
         else:
             cache = Path("/var/cache")
 
-        return cache / "mkosi"
+        return cache
 
     @classmethod
     def runtime_dir(cls) -> Path:

--- a/mkosi/user.py
+++ b/mkosi/user.py
@@ -66,7 +66,7 @@ class INVOKING_USER:
         else:
             d = Path("/run")
 
-        return d / "mkosi"
+        return d
 
     @classmethod
     def chown(cls, path: Path) -> None:

--- a/mkosi/user.py
+++ b/mkosi/user.py
@@ -28,19 +28,6 @@ class INVOKING_USER:
             return user
 
     @classmethod
-    def home(cls) -> Path:
-        if os.getuid() == 0 and Path.cwd().is_relative_to("/home") and len(Path.cwd().parents) > 2:
-            return list(Path.cwd().parents)[-3]
-
-        try:
-            return Path(pwd.getpwuid(os.getuid()).pw_dir or "/")
-        except KeyError:
-            if not (home := os.getenv("HOME")):
-                die(f"Could not find home directory for UID {os.getuid()}")
-
-            return Path(home)
-
-    @classmethod
     def is_regular_user(cls, uid: int) -> bool:
         return uid >= 1000
 
@@ -48,8 +35,8 @@ class INVOKING_USER:
     def cache_dir(cls) -> Path:
         if (env := os.getenv("XDG_CACHE_HOME")) or (env := os.getenv("CACHE_DIRECTORY")):
             cache = Path(env)
-        elif cls.is_regular_user(os.getuid()) and cls.home() != Path("/"):
-            cache = cls.home() / ".cache"
+        elif cls.is_regular_user(os.getuid()) and Path.home() != Path("/"):
+            cache = Path.home() / ".cache"
         elif os.getuid() == 0 and Path.cwd().is_relative_to("/root") and "XDG_SESSION_ID" in os.environ:
             cache = Path("/root/.cache")
         else:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -34,7 +34,7 @@ class Image:
         self.config = config
 
     def __enter__(self) -> "Image":
-        if (cache := INVOKING_USER.cache_dir()) and os.access(cache, os.W_OK):
+        if (cache := INVOKING_USER.cache_dir() / "mkosi") and os.access(cache, os.W_OK):
             tmpdir = cache
         else:
             tmpdir = Path("/var/tmp")


### PR DESCRIPTION
For the default tools tree, the cached image and the final image
are the same for all intents and purposes, so let's stop storing both
a cached image and a final image for the default tools tree and instead
only store the final image and use it as the cached image by always
writing a cache manifest next to it.

At the same time always use the name mkosi.tools to reduce the chance
of conflicts as "tools" is an incredibly common directory name.