### PR TITLE
Match compressed pacman packages too

### DIFF
--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -40,7 +40,7 @@ class Pacman(PackageManager):
 
     @classmethod
     def package_globs(cls) -> list[str]:
-        return ["*.pkg.tar"]
+        return ["*.pkg.tar*"]
 
     @classmethod
     def state_subdirs(cls, state: Path) -> list[Path]:


### PR DESCRIPTION
Arch packages can be compressed using various codecs, in which case the package filename is suffixed with the compression method (e.g. .zst for zstandard compression). Make sure to find such compressed packages in the volatile package directory exposed to the build script as $PACKAGEDIR, so they are installable using VolatilePackages=.

Fixes: 71ffced0 ("Rework PACKAGE_GLOBS to be a PackageManager classmethod")