### PR TITLE
Only write CLI arguments to history instead of full config

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -71,8 +71,8 @@ from mkosi.config import (
     cat_config,
     dump_json,
     expand_delayed_specifiers,
+    finalize_configdir,
     format_bytes,
-    get_configdir,
     have_history,
     in_sandbox,
     parse_boolean,
@@ -4486,7 +4486,7 @@ def generate_key_cert_pair(args: Args) -> None:
     keylength = 2048
     expiration_date = datetime.date.today() + datetime.timedelta(int(args.genkey_valid_days))
 
-    configdir = get_configdir(args)
+    configdir = finalize_configdir(args)
 
     for f in (configdir / "mkosi.key", configdir / "mkosi.crt"):
         if f.exists() and not args.force:

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -69,6 +69,7 @@ from mkosi.config import (
     Verity,
     Vmm,
     cat_config,
+    dump_json,
     expand_delayed_specifiers,
     format_bytes,
     get_configdir,
@@ -578,7 +579,7 @@ def finalize_host_scripts(
 @contextlib.contextmanager
 def finalize_config_json(config: Config) -> Iterator[Path]:
     with tempfile.NamedTemporaryFile(mode="w") as f:
-        f.write(config.to_json())
+        f.write(dump_json(config.to_dict()))
         f.flush()
         yield Path(f.name)
 
@@ -620,7 +621,7 @@ def run_configure_scripts(config: Config) -> Config:
                             *sources,
                         ],
                     ),
-                    input=config.to_json(indent=None),
+                    input=dump_json(config.to_dict(), indent=None),
                     stdout=subprocess.PIPE,
                 )  # fmt: skip
 
@@ -4933,10 +4934,6 @@ def run_build(
                 package_dir=package_dir,
             )
         )
-
-
-def dump_json(dict: dict[str, Any]) -> str:
-    return json.dumps(dict, cls=JsonEncoder, indent=4, sort_keys=True)
 
 
 def run_verb(args: Args, tools: Optional[Config], images: Sequence[Config], *, resources: Path) -> None:

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1787,10 +1787,6 @@ class Args:
     def to_dict(self) -> dict[str, Any]:
         return dataclasses.asdict(self, dict_factory=dict_with_capitalised_keys_factory)
 
-    def to_json(self, *, indent: Optional[int] = 4, sort_keys: bool = True) -> str:
-        """Dump Args as JSON string."""
-        return json.dumps(self.to_dict(), cls=JsonEncoder, indent=indent, sort_keys=sort_keys)
-
     @classmethod
     def from_json(cls, s: Union[str, dict[str, Any], SupportsRead[str], SupportsRead[bytes]]) -> "Args":
         """Instantiate a Args object from a (partial) JSON dump."""
@@ -2346,10 +2342,6 @@ class Config:
             d["BuildSubdirectory"] = self.build_subdir
 
         return d
-
-    def to_json(self, *, indent: Optional[int] = 4, sort_keys: bool = True) -> str:
-        """Dump Config as JSON string."""
-        return json.dumps(self.to_dict(), cls=JsonEncoder, indent=indent, sort_keys=sort_keys)
 
     @classmethod
     def from_json(cls, s: Union[str, dict[str, Any], SupportsRead[str], SupportsRead[bytes]]) -> "Config":
@@ -5508,6 +5500,10 @@ class JsonEncoder(json.JSONEncoder):
         elif isinstance(o, (Args, Config)):
             return o.to_dict()
         return super().default(o)
