### PR TITLE
postmarketos: provide missing i386-vars.fd

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.profiles/runtime/mkosi.conf.d/postmarketos/mkosi.conf.d/x86-64.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/runtime/mkosi.conf.d/postmarketos/mkosi.conf.d/x86-64.conf
@@ -6,4 +6,5 @@ Architecture=x86-64
 [Content]
 Packages=
         ovmf
+        qemu-system-i386
         qemu-system-x86_64


### PR DESCRIPTION
qemu on x86_64 seems to want this thing, and on Alpine it's in the qemu-systemd-i386 pkg.

Fixes:
    ‣ + /usr/bin/qemu-system-x86_64 --version
    ...
    ‣ Using 60-edk2-x86_64.json firmware description
    ‣ Firmware variables file mkosi.tools/usr/share/qemu/edk2-i386-vars.fd does not exist