### PR TITLE
Make ppc64le/s390x buildable

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -23,18 +23,20 @@ runs:
         KERNEL=="vhost-net", GROUP="kvm", MODE="0666", OPTIONS+="static_node=vhost-net"
         EOF
         sudo udevadm control --reload-rules
-        sudo modprobe kvm
-        sudo modprobe vhost_vsock
-        sudo modprobe vhost_net
+        # kvm/vhost might not be available (e.g.: s390x, ppc64le)
+        sudo modprobe kvm || true
+        sudo modprobe vhost_vsock || true
+        sudo modprobe vhost_net || true
         [[ -e /dev/kvm ]] && sudo udevadm trigger --name-match=kvm
-        sudo udevadm trigger --name-match=vhost-vsock
-        sudo udevadm trigger --name-match=vhost-net
+        [[ -e /dev/vhost-vsock ]] && sudo udevadm trigger --name-match=vhost-vsock
+        [[ -e /dev/vhost-net ]] && sudo udevadm trigger --name-match=vhost-net
         [[ -e /dev/kvm ]] && sudo chmod 666 /dev/kvm
-        sudo chmod 666 /dev/vhost-vsock
-        sudo chmod 666 /dev/vhost-net
+        [[ -e /dev/vhost-vsock ]] && sudo chmod 666 /dev/vhost-vsock
+        [[ -e /dev/vhost-net ]] && sudo chmod 666 /dev/vhost-net
         lsmod
         [[ -e /dev/kvm ]] && ls -l /dev/kvm
-        ls -l /dev/vhost-*
+        [[ -e /dev/vhost-vsock ]] && ls -l /dev/vhost-vsock
+        [[ -e /dev/vhost-net ]] && ls -l /dev/vhost-net
         id
 
     - name: Check clock source

--- a/mkosi.conf.d/20-opensuse/mkosi.conf
+++ b/mkosi.conf.d/20-opensuse/mkosi.conf
@@ -18,3 +18,9 @@ Packages=
         qemu-linux-user
         shim
         sudo-policy-wheel-auth-self
+
+        # Various packages added as dependencies. If they are not explicitly installed, the zypper inner
+        # logic picks the busybox-package variant, which adds also busybox in the image.
+        grep
+        gzip
+        xz

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -96,8 +96,20 @@ class Installer(DistributionInstaller):
             if context.config.release == "tumbleweed":
                 if context.config.architecture == Architecture.x86_64:
                     subdir = ""
+                elif context.config.architecture == Architecture.arm64:
+                    subdir = "ports/aarch64"
+                elif context.config.architecture == Architecture.arm:
+                    subdir = "ports/armv7hl"
+                elif context.config.architecture in (
+                    Architecture.ppc64_le,
+                    Architecture.ppc64,
+                    Architecture.ppc,
+                ):
+                    subdir = "ports/ppc"
+                elif context.config.architecture in (Architecture.s390x, Architecture.s390):
+                    subdir = "ports/zsystems"
                 else:
-                    subdir = f"ports/{cls.architecture(context.config.architecture)}"
+                    die(f"{context.config.architecture} not supported by openSUSE Tumbleweed")
             else:
                 if context.config.architecture != Architecture.x86_64:
                     die(f"Old snapshots are only supported for x86-64 on {cls.pretty_name()}")
@@ -156,8 +168,20 @@ class Installer(DistributionInstaller):
 
             if context.config.architecture == Architecture.x86_64:
                 subdir = ""
+            elif context.config.architecture == Architecture.arm64:
+                subdir = "ports/aarch64"
+            elif context.config.architecture == Architecture.arm:
+                subdir = "ports/armv7hl"
+            elif context.config.architecture in (
+                Architecture.ppc64_le,
+                Architecture.ppc64,
+                Architecture.ppc,
+            ):
+                subdir = "ports/ppc"
+            elif context.config.architecture in (Architecture.s390x, Architecture.s390):
+                subdir = "ports/zsystems"
             else:
