### PR TITLE
mkosi-tools: make sure p11-kit dir exists when configuring module

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.prepare
+++ b/mkosi/resources/mkosi-tools/mkosi.prepare
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -e
 
+mkdir -p "$BUILDROOT/usr/share/p11-kit/modules"
 echo "module: opensc-pkcs11.so" >"$BUILDROOT/usr/share/p11-kit/modules/opensc.module"


### PR DESCRIPTION
Fixes this failure, since I guess the dir may not exist:

```
‣  Running prepare script /tmp/tmphh1uwz2a/resources/mkosi-tools/mkosi.prepare…
/work/prepare: line 4: /buildroot/usr/share/p11-kit/modules/opensc.module: No such file or directory
```