### PR TITLE
Make sure apt sources are installed when BaseTrees= is in the mix

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -268,7 +268,7 @@ def install_distribution(context: Context) -> None:
         with complete_step(
             f"Installing extra packages for {context.config.distribution.installer.pretty_name()}"
         ):
-            context.config.distribution.installer.package_manager(context.config).install(context, packages)
+            context.config.distribution.installer.install_packages(context, packages)
     else:
         if context.config.overlay or context.config.output_format.is_extension_image():
             if packages:
@@ -307,9 +307,7 @@ def install_distribution(context: Context) -> None:
                 (context.root / "boot/loader/entries.srel").write_text("type1\n")
 
             if packages:
-                context.config.distribution.installer.package_manager(context.config).install(
-                    context, packages
-                )
+                context.config.distribution.installer.install_packages(context, packages)
 
     for f in (
         "var/lib/systemd/random-seed",
@@ -333,9 +331,7 @@ def install_build_packages(context: Context) -> None:
         ),
         setup_build_overlay(context),
     ):
-        context.config.distribution.installer.package_manager(context.config).install(
-            context, context.config.build_packages
-        )
+        context.config.distribution.installer.install_packages(context, context.config.build_packages)
 
 
 def install_volatile_packages(context: Context) -> None:
@@ -345,7 +341,7 @@ def install_volatile_packages(context: Context) -> None:
     with complete_step(
         f"Installing volatile packages for {context.config.distribution.installer.pretty_name()}"
     ):
