### PR TITLE
sandbox: Support using mkosi-sandbox as a library

### DIFF
--- a/mkosi/resources/man/mkosi-sandbox.1.md
+++ b/mkosi/resources/man/mkosi-sandbox.1.md
@@ -21,6 +21,20 @@ Note that this sandbox is not designed to be a security boundary. Its intended p
 is to allow running commands in an isolated environment so they are not affected by the
 host system.
 
+It is possible to use `mkosi-sandbox` to create an in process sandbox for python
+applications by importing it as a module and invoking its main function with only
+options. No command line to execute is needed in this case. As an example:
+
+```python
+import mkosi.sandbox
+
+mkosi.sandbox.main(["--become-root"])
+print(os.getuid())
+```
+
+Only the `main` function can be invoked. Invoking any other functions
+from `mkosi.sandbox` is not supported and may break in future versions.
+
 # OPTIONS
 
 `--tmpfs DST`


### PR DESCRIPTION
Let's allow using mkosi-sandbox to create an in process sandbox by not taking a command line to execute if mkosi-sandbox was itself imported and not executed.

If we were imported, also don't do any print()'s to behave like a proper library.