### PR TITLE
mkosi-tools: move 'man' pkg from generic list to distro-specific lists

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.profiles/misc/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/misc/mkosi.conf
@@ -12,7 +12,6 @@ Packages=
         grep
         jq
         less
-        man
         nano
         sed
         strace

--- a/mkosi/resources/mkosi-tools/mkosi.profiles/misc/mkosi.conf.d/arch.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/misc/mkosi.conf.d/arch.conf
@@ -6,5 +6,6 @@ Distribution=arch
 [Content]
 Packages=
         base
+        man
         man-pages
         git

--- a/mkosi/resources/mkosi-tools/mkosi.profiles/misc/mkosi.conf.d/azure-centos-fedora.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/misc/mkosi.conf.d/azure-centos-fedora.conf
@@ -11,4 +11,5 @@ Distribution=|azure
 [Content]
 Packages=
         git-core
+        man
         man-pages

--- a/mkosi/resources/mkosi-tools/mkosi.profiles/misc/mkosi.conf.d/debian-kali-ubuntu.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/misc/mkosi.conf.d/debian-kali-ubuntu.conf
@@ -10,5 +10,6 @@ Packages=
         git-core
         libnss-resolve
         libnss-myhostname
+        man
         manpages
         systemd-coredump

--- a/mkosi/resources/mkosi-tools/mkosi.profiles/misc/mkosi.conf.d/opensuse.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/misc/mkosi.conf.d/opensuse.conf
@@ -6,6 +6,7 @@ Distribution=opensuse
 [Content]
 Packages=
         git-core
+        man
         man-pages
         patterns-base-minimal_base
         perf


### PR DESCRIPTION
Follow up to 94cc136fbe, this moves the man pkg to distro-specific pkg lists to support distros that use a different name for this package.