### PR TITLE
Generate key-cert pair in config directory (fixes #3655)

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -71,6 +71,7 @@ from mkosi.config import (
     cat_config,
     expand_delayed_specifiers,
     format_bytes,
+    get_configdir,
     have_history,
     in_sandbox,
     parse_boolean,
@@ -4478,8 +4479,10 @@ def generate_key_cert_pair(args: Args) -> None:
     keylength = 2048
     expiration_date = datetime.date.today() + datetime.timedelta(int(args.genkey_valid_days))
 
-    for f in ("mkosi.key", "mkosi.crt"):
-        if Path(f).exists() and not args.force:
+    configdir = get_configdir(args)
+
+    for f in (configdir / "mkosi.key", configdir / "mkosi.crt"):
+        if f.exists() and not args.force:
             die(
                 f"{f} already exists",
                 hint="To generate new keys, first remove mkosi.key and mkosi.crt",
@@ -4502,8 +4505,8 @@ def generate_key_cert_pair(args: Args) -> None:
             "-new",
             "-x509",
             "-newkey", f"rsa:{keylength}",
-            "-keyout", "mkosi.key",
-            "-out", "mkosi.crt",
+            "-keyout", configdir / "mkosi.key",
+            "-out", configdir / "mkosi.crt",
             "-days", str(args.genkey_valid_days),
             "-subj", f"/CN={args.genkey_common_name}/",
             "-nodes"

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -4964,6 +4964,20 @@ def finalize_default_tools(
     return Config.from_dict(context.finalize())
 
 
+def get_configdir(args: Args) -> Path:
+    """Allow locating all mkosi configuration in a mkosi/ subdirectory
+    instead of in the top-level directory of a git repository.
+    """
+    if (
+        args.directory is not None
+        and not (Path("mkosi.conf").exists() or Path("mkosi.tools.conf").exists())
+        and (Path("mkosi/mkosi.conf").is_file() or Path("mkosi/mkosi.tools.conf").exists())
+    ):
+        return Path.cwd() / "mkosi"
+
+    return Path.cwd()
+
+
 def parse_config(
     argv: Sequence[str] = (),
     *,
@@ -5050,16 +5064,7 @@ def parse_config(
 
     context.config["files"] = []
 
-    # Allow locating all mkosi configuration in a mkosi/ subdirectory instead of in the top-level directory
-    # of a git repository.
-    if (
-        args.directory is not None
-        and not (Path("mkosi.conf").exists() or Path("mkosi.tools.conf").exists())
-        and (Path("mkosi/mkosi.conf").is_file() or Path("mkosi/mkosi.tools.conf").exists())
-    ):
-        configdir = Path.cwd() / "mkosi"
-    else:
-        configdir = Path.cwd()
+    configdir = get_configdir(args)
 
     # Parse the global configuration unless the user explicitly asked us not to.
     if args.directory is not None:


### PR DESCRIPTION
Returning the used configpath from `parse_config` seems like the easiest way to do this as they cannot be really attached to the image configs or args. If you have better suggestions I would be happy to change this