### PR TITLE
Allow PCR signing settings to be overridden in sub-images

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3446,7 +3446,7 @@ SETTINGS: list[ConfigSetting[Any]] = [
         parse=config_parse_key,
         path_suffixes=("key",),
         help="Private key for signing expected PCR signature",
-        scope=SettingScope.universal,
+        scope=SettingScope.inherit,
     ),
     ConfigSetting(
         dest="sign_expected_pcr_key_source",
@@ -3455,7 +3455,7 @@ SETTINGS: list[ConfigSetting[Any]] = [
         parse=config_parse_key_source,
         default=KeySource(type=KeySourceType.file),
         help="The source to use to retrieve the expected PCR signing key",
-        scope=SettingScope.universal,
+        scope=SettingScope.inherit,
     ),
     ConfigSetting(
         dest="sign_expected_pcr_certificate",
@@ -3464,7 +3464,7 @@ SETTINGS: list[ConfigSetting[Any]] = [
         parse=config_parse_certificate,
         path_suffixes=("crt",),
         help="Certificate for signing expected PCR signature in X509 format",
-        scope=SettingScope.universal,
+        scope=SettingScope.inherit,
     ),
     ConfigSetting(
         dest="sign_expected_pcr_certificate_source",
@@ -3473,7 +3473,7 @@ SETTINGS: list[ConfigSetting[Any]] = [
         parse=config_parse_certificate_source,
         default=CertificateSource(type=CertificateSourceType.file),
         help="The source to use to retrieve the expected PCR signing certificate",
-        scope=SettingScope.universal,
+        scope=SettingScope.inherit,
     ),
     ConfigSetting(
         dest="passphrase",

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -2913,10 +2913,6 @@ following settings are universal and cannot be configured in subimages:
 - `VerityCertificateSource=`
 - `VerityKey=`
 - `VerityKeySource=`
-- `SignExpectedPcrCertificate=`
-- `SignExpectedPcrCertificateSource=`
-- `SignExpectedPcrKey=`
-- `SignExpectedPcrKeySource=`
 - `VolatilePackageDirectories=`
 - `WithNetwork=`
 - `WithTests`
@@ -2934,6 +2930,10 @@ down to subimages but can be overridden:
 - `CacheKey=`
 - `BuildKey=`
 - `CompressLevel=`
+- `SignExpectedPcrKey=`
+- `SignExpectedPcrKeySource=`
+- `SignExpectedPcrCertificate=`
+- `SignExpectedPcrCertificateSource=`
 
 Additionally, there are various settings that can only be configured in
 the main image but which are not passed down to subimages:


### PR DESCRIPTION
A sub-image is usually built from the same base image. That base image may be used for a rescue image and a primary workstation image. If the rescue image has PCR signing enabled then it could allow the disk to be automatically unlocked. This change allows specifying separate PCR signing keys which will support only the workstation sub-image performing an automatic unlock.