### PR TITLE
Check that keys are both in context.cli and history

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -5134,7 +5134,7 @@ def parse_config(
                 history.pop(s.dest, None)
                 continue
 
-            if s.dest in context.cli and context.cli[s.dest] != history[s.dest]:
+            if s.dest in context.cli and s.dest in history and context.cli[s.dest] != history[s.dest]:
                 logging.warning(
                     f"Ignoring {s.long} from the CLI. Run with -f to rebuild the image with this setting"
                 )


### PR DESCRIPTION
Otherwise we'll get a KeyError trying to access a key in the history dict that isn't there.

Fixes #3747.