### PR TITLE
Assorted regex fixes

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -171,7 +171,7 @@ from mkosi.versioncomp import GenericVersion
 from mkosi.vmspawn import run_vmspawn
 
 # Allowed characters from https://uapi-group.org/specifications/specs/version_format_specification
-KERNEL_VERSION_PATTERN = r"\d+\.\d+[\w.\-~^+]*"
+KERNEL_VERSION_PATTERN = re.compile(r"\d+\.\d+[\w.\-~^+]*")
 
 
 @contextlib.contextmanager
@@ -1298,9 +1298,7 @@ def gzip_binary(context: Context) -> str:
 def kernel_get_ver_from_modules(context: Context) -> Optional[str]:
     # Try to get version from the first dir under usr/lib/modules but fail if multiple versions are found
     versions = [
-        p.name
-        for p in (context.root / "usr/lib/modules").glob("*")
-        if re.match(KERNEL_VERSION_PATTERN, p.name)
+        p.name for p in (context.root / "usr/lib/modules").glob("*") if KERNEL_VERSION_PATTERN.match(p.name)
     ]
     if len(versions) > 1:
         die(
@@ -1321,7 +1319,7 @@ def fixup_vmlinuz_location(context: Context) -> None:
 
             # Extract kernel version pattern from filename
             filename = d.name.removeprefix(f"{type}-")
-            match = re.search(KERNEL_VERSION_PATTERN, filename)
+            match = KERNEL_VERSION_PATTERN.search(filename)
             kver = match.group(0) if match else kernel_get_ver_from_modules(context)
             if kver is None:
                 logging.debug("Unable to get kernel version from modules directory")

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -171,7 +171,7 @@ from mkosi.versioncomp import GenericVersion
 from mkosi.vmspawn import run_vmspawn
 
 # Allowed characters from https://uapi-group.org/specifications/specs/version_format_specification
-KERNEL_VERSION_PATTERN = re.compile(r"\d+\.\d+[\w.\-~^+]*")
+KERNEL_VERSION_PATTERN = re.compile(r"\d+\.\d+[\w\-.~^+]*", re.ASCII)
 
 
 @contextlib.contextmanager
@@ -1930,7 +1930,7 @@ def systemd_stub_version(context: Context, stub: Path) -> Optional[GenericVersio
 
     if not (
         version := re.match(
-            r"#### LoaderInfo: systemd-stub (?P<version>[.~^a-zA-Z0-9-+_]+) ####", sdmagic_text
+            r"#### LoaderInfo: systemd-stub (?P<version>[\w\-.~^+]+) ####", sdmagic_text, re.ASCII
         )
     ):
         die(f"Unable to determine systemd-stub version, found {sdmagic_text!r}")

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -39,7 +39,7 @@ def read_remote_rawhide_key_symlink(context: Context) -> str:
 
 @tuplify
 def find_fedora_rpm_gpgkeys(context: Context) -> Iterable[str]:
-    versionre = re.compile(r"RPM-GPG-KEY-fedora-(\d+)-primary")
+    versionre = re.compile(r"RPM-GPG-KEY-fedora-(\d+)-primary", re.ASCII)
     # ELN uses the rawhide GPG keys.
     release = "rawhide" if context.config.release == "eln" else context.config.release
 

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -83,7 +83,7 @@ def read_env_file(path: PathString) -> Iterator[tuple[str, str]]:
             line = line.rstrip()
             if not line or line.startswith("#"):
                 continue
-            if m := re.match(r"([A-Z][A-Z_0-9]+)=(.*)", line):
+            if m := re.match(r"([a-zA-Z_][a-zA-Z_0-9]+)=(.*)", line):
                 name, val = m.groups()
                 if val and val[0] in "\"'":
                     val = ast.literal_eval(val)


### PR DESCRIPTION
This adds `re.ASCII` in places where we use backslash character classes (`\d` or `\w`), so that arbitrary unicode numbers and letters are not accepted, where we might not expect them.

Also the character classes accepted for variable names in `read_env_files` is widened to what shells allow, so that we can guarantee roundtripping files read with it.