### PR TITLE
Look for .sdmagic before we consider a PE binary a UKI/addon

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -29,6 +29,7 @@ from typing import Any, Optional, Union, cast
 
 from mkosi.archive import can_extract_tar, extract_tar, make_cpio, make_tar
 from mkosi.bootloader import (
+    KernelType,
     efi_boot_binary,
     extract_pe_section,
     gen_kernel_images,
@@ -106,7 +107,6 @@ from mkosi.mounts import (
 from mkosi.pager import page
 from mkosi.partition import Partition, finalize_root, finalize_roothash
 from mkosi.qemu import (
-    KernelType,
     copy_ephemeral,
     finalize_credentials,
     finalize_kernel_command_line_extra,


### PR DESCRIPTION
In ubuntu devel they started using the stubble bootloader for their kernel images which includes a .linux and a .osrel section which means it identifies as a UKI so we skip it. Let's additionally look for .sdmagic as a workaround to fix this for now.

To implement this we can't make use of bootctl kernel-identify anymore so we reimplement the logic ourselves with pefile. While we're at it, we move KernelType to bootloader.py as it makes more sense to live there than in qemu.py.