-                subdir = f"ports/{cls.architecture(context.config.architecture)}"
+                die(f"{context.config.architecture} not supported by openSUSE {context.config.release}")
 
             for repo in ("oss", "non-oss"):
                 url = join_mirror(mirror, f"{subdir}/distribution/{release}/repo/{repo}")
@@ -208,6 +232,8 @@ class Installer(DistributionInstaller):
         a = {
             Architecture.x86_64: "x86_64",
             Architecture.arm64:  "aarch64",
+            Architecture.ppc64_le: "ppc64le",
+            Architecture.s390x:  "s390x",
         }.get(arch)  # fmt: skip
 
         if not a:

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/azure-centos-fedora/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/azure-centos-fedora/mkosi.conf
@@ -11,7 +11,6 @@ Distribution=|azure
 [Content]
 Packages=
         createrepo_c
-        grub2-tools
         libseccomp
         policycoreutils
         qemu-img

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/azure-centos-fedora/mkosi.conf.d/efi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/azure-centos-fedora/mkosi.conf.d/efi.conf
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 [Match]
-Architecture=|x86-64
-Architecture=|arm64
+Architecture=uefi
 
 [Content]
 Packages=
-        sbsigntools
+        grub2-tools

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/azure-fedora/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/azure-fedora/mkosi.conf
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=|fedora
+Distribution=|azure
+Architecture=uefi
+
+[Content]
+Packages=
+        sbsigntools

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/centos/mkosi.conf.d/20-epel-packages-efi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/centos/mkosi.conf.d/20-epel-packages-efi.conf
@@ -2,9 +2,8 @@
 
 [Match]
 Repositories=epel
-Release=9
+Architecture=uefi
 
 [Content]
 Packages=
-        btrfs-progs
-        distribution-gpg-keys
+        sbsigntools

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
@@ -18,6 +18,5 @@ Packages=
         policycoreutils
         python3-pefile
         reprepro
-        sbsigntool
         squashfs-tools
         xz-utils

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/efi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/efi.conf
@@ -11,7 +11,11 @@ Release=!jammy
 [TriggerMatch]
 Distribution=kali
 
+[Match]
+Architecture=uefi
+
 [Content]
 Packages=
+        sbsigntool
         systemd-boot
         systemd-boot-efi

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/opensuse.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/opensuse.conf
@@ -14,7 +14,6 @@ Packages=
         pkcs11-provider
         policycoreutils
         python3-pefile
-        sbsigntools
         squashfs
         systemd-experimental
         tpm2.0-tools

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/opensuse/mkosi.conf.d/sbsigntools.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/opensuse/mkosi.conf.d/sbsigntools.conf
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=opensuse
+Architecture=uefi
+
+[Content]
+Packages=
+        sbsigntools

--- a/mkosi/resources/mkosi-tools/mkosi.profiles/runtime/mkosi.conf.d/opensuse/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/runtime/mkosi.conf.d/opensuse/mkosi.conf
@@ -6,11 +6,7 @@ Distribution=opensuse
 [Content]
 Packages=
         openssh-clients
-        ovmf
         qemu-headless
-        qemu-ipxe
-        qemu-ovmf-x86_64
-        qemu-uefi-aarch64
         shadow
         systemd-container
         systemd-journal-remote

--- a/mkosi/resources/mkosi-tools/mkosi.profiles/runtime/mkosi.conf.d/opensuse/mkosi.conf.d/efi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/runtime/mkosi.conf.d/opensuse/mkosi.conf.d/efi.conf
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Architecture=uefi
+
+[Content]
+Packages=
+        ovmf
+        qemu-ipxe
+        qemu-ovmf-x86_64
+        qemu-uefi-aarch64


### PR DESCRIPTION
The CI builds images, but can't boot them in nspawn due to permission issues, which are likely related to the build worker and not mkosi itself. Making the CI work will continue at https://github.com/systemd/mkosi/pull/3791 but for now we can make the images buildable at least