### PR TITLE
kmod: Make sure we include all intermediate firmware symlinks as well

### DIFF
--- a/mkosi.tools.conf/mkosi.conf.d/arch.conf
+++ b/mkosi.tools.conf/mkosi.conf.d/arch.conf
@@ -6,6 +6,7 @@ Distribution=arch
 [Content]
 Packages=
         cryptsetup
+        mkinitcpio
         mypy
         python-pytest
         ruff

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1590,6 +1590,9 @@ def build_kernel_modules_initrd(context: Context, kver: str) -> Path:
 
         maybe_compress(context, compression, kmods, kmods)
 
+    if ArtifactOutput.kernel_modules_initrd in context.config.split_artifacts:
+        shutil.copy(kmods, context.staging / context.config.output_split_kernel_modules_initrd)
+
     return kmods
 
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -620,6 +620,7 @@ class ArtifactOutput(StrEnum):
     pcrs = enum.auto()
     roothash = enum.auto()
     os_release = enum.auto()
+    kernel_modules_initrd = enum.auto()
 
     @staticmethod
     def compat_no() -> list["ArtifactOutput"]:
@@ -2266,6 +2267,10 @@ class Config:
         return f"{self.output}.osrelease"
 
     @property
+    def output_split_kernel_modules_initrd(self) -> str:
+        return f"{self.output}.kernel-modules-initrd"
+
+    @property
     def output_nspawn_settings(self) -> str:
         return f"{self.output}.nspawn"
 
@@ -2306,6 +2311,7 @@ class Config:
             self.output_split_pcrs,
             self.output_split_roothash,
             self.output_split_os_release,
+            self.output_split_kernel_modules_initrd,
             self.output_nspawn_settings,
             self.output_checksum,
             self.output_signature,

--- a/mkosi/kmod.py
+++ b/mkosi/kmod.py
@@ -10,10 +10,10 @@ from collections.abc import Iterable, Iterator, Reversible
 from pathlib import Path
 
 from mkosi.context import Context
-from mkosi.log import complete_step, log_step
+from mkosi.log import complete_step, die, log_step
 from mkosi.run import chroot_cmd, run
 from mkosi.sandbox import chase
-from mkosi.util import chdir, parents_below
+from mkosi.util import chdir, parents_below, path_and_parents_below
 
 
 def loaded_modules() -> list[str]:
