### PR TITLE
Pass unexpanded values to config parsers

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -699,6 +699,7 @@ def parse_path(
     directory: bool = False,
     exclude: Sequence[PathString] = (),
     constants: Sequence[str] = (),
+    unexp_value: Optional[str] = None,
 ) -> Path:
     if value in constants:
         return Path(value)
@@ -711,7 +712,13 @@ def parse_path(
     if expanduser:
         path = path.expanduser()
 
-    if required:
+    if required and (
+        value == unexp_value
+        or (
+            unexp_value
+            and not unexp_value.startswith(f"%{SETTINGS_LOOKUP_BY_NAME['OutputDirectory'].specifier}")
+        )
+    ):
         if not path.exists():
             die(f"{value} does not exist")
 
@@ -1368,6 +1375,7 @@ def config_make_path_parser(
             secret=secret,
             absolute=absolute,
             constants=constants,
+            unexp_value=unexp_value,
         )
 
     return config_parse_path

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -4995,8 +4995,7 @@ class ParseContext:
                 name = k.removeprefix("@")
                 if name != k:
                     logging.warning(
-                        f"{path.absolute()}: The '@' specifier is deprecated, please use {name} instead of "
-                        f"{k}"
+                        f"{path.absolute()}: The '@' specifier is deprecated, please use {name} instead of {k}"  # noqa: E501
                     )
 
                 if not (s := SETTINGS_LOOKUP_BY_NAME.get(name)):
@@ -5009,8 +5008,7 @@ class ParseContext:
 
                 if section != s.section:
                     logging.warning(
-                        f"{path.absolute()}: Setting {name} should be configured in [{s.section}], not "
-                        f"[{section}]."
+                        f"{path.absolute()}: Setting {name} should be configured in [{s.section}], not [{section}]."  # noqa: E501
                     )
 
                 if name != s.name:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,8 +20,8 @@ from mkosi.config import (
     ConfigTree,
     OutputFormat,
     Verb,
-    config_parse_bytes,
     in_box,
+    parse_bytes,
     parse_config,
     parse_ini,
 )
@@ -1152,24 +1152,23 @@ def test_wrong_section_warning(
 
 
 def test_config_parse_bytes() -> None:
-    assert config_parse_bytes(None) is None
-    assert config_parse_bytes("1") == 4096
-    assert config_parse_bytes("8000") == 8192
-    assert config_parse_bytes("8K") == 8192
-    assert config_parse_bytes("4097") == 8192
-    assert config_parse_bytes("1M") == 1024**2
-    assert config_parse_bytes("1.9M") == 1994752
-    assert config_parse_bytes("1G") == 1024**3
-    assert config_parse_bytes("7.3G") == 7838318592
+    assert parse_bytes("1") == 4096
+    assert parse_bytes("8000") == 8192
+    assert parse_bytes("8K") == 8192
+    assert parse_bytes("4097") == 8192
+    assert parse_bytes("1M") == 1024**2
+    assert parse_bytes("1.9M") == 1994752
+    assert parse_bytes("1G") == 1024**3
+    assert parse_bytes("7.3G") == 7838318592
 
     with pytest.raises(SystemExit):
-        config_parse_bytes("-1")
+        parse_bytes("-1")
     with pytest.raises(SystemExit):
-        config_parse_bytes("-2K")
+        parse_bytes("-2K")
     with pytest.raises(SystemExit):
-        config_parse_bytes("-3M")
+        parse_bytes("-3M")
     with pytest.raises(SystemExit):
-        config_parse_bytes("-4G")
+        parse_bytes("-4G")
 
 
 def test_specifiers(tmp_path: Path) -> None:


### PR DESCRIPTION
This is an alternative to #3817, making the unexpanded values available to config parsers, allowing the path parser to not require paths to exist that might be generated later because they are in the output directory.