### PR TITLE
Allow MinimumVersion to be a git sha

### DIFF
--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -2166,6 +2166,12 @@ config file is read:
 :   The minimum **mkosi** version required to build this configuration. If
     specified multiple times, the highest specified version is used.
 
+    The minimum version can also be specified as a unabbreviated git
+    commit hash, in which case mkosi must be executed from a git
+    checkout and the specified git commit hash must be an ancestor of
+    the currently checked out git commit in the repository that mkosi is
+    being executed from.
+
 `ConfigureScripts=`, `--configure-script=`
 :   Takes a comma-separated list of paths to executables that are used as
     the configure scripts for this image. See the **Scripts** section for

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -43,7 +43,6 @@ from mkosi.config import (
     VsockCID,
 )
 from mkosi.distributions import Distribution
-from mkosi.versioncomp import GenericVersion
 
 
 @pytest.mark.parametrize("path", [None, "/baz/qux"])
@@ -509,7 +508,7 @@ def test_config() -> None:
         manifest_format=[ManifestFormat.json, ManifestFormat.changelog],
         microcode_host=True,
         devicetree=Path("freescale/imx8mm-verdin-nonwifi-dev.dtb"),
-        minimum_version=GenericVersion("123"),
+        minimum_version="123",
         mirror=None,
         nspawn_settings=None,
         openpgp_tool="gpg",


### PR DESCRIPTION
In systemd we very often require newer mkosi git commits which means that setting MinimumVersion=25~devel doesn't work anymore. Let's allow the MinimumVersion= to be a git sha so that we can enforce the mkosi version to be new enough.

We skip git commit checks if we're in the sandbox since mkosi will be a zipapp there and we won't have access to the git repository to do the check.