### PR TITLE
obs: parse /usr/src/packages/SOURCES/mkosi.conf at high priority if it exists

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -4616,6 +4616,9 @@ class ParseContext:
             else:
                 path = p
 
+            if not path.exists():
+                logging.warning(f"{path.absolute()}: Include file {p} does not exist, ignoring")
+                continue
             st = path.stat()
 
             if (st.st_dev, st.st_ino) in self.includes:
@@ -4813,6 +4816,8 @@ class ParseContext:
                 for localpath in (
                     *([p] if (p := path.parent / "mkosi.local").is_dir() else []),
                     *([p] if (p := path.parent / "mkosi.local.conf").is_file() else []),
+                    # Support top-level entry point automatically extracted by OBS
+                    *([p] if (p := Path("/usr/src/packages/SOURCES/mkosi.conf")).is_file() else []),
                 ):
                     with chdir(localpath if localpath.is_dir() else Path.cwd()):
                         self.parse_config_one(localpath if localpath.is_file() else Path.cwd())


### PR DESCRIPTION
When building a mkosi repository called 'particleos', OBS calls mkosi with a top-level config file extracted to /usr/src/packages/SOURCES/mkosi.conf but it runs from the repo directory at /usr/src/packages/SOURCES/particleos/

with SOURCES/mkosi.conf being the source file extracted at source time, ie: defined by the user, among the many files available in the repository. So this can be used to select the entry point, that defines what to build, when a repository provides many build types, profiles, images, etc.

If it exists, parse this entry point always, at a higher priority than the rest, so that it can set the defaults for the OBS build.

Given this is always parsed, regardless of which stage we are at, we also need to skip non-existing includes. I.E. when trying to figure out the default config, mkosi will set the resources folder to / and then try to load the includes defined in this entry point, I.E.: Include=mkosi-obs will result in mkosi trying to load a non-existent /mkosi-obs and fail. Skip the include gracefully if it doesn't exist.

With this I can add entry points to hidden directories in a repo, or even outside of it, and select them in the _service on OBS and build multiple different images from the same git repo and branch, for example the particleos gnome image:

https://build.opensuse.org/projects/home:bluca:branches:home:bluca:systemd/packages/particleos/files/_service?expand=1