### PR TITLE
obs: fix sign-efi-sig-list parameter format

### DIFF
--- a/mkosi/resources/mkosi-obs/mkosi.build
+++ b/mkosi/resources/mkosi-obs/mkosi.build
@@ -229,7 +229,7 @@ while read -r SIG; do
     fbase="${fbase%.auth}"
     fbase="${fbase%%-*}"
     perl -0777 -npe 's/\A(?:[\040-\176]\0)+.{18}\0\0.{14}\0\0//s' < "$f" > "$f.orig"
-    sign-efi-sig-list -t "${SOURCE_DATE_EPOCH:-$(date +%s)}" -i "$f.p7sd" "$fbase" "$f.orig" "$f.tmp"
+    sign-efi-sig-list -t "$(date -d "@${SOURCE_DATE_EPOCH:-0}" "+%Y-%m-%d %H:%M:%S")" -i "$f.p7sd" "$fbase" "$f.orig" "$f.tmp"
     mv "$f.tmp" "$f"
     rm -f "$f.p7s" "$f.p7sd" "$f.orig"
 done < <(find hashes/authvars -type f -name '*.auth.sig')

--- a/mkosi/resources/mkosi-obs/mkosi.postoutput
+++ b/mkosi/resources/mkosi-obs/mkosi.postoutput
@@ -111,7 +111,7 @@ if ((${#DDIS[@]} > 0)); then
     cp db.esl KEK.esl
     cp db.esl PK.esl
     for i in *.esl; do
-        sign-efi-sig-list -o -g "$guid" -t "${SOURCE_DATE_EPOCH:-$(date +%s)}" "${i%.esl}" "$i" "${i%.esl}.auth"
+        sign-efi-sig-list -o -g "$guid" -t "$(date -d "@${SOURCE_DATE_EPOCH:-0}" "+%Y-%m-%d %H:%M:%S")" "${i%.esl}" "$i" "${i%.esl}.auth"
     done
     popd 2>/dev/null
 fi


### PR DESCRIPTION
It wants a date in the format Y-m-d H:M:S rather than unix seconds. Also if SOURCE_DATE_EPOCH is not defined, use actual epoch, as the timestamps must match when creating the signature and when attaching it