### PR TITLE
Make sure not all subimages depend on default-initrd subimage

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -5425,10 +5425,14 @@ def parse_config(
             )
 
         subimages = [
-            dataclasses.replace(
-                image,
-                initrds=[*image.initrds, initrd.output_dir_or_cwd() / initrd.output],
-                dependencies=image.dependencies + [initrd.image],
+            (
+                dataclasses.replace(
+                    image,
+                    initrds=[*image.initrds, initrd.output_dir_or_cwd() / initrd.output],
+                    dependencies=image.dependencies + [initrd.image],
+                )
+                if want_default_initrd(image)
+                else image
             )
             for image in subimages
         ]


### PR DESCRIPTION
Subimages should only depend on the default initrd if they need one.