### PR TITLE
create missing dir

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -655,6 +655,7 @@ def run_sync_scripts(config: Config) -> None:
     if config.profiles:
         env["PROFILES"] = " ".join(config.profiles)
 
+    config.workspace_dir_or_default().mkdir(parents=True, exist_ok=True)
     with (
         finalize_source_mounts(config, ephemeral=False) as sources,
         finalize_config_json(config) as json,


### PR DESCRIPTION
Create the cache dir, otherwise mkosi dies with:
```
$ mkosi -f sandbox -- meson setup build
Traceback (most recent call last):
  File "/home/teknoraver/src/mkosi/mkosi/run.py", line 51, in uncaught_exception_handler
    yield
  File "/usr/local/fbcode/platform010/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/teknoraver/src/mkosi/mkosi/__main__.py", line 44, in main
    run_verb(args, tools, images, resources=resources)
  File "/home/teknoraver/src/mkosi/mkosi/__init__.py", line 5074, in run_verb
    run_sync_scripts(tools)
  File "/home/teknoraver/src/mkosi/mkosi/__init__.py", line 661, in run_sync_scripts
    tempfile.TemporaryDirectory(
  File "/usr/local/fbcode/platform010/lib/python3.12/tempfile.py", line 886, in __init__
    self.name = mkdtemp(suffix, prefix, dir)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/fbcode/platform010/lib/python3.12/tempfile.py", line 384, in mkdtemp
    _os.mkdir(file, 0o700)
FileNotFoundError: [Errno 2] No such file or directory: '/home/teknoraver/.cache/mkosi/mkosi-metadata-cc6a97fv'
```