### PR TITLE
mkosi-initrd: Add amd_atl to default modules

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -42,6 +42,7 @@ WithDocs=no
 # Make sure various core modules are always included in the initrd.
 KernelModules=
         ahci
+        amd_atl
         amd_ctl
         amd-pmc
         amd64_edac


### PR DESCRIPTION
Another harmless CPU module without any dependencies that gets loaded by default.