### PR TITLE
log: terminate OSC escape sequences with ST code

### DIFF
--- a/mkosi/log.py
+++ b/mkosi/log.py
@@ -16,6 +16,11 @@ ARG_DEBUG_SHELL = contextvars.ContextVar("debug-shell", default=False)
 ARG_DEBUG_SANDBOX = contextvars.ContextVar("debug-sandbox", default=False)
 LEVEL = 0
 
+# Terminal control characters
+ESCAPE_CODE_OSC = "\033]"
+ESCAPE_CODE_ST = "\033\\"
+ESCAPE_CODE_CSI = "\033["
+
 
 def die(message: str, *, hint: Optional[str] = None) -> NoReturn:
     logging.error(f"{message}")
@@ -33,11 +38,11 @@ def log_step(text: str) -> None:
         # easily which step generated the exception. The exception
         # or error will only be printed after we finish cleanup.
         if not terminal_is_dumb():
-            print(f"\033]0;mkosi: {text}", file=sys.stderr, end="")
+            print(f"{ESCAPE_CODE_OSC}0;mkosi: {text}{ESCAPE_CODE_ST}", file=sys.stderr, end="")
         logging.info(f"{prefix}({text})")
     else:
         if not terminal_is_dumb():
-            print(f"\033]0;mkosi: {text}", file=sys.stderr, end="")
+            print(f"{ESCAPE_CODE_OSC}0;mkosi: {text}{ESCAPE_CODE_ST}", file=sys.stderr, end="")
         logging.info(f"{prefix}{Style.bold}{text}{Style.reset}")
 
 
@@ -96,10 +101,10 @@ def stash_terminal_title() -> Iterator[None]:
     try:
         # push terminal window title to stack
         if not terminal_is_dumb():
-            print("\033[22t", file=sys.stderr, end="")
+            print(f"{ESCAPE_CODE_CSI}22t", file=sys.stderr, end="")
 
         yield
     finally:
         # pop terminal window title from stack to reset
         if not terminal_is_dumb():
-            print("\033[23t", file=sys.stderr, end="")
+            print(f"{ESCAPE_CODE_CSI}23t", file=sys.stderr, end="")


### PR DESCRIPTION
Commit f26cb341 introduced some OSC escape sequences that resulted in all mkosi output being hidden when using the Kitty terminal: https://github.com/kovidgoyal/kitty/issues/9139

This commit rectifies the situation by correctly sending the `ST` code after `OSC` has been sent, thereby ending the OSC sequence.

<img width="1116" height="857" alt="image" src="https://github.com/user-attachments/assets/7c5b8e59-2cc1-4b31-894e-a9f669641e0c" />


Ref:
- https://en.wikipedia.org/wiki/ANSI_escape_code#Operating_System_Command_sequences
- https://sw.kovidgoyal.net/kitty/shell-integration/#notes-for-shell-developers
- https://ghostty.org/docs/vt/concepts/sequences#osc-sequences