### PR TITLE
dnf: Fix /var package cache directory check in package_subdirs()

### DIFF
--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -29,8 +29,10 @@ class Dnf(PackageManager):
         dirs = [p for p in cache.iterdir() if p.is_dir() and "-" in p.name and "mkosi" not in p.name]
         return [
             (
+                # If the package cache directory is set to /var, we need to make sure we look up packages
+                # where they were stored by dnf, so don't do any special handling in that case.
                 d.relative_to(cache) / "packages"
-                if cache == Path("/var")
+                if cache.parent == Path("/var/cache")
                 # Cache directories look like <repo-id>-<baseurl-hash> so let's strip off the hash to reuse
                 # the same package cache directory regardless of baseurl.
                 else Path("packages") / d.name[: d.name.rfind("-")],


### PR DESCRIPTION
package_subdirs() receives the full cache directory path, not the configured package cache directory (something like /var/cache/libdnf5), so we fix the check to check if the parent directory of the given cache directory is /var/cache so we don't have to know whether the last component is dnf or libdnf5.