### PR TITLE
mkosi-initrd: install systemd-container in network profile

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.profiles/network/mkosi.conf.d/systemd-container.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.profiles/network/mkosi.conf.d/systemd-container.conf
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=!arch
+
+[Content]
+Packages=systemd-container


### PR DESCRIPTION
In fedora/suse/debian/ubuntu systemd-importd is in this package, which is used to pull the remote DDI in the netboot case