### PR TITLE
Introduce distribution installer finalize function

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -295,6 +295,9 @@ def install_distribution(context: Context) -> None:
                     context, context.config.packages
                 )
 
+    with complete_step(f"Finalizing {context.config.distribution.pretty_name()}"):
+        context.config.distribution.finalize(context)
+
     for f in (
         "var/lib/systemd/random-seed",
         "var/lib/systemd/credential.secret",

--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -43,6 +43,10 @@ class DistributionInstaller:
         raise NotImplementedError
 
     @classmethod
+    def finalize(cls, context: "Context") -> None:
+        raise NotImplementedError
+
+    @classmethod
     def filesystem(cls) -> str:
         return "ext4"
 
@@ -126,6 +130,9 @@ class Distribution(StrEnum):
 
     def install(self, context: "Context") -> None:
         return self.installer().install(context)
+
+    def finalize(self, context: "Context") -> None:
+        return self.installer().finalize(context)
 
     def filesystem(self) -> str:
         return self.installer().filesystem()

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -64,6 +64,10 @@ class Installer(DistributionInstaller):
         Pacman.install(context, ["filesystem"], apivfs=False)
 
     @classmethod
+    def finalize(cls, context: Context) -> None:
+        pass
+
+    @classmethod
     def repositories(cls, context: Context) -> Iterable[PacmanRepository]:
         if context.config.local_mirror:
             yield PacmanRepository("core", context.config.local_mirror)

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -80,6 +80,10 @@ class Installer(DistributionInstaller):
         Dnf.install(context, ["basesystem"], apivfs=False)
 
     @classmethod
+    def finalize(cls, context: Context) -> None:
+        pass
+
+    @classmethod
     def architecture(cls, arch: Architecture) -> str:
         a = {
             Architecture.x86_64:   "x86_64",

--- a/mkosi/distributions/custom.py
+++ b/mkosi/distributions/custom.py
@@ -27,3 +27,7 @@ class Installer(DistributionInstaller):
     @classmethod
     def install(cls, context: Context) -> None:
         pass
+
+    @classmethod
+    def finalize(cls, context: Context) -> None:
+        pass

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -189,6 +189,8 @@ class Installer(DistributionInstaller):
 
         fixup_os_release(context)
 
+    @classmethod
+    def finalize(cls, context: Context) -> None:
         if (
             "apt" in itertools.chain(context.config.packages, context.config.volatile_packages)
             or (context.root / "usr/bin/apt").exists()

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -131,6 +131,10 @@ class Installer(DistributionInstaller):
         Dnf.install(context, ["basesystem"], apivfs=False)
 
     @classmethod
+    def finalize(cls, context: Context) -> None:
+        pass
+
+    @classmethod
     def repositories(cls, context: Context) -> Iterable[RpmRepository]:
         gpgurls = find_fedora_rpm_gpgkeys(context)
 

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -56,6 +56,10 @@ class Installer(DistributionInstaller):
         cls.package_manager(context.config).install(context, ["filesystem"], apivfs=False)
 
     @classmethod
+    def finalize(cls, context: Context) -> None:
+        pass
+
+    @classmethod
     def repositories(cls, context: Context) -> Iterable[RpmRepository]:
         if context.config.local_mirror:
             yield RpmRepository(id="local-mirror", url=f"baseurl={context.config.local_mirror}", gpgurls=())


### PR DESCRIPTION
This adds an ability to do something "after" installing is done. The current use case is for Debian based distribution to install APT sources files if needed.

Closes: #3715