### PR TITLE
Partially revert "resources: add systemd-boot-efi"

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
@@ -23,7 +23,5 @@ Packages=
         # Various libraries that are dlopen'ed by systemd
         libfido2-1
 
-        systemd-boot-efi
-
 RemoveFiles=
         /usr/share/locale/*


### PR DESCRIPTION
systemd-boot-efi is only available for EFI architectures, but we use mkosi to do the integration tests on all architectures, so this commit breaks them:

5044s E: Package 'systemd-boot-efi' has no installation candidate

https://autopkgtest.ubuntu.com/results/autopkgtest-noble-upstream-systemd-ci-systemd-ci/noble/s390x/s/systemd-upstream/20250608_124726_4f883@/log.gz

This package should not be included in the initrd anyway, it's only needed at build time, not inside the initrd

This reverts commit 9a0d8a8906695a35011ecfd81b36fe82c1577488.