### PR TITLE
Make sure tools tree recorded in history doesn't change when in sandbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 mkosi.local
 mkosi.local.conf
 mkosi.tools
+mkosi.tools.manifest
 /mkosi.key
 /mkosi.crt
 __pycache__

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4512,7 +4512,6 @@ def finalize_default_tools(config: Config, *, resources: Path) -> Config:
         f"--repository-key-check={config.repository_key_check}",
         f"--repository-key-fetch={config.repository_key_fetch}",
         f"--cache-only={config.cacheonly}",
-        *([f"--output-directory={os.fspath(p)}"] if (p := config.output_dir) else []),
         *([f"--workspace-directory={os.fspath(p)}"] if (p := config.workspace_dir) else []),
         *([f"--package-cache-directory={os.fspath(p)}"] if (p := config.package_cache_dir) else []),
         "--incremental=no",

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -650,6 +650,10 @@ def parse_boolean(s: str) -> bool:
     return value
 
 
+def in_sandbox() -> bool:
+    return parse_boolean(os.getenv("MKOSI_IN_SANDBOX", "0"))
+
+
 def parse_path(
     value: str,
     *,
@@ -2116,6 +2120,9 @@ class Config:
         return self.package_cache_dir or (INVOKING_USER.cache_dir() / "mkosi" / key)
 
     def tools(self) -> Path:
+        if in_sandbox():
+            return Path("/")
+
         return self.tools_tree or Path("/")
 
     @classmethod


### PR DESCRIPTION
Currently, when in the sandbox, the tools tree will always be recorded as "null" in the history. This causes problems if an image build is done inside of mkosi sandbox and mkosi is later invoked outside of the sandbox as the history will say no tools tree was used and so the tools tree won't be used, even if we're running outside of the sandbox.

To fix the issue, let's make sure we always record the proper tools tree, but let's not make use of it in the sandbox by moving the sandbox check to the Config object's tools() method.