### PR TITLE
mkosi-initrd: Add atkbd and i8042 modules to the default initrd modules

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -46,6 +46,7 @@ KernelModules=
         amd_ctl
         amd-pmc
         amd64_edac
+        atkbd
         autofs4
         binfmt_misc
         btrfs
@@ -73,6 +74,7 @@ KernelModules=
         i2c_hid_acpi
         i2c-mux
         i2c-smbus
+        i8042
         intel-gtt
         intel_rapl_common
         intel-uncore-frequency-common
@@ -131,4 +133,3 @@ KernelModules=
         xhci-pci-renesas
         /fs/nls/
         crypto/
-


### PR DESCRIPTION
Required to get my laptop keyboard working in an initrd with just the default modules.