### PR TITLE
ubuntu: Switch to devel as the default release

### DIFF
--- a/mkosi.conf.d/ubuntu.conf
+++ b/mkosi.conf.d/ubuntu.conf
@@ -4,5 +4,5 @@
 Distribution=ubuntu
 
 [Distribution]
-Release=noble
+Release=devel
 Repositories=universe

--- a/mkosi/distributions/ubuntu.py
+++ b/mkosi/distributions/ubuntu.py
@@ -21,7 +21,7 @@ class Installer(debian.Installer):
 
     @classmethod
     def default_release(cls) -> str:
-        return "noble"
+        return "devel"
 
     @classmethod
     def default_tools_tree_distribution(cls) -> Distribution:


### PR DESCRIPTION
Same reasoning as for the other distros, devel will always point to something recent, whereas hardcoding stable release names will get out of date very soon.