### PR TITLE
mkosi-initrd: Install libseccomp explicitly

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/arch.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/arch.conf
@@ -12,6 +12,7 @@ Packages=
 
         # Various libraries that are dlopen'ed by systemd
         libfido2
+        libseccomp
         tpm2-tss
 
         procps-ng

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/azure-centos-fedora.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/azure-centos-fedora.conf
@@ -11,6 +11,7 @@ Distribution=|azure
 [Content]
 Packages=
         # Various libraries that are dlopen'ed by systemd
+        libseccomp
         tpm2-tss
 
         # File system checkers for supported root file systems

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
@@ -11,6 +11,7 @@ Packages=
         dmsetup  # Not pulled in as a dependency on Debian/Ubuntu
 
         libcryptsetup12
+        libseccomp2
 
         # xfsprogs pulls in python on Debian (???) and XFS generally
         # isn't used on Debian so we don't install xfsprogs.

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/opensuse.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/opensuse.conf
@@ -16,6 +16,7 @@ Packages=
 
         # Various libraries that are dlopen'ed by systemd
         libfido2-1
+        libseccomp2
         libtss2-esys0
         libtss2-mu0
         libtss2-rc0

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/postmarketos.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/postmarketos.conf
@@ -6,5 +6,6 @@ Distribution=postmarketos
 [Content]
 Packages=
         kbd
+        libseccomp
         util-linux-login
         systemd-udevd


### PR DESCRIPTION
It might become a Recommends of systemd in the future in distribution packages but we should make sure it is available in the initrd regardless.