### PR TITLE
initrd: shadow-utils removal is only necessary on old Fedora

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-fedora-stable.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-fedora-stable.conf
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=fedora
+Release=|40
+Release=|41
+Release=|42
+
+[Content]
+RemovePackages=
+        # Various packages pull in shadow-utils to create users, we can remove it afterwards
+        shadow-utils

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-fedora.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-fedora.conf
@@ -9,7 +9,3 @@ Packages=
         libfido2
         util-linux-core
         erofs-utils
-
-RemovePackages=
-        # Various packages pull in shadow-utils to create users, we can remove it afterwards
-        shadow-utils


### PR DESCRIPTION
On rawhide, we get:
"No packages to remove for argument: shadow-utils"