### PR TITLE
Set MakeInitrd=yes in documentation for building custom initrd

### DIFF
--- a/docs/initrd.md
+++ b/docs/initrd.md
@@ -15,6 +15,7 @@ Building an image with a mkosi-built initrd is a two step process, because you w
 Format=cpio
 
 [Content]
+MakeInitrd=yes
 Packages=systemd
          udev
          kmod


### PR DESCRIPTION
Otherwise /etc/initrd-release won't exist in the initrd and systemd won't do the usual initrd stuff