### PR TITLE
Prevent using Overlay=yes with Format=portable

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2694,6 +2694,16 @@ def check_inputs(config: Config) -> None:
     ):
         die(f"A cache directory must be configured in order to use CacheOnly={config.cacheonly}")
 
+    if config.output_format == OutputFormat.portable and config.overlay:
+        die(
+            "Overlay=yes cannot be used with Format=portable",
+            hint=(
+                "Portable service images are always full images and cannot be overlay images.\n"
+                "See https://systemd.io/PORTABLE_SERVICES/#extension-images for how to use extension\n"
+                "images with portable services."
+            ),
+        )
+
 
 def check_tool(config: Config, *tools: PathString, reason: str, hint: Optional[str] = None) -> Path:
     tool = config.find_binary(*tools)

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -736,8 +736,7 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     initially empty. Thus files that are not modified compared to the base trees
     will not be present in the final output.
 
-    This option may be used to create [systemd *system extensions* or
-    *portable services*](https://uapi-group.org/specifications/specs/extension_image).
+    This option may be used to create [systemd *system extensions*](https://uapi-group.org/specifications/specs/extension_image).
 
 `Seed=`, `--seed=`
 :   Takes a UUID as argument or the special value `random`.


### PR DESCRIPTION
Portable services cannot be extension images so let's error out early if anyone tries to do that.

Fixes #3927