+
+
+def dump_json(dict: dict[str, Any], indent: Optional[int] = 4) -> str:
+    return json.dumps(dict, cls=JsonEncoder, indent=indent, sort_keys=True)
 
 
 E = TypeVar("E", bound=StrEnum)

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -4971,7 +4971,7 @@ def finalize_default_tools(
     return Config.from_dict(context.finalize())
 
 
-def get_configdir(args: Args) -> Path:
+def finalize_configdir(args: Args) -> Path:
     """Allow locating all mkosi configuration in a mkosi/ subdirectory
     instead of in the top-level directory of a git repository.
     """
@@ -5077,7 +5077,7 @@ def parse_config(
 
     context.config["files"] = []
 
-    configdir = get_configdir(args)
+    configdir = finalize_configdir(args)
 
     # Parse the global configuration unless the user explicitly asked us not to.
     if args.directory is not None:

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -5017,6 +5017,9 @@ def parse_config(
     if args.rerun_build_scripts and not args.verb.needs_build():
         die(f"--rerun-build-scripts cannot be used with the '{args.verb}' command")
 
+    if args.rerun_build_scripts and args.force:
+        die("--force cannot be used together with --rerun-build-scripts")
+
     if args.cmdline and not args.verb.supports_cmdline():
         die(f"Arguments after verb are not supported for the '{args.verb}' command")
 

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1583,15 +1583,11 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     up in the generated XFS filesystem.
 
 `History=`, `--history=`
-:   Takes a boolean. If enabled, **mkosi** will write information about
-    the latest build to the `.mkosi-private` subdirectory in the
-    directory from which it was invoked. This information is then used
-    to restore the config of the latest build when running any verb that
-    does not rebuild the image or when running any verb that may rebuild
-    the image without specifying `--force`.
-
-    Note that configure scripts will not be executed if we reuse the
-    history from a previous build.
+:   Takes a boolean. If enabled, **mkosi** will write the configuration
+    provided via the CLI for the latest build to the `.mkosi-private`
+    subdirectory in the directory from which it was invoked. These
+    arguments are then reused as long as the image is not rebuilt to
+    avoid having to specify them over and over again.
 
     To give an example of why this is useful, if you run
     `mkosi -O my-custom-output-dir -f` followed by `mkosi vm`, **mkosi**

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -178,7 +178,11 @@ The following command line verbs are known:
     simple versioning scheme: each time this verb is called the version is
     bumped in preparation for the subsequent build. Note that
     `--auto-bump`/`-B` may be used to automatically bump the version
-    after each successful build.
+    as part of a build. The new version is only written to
+    `mkosi.version` if the build succeeds in that case.
+
+    If `mkosi.bump` exists, it is invoked to generate the new version to
+    be used instead of using mkosi's own logic.
 
 `genkey`
 :   Generate a pair of SecureBoot keys for usage with the
@@ -281,11 +285,14 @@ Those settings cannot be configured in the configuration files.
     Defaults to two years (730 days).
 
 `--auto-bump=`, `-B`
-:   If specified, after each successful build the version is bumped in a
-    fashion equivalent to the `bump` verb, in preparation for the next
-    build. This is useful for simple, linear version management: each
-    build in a series will have a version number one higher then the
-    previous one.
+:   If specified, the version is bumped and if the build succeeds, the
+    version is written to `mkosi.version` in a fashion equivalent to the
+    `bump` verb. This is useful for simple, linear version management:
+    each build in a series will have a version number one higher then
+    the previous one.
+
+    If `mkosi.bump` exists, it is invoked to generate the new version to
+    be used instead of using mkosi's own logic.
 
 `--doc-format`
 :   The format to show the documentation in. Supports the values `markdown`,

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -307,8 +307,8 @@ Those settings cannot be configured in the configuration files.
 `--rerun-build-scripts`, `-R`
 :   Rerun build scripts. Requires the `Incremental=` option to be
     enabled and the image to have been built once already. If `History=`
-    is enabled, the config from the previous build will be reused and no
-    new history will be written.
+    is enabled, the history from the previous build will be reused and
+    no new history will be written.
 
 ## Supported output formats
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -41,6 +41,7 @@ from mkosi.config import (
     Verity,
     Vmm,
     VsockCID,
+    dump_json,
 )
 from mkosi.distributions import Distribution
 
@@ -92,7 +93,7 @@ def test_args(path: Optional[Path]) -> None:
         wipe_build_dir=True,
     )
 
-    assert args.to_json(indent=4, sort_keys=True) == dump.rstrip()
+    assert dump_json(args.to_dict()) == dump.rstrip()
     assert Args.from_json(dump) == args
 
 
@@ -615,5 +616,5 @@ def test_config() -> None:
         workspace_dir=Path("/cwd"),
     )
 
-    assert args.to_json() == dump.rstrip()
+    assert dump_json(args.to_dict()) == dump.rstrip()
     assert Config.from_json(dump) == args


### PR DESCRIPTION
The huge downside of writing the full config to the history is that
any modifications to config files are ignored until the image is
rebuilt.

If we make the argument that changes to config files are usually
supposed to be permanent rather than ephemeral, it doesn't make sense
to not take them into account when reusing the history. Especially since
the primary purpose of the history is to avoid specifying the same CLI
arguments over and over again without encoding those CLI arguments into
a config file.

So instead of saving the full config to the history and not reparsing
the configuration when reusing the history, let's only save the CLI
arguments to the history and always reparse the configuration, even when
we end up reusing the history.

This keeps the crucial benefit of the history intact (not having to repeat
yourself endlessly) while still making sure any new settings added to the
configuration files are taken into account immediately.

It also simplifies the implementation quite a bit, as we can get away
again with maintaining a single history file instead of two.

Additionally, we opt to completely ignore the history when using the sandbox
verb. The idea here is that the history only applies to the final image (and
subimages). This was already the case as any --tools-tree-xxx CLI options aren't
saved in the history as they are not fields of the Config object.