### PR TITLE
postmarketos: implement is_kernel_package

### DIFF
--- a/mkosi/distributions/postmarketos.py
+++ b/mkosi/distributions/postmarketos.py
@@ -112,5 +112,21 @@ class Installer(DistributionInstaller):
 
     @classmethod
     def is_kernel_package(cls, package: str) -> bool:
-        # TODO: Cover all of postmarketos's kernel packages.
-        return package == "linux-virt"
+        if not package.startswith("linux-"):
+            return False
+
+        if package.endswith(("-doc", "-dev", "-manual")):
+            return False
+
+        # These pkgs end with many different things
+        if package.startswith(("linux-tools-", "linux-firmware-")):
+            return False
+
+        if package in {
+            "linux-timemachine",
+            "linux-headers",
+            "linux-apfs-rw-src",
+        }:
+            return False
+
+        return True


### PR DESCRIPTION
There are many many kernel packages in pmOS+Alpine and the pkg names don't follow any specific pattern that sets them apart from some other non-kernel packages, so the implementation tries to exclude known pkgs that are not kernels and assume anything that doesn't match these package names/patterns are kernel packages.