### PR TITLE
mkosi-initrd/vm: ensure TPM2 core modules are installed in the initrd

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -102,6 +102,7 @@ KernelModules=
         snd-soc-hda-codec
         squashfs
         thunderbolt_net
+        tpm_tis
         ttm
         typec_ucsi
         ucsi_acpi

--- a/mkosi/resources/mkosi-vm/mkosi.conf
+++ b/mkosi/resources/mkosi-vm/mkosi.conf
@@ -15,3 +15,6 @@ Packages=
         strace
         systemd
         udev
+
+KernelInitrdModules=
+        tpm_tis


### PR DESCRIPTION
On arm64 the tpm_tis modules are not built-in, so /dev/tpmrm0 does not show up in the initrd and it times out, and unlocking using the tpm doesn't work.
Ensure the modules are included in the initrd if they are not built in.

Jul 28 23:19:45 localhost systemd[1]: Expecting device dev-tpmrm0.device - /dev/tpmrm0...
Jul 28 23:19:48 localhost (udev-worker)[212]: ctx=0xaaab038cd650 path=/lib/modules/6.12.33+deb13-cloud-arm64/kernel/drivers/char/tpm/tpm_tis_core.ko.xz error=No such file or directory
Jul 28 23:19:49 localhost (udev-worker)[210]: ctx=0xaaab038cd650 path=/lib/modules/6.12.33+deb13-cloud-arm64/kernel/drivers/char/tpm/tpm_tis_core.ko.xz error=No such file or directory
Jul 28 23:21:11 localhost systemd[1]: dev-tpmrm0.device: Job dev-tpmrm0.device/start timed out.

https://oracle.github.io/kconfigs/?config=UTS_RELEASE&config=TCG_TIS&config=TCG_TIS_CORE