### PR TITLE
opensuse: repository non-oss-debug is invalid

### DIFF
--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -133,6 +133,8 @@ class Installer(DistributionInstaller):
 
                 if not context.config.snapshot:
                     for d in ("debug", "source"):
+                        if repo == "non-oss" and d == "debug":
+                            continue
                         url = join_mirror(mirror, f"{subdir}/{d}/tumbleweed/repo/{repo}")
                         yield RpmRepository(
                             id=f"{repo}-{d}",


### PR DESCRIPTION
* non-oss-debug is not a valid repository. Better to remove it, otherwise command like `zypper refresh` fails.

It happens when trying to add `--tools-tree-repository` from `mkosi -f`:

```bash
Repository 'non-oss-debug' is invalid.
[non-oss-debug|https://download.opensuse.org/debug/tumbleweed/repo/non-oss] Failed to retrieve new repository metadata.
History:
 - [non-oss-debug|https://download.opensuse.org/debug/tumbleweed/repo/non-oss] Repository type can't be determined.
Please check if the URIs defined for this repository are pointing to a valid repository.
Skipping repository 'non-oss-debug' because of the above error.
```

As soon as the repositories change, `mkosi` want to refresh with all Tumbleweed repositories included the invalide non-oss-debug one.