### PR TITLE
config: serialize dataclass instances in our JSONEncoder

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -5784,6 +5784,8 @@ class JsonEncoder(json.JSONEncoder):
             return str(o)
         elif isinstance(o, (Args, Config)):
             return o.to_dict()
+        elif dataclasses.is_dataclass(o) and not isinstance(o, type):
+            return dataclasses.asdict(o)
         return super().default(o)
 
 


### PR DESCRIPTION
During config parsing we have partial dictionaries of our config, that are not
our Config object, but that we need to serialize as well. These may contain
dataclass instances such as ConfigTree objects on which the default encoder
chokes.

Fixes: #3924