### PR TITLE
installer: Make sure package manager state is preserved in the image

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3884,7 +3884,7 @@ def copy_repository_metadata(config: Config, dst: Path) -> None:
                 if d == "cache":
                     exclude = flatten(
                         ("--ro-bind", tmp, workdir(p))
-                        for p in config.distribution.package_manager(config).cache_subdirs(src)
+                        for p in config.distribution.package_manager(config).package_subdirs(src)
                     )
                 else:
                     exclude = flatten(
@@ -4853,7 +4853,7 @@ def sync_repository_metadata(
                 )
 
     src = last.package_cache_dir_or_default() / "cache" / subdir
-    for p in last.distribution.package_manager(last).cache_subdirs(src):
+    for p in last.distribution.package_manager(last).package_subdirs(src):
         p.mkdir(parents=True, exist_ok=True)
 
     # If we're in incremental mode and caching metadata is not explicitly disabled, cache the keyring and the

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3899,6 +3899,10 @@ def copy_repository_metadata(config: Config, dst: Path) -> None:
             logging.debug(f"{cachedir} does not exist, not copying repository metadata from it")
 
         statedir = config.package_cache_dir_or_default() / "lib" / subdir
+
+        with umask(~0o755):
+            (dst / "lib" / subdir).mkdir(parents=True, exist_ok=True)
+
         for src in config.distribution.package_manager(config).state_subdirs(statedir):
             if not src.exists():
                 logging.debug(f"{src} does not exist, not copying repository metadata from it")

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3869,30 +3869,22 @@ def copy_repository_metadata(config: Config, dst: Path) -> None:
     subdir = config.distribution.package_manager(config).subdir(config)
 
     with complete_step("Copying repository metadata"):
-        for d in ("cache", "lib"):
-            src = config.package_cache_dir_or_default() / d / subdir
-            if not src.exists():
-                logging.debug(f"{src} does not exist, not copying repository metadata from it")
-                continue
+        cachedir = config.package_cache_dir_or_default() / "cache" / subdir
+        if cachedir.exists():
+            with umask(~0o755):
+                (dst / "cache" / subdir).mkdir(parents=True, exist_ok=True)
 
             with tempfile.TemporaryDirectory() as tmp:
                 os.chmod(tmp, 0o755)
 
                 # cp doesn't support excluding directories but we can imitate it by bind mounting
                 # an empty directory over the directories we want to exclude.
-                exclude: list[PathString]
-                if d == "cache":
-                    exclude = flatten(
-                        ("--ro-bind", tmp, workdir(p))
-                        for p in config.distribution.package_manager(config).package_subdirs(src)
-                    )
-                else:
-                    exclude = flatten(
-                        ("--ro-bind", tmp, workdir(p))
-                        for p in config.distribution.package_manager(config).state_subdirs(src)
-                    )
+                exclude = flatten(
+                    ("--ro-bind", tmp, workdir(p))
+                    for p in config.distribution.package_manager(config).package_subdirs(cachedir)
+                )
 
-                subdst = dst / d / subdir
+                subdst = dst / "cache" / subdir
                 with umask(~0o755):
                     subdst.mkdir(parents=True, exist_ok=True)
 
@@ -3902,7 +3894,21 @@ def copy_repository_metadata(config: Config, dst: Path) -> None:
                 ) -> AbstractContextManager[list[PathString]]:
                     return config.sandbox(options=[*options, *exclude])
 
-                copy_tree(src, subdst, sandbox=sandbox)
+                copy_tree(cachedir, subdst, sandbox=sandbox)
+        else:
+            logging.debug(f"{cachedir} does not exist, not copying repository metadata from it")
+
+        statedir = config.package_cache_dir_or_default() / "lib" / subdir
+        for src in config.distribution.package_manager(config).state_subdirs(statedir):
+            if not src.exists():
+                logging.debug(f"{src} does not exist, not copying repository metadata from it")
+                continue
+
+            subdst = dst / "lib" / subdir / src.relative_to(statedir)
+            with umask(~0o755):
+                subdst.mkdir(parents=True, exist_ok=True)
+
+            copy_tree(src, subdst, sandbox=config.sandbox)
 
 
 @contextlib.contextmanager

--- a/mkosi/installer/__init__.py
+++ b/mkosi/installer/__init__.py
@@ -22,7 +22,7 @@ class PackageManager:
         return Path("custom")
 
     @classmethod
-    def cache_subdirs(cls, cache: Path) -> list[Path]:
+    def package_subdirs(cls, cache: Path) -> list[Path]:
         return []
 
     @classmethod
@@ -85,7 +85,7 @@ class PackageManager:
             # configured package cache directory in this scenario, we mount in the relevant directories from
             # the configured package cache directory.
             if d == "cache" and context.metadata_dir != context.config.package_cache_dir_or_default():
