### PR TITLE
mkosi-initrd: fix vconsole configuration for Ubuntu

### DIFF
--- a/mkosi/initrd.py
+++ b/mkosi/initrd.py
@@ -181,14 +181,12 @@ def process_crypttab(staging_dir: Path) -> list[str]:
     return cmdline
 
 
-def add_raid_config() -> list[str]:
-    cmdline = []
-
-    for f in ("/etc/mdadm.conf", "/etc/mdadm.conf.d", "/etc/mdadm/mdadm.conf", "/etc/mdadm/mdadm.conf.d"):
-        if Path(f).exists():
-            cmdline += ["--extra-tree", f"{f}:{f}"]
-
-    return cmdline
+def raid_config() -> list[str]:
+    return [
+        f"--extra-tree={f}:{f}"
+        for f in ("/etc/mdadm.conf", "/etc/mdadm.conf.d", "/etc/mdadm/mdadm.conf", "/etc/mdadm/mdadm.conf.d")
+        if Path(f).exists()
+    ]
 
 
 def vconsole_config() -> list[str]:
@@ -315,7 +313,7 @@ def main() -> None:
         for p in args.profile:
             cmdline += ["--profile", p]
             if p == "raid":
-                cmdline += add_raid_config()
+                cmdline += raid_config()
 
         if args.kernel_image:
             cmdline += [

--- a/mkosi/initrd.py
+++ b/mkosi/initrd.py
@@ -191,6 +191,12 @@ def add_raid_config() -> list[str]:
     return cmdline
 
 
+def vconsole_config() -> list[str]:
+    return [
+        f"--extra-tree={f}:{f}" for f in ("/etc/default/keyboard", "/etc/vconsole.conf") if Path(f).exists()
+    ]
+
+
 def initrd_finalize(staging_dir: Path, output: str, output_dir: Optional[Path]) -> None:
     if output_dir:
         with umask(~0o700) if os.getuid() == 0 else cast(umask, contextlib.nullcontext()):
@@ -380,8 +386,7 @@ def main() -> None:
         if Path("/etc/kernel/cmdline").exists():
             cmdline += ["--kernel-command-line", Path("/etc/kernel/cmdline").read_text()]
 
-        if Path("/etc/vconsole.conf").exists():
-            cmdline += ["--extra-tree=/etc/vconsole.conf:/etc/vconsole.conf"]
+        cmdline += vconsole_config()
 
         # Resolve dnf binary to determine which version the host uses by default
         # (to avoid preferring dnf5 if the host uses dnf4)


### PR DESCRIPTION
Ubuntu (and Debian?) installs `/etc/vconsole.conf` as a dangling symlink to `/etc/default/keyboard`, and that causes the `mkosi-initrd` build to fail:

```
\u2023  Copying in extra file trees\u2026
cp: not writing through dangling symlink '/work/var/tmp/mkosi-workspace-us4prlhz/root/etc/vconsole.conf'
\u2023 "cp --recursive --no-dereference --preserve=mode,links --reflink=auto --copy-contents /work/etc/default/keyboard /work/var/tmp/mkosi-workspace-us4prlhz/root/etc/vconsole.conf" returned non-zero exit code 1.
bash-5.2# ls -l /work/var/tmp/mkosi-workspace-us4prlhz/root/etc/vconsole.conf
lrwxrwxrwx 1 0 0 16 Apr  2 14:49 /work/var/tmp/mkosi-workspace-us4prlhz/root/etc/vconsole.conf -> default/keyboard
bash-5.2# ls -l /work/var/tmp/mkosi-workspace-us4prlhz/root/etc/default/keyboard
ls: cannot access '/work/var/tmp/mkosi-workspace-us4prlhz/root/etc/default/keyboard': No such file or directory
```

Follow-up for 8856a2f1204fac775f8efe91bf155a91ec67e5fe