@@ -349,14 +349,56 @@ def gen_required_kernel_modules(
     # Include or exclude firmware explicitly configured
     firmware = filter_firmware(context.root, firmware, include=firmware_include, exclude=firmware_exclude)
 
-    # Some firmware dependencies are symbolic links, so the targets for those must be included in the list
-    # of required firmware files too. Intermediate symlinks are not included, and so links pointing to links
-    # results in dangling symlinks in the final image.
-    for fw in firmware.copy():
-        if (context.root / fw).is_symlink():
-            target = Path(chase(os.fspath(context.root), os.fspath(fw)))
-            if target.exists():
-                firmware.add(target.relative_to(context.root))
+    # /usr/lib/firmware makes use of symbolic links so we have to make sure the symlinks and their targets
+    # are all included.
+    todo = firmware.copy()
+    firmware.clear()
+    for fw in todo:
+        # Every path component from /usr/lib/firmware up to and including the firmware file itself might be a
+        # symlink. We need to make sure we include all of them so we iterate over them and keep resolving
+        # each symlink separately (and recursively) and add all of them to the list of firmware to add.
+        #
+        # As of the time of writing this logic, the only firmware that actually requires intermediate path
+        # symlink resolution are the following:
+        #
+        # $ find /usr/lib/firmware -type l | grep -v "\."
+        # /usr/lib/firmware/intel/sof-ace-tplg
+        # /usr/lib/firmware/nvidia/ad103
+        # /usr/lib/firmware/nvidia/ad104
+        # /usr/lib/firmware/nvidia/ad106
+        # /usr/lib/firmware/nvidia/ad107
+        # /usr/lib/firmware/nvidia/ga103/gsp
+        # /usr/lib/firmware/nvidia/ga104/gsp
+        # /usr/lib/firmware/nvidia/ga106/gsp
+        # /usr/lib/firmware/nvidia/ga107/gsp
+        # /usr/lib/firmware/nvidia/gb102
+        # /usr/lib/firmware/nvidia/gb203
+        # /usr/lib/firmware/nvidia/gb205
+        # /usr/lib/firmware/nvidia/gb206
+        # /usr/lib/firmware/nvidia/gb207
+        # /usr/lib/firmware/nvidia/tu104/gsp
+        # /usr/lib/firmware/nvidia/tu106/gsp
+        # /usr/lib/firmware/nvidia/tu117/gsp
+
+        for p in reversed(path_and_parents_below(context.root / fw, context.root / firmwared)):
+            # Make sure only the last component of the path we're working is a symlink. We don't want to
+            # yield any paths with multiple components in them that are symlinks as these paths are passed to
+            # cpio and it interprets intermediary path components that are symlinks as regular directories.
+            # Additionally, intermediary path components that are symlinks also mess up the path
+            # deduplication we want to get by putting all the firmware to add in a set as the paths will hash
+            # differently even though they're the same paths after resolution.
+            p = p.parent.resolve(strict=True).joinpath(p.name)
+
+            while p.is_symlink():
+                target = p.readlink()
+                if target.is_absolute():
+                    die(f"Found unexpected absolute symlink {target} in {firmwared}")
+
+                firmware.add(p.relative_to(context.root))
+                p = p.parent / target
+
+        # Finally, add the actual fully resolved path to the firmware file.
+        firmware.add((context.root / fw).resolve(strict=True).relative_to(context.root))
 
     yield from sorted(
         itertools.chain(

--- a/mkosi/kmod.py
+++ b/mkosi/kmod.py
@@ -165,7 +165,7 @@ def filter_firmware(
     if include:
         firmwared = Path("usr/lib/firmware")
         with chdir(root):
-            all_firmware = set(firmwared.rglob("*"))
+            all_firmware = {p for p in firmwared.rglob("*") if p.is_file() or p.is_symlink()}
 
         patterns = [p[3:] for p in include if p.startswith("re:")]
         regex = re.compile("|".join(patterns))

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -651,8 +651,8 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 `SplitArtifacts=`, `--split-artifacts=`
 :   The artifact types to split out of the final image. A comma-delimited
     list consisting of `uki`, `kernel`, `initrd`, `os-release`, `prcs`, `partitions`,
-    `roothash` and `tar`. When building a bootable image `kernel` and `initrd`
-    correspond to their artifact found in the image (or in the UKI),
+    `roothash`, `kernel-modules-initrd` and `tar`. When building a bootable image `kernel`
+    and `initrd` correspond to their artifact found in the image (or in the UKI),
     while `uki` copies out the entire UKI. If `pcrs` is specified, a JSON
     file containing the pre-calculated TPM2 digests is written out, according
     to the [UKI specification](https://uapi-group.org/specifications/specs/unified_kernel_image/#json-format-for-pcrsig),
@@ -672,6 +672,11 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
     When `roothash` is specified and a dm-verity disk image is built, the dm-verity
     roothash is written out as a separate file, which is useful for offline signing.
+
+    `kernel-modules-initrd` corresponds to the separate kernel modules initrd which
+    mkosi appends to the main initrd. This is primarily intended for debugging as many
+    initrd inspection tools don't properly handle multiple initrds appended to each
+    other.
 
     By default `uki`, `kernel` and `initrd` are split out.
 

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -194,6 +194,10 @@ def parents_below(path: Path, below: Path) -> list[Path]:
     return parents[: parents.index(below)]
 
 
+def path_and_parents_below(path: Path, below: Path) -> list[Path]:
+    return [path] + parents_below(path, below)
+
+
 @contextlib.contextmanager
 def resource_path(mod: ModuleType) -> Iterator[Path]:
     t = importlib.resources.files(mod)


### PR DESCRIPTION
Replaces #3822