### PR TITLE
Use mkosi/ subdirectory if no configuration exists in cwd

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -4999,6 +4999,16 @@ def parse_config(
     if not args.verb.needs_config():
         return args, None, ()
 
+    # Allow locating all mkosi configuration in a mkosi/ subdirectory instead of in the top-level directory
+    # of a git repository.
+    if (
+        args.directory is not None
+        and not (Path("mkosi.conf").exists() or Path("mkosi.tools.conf").exists())
+        and (Path("mkosi/mkosi.conf").is_file() or Path("mkosi/mkosi.tools.conf").exists())
+    ):
+        os.chdir(args.directory / "mkosi")
+        args = dataclasses.replace(args, directory=args.directory / "mkosi")
+
     if have_history(args):
         try:
             j = json.loads(Path(".mkosi-private/history/latest.json").read_text())

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -248,7 +248,14 @@ Those settings cannot be configured in the configuration files.
 :   Takes a path to a directory. **mkosi** switches to this directory before
     doing anything. Note that the various configuration files are searched
     for in this directory, hence using this option is an effective way to
-    build a project located in a specific directory.
+    build a project located in a specific directory. Defaults to the current
+    working directory. If the empty string is specified, all configuration in
+    the current working directory will be ignored.
+
+:   If the specified directory does not contain a `mkosi.conf` or
+    `mkosi.tools.conf` and a `mkosi/mkosi.conf` or `mkosi/mkosi.tools.conf`
+    exists, the `mkosi/` subdirectory of the specified directory will be
+    used instead.
 
 `--debug`
 :   Enable additional debugging output.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1460,3 +1460,31 @@ def test_tools(tmp_path: Path) -> None:
         _, tools, _ = parse_config(argv, resources=resources)
         assert tools
         assert tools.distribution == Distribution.arch
+
+
+def test_subdir(tmp_path: Path) -> None:
+    d = tmp_path
+
+    with chdir(d):
+        (d / "mkosi").mkdir()
+        (d / "mkosi/mkosi.conf").write_text(
+            """
+            [Output]
+            Output=qed
+            """
+        )
+
+        _, _, [config] = parse_config()
+        assert config.output == "qed"
+
+        os.chdir(d)
+
+        (d / "mkosi.conf").write_text(
+            """
+            [Output]
+            Output=abc
+            """
+        )
+
+        _, _, [config] = parse_config()
+        assert config.output == "abc"


### PR DESCRIPTION
In systemd we've ended up with a large amount of mkosi specific files and directories in the top level of the repository. Let's allow moving these to a mkosi/ directory by transparently picking this up.