### PR TITLE
Fix version bump check if image version was passed on CLI

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -5147,7 +5147,7 @@ def parse_config(
 
     if (
         ((args.auto_bump and args.verb.needs_build()) or args.verb == Verb.bump)
-        and context.cli.get("image_version") is not None
+        and context.cli.get("image_version") is None
         and configdir is not None
     ):
         context.cli["image_version"] = bump_image_version(configdir)


### PR DESCRIPTION
We only want to generate a new version if no version was specified on the CLI. To do that we need to check that the version on the CLI is None, not the opposite.

Replaces #3721