### PR TITLE
pacman: do not call pacman-key when --repository-key-check=no

### DIFF
--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -231,9 +231,10 @@ class Pacman(PackageManager):
                 sandbox=context.sandbox,
             )
 
-        with complete_step("Populating pacman keyring"):
-            run(["pacman-key", "--init"], sandbox=sandbox())
-            run(["pacman-key", "--populate"], sandbox=sandbox())
+        if context.config.repository_key_check:
+            with complete_step("Populating pacman keyring"):
+                run(["pacman-key", "--init"], sandbox=sandbox())
+                run(["pacman-key", "--populate"], sandbox=sandbox())
 
     @classmethod
     def sync(cls, context: Context, force: bool) -> None:


### PR DESCRIPTION
It gets stuck on my machine:

==> Generating pacman master key. This may take some time. gpg: Generating pacman keyring master key...
gpg: directory '/etc/pacman.d/gnupg/openpgp-revocs.d' created gpg: revocation certificate stored as '/etc/pacman.d/gnupg/openpgp-revocs.d/EB164F6892020464A09A4A6B7E2D4967893A191E.rev' gpg: Done
==> Updating trust database...
gpg: marginals needed: 3  completes needed: 1  trust model: pgp
gpg: depth: 0  valid:   1  signed:   0  trust: 0-, 0q, 0n, 0m, 0f, 1u
==> Appending keys from archlinux.gpg...
==> Appending keys from debian-archive-bookworm-automatic.gpg...
==> Appending keys from debian-archive-bookworm-security-automatic.gpg...
==> Appending keys from debian-archive-bookworm-stable.gpg...
==> Appending keys from debian-archive-bullseye-automatic.gpg...
==> Appending keys from debian-archive-bullseye-security-automatic.gpg...
==> Appending keys from debian-archive-bullseye-stable.gpg...
==> Appending keys from debian-archive-keyring.gpg...
==> Appending keys from debian-archive-removed-keys.gpg...
==> Appending keys from debian-archive-trixie-automatic.gpg...
==> Appending keys from debian-archive-trixie-security-automatic.gpg...
==> Appending keys from debian-archive-trixie-stable.gpg...
==> Appending keys from debian-keyring.gpg...

Avoid calling it when --repository-key-check=no is used, as there's no point anyway, it won't be used