### PR TITLE
Revert license-files property

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,7 @@ version = "25.3"
 description = "Build Bespoke OS Images"
 readme = "README.md"
 requires-python = ">=3.9"
-license-files = [
-    "LICENSES/GPL-2.0-only.txt",
-    "LICENSES/LGPL-2.1-or-later.txt",
-    "LICENSES/OFL-1.1.txt",
-    "LICENSES/PSF-2.0.txt"
-]
+license = {file = "LICENSES/LGPL-2.1-or-later.txt"}
 
 [project.optional-dependencies]
 bootable = [


### PR DESCRIPTION
As mentioned in #3720, the `license-files` is not widely adopted enough right now and breaks backwards compatibility.
This change restores the `license` property and points it to the new location of the main license.