### PR TITLE
Fail if --rerun-build-scripts is used and tools is out of date

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5030,8 +5030,7 @@ def run_verb(args: Args, tools: Optional[Config], images: Sequence[Config], *, r
     if tools and not have_cache(tools):
         if (args.rerun_build_scripts or args.verb != Verb.build) and args.force == 0:
             die(
-                f"Default tools tree requested for image '{last.image}' but it is out-of-date or has not "
-                "been built yet",
+                "Default tools tree requested but it is out-of-date or has not been built yet",
                 hint="Make sure to (re)build the tools tree first with 'mkosi build' or use '--force'",
             )
         elif last.incremental == Incremental.strict:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5028,7 +5028,7 @@ def run_verb(args: Args, tools: Optional[Config], images: Sequence[Config], *, r
 
     # For the default tools tree have_cache() encompasses the "has the tools tree been built at all" check.
     if tools and not have_cache(tools):
-        if args.verb != Verb.build and args.force == 0:
+        if (args.rerun_build_scripts or args.verb != Verb.build) and args.force == 0:
             die(
                 f"Default tools tree requested for image '{last.image}' but it is out-of-date or has not "
                 "been built yet",


### PR DESCRIPTION
If --rerun-build-scripts is used, we shouldn't rebuild the tools tree unless --force is specified as well, so make sure we check for that specific case.