### PR TITLE
Do not build default initrd if Initrds= is specified

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -5221,6 +5221,9 @@ def want_default_initrd(config: Config) -> bool:
     if not want_kernel(config):
         return False
 
+    if config.initrds:
+        return False
+
     if config.bootable == ConfigFeature.auto and not any(
         config.distribution.is_kernel_package(p)
         for p in itertools.chain(config.packages, config.volatile_packages)

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1082,10 +1082,12 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 :   Use user-provided initrd(s). Takes a comma-separated list of paths to initrd
     files. This option may be used multiple times in which case the initrd lists
     are combined. If no initrds are specified and a bootable image is requested,
-    **mkosi** will look for initrds in a subdirectory `io.mkosi.initrd` of the
-    artifact directory (see `$ARTIFACTDIR` in the section **ENVIRONMENT
-    VARIABLES**), if none are found there **mkosi** will automatically build a
-    default initrd.
+    **mkosi** will automatically build a default initrd.
+
+    **mkosi** will also look for initrds in a subdirectory `io.mkosi.initrd` of
+    the artifact directory (see `$ARTIFACTDIR` in the section **ENVIRONMENT
+    VARIABLES**). Any initrds found there are appended to the user-provided
+    initrd(s) and any default initrd built by mkosi.
 
 `InitrdProfiles=`, `--initrd-profile=`
 :   Set the profiles to enable for the default initrd. Takes a


### PR DESCRIPTION
Fixes https://github.com/systemd/systemd/issues/39309

Also update the documentation of Initrds= to match the new behavior since 30956dc4bbd27c50b03f3bb14b1591c2a993eae2.