### PR TITLE
debian: Remove check if apt exists from install_apt_sources()

### DIFF
--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -219,12 +219,11 @@ class Installer(DistributionInstaller):
 
 
 def install_apt_sources(context: Context, repos: Iterable[AptRepository]) -> None:
-    if not (context.root / "usr/bin/apt").exists():
-        return
-
     sources = context.root / f"etc/apt/sources.list.d/{context.config.release}.sources"
     if not sources.exists():
-        with sources.open("w") as f:
+        with umask(~0o755):
+            sources.parent.mkdir(parents=True, exist_ok=True)
+        with umask(~0o644), sources.open("w") as f:
             for repo in repos:
                 f.write(str(repo))
 


### PR DESCRIPTION
We now install the apt sources before we install apt into the image so this check can never succeed so let's drop it.