### PR TITLE
Move configuration of tools tree output format to mkosi-tools config …

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -4998,8 +4998,6 @@ def finalize_default_tools(
 
             ns[dest] = copy.deepcopy(finalized[s.dest])
 
-    context.cli["output_format"] = OutputFormat.directory
-
     context.config |= {
         "image": "tools",
         "directory": finalized["directory"],

--- a/mkosi/resources/mkosi-tools/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 [Output]
+Format=directory
 Output=mkosi.tools
 
 [Content]


### PR DESCRIPTION
…again

There was no particular need to move this into code so let's move it back into the configuration.

Fixes #3719