### PR TITLE
preset: drop systemd-networkd-wait-online.service

### DIFF
--- a/mkosi.extra/usr/lib/systemd/system-preset/00-mkosi.preset
+++ b/mkosi.extra/usr/lib/systemd/system-preset/00-mkosi.preset
@@ -9,7 +9,6 @@ enable dbus-broker.service
 
 # Make sure we have networking available.
 enable systemd-networkd.service
-enable systemd-networkd-wait-online.service
 enable systemd-resolved.service
 
 # We install dnf in some images but it's only going to be used rarely,


### PR DESCRIPTION
networkd already enables it via Also= and in some cases we want to disable it, so drop it