### PR TITLE
mkosi-initrd: copy local vconsole configuration

### DIFF
--- a/mkosi/initrd.py
+++ b/mkosi/initrd.py
@@ -380,6 +380,9 @@ def main() -> None:
         if Path("/etc/kernel/cmdline").exists():
             cmdline += ["--kernel-command-line", Path("/etc/kernel/cmdline").read_text()]
 
+        if Path("/etc/vconsole.conf").exists():
+            cmdline += ["--extra-tree=/etc/vconsole.conf:/etc/vconsole.conf"]
+
         # Resolve dnf binary to determine which version the host uses by default
         # (to avoid preferring dnf5 if the host uses dnf4)
         # as there's a much bigger chance that it has a populated dnf cache directory.


### PR DESCRIPTION
Otherwise it can be very hard to enter a password set on the host using a keyboard with some specific language layout.