### PR TITLE
mkosi-vm: install systemd-boot-efi-signed where available

### DIFF
--- a/mkosi/resources/mkosi-vm/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/systemd-boot-signed.conf
+++ b/mkosi/resources/mkosi-vm/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/systemd-boot-signed.conf
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[TriggerMatch]
+Distribution=debian
+Release=!bullseye
+Release=!bookworm
+
+[Match]
+Architecture=|x86-64
+Architecture=|arm64
+
+[Content]
+Packages=
+        systemd-boot-efi-signed


### PR DESCRIPTION
Needed for Bootloader=systemd-boot-signed