### PR TITLE
mkosi-tools: virtiofsd is only available on a subset of architectures on debian/ubuntu

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.profiles/runtime/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/runtime/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
@@ -7,7 +7,6 @@ Distribution=|ubuntu
 
 [Content]
 Packages=
-        ?exact-name(virtiofsd)
         openssh-client
         ovmf
         qemu-efi-aarch64

--- a/mkosi/resources/mkosi-tools/mkosi.profiles/runtime/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/virtiofsd.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/runtime/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/virtiofsd.conf
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[TriggerMatch]
+Distribution=debian
+Release=!bullseye
+
+[TriggerMatch]
+Distribution=ubuntu
+Release=!jammy
+
+[TriggerMatch]
+Distribution=kali
+
+[Match]
+Architecture=|x86-64
+Architecture=|arm64
+Architecture=|ppc64-le
+Architecture=|s390x
+
+[Content]
+Packages=
+        virtiofsd


### PR DESCRIPTION
It's a rust program, so of course it's a major pain to ship it, so it has been restricted to a few arches and it's not available on the rest, and likely won't