### PR TITLE
Rework history <=> sandbox integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,9 @@ jobs:
               chmod +x "mkosi.${script}"
           done
 
+      - name: Generate key
+        run: sudo mkosi genkey
+
       - name: Summary
         run: sudo mkosi summary
 

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1587,7 +1587,8 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     the latest build to the `.mkosi-private` subdirectory in the
     directory from which it was invoked. This information is then used
     to restore the config of the latest build when running any verb that
-    needs a build without specifying `--force`.
+    does not rebuild the image or when running any verb that may rebuild
+    the image without specifying `--force`.
 
     Note that configure scripts will not be executed if we reuse the
     history from a previous build.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -157,9 +157,6 @@ class Image:
 
         return result
 
-    def genkey(self) -> CompletedProcess:
-        return self.mkosi("genkey", ["--force"])
-
 
 @pytest.fixture(scope="session", autouse=True)
 def suspend_capture_stdin(pytestconfig: Any) -> Iterator[None]:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -26,7 +26,6 @@ class ImageConfig:
     distribution: Distribution
     release: str
     debug_shell: bool
-    tools: Optional[Path]
 
 
 class Image:
@@ -67,7 +66,6 @@ class Image:
         return run(
             [
                 "python3", "-m", "mkosi",
-                *(["--tools-tree", os.fspath(self.config.tools)] if self.config.tools else []),
                 "--debug",
                 *options,
                 verb,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 from collections.abc import Iterator
-from pathlib import Path
 from typing import Any, cast
 
 import pytest
@@ -50,7 +49,6 @@ def config(request: Any) -> ImageConfig:
         distribution=distribution,
         release=release,
         debug_shell=request.config.getoption("--debug-shell"),
-        tools=p if (p := Path("mkosi.tools")).exists() else None,
     )
 
 

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -32,7 +32,6 @@ def test_format(config: ImageConfig, format: OutputFormat) -> None:
         ):
             pytest.skip("Cannot build RHEL-UBI images with format 'esp' or 'uki'")
 
-        image.genkey()
         image.build(options=["--format", str(format)])
 
         if format in (OutputFormat.disk, OutputFormat.directory) and os.getuid() == 0:
@@ -80,6 +79,5 @@ def test_bootloader(config: ImageConfig, bootloader: Bootloader) -> None:
     firmware = Firmware.linux if bootloader == Bootloader.none else Firmware.auto
 
     with Image(config) as image:
-        image.genkey()
         image.build(["--format=disk", "--bootloader", str(bootloader)])
         image.vm(["--firmware", str(firmware)])


### PR DESCRIPTION
Until now, we read the tools tree configuration both inside and outside the sandbox. This is problematic for a few reasons:

- For a number of reasons, the tools tree configuration inside and outside the sandbox may be different. This is especially true when the history is used, as when invoking mkosi sandbox and mkosi is invoked again within the sandbox, we don't know when invoking mkosi sandbox whether the nested invocation will reuse the history or not. This can lead to situations where mkosi sandbox thinks the tools tree is up-to-date whereas mkosi inside the sandbox thinks the tools tree is out of date, which is a situation that is very hard to resolve for users.
- Even if we read the tools tree configuration inside the sandbox, there's no real point to it except maybe for showing the summary. Since the tools tree has already been built and mounted at that point, we can't build or use a new tools tree, or clean up an old one.

Let's fix these issues by *not* reading the tools tree configuration inside the sandbox, neither from configuration not from history. The one piece of tools tree configuration we do need to pass into the sandbox is the default tools tree path as that gets included in the history of the other images so we pass it in via an environment variable $MKOSI_DEFAULT_TOOLS_TREE_PATH.

As a consequence of this approach, we cannot write the tools tree history from within the sandbox anymore, so we write it to a separate file from outside the sandbox instead.

Additionally, we make more commands use the history. Up until now clean, summary and other verbs did not make use of the history. This doesn't really make sense, so let's make sure they make use of the history as well. summary in particular is important as it may be used to query information about the built image after building it which needs to take the history into account.