### PR TITLE
FirmwareVariables: allow generating during image build

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -4178,7 +4178,7 @@ SETTINGS: list[ConfigSetting[Any]] = [
         dest="firmware_variables",
         metavar="PATH",
         section="Runtime",
-        parse=config_make_path_parser(constants=("custom", "microsoft", "microsoft-mok")),
+        parse=config_make_path_parser(constants=("custom", "microsoft", "microsoft-mok"), required=False),
         help="Set the path to the firmware variables file to use",
         compat_longs=("--qemu-firmware-variables",),
         compat_names=("QemuFirmwareVariables",),

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -768,6 +768,8 @@ def finalize_firmware_variables(
             if config.firmware_variables == Path("microsoft") or not config.firmware_variables
             else config.firmware_variables
         )
+        if not vars.exists():
+            die(f"Firmware variables file {vars} does not exist")
         shutil.copy(vars, ovmf_vars)
 
     return ovmf_vars, ovmf_vars_format


### PR DESCRIPTION
The build immediately fails if FirmwareVariables=%O/somefile is used, as the config parser won't be able to find it, so it is not possible to generate it during the image build itself (e.g: mkosi.postoutput) in order to add generated keys to MOK. Set required=False.