### PR TITLE
Rename sandbox verb to box

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,14 +212,14 @@ jobs:
         run: sudo mkosi summary
 
       - name: Build tools tree
-        run: sudo mkosi -f sandbox -- true
+        run: sudo mkosi -f box -- true
 
       - name: Build image
         run: sudo mkosi --distribution ${{ matrix.distro }} -f
 
       - name: Run integration tests
         run: |
-          sudo mkosi sandbox -- \
+          sudo mkosi box -- \
             timeout -k 30 1h \
             python3 -m pytest \
             --tb=no \

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -74,7 +74,7 @@ from mkosi.config import (
     expand_delayed_specifiers,
     finalize_configdir,
     format_bytes,
-    in_sandbox,
+    in_box,
     parse_boolean,
     parse_config,
     resolve_deps,
@@ -4114,11 +4114,11 @@ def build_image(context: Context) -> None:
     print_output_size(context.config.output_dir_or_cwd() / context.config.output_with_compression)
 
 
-def run_sandbox(args: Args, config: Config) -> None:
-    if in_sandbox():
+def run_box(args: Args, config: Config) -> None:
+    if in_box():
         die(
-            "mkosi sandbox cannot be invoked from within another mkosi sandbox environment",
-            hint="Exit the current sandbox environment and try again",
+            "mkosi box cannot be invoked from within another mkosi box environment",
+            hint="Exit the current mkosi box environment and try again",
         )
 
     if not args.cmdline:
@@ -4139,7 +4139,7 @@ def run_sandbox(args: Args, config: Config) -> None:
 
     hd, hr = detect_distribution()
 
-    env = {"MKOSI_IN_SANDBOX": "1"}
+    env = {"MKOSI_IN_BOX": "1"}
     if hd:
         env |= {"MKOSI_HOST_DISTRIBUTION": str(hd)}
     if hr:
@@ -5106,7 +5106,8 @@ def run_verb(args: Args, tools: Optional[Config], images: Sequence[Config], *, r
             Verb.ssh: run_ssh,
             Verb.journalctl: run_journalctl,
             Verb.coredumpctl: run_coredumpctl,
-            Verb.sandbox: run_sandbox,
+            Verb.box: run_box,
+            Verb.sandbox: run_box,
         }[args.verb](args, last)
 
     if last.output_format == OutputFormat.none:

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -30,7 +30,7 @@ mkosi — Build Bespoke OS Images
 
 `mkosi [options…] sysupdate [-- sysupdate settings…]`
 
-`mkosi [options…] sandbox [-- command line…]`
+`mkosi [options…] box [-- command line…]`
 
 `mkosi [options…] dependencies [-- options…]`
 
@@ -143,8 +143,8 @@ The following command line verbs are known:
     specified after the `sysupdate` verb and separated from the regular
     options with `--` are passed directly to **systemd-sysupdate**.
 
-`sandbox`
-:   Run arbitrary commands inside of the same sandbox used to execute
+`box`
+:   Run arbitrary commands inside of the same environment used to execute
     other verbs such as `boot`, `shell`, `vm` and more. This means
     `/usr` will be replaced by `/usr` from the tools tree if one is used
     while everything else will remain in place. If no command is provided,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,7 +21,7 @@ from mkosi.config import (
     OutputFormat,
     Verb,
     config_parse_bytes,
-    in_sandbox,
+    in_box,
     parse_config,
     parse_ini,
 )
@@ -1487,8 +1487,8 @@ def test_tools(tmp_path: Path) -> None:
     d = tmp_path
     argv = ["--tools-tree=default"]
 
-    if in_sandbox():
-        pytest.skip("Cannot run test_tools() test within mkosi sandbox environment")
+    if in_box():
+        pytest.skip("Cannot run test_tools() test within mkosi box environment")
 
     with resource_path(mkosi.resources) as resources, chdir(d):
         _, tools, _ = parse_config(argv, resources=resources)


### PR DESCRIPTION
It's both shorter, and doesn't give the wrong impression that this is about security sandboxing, so let's rename the sandbox name to just box. Keep the old name as well of course for compat.