### PR TITLE
fedora: Rework rawhide GPG key logic

### DIFF
--- a/mkosi/installer/rpm.py
+++ b/mkosi/installer/rpm.py
@@ -61,7 +61,7 @@ def find_rpm_gpgkey(
 
     paths = (
         run(
-            ["bash", "-c", rf"shopt -s nullglob && printf '%s\n' {' '.join(globs)}"],
+            ["bash", "-c", rf"shopt -s nullglob && printf '%s\n' {' '.join(globs)} | xargs -r readlink -f"],
             sandbox=context.sandbox(),
             stdout=subprocess.PIPE,
         )


### PR DESCRIPTION
- Drop secondary key logic as looking at https://github.com/rpm-software-management/distribution-gpg-keys/tree/main/keys/fedora,
  this hasn't been used for a long time.
- If repository key fetching is enabled, always look up the key remotely
  as e.g. on CentOS 9 or so the rawhide symlink might be horribly outdated.
- If not using repository key fetching, Use all local keys newer than the
  rawhide key as well to maximize the chances of including the current rawhide
  key.
- Resolve symlinks within the sandbox in find_rpm_gpgkey() as we might not be
  able to resolve the symlinks outside of the sandbox.