### PR TITLE
mkosi-initd: install libseccomp in debian/ubuntu

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
@@ -10,8 +10,6 @@ Packages=
         kmod     # Not pulled in as a dependency on Debian/Ubuntu
         dmsetup  # Not pulled in as a dependency on Debian/Ubuntu
 
-        libcryptsetup12
-
         # xfsprogs pulls in python on Debian (???) and XFS generally
         # isn't used on Debian so we don't install xfsprogs.
         btrfs-progs
@@ -22,7 +20,9 @@ Packages=
         util-linux
 
         # Various libraries that are dlopen'ed by systemd
+        libcryptsetup12
         libfido2-1
+        libseccomp2
 
 RemoveFiles=
         /usr/share/locale/*


### PR DESCRIPTION
It is now a dlopen optional dep so it's only recommended by the packages, so pull it in like libcryptsetup and libfido2.