### PR TITLE
Add "nfs" (and "network") initrd profiles

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -637,6 +637,7 @@ class ToolsTreeProfile(StrEnum):
 class InitrdProfile(StrEnum):
     lvm = enum.auto()
     network = enum.auto()
+    nfs = enum.auto()
     pkcs11 = enum.auto()
     plymouth = enum.auto()
     raid = enum.auto()

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -636,6 +636,7 @@ class ToolsTreeProfile(StrEnum):
 
 class InitrdProfile(StrEnum):
     lvm = enum.auto()
+    network = enum.auto()
     pkcs11 = enum.auto()
     plymouth = enum.auto()
     raid = enum.auto()

--- a/mkosi/initrd.py
+++ b/mkosi/initrd.py
@@ -196,6 +196,20 @@ def process_crypttab(staging_dir: Path) -> list[str]:
     return cmdline
 
 
+def network_config() -> list[str]:
+    return [
+        f"--extra-tree={f}:{f}"
+        for f in (
+            "/etc/systemd/network",
+            "/etc/systemd/networkd.conf",
+            "/etc/systemd/networkd.conf.d",
+            "/etc/systemd/resolved.conf",
+            "/etc/systemd/resolved.conf.d",
+        )
+        if Path(f).exists()
+    ]
+
+
 def raid_config() -> list[str]:
     return [
         f"--extra-tree={f}:{f}"
@@ -333,7 +347,9 @@ def main() -> None:
 
         for p in args.profile:
             cmdline += ["--profile", p]
-            if p == "raid":
+            if p == "network":
+                cmdline += network_config()
+            elif p == "raid":
                 cmdline += raid_config()
 
         if args.kernel_image:

--- a/mkosi/initrd.py
+++ b/mkosi/initrd.py
@@ -210,6 +210,10 @@ def network_config() -> list[str]:
     ]
 
 
+def nfs_config() -> list[str]:
+    return [f"--extra-tree={f}:{f}" for f in ("/etc/idmapd.conf", "/etc/idmapd.conf.d") if Path(f).exists()]
+
+
 def raid_config() -> list[str]:
     return [
         f"--extra-tree={f}:{f}"
@@ -349,6 +353,8 @@ def main() -> None:
             cmdline += ["--profile", p]
             if p == "network":
                 cmdline += network_config()
+            elif p == "nfs":
+                cmdline += nfs_config()
             elif p == "raid":
                 cmdline += raid_config()
 

--- a/mkosi/resources/man/mkosi-initrd.1.md
+++ b/mkosi/resources/man/mkosi-initrd.1.md
@@ -46,6 +46,8 @@ initrds and Unified Kernel Images for the current running system.
 
     The `lvm` profile enables support for LVM.
     The `network` profile enables support for network via **systemd-networkd**.
+    The `nfs` profile enables support for NFS. It requires networking in the
+    initrd, using the `network` profile, or some other custom method.
     The `pkcs11` profile enables support for PKCS#11.
     The `plymouth` profile provides a graphical interface at boot (animation and
     password prompt).

--- a/mkosi/resources/man/mkosi-initrd.1.md
+++ b/mkosi/resources/man/mkosi-initrd.1.md
@@ -45,6 +45,7 @@ initrds and Unified Kernel Images for the current running system.
     disabled.
 
     The `lvm` profile enables support for LVM.
+    The `network` profile enables support for network via **systemd-networkd**.
     The `pkcs11` profile enables support for PKCS#11.
     The `plymouth` profile provides a graphical interface at boot (animation and
     password prompt).

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1053,6 +1053,7 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     disabled.
 
     The `lvm` profile enables support for LVM.
+    The `network` profile enables support for network via **systemd-networkd**.
     The `pkcs11` profile enables support for PKCS#11.
     The `plymouth` profile provides a graphical interface at boot (animation and
     password prompt).

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1054,6 +1054,8 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
     The `lvm` profile enables support for LVM.
     The `network` profile enables support for network via **systemd-networkd**.
+    The `nfs` profile enables support for NFS. It requires networking in the
+    initrd, using the `network` profile, or some other custom method.
     The `pkcs11` profile enables support for PKCS#11.
     The `plymouth` profile provides a graphical interface at boot (animation and
     password prompt).

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-arch.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-arch.conf
@@ -14,6 +14,7 @@ Packages=
         libfido2
         tpm2-tss
 
+        procps-ng
         util-linux
 
 RemoveFiles=

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-azure-centos-fedora.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-azure-centos-fedora.conf
@@ -17,3 +17,5 @@ Packages=
         e2fsprogs
         xfsprogs
         dosfstools
+
+        procps-ng

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-debian-kali-ubuntu/mkosi.conf
@@ -18,6 +18,7 @@ Packages=
         e2fsprogs
         dosfstools
 
+        procps
         util-linux
 
         # Various libraries that are dlopen'ed by systemd

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-opensuse.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/10-opensuse.conf
@@ -27,6 +27,7 @@ Packages=
         xfsprogs
         dosfstools
 
+        procps
         util-linux
 
 RemovePackages=

--- a/mkosi/resources/mkosi-initrd/mkosi.profiles/network/mkosi.conf.d/systemd-networkd.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.profiles/network/mkosi.conf.d/systemd-networkd.conf
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=|fedora
+Distribution=|opensuse
+
+[Content]
+Packages=systemd-networkd

--- a/mkosi/resources/mkosi-initrd/mkosi.profiles/network/mkosi.conf.d/systemd-resolved.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.profiles/network/mkosi.conf.d/systemd-resolved.conf
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=!arch
+
+[Content]
+Packages=systemd-resolved

--- a/mkosi/resources/mkosi-initrd/mkosi.profiles/nfs/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.profiles/nfs/mkosi.conf
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Content]
+KernelModules=
+        fs/nfs/
+        net/sunrpc/
+        nfs_acl

