### PR TITLE
Use SPDX identifier instead of file path for license in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ version = "25.3"
 description = "Build Bespoke OS Images"
 readme = "README.md"
 requires-python = ">=3.9"
-license = {file = "LICENSES/LGPL-2.1-or-later.txt"}
+license = {text = "LGPL-2.1-or-later"}
 
 [project.optional-dependencies]
 bootable = [


### PR DESCRIPTION
#3724 did not fix all build problems, so this is hopefully the final fix, because otherwise I do not know how to rectify this except pinning package builds to the last release with the broken license `pyproject.toml`.

This fix uses the text key specified in the [legacy specification](https://packaging.python.org/en/latest/specifications/pyproject-toml/#legacy-specification) of the `license` property.
I chose the the [SPDX identifier](https://spdx.org/licenses/) of the main license, because that seemed the most appropriate.