### PR TITLE
arch: Switch to the newly established fastly mirror

### DIFF
--- a/mkosi/distribution/arch.py
+++ b/mkosi/distribution/arch.py
@@ -80,7 +80,7 @@ class Installer(DistributionInstaller, distribution=Distribution.arch):
                 elif context.config.snapshot:
                     mirror = "https://archive.archlinux.org"
                 else:
-                    mirror = "https://geo.mirror.pkgbuild.com"
+                    mirror = "https://fastly.mirror.pkgbuild.com"
 
             if context.config.snapshot:
                 url = join_mirror(mirror, f"repos/{context.config.snapshot}/$repo/os/$arch")

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -516,21 +516,21 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     The default mirrors for each distribution are as follows (unless
     specified, the same mirror is used for all architectures):
 
-    |                | x86-64                            | aarch64                        |
-    |----------------|-----------------------------------|--------------------------------|
-    | `debian`       | http://deb.debian.org             |                                |
-    | `arch`         | https://geo.mirror.pkgbuild.com   | http://mirror.archlinuxarm.org |
-    | `opensuse`     | http://download.opensuse.org      |                                |
-    | `kali`         | http://http.kali.org/kali         |                                |
-    | `ubuntu`       | http://archive.ubuntu.com         | http://ports.ubuntu.com        |
-    | `centos`       | https://mirrors.centos.org        |                                |
-    | `rocky`        | https://mirrors.rockylinux.org    |                                |
-    | `alma`         | https://mirrors.almalinux.org     |                                |
-    | `fedora`       | https://mirrors.fedoraproject.org |                                |
-    | `rhel-ubi`     | https://cdn-ubi.redhat.com        |                                |
-    | `mageia`       | https://www.mageia.org            |                                |
-    | `openmandriva` | http://mirrors.openmandriva.org   |                                |
-    | `azure`        | https://packages.microsoft.com/   |                                |
+    |                | x86-64                             | aarch64                        |
+    |----------------|------------------------------------|--------------------------------|
+    | `debian`       | http://deb.debian.org              |                                |
+    | `arch`         | https://fastly.mirror.pkgbuild.com | http://mirror.archlinuxarm.org |
+    | `opensuse`     | http://download.opensuse.org       |                                |
+    | `kali`         | http://http.kali.org/kali          |                                |
+    | `ubuntu`       | http://archive.ubuntu.com          | http://ports.ubuntu.com        |
+    | `centos`       | https://mirrors.centos.org         |                                |
+    | `rocky`        | https://mirrors.rockylinux.org     |                                |
+    | `alma`         | https://mirrors.almalinux.org      |                                |
+    | `fedora`       | https://mirrors.fedoraproject.org  |                                |
+    | `rhel-ubi`     | https://cdn-ubi.redhat.com         |                                |
+    | `mageia`       | https://www.mageia.org             |                                |
+    | `openmandriva` | http://mirrors.openmandriva.org    |                                |
+    | `azure`        | https://packages.microsoft.com/    |                                |
 
 `Snapshot=`
 :   Download packages from the given snapshot instead of downloading the latest


### PR DESCRIPTION
Since we can expect quite good caching results for CI-type setups it
might make sense to use this new mirror as a default for mkosi.

---

cc @antiz96 @pitastrudl
