### PR TITLE
mkosi-obs: also allow enrolling additional certs in KEK

### DIFF
--- a/mkosi/resources/mkosi-obs/mkosi.postoutput
+++ b/mkosi/resources/mkosi-obs/mkosi.postoutput
@@ -118,6 +118,12 @@ if ((${#DDIS[@]} > 0)); then
         cat tmp.esl >>db.esl
         rm -f tmp.esl
     done
+    for cert in /usr/src/packages/SOURCES/*/mkosi.uefi.KEK/*.crt; do
+        test -f "$cert" || continue
+        cert-to-efi-sig-list -g "$guid" "$cert" tmp.esl
+        cat tmp.esl >>KEK.esl
+        rm -f tmp.esl
+    done
 
     for i in *.esl; do
         sign-efi-sig-list -o -g "$guid" -t "$(date -d "@${SOURCE_DATE_EPOCH:-0}" "+%Y-%m-%d %H:%M:%S")" "${i%.esl}" "$i" "${i%.esl}.auth"


### PR DESCRIPTION
Same as db, useful to be able to get DBX updates