### PR TITLE
fix: Remove erofs-utils from initrd

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-arch.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-arch.conf
@@ -8,7 +8,6 @@ Packages=
         btrfs-progs
         e2fsprogs
         xfsprogs
-        erofs-utils
         dosfstools
 
         # Various libraries that are dlopen'ed by systemd

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-centos/mkosi.conf.d/20-epel-packages.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-centos/mkosi.conf.d/20-epel-packages.conf
@@ -6,4 +6,3 @@ Repositories=epel
 [Content]
 Packages=
         btrfs-progs
-        erofs-utils

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
@@ -16,7 +16,6 @@ Packages=
         # isn't used on Debian so we don't install xfsprogs.
         btrfs-progs
         e2fsprogs
-        erofs-utils
         dosfstools
 
         util-linux

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-fedora.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-fedora.conf
@@ -8,4 +8,3 @@ Packages=
         btrfs-progs
         libfido2
         util-linux-core
-        erofs-utils

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-opensuse.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-opensuse.conf
@@ -25,7 +25,6 @@ Packages=
         btrfsprogs
         e2fsprogs
         xfsprogs
-        erofs-utils
         dosfstools
 
         util-linux


### PR DESCRIPTION
Since Ubuntu now includes `erofs-utils` in the universe repository, add it to the default repositories. This fixes a bug causing the initrd stage of Ubuntu images to fail.

Closes https://github.com/systemd/mkosi/issues/3751.