--- a/mkosi/resources/mkosi-initrd/mkosi.profiles/nfs/mkosi.conf.d/arch.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.profiles/nfs/mkosi.conf.d/arch.conf
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=arch
+
+[Content]
+Packages=nfs-utils

--- a/mkosi/resources/mkosi-initrd/mkosi.profiles/nfs/mkosi.conf.d/debian-ubuntu.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.profiles/nfs/mkosi.conf.d/debian-ubuntu.conf
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=|debian
+Distribution=|ubuntu
+
+[Content]
+Packages=nfs-common

--- a/mkosi/resources/mkosi-initrd/mkosi.profiles/nfs/mkosi.conf.d/fedora.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.profiles/nfs/mkosi.conf.d/fedora.conf
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=fedora
+
+[Content]
+Packages=
+        nfs-utils
+        libnfsidmap

--- a/mkosi/resources/mkosi-initrd/mkosi.profiles/nfs/mkosi.conf.d/opensuse.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.profiles/nfs/mkosi.conf.d/opensuse.conf
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=opensuse
+
+[Content]
+Packages=
+        nfs-client
+        libnfsidmap1


### PR DESCRIPTION
nfs-utils-2.8.4 will provide its own nfsroot-generator [1] to allow mounting the real rootfs via NFSv4, so we can create an "nfs" initrd profile to support it. Also, this requires some type of networking in the initrd, so I also created a "network" profile to enable systemd-networkd.

Tested in openSUSE Tumbleweed using a custom OBS build [2] and in Fedora rawhide, since it already ships nfs-utils-2-8-4-rc2 [3].

[1] http://git.linux-nfs.org/?p=steved/nfs-utils.git;a=commit;h=ed86ea08dadafbac948c6a45629a6f3282a77233
[2] https://build.opensuse.org/package/show/home:afeijoo:branches:openSUSE:Factory:nfsroot/nfs-utils
[3] https://src.fedoraproject.org/rpms/nfs-utils/c/e7f85470bc0ba53a3338468f50ffc62bf0f03cba?branch=rawhide