### PR TITLE
Allow users to disable custom console background color

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -80,6 +80,7 @@ from mkosi.config import (
     parse_config,
     resolve_deps,
     summary,
+    systemd_pty_forward,
     systemd_tool_version,
     want_kernel,
     want_selinux_relabel,
@@ -4059,13 +4060,8 @@ def run_box(args: Args, config: Config) -> None:
 
     cmdline = [*args.cmdline]
 
-    if sys.stdin.isatty() and sys.stdout.isatty() and config.find_binary("systemd-pty-forward"):
-        cmdline = [
-            "systemd-pty-forward",
-            "--title=mkosi-sandbox",
-            "--background=48;2;12;51;51",  # cyan
-            *cmdline,
-        ]
+    if sys.stdin.isatty() and sys.stdout.isatty():
+        cmdline = systemd_pty_forward(config, "48;2;12;51;51", "mkosi-sandbox") + cmdline
 
     with contextlib.ExitStack() as stack:
         if config.tools() != Path("/"):

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -6036,3 +6036,24 @@ def systemd_tool_version(*tool: PathString, sandbox: SandboxProtocol = nosandbox
     logging.debug(f"Version reported by {tool[-1]} is {version}")
 
     return version
+
+
+def systemd_pty_forward(config: Config, background: str, title: str) -> list[str]:
+    tint_bg = parse_boolean(config.environment.get("SYSTEMD_TINT_BACKGROUND", "1")) and parse_boolean(
+        os.environ.get("SYSTEMD_TINT_BACKGROUND", "1")
+    )
+    adjust_title = parse_boolean(
+        config.environment.get("SYSTEMD_ADJUST_TERMINAL_TITLE", "1")
+    ) and parse_boolean(os.environ.get("SYSTEMD_ADJUST_TERMINAL_TITLE", "1"))
+
+    if not tint_bg and not adjust_title:
+        return []
+    if not config.find_binary("systemd-pty-forward"):
+        return []
+
+    cmd = ["systemd-pty-forward"]
+    if tint_bg:
+        cmd += [f"--background={background}"]
+    if adjust_title:
+        cmd += ["--title=", title]
+    return cmd

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -43,6 +43,7 @@ from mkosi.config import (
     VsockCID,
     finalize_term,
     format_bytes,
+    systemd_pty_forward,
     systemd_tool_version,
     want_selinux_relabel,
     yes_no,
@@ -1183,10 +1184,9 @@ def run_qemu(args: Args, config: Config) -> None:
     cmdline: list[PathString] = []
 
     if config.console in (ConsoleMode.interactive, ConsoleMode.read_only):
-        cmdline += [
-            "systemd-pty-forward", "--background=48;2;12;51;19",  # green
-            "--title", f"Virtual Machine {config.machine_or_name()}",
-        ]  # fmt: skip
+        cmdline += systemd_pty_forward(
+            config, "48;2;12;51;19", f"Virtual Machine {config.machine_or_name()}"
+        )
 
         if config.console == ConsoleMode.read_only:
             cmdline += ["--read-only"]


### PR DESCRIPTION
When mkosi creates a new console with systemd-pty-forward, it sets a custom (dark) color, which might not play nice depending on your terminal theme.

Introduce the WithConsoleBackground= [Runtime] option to disable with behaviour. Custom console background is enabled by default, so the current behaviour is not modified.