### PR TITLE
Don't use default value if optional settings are set to none

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -450,6 +450,20 @@ def test_override_default(tmp_path: Path) -> None:
     assert config.tools_tree is None
     assert "MY_KEY" not in config.environment
 
+    (d / "mkosi.tools.conf").touch()
+
+    (d / "mkosi.local.conf").write_text(
+        """\
+        [Build]
+        ToolsTree=
+        """
+    )
+
+    with chdir(d):
+        _, _, [config] = parse_config([])
+
+    assert config.tools_tree is None
+
 
 def test_local_config(tmp_path: Path) -> None:
     d = tmp_path


### PR DESCRIPTION
Just like it's possible to disable usage of default values for collection based settings, we should also support it for optional settings. This can be used to disable usage of the tools tree even if mkosi.tools.conf exists by setting ToolsTree= in mkosi.local.conf.