### PR TITLE
mkosi-tools: Drop systemd-boot-efi package

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/efi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/efi.conf
@@ -17,4 +17,3 @@ Architecture=uefi
 [Content]
 Packages=
         sbsigntool
-        systemd-boot-efi


### PR DESCRIPTION
There's no need to install systemd-boot, systemd-stub, ... in the tools tree as these are picked up from inside the image so let's stop installing systemd-boot-efi in the tools tree.

Follow up for 9a0d8a8906695a35011ecfd81b36fe82c1577488