### PR TITLE
action: make it work when used as a submodule

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -80,7 +80,7 @@ runs:
     - name: Ensure git history is available
       shell: bash
       run: |
-        if [[ ! -d "${{ github.action_path }}/.git" ]]; then
+        if [[ ! -e "${{ github.action_path }}/.git" ]]; then
             rm -rf "${{ github.action_path }}"
             git clone "https://github.com/${{ inputs.action_repository }}" "${{ github.action_path }}"
             git -C "${{ github.action_path }}" checkout "${{ inputs.action_ref }}"


### PR DESCRIPTION
When consuming the mkosi GitHub action from a submodule (e.g. in https://github.com/davide125/arcadeos/pull/10), `.git` will be a text file, not a folder, so the check fails. Make it more generic to cover this scenario as well.