### PR TITLE
Pass `DEBUG` enviroment variable to scripts

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -599,6 +599,7 @@ def run_configure_scripts(config: Config) -> Config:
         SRCDIR="/work/src",
         MKOSI_UID=str(os.getuid()),
         MKOSI_GID=str(os.getgid()),
+        DEBUG=one_zero(ARG_DEBUG.get()),
     )
 
     if config.profiles:
@@ -641,6 +642,7 @@ def run_sync_scripts(config: Config) -> None:
         MKOSI_GID=str(os.getgid()),
         MKOSI_CONFIG="/work/config.json",
         CACHED=one_zero(have_cache(config)),
+        DEBUG=one_zero(ARG_DEBUG.get()),
     )
 
     if config.profiles:
@@ -761,6 +763,7 @@ def run_prepare_scripts(context: Context, build: bool) -> None:
         WITH_DOCS=one_zero(context.config.with_docs),
         WITH_NETWORK=one_zero(context.config.with_network),
         WITH_TESTS=one_zero(context.config.with_tests),
+        DEBUG=one_zero(ARG_DEBUG.get()),
     )
 
     if context.config.profiles:
@@ -830,6 +833,7 @@ def run_build_scripts(context: Context) -> None:
         WITH_DOCS=one_zero(context.config.with_docs),
         WITH_NETWORK=one_zero(context.config.with_network),
         WITH_TESTS=one_zero(context.config.with_tests),
+        DEBUG=one_zero(ARG_DEBUG.get()),
     )
 
     if context.config.profiles:
@@ -902,6 +906,7 @@ def run_postinst_scripts(context: Context) -> None:
         MKOSI_GID=str(os.getgid()),
         MKOSI_CONFIG="/work/config.json",
         WITH_NETWORK=one_zero(context.config.with_network),
+        DEBUG=one_zero(ARG_DEBUG.get()),
     )
 
     if context.config.profiles:
@@ -970,6 +975,7 @@ def run_finalize_scripts(context: Context) -> None:
         MKOSI_GID=str(os.getgid()),
         MKOSI_CONFIG="/work/config.json",
         WITH_NETWORK=one_zero(context.config.with_network),
+        DEBUG=one_zero(ARG_DEBUG.get()),
     )
 
     if context.config.profiles:
@@ -1030,6 +1036,7 @@ def run_postoutput_scripts(context: Context) -> None:
         MKOSI_UID=str(os.getuid()),
         MKOSI_GID=str(os.getgid()),
         MKOSI_CONFIG="/work/config.json",
+        DEBUG=one_zero(ARG_DEBUG.get()),
     )
 
     if context.config.profiles:
@@ -4587,6 +4594,7 @@ def run_clean_scripts(config: Config) -> None:
         MKOSI_UID=str(os.getuid()),
         MKOSI_GID=str(os.getgid()),
         MKOSI_CONFIG="/work/config.json",
+        DEBUG=one_zero(ARG_DEBUG.get()),
     )
 
     if config.profiles:

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -2491,7 +2491,7 @@ Scripts executed by **mkosi** receive the following environment variables:
 * `$PROFILES` contains the profiles from the `Profiles=` setting as a
   comma-delimited string.
 
-* `$CACHED=` is set to `1` if a cached image is available, `0` otherwise.
+* `$CACHED` is set to `1` if a cached image is available, `0` otherwise.
 
 * `$CHROOT_SCRIPT` contains the path to the running script relative to
   the image root directory. The primary usecase for this variable is in
@@ -2584,33 +2584,33 @@ Consult this table for which script receives which environment variables:
 | Variable                    | `configure` | `sync` | `prepare` | `build` | `postinst` | `finalize` | `postoutput` | `clean` |
 |-----------------------------|:-----------:|:------:|:---------:|:-------:|:----------:|:----------:|:------------:|:-------:|
 | `ARCHITECTURE`              | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |
-| `QEMU_ARCHITECTURE`         | ✓           |        |           |         |            |            |              |         |
+| `ARTIFACTDIR`               |             |        | ✓         | ✓       | ✓          | ✓          |              |         |
+| `BUILDDIR`                  |             |        |           | ✓       | ✓          | ✓          |              |         |
+| `BUILDROOT`                 |             |        | ✓         | ✓       | ✓          | ✓          |              |         |
+| `CACHED`                    |             | ✓      |           |         |            |            |              |         |
+| `CHROOT_BUILDDIR`           |             |        |           | ✓       |            |            |              |         |
+| `CHROOT_DESTDIR`            |             |        |           | ✓       |            |            |              |         |
+| `CHROOT_OUTPUTDIR`          |             |        |           |         | ✓          | ✓          |              |         |
+| `CHROOT_SCRIPT`             |             |        | ✓         | ✓       | ✓          | ✓          |              |         |
+| `CHROOT_SRCDIR`             |             |        | ✓         | ✓       | ✓          | ✓          |              |         |
+| `DESTDIR`                   |             |        |           | ✓       |            |            |              |         |
 | `DISTRIBUTION`              | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |
 | `DISTRIBUTION_ARCHITECTURE` | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |
