### PR TITLE
mkosi-tools: include opensuse-release in suse builds

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf
@@ -11,6 +11,7 @@ Packages=
         curl
         dosfstools
         e2fsprogs
+        jq
         keyutils
         kmod
         mtools

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/efi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/efi.conf
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Architecture=uefi
+
+[Content]
+Packages=
+        efitools

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/opensuse.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/opensuse.conf
@@ -12,6 +12,7 @@ Packages=
         erofs-utils
         grub2-common
         libseccomp2
+        openSUSE-release
         pkcs11-provider
         policycoreutils
         python3-pefile

--- a/mkosi/resources/mkosi-tools/mkosi.profiles/misc/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/misc/mkosi.conf
@@ -10,7 +10,6 @@ Packages=
         findutils
         gawk
         grep
-        jq
         less
         man
         nano


### PR DESCRIPTION
Otherwise os-release is missing and the img can't be identified