### PR TITLE
Replace RuntimeHome= with BindUser=

### DIFF
--- a/mkosi.postinst
+++ b/mkosi.postinst
@@ -15,6 +15,7 @@ mkosi-chroot \
     --password "$(openssl passwd -1 mkosi)" \
     --groups "$SUDO_GROUP",systemd-journal \
     --shell /bin/bash \
+    --uid 4711 \
     mkosi
 
 systemctl --root="$BUILDROOT" mask lvm2-monitor.service

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4,6 +4,7 @@ import contextlib
 import dataclasses
 import datetime
 import functools
+import getpass
 import hashlib
 import itertools
 import json
@@ -155,7 +156,6 @@ from mkosi.tree import copy_tree, make_tree, move_tree, rmtree
 from mkosi.user import INVOKING_USER, become_root_cmd
 from mkosi.util import (
     PathString,
-    current_home_dir,
     flatten,
     flock,
     flock_or_die,
@@ -4370,9 +4370,8 @@ def run_shell(args: Args, config: Config) -> None:
             uidmap = "rootidmap" if tree.source.stat().st_uid != 0 else "noidmap"
             cmdline += ["--bind", f"{tree.source}:{target}:norbind,{uidmap}"]
 
-        if config.runtime_home and (path := current_home_dir()):
-            uidmap = "rootidmap" if path.stat().st_uid != 0 else "noidmap"
-            cmdline += ["--bind", f"{path}:/root:norbind,{uidmap}"]
+        if config.bind_user:
+            cmdline += ["--bind-user", getpass.getuser()]
 
         if config.runtime_scratch == ConfigFeature.enabled or (
             config.runtime_scratch == ConfigFeature.auto and config.output_format == OutputFormat.disk

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2105,7 +2105,7 @@ class Config:
     runtime_scratch: ConfigFeature
     runtime_network: Network
     runtime_build_sources: bool
-    runtime_home: bool
+    bind_user: bool
     unit_properties: list[str]
     ssh_key: Optional[Path]
     ssh_certificate: Optional[Path]
@@ -4009,11 +4009,11 @@ SETTINGS: list[ConfigSetting[Any]] = [
         scope=SettingScope.main,
     ),
     ConfigSetting(
-        dest="runtime_home",
+        dest="bind_user",
         metavar="BOOL",
         section="Runtime",
         parse=config_parse_boolean,
-        help="Mount current home directory to /root when booting the image",
+        help="Bind current user from host into container or virtual machine",
         scope=SettingScope.main,
     ),
     ConfigSetting(
@@ -5610,7 +5610,7 @@ def summary(config: Config) -> str:
                     Runtime Scratch: {config.runtime_scratch}
                     Runtime Network: {config.runtime_network}
               Runtime Build Sources: {config.runtime_build_sources}
-  Runtime Home or Working Directory: {yes_no(config.runtime_home)}
+                          Bind User: {yes_no(config.bind_user)}
                     Unit Properties: {line_join_list(config.unit_properties)}
                     SSH Signing Key: {none_to_none(config.ssh_key)}
                     SSH Certificate: {none_to_none(config.ssh_certificate)}

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -54,7 +54,6 @@ from mkosi.user import INVOKING_USER, become_root_in_subuid_range, become_root_i
 from mkosi.util import (
     PathString,
     StrEnum,
-    current_home_dir,
     flock,
     flock_or_die,
     groupby,
@@ -1146,6 +1145,9 @@ def run_qemu(args: Args, config: Config) -> None:
     ):
         die("SecureBootCertificate= must be configured to use FirmwareVariables=custom|microsoft-mok")
 
+    if config.bind_user:
+        die("mkosi qemu does not support --bind-user=")
+
     # After we unshare the user namespace to sandbox qemu, we might not have access to /dev/kvm or related
     # device nodes anymore as access to these might be gated behind the kvm group and we won't be part of the
     # kvm group anymore after unsharing the user namespace. To get around this, open all those device nodes
@@ -1216,7 +1218,6 @@ def run_qemu(args: Args, config: Config) -> None:
     if (
         config.runtime_trees
         or config.runtime_build_sources
-        or config.runtime_home
         or config.output_format == OutputFormat.directory
     ):
         shm = ["-object", f"memory-backend-memfd,id=mem,size={config.ram // 1024**2}M,share=on"]

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1946,9 +1946,9 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     they were mounted to when running the build script when using `mkosi
     boot` or `mkosi vm`.
 
-`RuntimeHome=`, `--runtime-home=`
-:   Mount the current home directory from which **mkosi** is running to
-    `/root` when using `mkosi boot` or `mkosi vm`.
+`BindUser=`, `--bind-user=`
+:   Bind the home directory of the current user into the container/vm.
+    Takes a boolean. Disabled by default.
 
 `UnitProperties=`, `--unit-property=`
 :   Configure systemd unit properties to add to the systemd scopes

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -243,23 +243,6 @@ def groupby(seq: Sequence[T], key: Callable[[T], S]) -> list[tuple[S, list[T]]]:
     return [(key, group) for key, group in grouped.items()]
 
 
-def current_home_dir() -> Optional[Path]:
-    home = Path(h) if (h := os.getenv("HOME")) else None
-
-    if Path.cwd() in (Path("/"), Path("/home")):
-        return home
-
-    if Path.cwd().is_relative_to("/root"):
-        return Path("/root")
-
-    if Path.cwd().is_relative_to("/home"):
-        # `Path.parents` only supports slices and negative indexing from Python 3.10 onwards.
-        # TODO: Remove list() when we depend on Python 3.10 or newer.
-        return list(Path.cwd().parents)[-3]
-
-    return home
-
-
 def unique(seq: Sequence[T]) -> list[T]:
     return list(dict.fromkeys(seq))
 

--- a/mkosi/vmspawn.py
+++ b/mkosi/vmspawn.py
@@ -24,7 +24,7 @@ from mkosi.qemu import (
     finalize_register,
 )
 from mkosi.run import run
-from mkosi.util import PathString, current_home_dir
+from mkosi.util import PathString
 
 
 def run_vmspawn(args: Args, config: Config) -> None:
@@ -36,6 +36,9 @@ def run_vmspawn(args: Args, config: Config) -> None:
 
     if config.cdrom:
         die("systemd-vmspawn does not support CD-ROM images")
+
+    if config.bind_user:
+        die("systemd-vmspawn does not support --bind-user=")
 
     if config.firmware_variables and config.firmware_variables != Path("microsoft"):
         die("mkosi vmspawn does not support FirmwareVariables=")
@@ -87,9 +90,6 @@ def run_vmspawn(args: Args, config: Config) -> None:
         for tree in config.runtime_trees:
             target = Path("/root/src") / (tree.target or "")
             cmdline += ["--bind", f"{tree.source}:{target}"]
-
-        if config.runtime_home and (p := current_home_dir()):
-            cmdline += ["--bind", f"{p}:/root"]
 
         if kernel:
             cmdline += ["--linux", kernel]

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -108,6 +108,7 @@ def test_config() -> None:
             "BaseTrees": [
                 "/hello/world"
             ],
+            "BindUser": true,
             "BiosBootloader": "none",
             "Bootable": "disabled",
             "Bootloader": "grub",
@@ -313,7 +314,6 @@ def test_config() -> None:
             ],
             "RootShell": "/bin/tcsh",
             "RuntimeBuildSources": true,
-            "RuntimeHome": true,
             "RuntimeNetwork": "interface",
             "RuntimeScratch": "enabled",
             "RuntimeSize": 8589934592,
@@ -441,6 +441,7 @@ def test_config() -> None:
         architecture=Architecture.ia64,
         autologin=False,
         base_trees=[Path("/hello/world")],
+        bind_user=True,
         bios_bootloader=BiosBootloader.none,
         bootable=ConfigFeature.disabled,
         bootloader=Bootloader.grub,
@@ -553,7 +554,6 @@ def test_config() -> None:
         root_password=("test1234", False),
         root_shell="/bin/tcsh",
         runtime_build_sources=True,
-        runtime_home=True,
         runtime_network=Network.interface,
         runtime_scratch=ConfigFeature.enabled,
         runtime_size=8589934592,


### PR DESCRIPTION
Let's replace our home grown RuntimeHome= option with BindUser= to
mimick systemd-nspawn's --bind-user= option. systemd-vmspawn will soon
learn to support --bind-user= as well and we'll enable the option for
it when that happens as well.