-        context.config.distribution.installer.package_manager(context.config).install(
+        context.config.distribution.installer.install_packages(
             context, context.config.volatile_packages, allow_downgrade=True
         )
 

--- a/mkosi/distribution/__init__.py
+++ b/mkosi/distribution/__init__.py
@@ -3,6 +3,7 @@
 import enum
 import importlib
 import urllib.parse
+from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
@@ -100,6 +101,22 @@ class DistributionInstaller:
     @classmethod
     def install(cls, context: "Context") -> None:
         raise NotImplementedError
+
+    @classmethod
+    def install_packages(
+        cls,
+        context: "Context",
+        packages: Sequence[str],
+        *,
+        apivfs: bool = True,
+        allow_downgrade: bool = False,
+    ) -> None:
+        return cls.package_manager(context.config).install(
+            context,
+            packages,
+            apivfs=apivfs,
+            allow_downgrade=allow_downgrade,
+        )
 
     @classmethod
     def filesystem(cls) -> str:

--- a/mkosi/distribution/arch.py
+++ b/mkosi/distribution/arch.py
@@ -62,7 +62,7 @@ class Installer(DistributionInstaller, distribution=Distribution.arch):
 
     @classmethod
     def install(cls, context: Context) -> None:
-        Pacman.install(context, ["filesystem"], apivfs=False)
+        cls.install_packages(context, ["filesystem"], apivfs=False)
 
     @classmethod
     def repositories(cls, context: Context) -> Iterable[PacmanRepository]:

--- a/mkosi/distribution/azure.py
+++ b/mkosi/distribution/azure.py
@@ -34,7 +34,7 @@ class Installer(fedora.Installer, distribution=Distribution.azure):
 
     @classmethod
     def install(cls, context: Context) -> None:
-        Dnf.install(context, ["filesystem", "azurelinux-release"], apivfs=False)
+        cls.install_packages(context, ["filesystem", "azurelinux-release"], apivfs=False)
 
     @classmethod
     def repositories(cls, context: Context) -> Iterable[RpmRepository]:

--- a/mkosi/distribution/centos.py
+++ b/mkosi/distribution/centos.py
@@ -79,7 +79,7 @@ class Installer(DistributionInstaller, distribution=Distribution.centos):
 
     @classmethod
     def install(cls, context: Context) -> None:
-        Dnf.install(context, ["basesystem"], apivfs=False)
+        cls.install_packages(context, ["basesystem"], apivfs=False)
 
     @classmethod
     def architecture(cls, arch: Architecture) -> str:

--- a/mkosi/distribution/fedora.py
+++ b/mkosi/distribution/fedora.py
@@ -137,7 +137,7 @@ class Installer(DistributionInstaller, distribution=Distribution.fedora):
 
     @classmethod
     def install(cls, context: Context) -> None:
-        Dnf.install(context, ["basesystem"], apivfs=False)
+        cls.install_packages(context, ["basesystem"], apivfs=False)
 
     @classmethod
     def repositories(cls, context: Context) -> Iterable[RpmRepository]:

--- a/mkosi/distribution/mageia.py
+++ b/mkosi/distribution/mageia.py
@@ -5,7 +5,6 @@ from collections.abc import Iterable
 from mkosi.config import Architecture
 from mkosi.context import Context
 from mkosi.distribution import Distribution, fedora, join_mirror
-from mkosi.installer.dnf import Dnf
 from mkosi.installer.rpm import RpmRepository, find_rpm_gpgkey
 from mkosi.log import die
 
@@ -25,7 +24,7 @@ class Installer(fedora.Installer, distribution=Distribution.mageia):
 
     @classmethod
     def install(cls, context: Context) -> None:
-        Dnf.install(context, ["filesystem"], apivfs=False)
+        cls.install_packages(context, ["filesystem"], apivfs=False)
 
     @classmethod
     def repositories(cls, context: Context) -> Iterable[RpmRepository]:

--- a/mkosi/distribution/openmandriva.py
+++ b/mkosi/distribution/openmandriva.py
@@ -5,7 +5,6 @@ from collections.abc import Iterable
 from mkosi.config import Architecture
 from mkosi.context import Context
 from mkosi.distribution import Distribution, fedora, join_mirror
-from mkosi.installer.dnf import Dnf
 from mkosi.installer.rpm import RpmRepository, find_rpm_gpgkey
 from mkosi.log import die
 
@@ -25,7 +24,7 @@ class Installer(fedora.Installer, distribution=Distribution.openmandriva):
 
     @classmethod
     def install(cls, context: Context) -> None:
-        Dnf.install(context, ["filesystem"], apivfs=False)
+        cls.install_packages(context, ["filesystem"], apivfs=False)
 
     @classmethod
     def repositories(cls, context: Context) -> Iterable[RpmRepository]:

--- a/mkosi/distribution/opensuse.py
+++ b/mkosi/distribution/opensuse.py
@@ -57,7 +57,7 @@ class Installer(DistributionInstaller, distribution=Distribution.opensuse):
         if not any(p.endswith("-release") for p in context.config.packages):
             packages += ["openSUSE-release"]
 
-        cls.package_manager(context.config).install(context, packages, apivfs=False)
+        cls.install_packages(context, packages, apivfs=False)
 
     @classmethod
     def repositories(cls, context: Context) -> Iterable[RpmRepository]:

--- a/mkosi/distribution/postmarketos.py
+++ b/mkosi/distribution/postmarketos.py
@@ -71,7 +71,7 @@ class Installer(DistributionInstaller, distribution=Distribution.postmarketos):
             (context.root / "usr" / dir).mkdir(parents=True, exist_ok=True)
             (context.root / dir).symlink_to(f"usr/{dir}")
 
-        Apk.install(context, ["postmarketos-baselayout", "postmarketos-release"], apivfs=False)
+        cls.install_packages(context, ["postmarketos-baselayout", "postmarketos-release"], apivfs=False)
 
     @classmethod
     def repositories(cls, context: Context) -> Iterable[ApkRepository]:


### PR DESCRIPTION
Let's make sure to install apt sources every time we install the apt package, even if BaseTrees= or volatile packages or such are in the mix.

To make this work we unfortunately have to reintroduce install_packages().

While we're at it, make sure the installed apt sources don't use the configured mirror or snapshot. We only install a default set of sources and for anything custom users should install their own sources.