### PR TITLE
Add "plymouth" initrd profile

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -627,6 +627,7 @@ class ToolsTreeProfile(StrEnum):
 class InitrdProfile(StrEnum):
     lvm = enum.auto()
     pkcs11 = enum.auto()
+    plymouth = enum.auto()
     raid = enum.auto()
 
 

--- a/mkosi/resources/man/mkosi-initrd.1.md
+++ b/mkosi/resources/man/mkosi-initrd.1.md
@@ -46,6 +46,8 @@ initrds and Unified Kernel Images for the current running system.
 
     The `lvm` profile enables support for LVM.
     The `pkcs11` profile enables support for PKCS#11.
+    The `plymouth` profile provides a graphical interface at boot (animation and
+    password prompt).
     The `raid` profile enables support for RAID arrays.
 
 `--debug`

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1043,6 +1043,8 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
     The `lvm` profile enables support for LVM.
     The `pkcs11` profile enables support for PKCS#11.
+    The `plymouth` profile provides a graphical interface at boot (animation and
+    password prompt).
     The `raid` profile enables support for RAID arrays.
 
 `InitrdPackages=`, `--initrd-package=`

--- a/mkosi/resources/mkosi-initrd/mkosi.profiles/plymouth/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.profiles/plymouth/mkosi.conf
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Content]
+Packages=plymouth

--- a/mkosi/resources/mkosi-initrd/mkosi.profiles/plymouth/mkosi.conf.d/10-fedora.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.profiles/plymouth/mkosi.conf.d/10-fedora.conf
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=fedora
+
+[Content]
+Packages=
+        abattis-cantarell-fonts
+        plymouth-system-theme

--- a/mkosi/resources/mkosi-initrd/mkosi.profiles/plymouth/mkosi.conf.d/10-opensuse.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.profiles/plymouth/mkosi.conf.d/10-opensuse.conf
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=opensuse
+
+[Content]
+Packages=
+        cantarell-fonts
+        distribution-logos-openSUSE-Tumbleweed
+        plymouth-branding-openSUSE

--- a/mkosi/resources/mkosi-initrd/mkosi.profiles/plymouth/mkosi.conf.d/10-ubuntu.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.profiles/plymouth/mkosi.conf.d/10-ubuntu.conf
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=ubuntu
+
+[Content]
+Packages=
+        kbd
+        plymouth-themes
+        plymouth-theme-ubuntu-text


### PR DESCRIPTION
This initrd profile provides a graphical interface at boot (animation and password prompt). I only added support for what I've already tested successfully: openSUSE, Fedora and Ubuntu.

Closes #3650