### PR TITLE
Check whether a UKI is wanted in make_uki() like in other paths

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3700,7 +3700,7 @@ def make_esp(
     if not context.config.architecture.to_efi():
         die(f"Architecture {context.config.architecture} does not support UEFI")
 
-    if stub and kver and kimg:
+    if stub and kver and kimg and want_uki(context):
         token = find_entry_token(context)
         uki = context.root / finalize_uki_path(
             context, finalize_bootloader_entry_format(context, kver, token)


### PR DESCRIPTION
Otherwise it will be built for the ESP even if it's not wanted, like in the netesp case in particleos