### PR TITLE
ci: Disable PPC jobs temporarily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,12 +159,13 @@ jobs:
           - distro: ubuntu
             tools: ubuntu
             runner: ubuntu-24.04-arm
-          - distro: fedora
-            tools: fedora
-            runner: ubuntu-24.04-ppc64le
-          - distro: debian
-            tools: debian
-            runner: ubuntu-24.04-ppc64le
+          # TODO: Re-enable when https://github.com/IBM/actionspz/issues/27 is addressed.
+          # - distro: fedora
+          #   tools: fedora
+          #   runner: ubuntu-24.04-ppc64le
+          # - distro: debian
+          #   tools: debian
+          #   runner: ubuntu-24.04-ppc64le
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
Something in the PPC runners is broken causing all CI jobs to get cancelled when trying to rerun CI jobs. Let's disable the PPC jobs temporarily until the issues with the underlying runners are fixed so the rest of CI can run again and we can merge PRs again.