-| `RELEASE`                   | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |
-| `PROFILES`                  | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          |              | ✓       |
-| `CACHED`                    |             | ✓      |           |         |            |            |              |         |
-| `CHROOT_SCRIPT`             |             |        | ✓         | ✓       | ✓          | ✓          |              |         |
-| `SRCDIR`                    | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |
-| `CHROOT_SRCDIR`             |             |        | ✓         | ✓       | ✓          | ✓          |              |         |
-| `BUILDDIR`                  |             |        |           | ✓       | ✓          | ✓          |              |         |
-| `CHROOT_BUILDDIR`           |             |        |           | ✓       |            |            |              |         |
-| `DESTDIR`                   |             |        |           | ✓       |            |            |              |         |
-| `CHROOT_DESTDIR`            |             |        |           | ✓       |            |            |              |         |
-| `OUTPUTDIR`                 |             |        |           |         | ✓          | ✓          | ✓            | ✓       |
-| `CHROOT_OUTPUTDIR`          |             |        |           |         | ✓          | ✓          |              |         |
-| `BUILDROOT`                 |             |        | ✓         | ✓       | ✓          | ✓          |              |         |
-| `PACKAGEDIR`                |             |        | ✓         | ✓       | ✓          | ✓          |              |         |
-| `ARTIFACTDIR`               |             |        | ✓         | ✓       | ✓          | ✓          |              |         |
-| `WITH_DOCS`                 |             |        | ✓         | ✓       |            |            |              |         |
-| `WITH_TESTS`                |             |        | ✓         | ✓       |            |            |              |         |
-| `WITH_NETWORK`              |             |        | ✓         | ✓       | ✓          | ✓          |              |         |
-| `SOURCE_DATE_EPOCH`         |             |        | ✓         | ✓       | ✓          | ✓          |              | ✓       |
-| `MKOSI_UID`                 | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |
-| `MKOSI_GID`                 | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |
-| `MKOSI_CONFIG`              |             | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |
 | `IMAGE_ID`                  | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |
 | `IMAGE_VERSION`             | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |
+| `MKOSI_CONFIG`              |             | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |
+| `MKOSI_GID`                 | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |
+| `MKOSI_UID`                 | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |
+| `OUTPUTDIR`                 |             |        |           |         | ✓          | ✓          | ✓            | ✓       |
+| `PACKAGEDIR`                |             |        | ✓         | ✓       | ✓          | ✓          |              |         |
+| `PROFILES`                  | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          |              | ✓       |
+| `QEMU_ARCHITECTURE`         | ✓           |        |           |         |            |            |              |         |
+| `RELEASE`                   | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |
+| `SOURCE_DATE_EPOCH`         |             |        | ✓         | ✓       | ✓          | ✓          |              | ✓       |
+| `SRCDIR`                    | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |
+| `WITH_DOCS`                 |             |        | ✓         | ✓       |            |            |              |         |
+| `WITH_NETWORK`              |             |        | ✓         | ✓       | ✓          | ✓          |              |         |
+| `WITH_TESTS`                |             |        | ✓         | ✓       |            |            |              |         |
 
 Additionally, when a script is executed, a few scripts are made
 available via `$PATH` to simplify common usecases.

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -2579,6 +2579,9 @@ Scripts executed by **mkosi** receive the following environment variables:
 
 * `$IMAGE_VERSION` contains the version from the `ImageVersion=` or `--image-version=` setting.
 
+* `$DEBUG` is either `0` or `1` depending on whether debugging output is
+  enabled.
+
 Consult this table for which script receives which environment variables:
 
 | Variable                    | `configure` | `sync` | `prepare` | `build` | `postinst` | `finalize` | `postoutput` | `clean` |
@@ -2593,6 +2596,7 @@ Consult this table for which script receives which environment variables:
 | `CHROOT_OUTPUTDIR`          |             |        |           |         | ✓          | ✓          |              |         |
 | `CHROOT_SCRIPT`             |             |        | ✓         | ✓       | ✓          | ✓          |              |         |
 | `CHROOT_SRCDIR`             |             |        | ✓         | ✓       | ✓          | ✓          |              |         |
+| `DEBUG`                     | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |
 | `DESTDIR`                   |             |        |           | ✓       |            |            |              |         |
 | `DISTRIBUTION`              | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |
 | `DISTRIBUTION_ARCHITECTURE` | ✓           | ✓      | ✓         | ✓       | ✓          | ✓          | ✓            | ✓       |


### PR DESCRIPTION
So scripts can run debugging code if `mkosi` is running with `--debug`.

Also, sorted table with environment variables received by scripts, to make them easier to find.