### PR TITLE
apt: fix installing local packages when they are older than what the distro provides

### DIFF
--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -168,6 +168,7 @@ class Apt(PackageManager):
             "-o", f"APT::Install-Recommends={str(context.config.with_recommends).lower()}",
             "-o", "APT::Immediate-Configure=off",
             "-o", "APT::Get::Assume-Yes=true",
+            "-o", "APT::Get::allow-downgrades=true",
             "-o", "APT::Get::AutomaticRemove=true",
             "-o", "APT::Get::Allow-Change-Held-Packages=true",
             "-o", "APT::Get::Allow-Remove-Essential=true",
@@ -310,7 +311,7 @@ class Apt(PackageManager):
             textwrap.dedent(
                 """\
                 Package: *
-                Pin: origin mkosi
+                Pin: origin ""
                 Pin-Priority: 1100
                 """
             )


### PR DESCRIPTION
Need to allow downgrades in case the package is already installed (eg: libsystemd0), and also need to use "" as the origin so that it actually matches the local repository