### PR TITLE
Add mkosi init to install a tmpfiles dropin for the cache dir

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -139,7 +139,7 @@ from mkosi.sandbox import (
 )
 from mkosi.sysupdate import run_sysupdate
 from mkosi.tree import copy_tree, make_tree, move_tree, rmtree
-from mkosi.user import become_root_cmd
+from mkosi.user import INVOKING_USER, become_root_cmd
 from mkosi.util import (
     PathString,
     current_home_dir,
@@ -4930,6 +4930,11 @@ def run_build(
 
 def run_verb(args: Args, images: Sequence[Config], *, resources: Path) -> None:
     images = list(images)
+
+    if args.verb == Verb.init:
+        copy_tree(resources / "tmpfiles.d", INVOKING_USER.tmpfiles_dir(), preserve=False)
+        log_notice(f"Copied mkosi tmpfiles dropins to {INVOKING_USER.tmpfiles_dir()}")
+        return
 
     if args.verb == Verb.completion:
         return print_completion(args, resources=resources)

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -81,6 +81,7 @@ class Verb(StrEnum):
     completion = enum.auto()
     sysupdate = enum.auto()
     sandbox = enum.auto()
+    init = enum.auto()
 
     def supports_cmdline(self) -> bool:
         return self in (
@@ -119,6 +120,7 @@ class Verb(StrEnum):
             Verb.documentation,
             Verb.dependencies,
             Verb.completion,
+            Verb.init,
         )
 
 
@@ -4153,7 +4155,8 @@ def create_argument_parser(chdir: bool = True) -> argparse.ArgumentParser:
         # the synopsis below is supposed to be indented by two spaces
         usage="\n  "
         + textwrap.dedent("""\
-              mkosi [options…] {b}summary{e}
+              mkosi [options…] {b}init{e}
+                mkosi [options…] {b}summary{e}
                 mkosi [options…] {b}cat-config{e}
                 mkosi [options…] {b}build{e}         [-- command line…]
                 mkosi [options…] {b}shell{e}         [-- command line…]

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -8,6 +8,8 @@ mkosi — Build Bespoke OS Images
 
 # SYNOPSIS
 
+`mkosi [options…] init`
+
 `mkosi [options…] summary`
 
 `mkosi [options…] cat-config`
@@ -56,6 +58,13 @@ mkosi — Build Bespoke OS Images
 ## Command Line Verbs
 
 The following command line verbs are known:
+
+`init`
+:   Initialize **mkosi**. This is a one time operation that sets up various
+    config files required for an optimal experience. Currently this only
+    initialized a `tmpfiles.d` dropin for the mkosi package cache
+    directory to make sure old, unused files are cleaned up
+    automatically.
 
 `summary`
 :   Show a human-readable summary of all options used for building the images.

--- a/mkosi/resources/tmpfiles.d/mkosi.conf
+++ b/mkosi/resources/tmpfiles.d/mkosi.conf
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+d %C/mkosi - - - 90d

--- a/mkosi/user.py
+++ b/mkosi/user.py
@@ -41,6 +41,14 @@ class INVOKING_USER:
         return d
 
     @classmethod
+    def tmpfiles_dir(cls) -> Path:
+        config = Path(os.getenv("XDG_CONFIG_HOME", Path.home() / ".config"))
+        if config in (Path("/"), Path("/root")):
+            return Path("/etc/tmpfiles.d")
+
+        return config / "user-tmpfiles.d"
+
+    @classmethod
     def chown(cls, path: Path) -> None:
         # If we created a file/directory in a parent directory owned by a regular user, make sure the path
         # and any parent directories are owned by the invoking user as well.

--- a/mkosi/user.py
+++ b/mkosi/user.py
@@ -24,8 +24,6 @@ class INVOKING_USER:
             cache = Path(env)
         elif cls.is_regular_user(os.getuid()) and Path.home() != Path("/"):
             cache = Path.home() / ".cache"
-        elif os.getuid() == 0 and Path.cwd().is_relative_to("/root") and "XDG_SESSION_ID" in os.environ:
-            cache = Path("/root/.cache")
         else:
             cache = Path("/var/cache")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ packages = [
     "mkosi-tools/**/*",
     "mkosi-vm/**/*",
     "repart/**/*",
+    "tmpfiles.d/*",
 ]
 
 [tool.isort]


### PR DESCRIPTION
Let's clean up packages after they haven't been touched for 90
days.

Note that this has to be explicitly enabled by users by running mkosi
init for now. In the future we can look into automatically enabling
this.