### PR TITLE
Fix if check in install_systemd_boot()

### DIFF
--- a/mkosi/bootloader.py
+++ b/mkosi/bootloader.py
@@ -668,7 +668,7 @@ def install_systemd_boot(context: Context) -> None:
         if context.config.bootable == ConfigFeature.enabled:
             die(
                 f"An EFI bootable image with systemd-boot was requested but a {'signed ' if signed else ''}"
-                f"systemd-boot binary was not found at {directory.relative_to(context.root)}"
+                f"systemd-boot binary was not found at /{directory.relative_to(context.root)}"
             )
         return
 


### PR DESCRIPTION
A generator object always evaluates to True, we have to wrap it with
any() to check if it contains anything.