### PR TITLE
Fix licenses path in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,12 @@ version = "25.3"
 description = "Build Bespoke OS Images"
 readme = "README.md"
 requires-python = ">=3.9"
-license = {file = "LICENSE"}
+license-files = [
+    "LICENSES/GPL-2.0-only.txt",
+    "LICENSES/LGPL-2.1-or-later.txt",
+    "LICENSES/OFL-1.1.txt",
+    "LICENSES/PSF-2.0.txt"
+]
 
 [project.optional-dependencies]
 bootable = [


### PR DESCRIPTION
The old license file got removed in v25, which lead to the pyproject.toml not pointing to the correct license anymore.
Therefore it could not be installed as a dependency with poetry anymore.

I updated the pyproject.yaml to adhere to [PEP 639](https://peps.python.org/pep-0639/#add-license-files-key) which lets me install it with poetry again.