### PR TITLE
Drop microsecond resolution for datetime.now()

### DIFF
--- a/mkosi/manifest.py
+++ b/mkosi/manifest.py
@@ -69,7 +69,9 @@ class Manifest:
     packages: list[PackageManifest] = dataclasses.field(default_factory=list)
     source_packages: dict[str, SourcePackageManifest] = dataclasses.field(default_factory=dict)
 
-    _init_timestamp: datetime.datetime = dataclasses.field(init=False, default_factory=datetime.datetime.now)
+    _init_timestamp: datetime.datetime = dataclasses.field(
+        init=False, default_factory=lambda: datetime.datetime.now().replace(microsecond=0)
+    )
 
     def need_source_info(self) -> bool:
         return ManifestFormat.changelog in self.context.config.manifest_format


### PR DESCRIPTION
The RPM INSTALLTIME attribute is an integer represetantion of the installation time of the package, and datetime.now is a date representation of a float timestamp.  This can produce some rounding errors is powerful build servers.

For example, if the variable `_init_timestamp` has a value XXXXX.1 but in the same sub-second the package gets installed, the registered installation time will be the integer representation (XXXXX), making the comparison done for exclusion of the package to be `True`.

This patch will remove the microsecond granularity of the datetime, converting the timestamp on its integer representation, instead of the default float one.  The comparison is still done in the datetime data type.