### PR TITLE
initrd: Move p11-kit to pksc11 profile

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -613,6 +613,7 @@ class ToolsTreeProfile(StrEnum):
 
 class InitrdProfile(StrEnum):
     lvm = enum.auto()
+    pkcs11 = enum.auto()
     raid = enum.auto()
 
 

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1028,6 +1028,7 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     disabled.
 
     The `lvm` profile enables support for LVM.
+    The `pkcs11` profile enables support for PKCS#11.
     The `raid` profile enables support for RAID arrays.
 
 `InitrdPackages=`, `--initrd-package=`

--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -15,7 +15,6 @@ Packages=
         udev
         bash                      # for emergency logins
         less                      # this makes 'systemctl' much nicer to use ;)
-        p11-kit                   # dl-opened by systemd
         gzip                      # For compressed keymap unpacking by loadkeys
 
 RemoveFiles=

--- a/mkosi/resources/mkosi-initrd/mkosi.profiles/pkcs11/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.profiles/pkcs11/mkosi.conf
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Content]
+Packages=p11-kit


### PR DESCRIPTION
This stuff is rather niche, so let's move it to a profile similar to lvm and raid.