### PR TITLE
mkosi-tools: add grub2-common to openSUSE tools tree

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/opensuse.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/opensuse.conf
@@ -10,6 +10,7 @@ Packages=
         createrepo_c
         distribution-gpg-keys
         erofs-utils
+        grub2-common
         libseccomp2
         pkcs11-provider
         policycoreutils


### PR DESCRIPTION
Otherwise, with `BiosBootloader=grub`:

```
A BIOS bootable image with grub was requested but mkimage was not found
```

And with UEFI, an assertion is reached:

```
Traceback (most recent call last):
  File "/home/dev/mkosi/mkosi/run.py", line 51, in uncaught_exception_handler
    yield
  File "/home/dev/mkosi/mkosi/run.py", line 91, in fork_and_wait
    target(*args, **kwargs)
    ~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/dev/mkosi/mkosi/__init__.py", line 4964, in run_build
    build_image(
    ~~~~~~~~~~~^
        Context(
        ^^^^^^^^
    ...<7 lines>...
        )
        ^
    )
    ^
  File "/home/dev/mkosi/mkosi/__init__.py", line 4051, in build_image
    install_grub(context)
    ~~~~~~~~~~~~^^^^^^^^^
  File "/home/dev/mkosi/mkosi/bootloader.py", line 354, in install_grub
    grub_mkimage(
    ~~~~~~~~~~~~^
        context,
        ^^^^^^^^
    ...<3 lines>...
        sbat=sbat,
        ^^^^^^^^^^
    )
    ^
  File "/home/dev/mkosi/mkosi/bootloader.py", line 187, in grub_mkimage
    assert mkimage
           ^^^^^^^
AssertionError
```