### PR TITLE
Do not relabel files when building extension image

### DIFF
--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -24,6 +24,7 @@ def test_extension(config: ImageConfig, format: OutputFormat) -> None:
                     "--incremental=no",
                     "--base-tree", Path(image.output_dir) / "image",
                     "--overlay=yes",
+                    "--selinux-relabel=no",
                     "--package=lsof",
                     f"--format={format}",
                 ]


### PR DESCRIPTION
We disable relabelling for the main image, let's make sure we disable it for the extension images we build as well.