### PR TITLE
pacman: Always bind mount /var/lib/pacman/local from sandbox

### DIFF
--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -65,8 +65,11 @@ class Pacman(PackageManager):
         if (context.root / "var/lib/pacman/local").exists():
             # pacman reuses the same directory for the sync databases and the local database containing the
             # list of installed packages. The former should go in the cache directory, the latter should go
-            # in the image, so we bind mount the local directory from the image to make sure that happens.
-            mounts += ["--bind", context.root / "var/lib/pacman/local", "/var/lib/pacman/local"]
+            # in the image, so we bind mount the local directory from the image to make sure that happens. We
+            # make sure to bind mount directly from the mounted /buildroot directly instead of from the host
+            # root directory since /buildroot might be an overlay mount and we want to make sure any writes
+            # are done to the upperdir of the overlay mount.
+            mounts += ["--bind", "+/buildroot/var/lib/pacman/local", "/var/lib/pacman/local"]
 
         return mounts
 

--- a/mkosi/resources/man/mkosi-sandbox.1.md
+++ b/mkosi/resources/man/mkosi-sandbox.1.md
@@ -42,7 +42,9 @@ host system.
 `--bind SRC DST`
 :   The source path `SRC` is recursively bind mounted to `DST` in the sandbox. The
     mountpoint is created in the sandbox if it does not yet exist. Any missing parent
-    directories in the sandbox are created as well.
+    directories in the sandbox are created as well. The source path may optionally be
+    prefixed with a `+` character. If so, the source path is interpreted relative to the
+    sandbox root directory instead of the host root directory.
 
 `--bind-try SRC DST`
 :   Like `--bind`, but doesn't fail if the source path doesn't exist.


### PR DESCRIPTION
We want any writes to /var/lib/pacman/local to go to any configured
overlayfs on /buildroot, instead of going directly to the
/var/lib/pacman/local directory which might be a lowerdir in the
overlayfs if one is used. Let's implement this by simply specifying
a path relative to the sandbox instead of specifying the path on the
host.

Fixes https://github.com/systemd/mkosi/issues/3625