### PR TITLE
fix dead/404 link

### DIFF
--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -3024,7 +3024,7 @@ directory of the dependency. Or use the `%O` specifier to refer to the
 output directory.
 
 A good example on how to build multiple images can be found in the
-[systemd](https://github.com/systemd/systemd/tree/main/mkosi.images)
+[systemd](https://github.com/systemd/systemd/tree/main/mkosi/mkosi.images)
 repository.
 
 # ENVIRONMENT VARIABLES


### PR DESCRIPTION
`mkosi.images` moved under a `mkosi` subdirectory