### PR TITLE
tools: Add "devel" profile

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -601,9 +601,14 @@ class ArtifactOutput(StrEnum):
 
 
 class ToolsTreeProfile(StrEnum):
+    devel = enum.auto()
     misc = enum.auto()
     package_manager = enum.auto()
     runtime = enum.auto()
+
+    @classmethod
+    def default(cls) -> tuple["ToolsTreeProfile", ...]:
+        return (cls.misc, cls.package_manager, cls.runtime)
 
 
 class InitrdProfile(StrEnum):
@@ -3474,7 +3479,7 @@ SETTINGS: list[ConfigSetting[Any]] = [
         section="Build",
         parse=config_make_list_parser(delimiter=",", parse=make_enum_parser(ToolsTreeProfile)),
         choices=ToolsTreeProfile.values(),
-        default=list(ToolsTreeProfile),
+        default=ToolsTreeProfile.default(),
         help="Which profiles to enable for the default tools tree",
     ),
     ConfigSetting(

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1377,14 +1377,16 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 `ToolsTreeProfiles=`, `--tools-tree-profile=`
 :   Set the profiles to enable for the default tools tree. Takes a
-    comma-delimited list consisting of `misc`, `package-manager` and
-    `runtime`. By default, all profiles are enabled.
+    comma-delimited list consisting of `devel`, `misc`,
+    `package-manager` and `runtime`. By default, all profiles except
+    `devel` are enabled.
 
-    The `misc` profile contains various useful tools that are handy to
-    have available in scripts. The package manager profile contains
-    package managers and related tools other than those native to the
-    tools tree distribution. The `runtime` profile contains the tools
-    required to boot images in a systemd-nspawn container or in a
+    The `devel` profile contains tools required to build (C/C++)
+    projects. The `misc` profile contains various useful tools that are
+    handy to have available in scripts. The package manager profile
+    contains package managers and related tools other than those native
+    to the tools tree distribution. The `runtime` profile contains the
+    tools required to boot images in a systemd-nspawn container or in a
     virtual machine.
 
 `ToolsTreeMirror=`, `--tools-tree-mirror=`

--- a/mkosi/resources/mkosi-tools/mkosi.profiles/devel/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/devel/mkosi.conf
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Content]
+Packages=
+        autoconf
+        automake
+        binutils
+        bison
+        bzip2
+        cmake
+        flex
+        gcc
+        gettext
+        groff
+        libtool
+        m4
+        make
+        meson
+        patch
+        pkgconf

--- a/mkosi/resources/mkosi-tools/mkosi.profiles/misc/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/misc/mkosi.conf
@@ -6,10 +6,13 @@ Packages=
         attr
         bash
         diffutils
+        file
         findutils
+        gawk
         grep
         jq
         less
         nano
         sed
         strace
+        which


### PR DESCRIPTION
This profile contains tools required to build C/C++ projects. This is
useful to use mkosi sandbox to quickly build one off projects without
having to list a bunch of basic packages over and over again.