### PR TITLE
dnf: Stop messing around with plugins

### DIFF
--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -150,12 +150,8 @@ class Dnf(PackageManager):
             f"--setopt=cachedir=/var/cache/{cls.subdir(context.config)}",
             f"--setopt=install_weak_deps={int(context.config.with_recommends)}",
             "--setopt=check_config_file_age=0",
-            "--disable-plugin=*" if dnf == "dnf5" else "--disableplugin=*",
             "--setopt=persistdir=/buildroot/var/lib/dnf",
-        ]  # fmt: skip
-
-        for plugin in ("builddep", "versionlock", "reflink"):
-            cmdline += ["--enable-plugin", plugin] if dnf == "dnf5" else ["--enableplugin", plugin]
+        ]
 
         if ARG_DEBUG.get():
             cmdline += ["--setopt=debuglevel=10"]


### PR DESCRIPTION
We disabled plugins by default a long time ago because the versionlock plugin's configuration from the host was interfering with image builds. Now that we have completely ownership over /etc, there shouldn't be a need to disable plugins anymore if we assume they won't do anything nasty by default without configuration.