### PR TITLE
action: Ensure git history is available

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -73,9 +73,18 @@ runs:
         sudo aa-teardown || true
         sudo apt-get remove apparmor
 
-    - name: Unshallow
+    - name: Ensure git history is available
       shell: bash
-      run: git -C ${{ github.action_path }} fetch --unshallow
+      run: |
+        if [[ ! -d "${{ github.action_path }}/.git" ]]; then
+            rm -rf "${{ github.action_path }}"
+            git clone "$GITHUB_ACTION_REPOSITORY" "${{ github.action_path }}"
+            git -C "${{ github.action_path }}" checkout "$GITHUB_ACTION_REF"
+        fi
+      env:
+        # https://github.com/actions/runner/issues/2473
+        GITHUB_ACTION_REPOSITORY: ${{ github.action_repository }}
+        GITHUB_ACTION_REF: ${{ github.action_ref }}
 
     - name: Install
       shell: bash


### PR DESCRIPTION
Unshallowing the repository only works when the action is used as a local action within the mkosi repository. If the action is used in any other github repository, the git history is not available so we cannot unshallow the repository.

Instead, detect if the git history is available and clone the repository ourselves if the git history is not available.