### PR TITLE
mkosi-vm: Enable universe repository for ubuntu in mkosi-vm

### DIFF
--- a/mkosi/resources/mkosi-vm/mkosi.conf.d/ubuntu.conf
+++ b/mkosi/resources/mkosi-vm/mkosi.conf.d/ubuntu.conf
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=ubuntu
+
+[Distribution]
+Repositories=universe


### PR DESCRIPTION
dbus-broker, systemd-boot and various other packages installed by mkosi-vm come from the universe repository, so let's enable it for the mkosi-vm config.