### PR TITLE
qemu: Disable hpet for x86 VMs

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -554,6 +554,9 @@ class Architecture(StrEnum):
     def supports_smm(self) -> bool:
         return self.is_x86_variant()
 
+    def supports_hpet(self) -> bool:
+        return self.is_x86_variant()
+
     def can_kvm(self) -> bool:
         return self == Architecture.native() or (
             Architecture.native() == Architecture.x86_64 and self == Architecture.x86

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -1214,6 +1214,8 @@ def run_qemu(args: Args, config: Config) -> None:
         machine += f",smm={'on' if firmware == Firmware.uefi_secure_boot else 'off'}"
     if shm:
         machine += ",memory-backend=mem"
+    if config.architecture.supports_hpet():
+        machine += ",hpet=off"
 
     cmdline: list[PathString] = []
 


### PR DESCRIPTION
hpet is an emulated clocksource that is generally discouraged in favor of kvm-clock or tsc for virtual machines. While mkosi's virtual machines already use kvm-clock, leaving hpet enabled causes qemu on the host to consume a non-trivial amount of cpu, so let's disable the hpet feature since we're not making use of it anyway.