### PR TITLE
Don't try to copy selinux xattrs on zfs either

### DIFF
--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -57,6 +57,7 @@ NR_open_tree = 428
 OPEN_TREE_CLOEXEC = os.O_CLOEXEC
 OPEN_TREE_CLONE = 1
 OVERLAYFS_SUPER_MAGIC = 0x794C7630
+ZFS_SUPER_MAGIC = 0x0CB1BA00
 PR_CAP_AMBIENT = 47
 PR_CAP_AMBIENT_RAISE = 2
 # These definitions are taken from the libseccomp headers

--- a/mkosi/tree.py
+++ b/mkosi/tree.py
@@ -13,7 +13,15 @@ from pathlib import Path
 from mkosi.config import ConfigFeature
 from mkosi.log import ARG_DEBUG, die
 from mkosi.run import SandboxProtocol, nosandbox, run, workdir
-from mkosi.sandbox import BTRFS_SUPER_MAGIC, FS_NOCOW_FL, OVERLAYFS_SUPER_MAGIC, chattr, lsattr, statfs
+from mkosi.sandbox import (
+    BTRFS_SUPER_MAGIC,
+    FS_NOCOW_FL,
+    OVERLAYFS_SUPER_MAGIC,
+    ZFS_SUPER_MAGIC,
+    chattr,
+    lsattr,
+    statfs,
+)
 from mkosi.util import PathString, flatten
 from mkosi.versioncomp import GenericVersion
 
@@ -113,7 +121,10 @@ def copy_tree(
         attrs += ",timestamps,ownership"
 
         # Trying to copy selinux xattrs to overlayfs fails with "Operation not supported" in containers.
-        if statfs(os.fspath(dst.parent)) != OVERLAYFS_SUPER_MAGIC or not tree_has_selinux_xattr(src):
+        if statfs(os.fspath(dst.parent)) not in (
+            OVERLAYFS_SUPER_MAGIC,
+            ZFS_SUPER_MAGIC,
+        ) or not tree_has_selinux_xattr(src):
             attrs += ",xattr"
 
     def copy() -> None:


### PR DESCRIPTION
This also fails with permission denied errors so let's skip it on zfs as well.

Fixes #3684

@eadwu this should fix your selinux issue