### PR TITLE
mkosi: Use tools tree by default in repository config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,6 @@ jobs:
           KernelCommandLine=systemd.default_device_timeout_sec=180
 
           [Build]
-          ToolsTree=default
           ToolsTreeDistribution=${{ matrix.tools }}
           Environment=SYSTEMD_REPART_MKFS_OPTIONS_EROFS="--quiet"
 

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -13,6 +13,7 @@ Format=directory
 OutputDirectory=mkosi.output
 
 [Build]
+ToolsTree=default
 Incremental=yes
 BuildSources=.
 BuildSourcesEphemeral=yes


### PR DESCRIPTION
Might as well use a tools tree by default to minimize the number of packages that have to be installed on the host to build the default image.