### PR TITLE
mkosi-vm: Drop tpm_tis change

### DIFF
--- a/mkosi/resources/mkosi-vm/mkosi.conf
+++ b/mkosi/resources/mkosi-vm/mkosi.conf
@@ -15,6 +15,3 @@ Packages=
         strace
         systemd
         udev
-
-KernelInitrdModules=
-        tpm_tis


### PR DESCRIPTION
Follow up for 07c24a7d42b20d4fde14e6b0bf4b1d77ac299d13

Setting this for mkosi-vm means only tpm_tis is included and nothing else is included which is bogus so revert the change.