### PR TITLE
Make Bootable= determine whether we build a UKI for esp images

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3362,6 +3362,12 @@ def save_esp_components(
         if context.config.output_format == OutputFormat.uki:
             die("A kernel must be installed in the image to build a UKI")
 
+        if (
+            context.config.output_format == OutputFormat.esp
+            and context.config.bootable == ConfigFeature.enabled
+        ):
+            die("A kernel must be installed in the image to build a bootable ESP image")
+
         return None, None, None, []
 
     kimg = Path(shutil.copy2(context.root / kimg, context.workspace))
@@ -3700,7 +3706,11 @@ def make_esp(
     if not context.config.architecture.to_efi():
         die(f"Architecture {context.config.architecture} does not support UEFI")
 
-    if stub and kver and kimg:
+    if context.config.bootable == ConfigFeature.enabled or (
+        context.config.bootable == ConfigFeature.auto and stub and kver and kimg
+    ):
+        assert stub and kver and kimg
+
         token = find_entry_token(context)
         uki = context.root / finalize_uki_path(
             context, finalize_bootloader_entry_format(context, kver, token)

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -557,11 +557,11 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     tarball of the OS image is generated), `cpio` (similar, but a cpio
     archive is generated), `disk` (a block device OS image with a GPT
     partition table), `uki` (a unified kernel image with the OS image in
-    the `.initrd` PE section), `esp` (`uki` but wrapped in a disk image
-    with only an ESP partition), `oci` (a directory compatible with the
-    OCI image specification), `sysext`, `confext`, `portable`,
-    `addon` or `none` (the OS image is solely intended as a build
-    image to produce another artifact).
+    the `.initrd` PE section), `esp` (a disk image with only an ESP
+    partition, bootloader and optionally a UKI), `oci` (a directory
+    compatible with the OCI image specification), `sysext`, `confext`,
+    `portable`, `addon` or `none` (the OS image is solely intended as a
+    build image to produce another artifact).
 
     If the `disk` output format is used, the disk image is generated using
     **systemd-repart**. The repart partition definition files to use can be
@@ -927,6 +927,10 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     bootloader will be installed even if found inside the image, no
     unified kernel images will be generated and no ESP partition will be
     added to the image if the disk output format is used.
+
+    If the `esp` output format is used, an ESP partition and bootloader are
+    always added, and the `Bootable=` option only controls whether a UKI is
+    added to the ESP partition or not.
 
 `Bootloader=`, `--bootloader=`
 :   Takes one of `none`, `systemd-boot`, `uki`, `grub`,


### PR DESCRIPTION
Currently, we build a UKI for ESP images only if a kernel is installed. Let's make this a bit more flexible by hooking it up to the Bootable= setting. If Bootable=no, then we won't add a UKI to the esp regardless if a kernel is installed in the image or not.