### PR TITLE
Drop BuildSourcesEphemeral=yes from default image config

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -16,7 +16,6 @@ OutputDirectory=mkosi.output
 ToolsTree=default
 Incremental=yes
 BuildSources=.
-BuildSourcesEphemeral=yes
 
 [Content]
 Autologin=yes


### PR DESCRIPTION
I'm making sure the mkosi rpm spec build cleans up after itself in https://src.fedoraproject.org/rpms/mkosi/pull-request/24# so we don't need this anymore

Fixes #3808