### PR TITLE
ensure builds with cache over device boundaries

### DIFF
--- a/mkosi/tree.py
+++ b/mkosi/tree.py
@@ -88,7 +88,7 @@ def maybe_make_nocow(path: Path) -> None:
 
 
 def tree_has_selinux_xattr(path: Path) -> bool:
-    return any("security.selinux" in os.listxattr(p) for p in (path, *path.rglob("*")))
+    return any("security.selinux" in os.listxattr(p, follow_symlinks=False) for p in (path, *path.rglob("*")))
 
 
 def copy_tree(


### PR DESCRIPTION
when running mkosi with the default cache dir/XDG_CACHE_HOME on a different device than the mkosi working directory, mkosi falls back to trying to copy the cache using `copy_tree` from tree.py.

the cache contains symlinks which are pointing to files on the host:

e.g. `mkosi.cache/debian...cache/usr/bin/mt -> /etc/alternatives/mt`

`os.listxattr()` defaults to `follow_symlinks=True`, which leads to `FileNotFoundError`s if the files don't exist on the host, which stops the build.

this patch ignores symlinks, but feels like a workaround, as our assumption would be that such absolute links should not be traversed outside the chroot in the first place.

what do you think?