### PR TITLE
Run finalize scripts after installing kernel

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4048,13 +4048,14 @@ def build_image(context: Context) -> None:
 
     clean_package_manager_metadata(context)
     remove_files(context)
-    run_finalize_scripts(context)
 
     rmtree(context.root / "work")
 
     normalize_mtime(context.root, context.config.source_date_epoch)
     partitions = make_disk(context, skip=("esp", "xbootldr"), tabs=True, msg="Generating disk image")
     install_kernel(context, partitions)
+    run_finalize_scripts(context)
+
     normalize_mtime(context.root, context.config.source_date_epoch, directory=Path("boot"))
     normalize_mtime(context.root, context.config.source_date_epoch, directory=Path("efi"))
     partitions = make_disk(context, msg="Formatting ESP/XBOOTLDR partitions")

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -2337,8 +2337,8 @@ Then, for each image, we execute the following steps:
 1. Run **systemd-hwdb**
 1. Remove packages and files (`RemovePackages=`, `RemoveFiles=`)
 1. Run SELinux relabel is a SELinux policy is installed
-1. Run finalize scripts (`mkosi.finalize`)
 1. Generate unified kernel image if configured to do so
+1. Run finalize scripts (`mkosi.finalize`)
 1. Generate final output format
 1. Run post-output scripts (`mkosi.postoutput`)
 

--- a/mkosi/tree.py
+++ b/mkosi/tree.py
@@ -88,7 +88,9 @@ def maybe_make_nocow(path: Path) -> None:
 
 
 def tree_has_selinux_xattr(path: Path) -> bool:
-    return any("security.selinux" in os.listxattr(p, follow_symlinks=False) for p in (path, *path.rglob("*")))
+    return any(
+        "security.selinux" in os.listxattr(p, follow_symlinks=False) for p in (path, *path.rglob("*"))
+    )
 
 
 def copy_tree(


### PR DESCRIPTION
I needed a way to adjust the GRUB config, but there are no hooks between writing the bootloader config and building the disk image.

I considered adding a new hook for it, but I could not find any use of the finalize hook in the wild that wouldn't work just as well at this slightly later point in the build process.