### PR TITLE
shim: fix log message of installed binary

### DIFF
--- a/mkosi/bootloader.py
+++ b/mkosi/bootloader.py
@@ -585,11 +585,11 @@ def find_and_install_shim_binary(
 
                 rel = p.relative_to(context.root)
                 if (context.root / output).is_dir():
-                    # The ESP wants .efi files, not .efi.signed or .efi.signed.latest
-                    if rel.suffix and rel.suffix != ".efi":
-                        left_stem, _ = rel.name.split(".", maxsplit=1)
-                        rel = rel.with_name(f"{left_stem}.efi")
                     output /= rel.name
+                    # The ESP wants .efi files, not .efi.signed or .efi.signed.latest
+                    if output.suffix and output.suffix != ".efi":
+                        left_stem, _ = output.name.split(".", maxsplit=1)
+                        output = output.with_name(f"{left_stem}.efi")
 
                 log_step(f"Installing signed {name} EFI binary from /{rel} to /{output}")
                 shutil.copy2(p, context.root / output)


### PR DESCRIPTION
Followup to 10e50f8c55a56fc4260e171239b5fbdbde1b433d