### PR TITLE
mkosi-initrd: Optionally match t64 suffix for tss2 libraries

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf.d/10-libtss.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf.d/10-libtss.conf
@@ -7,7 +7,7 @@ Distribution=|ubuntu
 
 [Content]
 Packages=
-        ^libtss2-esys-[0-9.]+-0$
-        ^libtss2-mu[0-9.-]+$
-        libtss2-rc0
-        libtss2-tcti-device0
+        ^libtss2-esys-[0-9.]+-0(t64)?$
+        ^libtss2-mu[0-9.-]+(t64)?$
+        ^libtss2-rc0(t64)?$
+        ^libtss2-tcti-device0(t64)?$


### PR DESCRIPTION
On debian, these libraries have a t64 suffix on arm for "reasons". Let's take that into account by optionally matching a t64 suffix for these libraries.

Fixes #3733.