### PR TITLE
Don't fix up vmlinuz locations if not required

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1309,6 +1309,17 @@ def kernel_get_ver_from_modules(context: Context) -> Optional[str]:
 
 
 def fixup_vmlinuz_location(context: Context) -> None:
+    modulesd = Path("usr/lib/modules")
+
+    if not (context.root / modulesd).exists():
+        return
+
+    # Don't touch anything if all the modules directories contain a kernel image already.
+    if all(
+        (d / "vmlinuz").is_file() or (d / "vmlinux").is_file() for d in (context.root / modulesd).iterdir()
+    ):
+        return
+
     # Some architectures ship an uncompressed vmlinux (ppc64el, riscv64)
     for type in ("vmlinuz", "vmlinux"):
         for d in context.root.glob(f"boot/{type}-*"):


### PR DESCRIPTION
If we already have a kernel image for every directory in /usr/lib/modules then there's no need to do anything.

Fixes #3949