### PR TITLE
sandbox: handle case where dev node for tty doesn't exist

### DIFF
--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -885,7 +885,10 @@ def main() -> None:
     chdir = None
     become_root = suppress_chown = suppress_sync = unshare_net = unshare_ipc = suspend = pack_fds = False
 
-    ttyname = os.ttyname(2) if os.isatty(2) else ""
+    try:
+        ttyname = os.ttyname(2) if os.isatty(2) else ""
+    except FileNotFoundError:
+        ttyname = ""
 
     while argv:
         arg = argv.pop()


### PR DESCRIPTION
This fixes this crash, which happens even when isatty(2) is True:

```
Traceback (most recent call last):
  File "/sandbox.py", line 1095, in <module>
    main()
  File "/sandbox.py", line 891, in main
    ttyname = os.ttyname(2) if os.isatty(2) else ""
              ^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory
```

IIUC this is because isatty(2) is a valid file descriptor (inherited from the parent process?), but ttyname() is unable find a device node for it because it's not mounted in the sandbox.