### PR TITLE
apt: add a variable MKOSI__REPREPRO_EXTRA_ARGS to pass args to reprepro

### DIFF
--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import dataclasses
+import shlex
 import textwrap
 from collections.abc import Sequence
 from pathlib import Path
@@ -299,6 +300,7 @@ class Apt(PackageManager):
             [
                 "reprepro",
                 "--ignore=extension",
+                *shlex.split(context.config.environment.get("MKOSI__REPREPRO_EXTRA_ARGS", "")),
                 "includedeb",
                 "mkosi",
                 *names,

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -2999,6 +2999,14 @@ repository.
   value of the respective `extension-release` file when building a sysext
   or confext. By default the value is set to `initrd system portable`.
 
+Environment variables starting with `MKOSI__`, i.e. with two underscores after `MKOSI`, are internal to mkosi
+and are not guaranteed to be backwards compatible, but may be used to work around certain limitations,
+e.g. in external tools mkosi is calling, but any breakage due to the usage of these variables is not a bug.
+
+* `MKOSI__REPREPRO_EXTRA_ARGS` can be used to pass extra commandline options to **reprepro**, which mkosi
+  uses to generate the internal repository on deb-based systems. This can be used to set the package section,
+  priority or other fields.
+
 # EXAMPLES
 
 Create and run a raw *GPT* image with *ext4*, as `image.raw`:


### PR DESCRIPTION
This can be used to pass extra options to reprepro, e.g. to set section or priority when a package does not provide them, which reprepro complains. Clobbering these fields is generally not advisable, because e.g. priority interacts with the essential flag. Even though Debian policy only recommends these fields and dpkg therefore accepts packages without them, they are broken and should be fixed, alas some proprietary packages omit them and would need repackaging.

To make this easier on users, give them a knob they can use to try to work around this.

Fixes: #3727

@whiteley can you give this a try?