### PR TITLE
repart: use --append-fstab=auto if available

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3401,6 +3401,8 @@ def make_image(
             "--generate-fstab=/etc/fstab",
             "--generate-crypttab=/etc/crypttab",
         ]
+    if tabs and systemd_tool_version("systemd-repart", sandbox=context.sandbox) >= 258:
+        cmdline += ["--append-fstab=auto"]
 
     for d in definitions:
         cmdline += ["--definitions", workdir(d)]


### PR DESCRIPTION
When generating images there is a chance that a pre-existent /etc/fstab
is present in the mkosi buildroot.  systemd-repart can merge the already
existing fstab with the one generated, separating the sections in a way
that the systemd-repart can be reused several times.
