### PR TITLE
Implement ToolsTreeSyncScripts=

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4516,6 +4516,7 @@ def finalize_default_tools(config: Config, *, resources: Path) -> Config:
         *([f"--package-directory={os.fspath(directory)}" for directory in config.tools_tree_package_directories]),  # noqa: E501
         *([f"--build-sources={tree}" for tree in config.build_sources]),
         f"--build-sources-ephemeral={config.build_sources_ephemeral}",
+        *([f"--sync-script={os.fspath(script)}" for script in config.tools_tree_sync_scripts]),
         *([f"--prepare-script={os.fspath(script)}" for script in config.tools_tree_prepare_scripts]),
         *([f"--source-date-epoch={e}"] if (e := config.source_date_epoch) is not None else []),
         *([f"--environment={k}='{v}'" for k, v in config.environment.items()]),
@@ -5042,6 +5043,7 @@ def run_verb(args: Args, images: Sequence[Config], *, resources: Path) -> None:
 
         run_clean(args, tools)
 
+        run_sync_scripts(tools)
         check_tools(tools, Verb.build)
         ensure_directories_exist(tools)
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1988,6 +1988,7 @@ class Config:
     tools_tree_sandbox_trees: list[ConfigTree]
     tools_tree_packages: list[str]
     tools_tree_package_directories: list[Path]
+    tools_tree_sync_scripts: list[Path]
     tools_tree_prepare_scripts: list[Path]
     tools_tree_certificates: bool
     extra_search_paths: list[Path]
@@ -3535,6 +3536,16 @@ SETTINGS: list[ConfigSetting[Any]] = [
         section="Build",
         parse=config_make_list_parser(delimiter=",", parse=make_path_parser()),
         help="Specify a directory containing extra tools tree packages",
+    ),
+    ConfigSetting(
+        dest="tools_tree_sync_scripts",
+        long="--tools-tree-sync-script",
+        metavar="PATH",
+        section="Build",
+        parse=config_make_list_parser(delimiter=",", parse=make_path_parser()),
+        paths=("mkosi.tools.sync",),
+        recursive_paths=("mkosi.tools.sync.d/*",),
+        help="Sync script to run before building the tools tree",
     ),
     ConfigSetting(
         dest="tools_tree_prepare_scripts",
@@ -5240,6 +5251,7 @@ def summary(config: Config) -> str:
            Tools Tree Sandbox Trees: {line_join_list(config.tools_tree_sandbox_trees)}
                 Tools Tree Packages: {line_join_list(config.tools_tree_packages)}
      Tools Tree Package Directories: {line_join_list(config.tools_tree_package_directories)}
+            Tools Tree Sync Scripts: {line_join_list(config.tools_tree_sync_scripts)}
          Tools Tree Prepare Scripts: {line_join_list(config.tools_tree_prepare_scripts)}
             Tools Tree Certificates: {yes_no(config.tools_tree_certificates)}
 

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1417,6 +1417,9 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 `ToolsTreePackageDirectories=`, `--tools-tree-package-directory=`
 :   Same as `PackageDirectories=`, but for the default tools tree.
 
+`SyncScripts=`, `--sync-script=`
+:   Same as `SyncScripts=`, but for the default tools tree.
+
 `ToolsTreePrepareScripts=`, `--tools-tree-prepare-script=`
 :   Same as `PrepareScripts=`, but for the default tools tree.
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -406,6 +406,9 @@ def test_config() -> None:
                     "Target": "/"
                 }
             ],
+            "ToolsTreeSyncScripts": [
+                "/sync"
+            ],
             "UnifiedKernelImageFormat": "myuki",
             "UnifiedKernelImageProfiles": [
                 {
@@ -615,6 +618,7 @@ def test_config() -> None:
         tools_tree_release=None,
         tools_tree_repositories=["abc"],
         tools_tree_sandbox_trees=[ConfigTree(Path("/a/b/c"), Path("/"))],
+        tools_tree_sync_scripts=[Path("/sync")],
         tools_tree=None,
         tpm=ConfigFeature.auto,
         unified_kernel_image_format="myuki",


### PR DESCRIPTION
In systemd, we have prepare scripts for the build image to install all the build dependencies of the corresponding distribution's systemd packaging spec. The distribution packaging spec is checked out by a sync script.

We also need the systemd build dependencies installed in the default tools tree in systemd, so that we can build all the systemd tools required to build the image in the tools tree as well to later be used to build the image. Currently we list the the required dependencies manually as packages since we can't reuse the prepare script from the build image as the sync scripts run after the default tools tree has been built which means we can't depend on the packaging specs being available when building the default tools tree.

Let's fix the issue by introducing ToolsTreeSyncScripts= to define sync scripts to run before building the default tools tree.