### PR TITLE
kmod: Beef up firmware symlink chasing

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -28,6 +28,7 @@ Packages=
         gdb
         sudo
         tmux
+        wireless-regdb
         zsh
 
 InitrdProfiles=lvm

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4195,7 +4195,7 @@ def run_box(args: Args, config: Config) -> None:
 
     cmdline = [*args.cmdline]
 
-    if sys.stdin.isatty() and config.find_binary("systemd-pty-forward"):
+    if sys.stdin.isatty() and sys.stdout.isatty() and config.find_binary("systemd-pty-forward"):
         cmdline = [
             "systemd-pty-forward",
             "--title=mkosi-sandbox",

--- a/mkosi/kmod.py
+++ b/mkosi/kmod.py
@@ -276,9 +276,13 @@ def resolve_module_dependencies(
                 depends.update(normalize_module_name(d) for d in value.split() if not d.endswith(":"))
 
             elif key == "firmware":
-                glob = "" if value.endswith("*") else "*"
-                fw = [f for f in Path("usr/lib/firmware").glob(f"{value}{glob}")]
-                firmware.update(fw)
+                if (Path("usr/lib/firmware") / value).exists():
+                    firmware.add(Path("usr/lib/firmware") / value)
+
+                glob = "" if value.endswith("*") else ".*"
+
+                for fw in Path("usr/lib/firmware").glob(f"{value}{glob}"):
+                    firmware.add(fw)
 
             elif key == "name":
                 # The file names use dashes, but the module names use underscores. We track the names in

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -194,10 +194,6 @@ def parents_below(path: Path, below: Path) -> list[Path]:
     return parents[: parents.index(below)]
 
 
-def path_and_parents_below(path: Path, below: Path) -> list[Path]:
-    return [path] + parents_below(path, below)
-
-
 @contextlib.contextmanager
 def resource_path(mod: ModuleType) -> Iterator[Path]:
     t = importlib.resources.files(mod)


### PR DESCRIPTION
- It turns out we need to handle absolutely symlinks after all as /usr/lib/firmware/regulatory.db is a symlink to /etc/alternatives in Debian and derivatives.
- Our previous implementation didn't handle cases where a symlink target consisted out of two parts e.g. if C -> A/B then we wouldn't try to resolve A.

Fix both issues by switching to a minimal implementation of the chase() function in systemd.

Follow up for 221293e33defe30b111bc13957a0d52d2ea1c45b