### PR TITLE
Treat default initrd as a regular subimage

### DIFF
--- a/mkosi/distributions/__init__.py
+++ b/mkosi/distributions/__init__.py
@@ -72,6 +72,10 @@ class DistributionInstaller:
     def latest_snapshot(cls, config: "Config") -> str:
         die(f"{cls.pretty_name()} does not support snapshots")
 
+    @classmethod
+    def is_kernel_package(cls, package: str) -> bool:
+        return False
+
 
 class Distribution(StrEnum):
     # Please consult docs/distribution-policy.md and contact one
@@ -157,6 +161,9 @@ class Distribution(StrEnum):
 
     def latest_snapshot(self, config: "Config") -> str:
         return self.installer().latest_snapshot(config)
+
+    def is_kernel_package(self, package: str) -> bool:
+        return self.installer().is_kernel_package(package)
 
     def installer(self) -> type[DistributionInstaller]:
         modname = str(self).replace("-", "_")

--- a/mkosi/distributions/arch.py
+++ b/mkosi/distributions/arch.py
@@ -130,3 +130,7 @@ class Installer(DistributionInstaller):
         return datetime.datetime.fromtimestamp(int(curl(config, url)), datetime.timezone.utc).strftime(
             "%Y/%m/%d"
         )
+
+    @classmethod
+    def is_kernel_package(cls, package: str) -> bool:
+        return package in ("kernel", "linux-lts", "linux-zen", "linux-hardened", "linux-rt", "linux-rt-lts")

--- a/mkosi/distributions/centos.py
+++ b/mkosi/distributions/centos.py
@@ -471,3 +471,7 @@ class Installer(DistributionInstaller):
                 return snapshot
 
         die("composeinfo is missing compose ID field")
+
+    @classmethod
+    def is_kernel_package(cls, package: str) -> bool:
+        return package in ("kernel", "kernel-core")

--- a/mkosi/distributions/debian.py
+++ b/mkosi/distributions/debian.py
@@ -248,6 +248,10 @@ class Installer(DistributionInstaller):
         url = join_mirror(config.mirror or "https://snapshot.debian.org", "mr/timestamp")
         return cast(str, json.loads(curl(config, url))["result"]["debian"][-1])
 
+    @classmethod
+    def is_kernel_package(cls, package: str) -> bool:
+        return package.startswith("linux-image-")
+
 
 def install_apt_sources(context: Context, repos: Iterable[AptRepository]) -> None:
     sources = context.root / f"etc/apt/sources.list.d/{context.config.release}.sources"

--- a/mkosi/distributions/fedora.py
+++ b/mkosi/distributions/fedora.py
@@ -267,3 +267,7 @@ class Installer(DistributionInstaller):
         )
 
         return curl(config, url).removeprefix(f"Fedora-{config.release.capitalize()}-").strip()
+
+    @classmethod
+    def is_kernel_package(cls, package: str) -> bool:
+        return package in ("kernel", "kernel-core")

--- a/mkosi/distributions/opensuse.py
+++ b/mkosi/distributions/opensuse.py
@@ -258,6 +258,10 @@ class Installer(DistributionInstaller):
         url = join_mirror(config.mirror or "https://download.opensuse.org", "history/latest")
         return curl(config, url).strip()
 
+    @classmethod
+    def is_kernel_package(cls, package: str) -> bool:
+        return package in ("kernel-default", "kernel-kvmsmall")
+
 
 def fetch_gpgurls(context: Context, repourl: str) -> tuple[str, ...]:
     gpgurls = [f"{repourl}/repodata/repomd.xml.key"]

--- a/mkosi/distributions/postmarketos.py
+++ b/mkosi/distributions/postmarketos.py
@@ -109,3 +109,8 @@ class Installer(DistributionInstaller):
             die(f"Architecture {a} is not supported by postmarketOS")
 
         return a
+
+    @classmethod
+    def is_kernel_package(cls, package: str) -> bool:
+        # TODO: Cover all of postmarketos's kernel packages.
+        return package == "linux-virt"

--- a/mkosi/distributions/ubuntu.py
+++ b/mkosi/distributions/ubuntu.py
@@ -106,3 +106,7 @@ class Installer(debian.Installer):
                     locale.setlocale(locale.LC_TIME, lc)
 
         die("Release file is missing Date field")
+
+    @classmethod
+    def is_kernel_package(cls, package: str) -> bool:
+        return package.startswith("linux-")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -223,8 +223,10 @@ def test_parse_config(tmp_path: Path) -> None:
     (d / "abc/mkosi.conf").write_text(
         """\
         [Content]
-        Bootable=yes
         BuildPackages=abc
+
+        [Runtime]
+        CXL=yes
         """
     )
     (d / "abc/mkosi.conf.d").mkdir()
@@ -237,19 +239,19 @@ def test_parse_config(tmp_path: Path) -> None:
 
     with chdir(d):
         _, _, [config] = parse_config()
-        assert config.bootable == ConfigFeature.auto
+        assert not config.cxl
         assert config.split_artifacts == ArtifactOutput.compat_no()
 
         # Passing the directory should include both the main config file and the dropin.
         _, _, [config] = parse_config(["--include", os.fspath(d / "abc")] * 2)
-        assert config.bootable == ConfigFeature.enabled
+        assert config.cxl
         assert config.split_artifacts == ArtifactOutput.compat_yes()
         # The same extra config should not be parsed more than once.
         assert config.build_packages == ["abc"]
 
         # Passing the main config file should not include the dropin.
         _, _, [config] = parse_config(["--include", os.fspath(d / "abc/mkosi.conf")])
-        assert config.bootable == ConfigFeature.enabled
+        assert config.cxl
         assert config.split_artifacts == ArtifactOutput.compat_no()
 
     (d / "mkosi.images").mkdir()
@@ -318,7 +320,6 @@ def test_parse_includes_once(tmp_path: Path) -> None:
     (d / "mkosi.conf").write_text(
         """\
         [Content]
-        Bootable=yes
         BuildPackages=abc
         """
     )


### PR DESCRIPTION
Currently, because we build the default initrd as a substep of building
a regular image, we have lots of special cased logic for it and we still
propagate settings manually from the regular image to its default initrd.

Let's streamline this by treating the default initrd as a regular image.
The only complication about making this change is that we used to build
the default initrd on demand only if a kernel was actually installed into
the image. Because we have to make the decision of whether to build the
default initrd or not way earlier now, we can't check if kernels were
installed into the image or not. Instead, we check if any known kernel
packages are listed to be installed which should be a decent enough
heuristic.

Another regression is that the default initrd won't have access to any
packages built as part of the main image build anymore. We used to rely
on this in systemd but now we build the systemd packages in a separate
build subimage and those will still be available to the default initrd
image build.