-                caches = context.config.distribution.package_manager(context.config).cache_subdirs(src)
+                caches = context.config.distribution.package_manager(context.config).package_subdirs(src)
                 mounts += flatten(
                     (
                         "--bind",

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -102,6 +102,10 @@ class Apt(PackageManager):
         }  # fmt: skip
 
     @classmethod
+    def options(cls, *, root: PathString, apivfs: bool = True) -> list[PathString]:
+        return super().options(root=root, apivfs=apivfs) + ["--dir", "/var/lib/apt/lists/partial"]
+
+    @classmethod
     def setup(cls, context: Context, repositories: Sequence[AptRepository]) -> None:
         (context.sandbox_tree / "etc/apt").mkdir(exist_ok=True, parents=True)
         (context.sandbox_tree / "etc/apt/apt.conf.d").mkdir(exist_ok=True, parents=True)
@@ -171,7 +175,8 @@ class Apt(PackageManager):
             "-o", "Acquire::AllowReleaseInfoChange=true",
             "-o", "Acquire::Check-Valid-Until=false",
             "-o", "Dir::Cache=/var/cache/apt",
-            "-o", "Dir::State=/var/lib/apt",
+            "-o", "Dir::State=/buildroot/var/lib/apt",
+            "-o", "Dir::State::lists=/var/lib/apt/lists/",
             "-o", "Dir::Log=/var/log/apt",
             "-o", "Dir::State::Status=/buildroot/var/lib/dpkg/status",
             "-o", f"Dir::Bin::DPkg={context.config.find_binary('dpkg')}",

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -58,6 +58,10 @@ class Apt(PackageManager):
         return [cache / "archives"]
 
     @classmethod
+    def state_subdirs(cls, state: Path) -> list[Path]:
+        return [state / "lists"]
+
+    @classmethod
     def dpkg_cmd(cls, command: str) -> list[PathString]:
         return [
             command,

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -54,7 +54,7 @@ class Apt(PackageManager):
         return Path("apt")
 
     @classmethod
-    def cache_subdirs(cls, cache: Path) -> list[Path]:
+    def package_subdirs(cls, cache: Path) -> list[Path]:
         return [cache / "archives"]
 
     @classmethod

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -25,7 +25,7 @@ class Dnf(PackageManager):
         return Path("libdnf5" if cls.executable(config) == "dnf5" else "dnf")
 
     @classmethod
-    def cache_subdirs(cls, cache: Path) -> list[Path]:
+    def package_subdirs(cls, cache: Path) -> list[Path]:
         return [
             p / "packages" for p in cache.iterdir() if p.is_dir() and "-" in p.name and "mkosi" not in p.name
         ]

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -148,10 +148,10 @@ class Dnf(PackageManager):
             "--setopt=keepcache=1",
             "--setopt=logdir=/var/log",
             f"--setopt=cachedir=/var/cache/{cls.subdir(context.config)}",
-            f"--setopt=persistdir=/var/lib/{cls.subdir(context.config)}",
             f"--setopt=install_weak_deps={int(context.config.with_recommends)}",
             "--setopt=check_config_file_age=0",
             "--disable-plugin=*" if dnf == "dnf5" else "--disableplugin=*",
+            "--setopt=persistdir=/buildroot/var/lib/dnf",
         ]  # fmt: skip
 
         for plugin in ("builddep", "versionlock", "reflink"):

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -35,7 +35,7 @@ class Pacman(PackageManager):
         return Path("pacman")
 
     @classmethod
-    def cache_subdirs(cls, cache: Path) -> list[Path]:
+    def package_subdirs(cls, cache: Path) -> list[Path]:
         return [cache / "pkg"]
 
     @classmethod

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -40,7 +40,7 @@ class Pacman(PackageManager):
 
     @classmethod
     def state_subdirs(cls, state: Path) -> list[Path]:
-        return [state / "local"]
+        return [state / "sync"]
 
     @classmethod
     def scripts(cls, context: Context) -> dict[str, list[PathString]]:

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -23,7 +23,7 @@ class Zypper(PackageManager):
         return Path("zypp")
 
     @classmethod
-    def cache_subdirs(cls, cache: Path) -> list[Path]:
+    def package_subdirs(cls, cache: Path) -> list[Path]:
         return [cache / "packages"]
 
     @classmethod


### PR DESCRIPTION
installer: Make sure package manager state is preserved in the image

Package manager state should be preserved in the image as various
local features of the package manager may depend on this data to be
available. For pacman and zypper we already store local state inside
the image. For apt, we achieve this by storing all state in the image
by default except lists which is the repository metadata which we still
don't include in the image. For dnf/dnf5, we make sure the persistdir
points to inside the image.

Note that this state is still subject to removal by CleanPackageMetadata=
if the package manager is not installed or the option is explicitly enabled.

Fixes https://github.com/systemd/mkosi/issues/3659