### PR TITLE
mkosi-tools: move systemd-boot package to conf file matching older releases

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/efi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/efi.conf
@@ -17,5 +17,4 @@ Architecture=uefi
 [Content]
 Packages=
         sbsigntool
-        systemd-boot
         systemd-boot-efi

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/systemd-boot.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/systemd-boot.conf
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# TODO: drop once these releases are EOL and systemd-boot-tools is available everywhere
+[TriggerMatch]
+Distribution=debian
+Release=|bullseye
+Release=|bookworm
+
+[TriggerMatch]
+Distribution=ubuntu
+Release=|jammy
+Release=|noble
+Release=|plucky
+
+[Match]
+Architecture=uefi
+
+[Content]
+Packages=
+        systemd-boot


### PR DESCRIPTION
Since debian 13/ubuntu 25.04 the tools needed at build time (bootctl) are in the systemd-boot-tools package, so there's no need to pull in the systemd-boot package in the tools image, since it is an integration point that sets up the local ESP and so on