### PR TITLE
Partially revert 640000a861e9cd9a3807e4158e110a098c74d078

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1005,14 +1005,6 @@ def config_default_release(namespace: dict[str, Any]) -> str:
     return cast(str, namespace["distribution"].default_release())
 
 
-def config_default_tools_tree(namespace: dict[str, Any]) -> Optional[Path]:
-    if namespace.get("image") != "main":
-        return None
-
-    configdir = finalize_configdir(namespace["directory"])
-    return Path("default") if configdir and (configdir / "mkosi.tools.conf").exists() else None
-
-
 def config_default_tools_tree_distribution(namespace: dict[str, Any]) -> Distribution:
     if d := os.getenv("MKOSI_HOST_DISTRIBUTION"):
         return Distribution(d).default_tools_tree_distribution()
@@ -3541,7 +3533,6 @@ SETTINGS: list[ConfigSetting[Any]] = [
         section="Build",
         parse=config_make_path_parser(constants=("default",)),
         path_suffixes=("tools",),
-        default_factory=config_default_tools_tree,
         help="Look up programs to execute inside the given tree",
         scope=SettingScope.universal,
     ),

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1342,9 +1342,6 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     using the settings below or with `mkosi.tools.conf` which can either be a
     file or directory containing extra configuration for the default tools tree.
 
-    If `mkosi.tools.conf` exists in the directory mkosi is invoked in,
-    a default tools tree is used if no tools tree is specified.
-
     The following table shows for which distributions default tools tree
     packages are defined and which packages are included in those default
     tools trees:


### PR DESCRIPTION
This doesn't quite work as on the second run, mkosi.tools will be picked up as the default value of ToolsTree= instead of "default" so we lose cache invalidation.

Let's revert for now until we find a better solution.