### PR TITLE
initrd: Add intel_pmc_ssram_telemetry module by default

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -76,6 +76,7 @@ KernelModules=
         i2c-smbus
         i8042
         intel-gtt
+        intel_pmc_ssram_telemetry
         intel_rapl_common
         intel-uncore-frequency-common
         intel-vsec


### PR DESCRIPTION
This was split off from the core driver in
https://lwn.net/Articles/1019075/.