### PR TITLE
log: Drop konsole hack

### DIFF
--- a/mkosi/log.py
+++ b/mkosi/log.py
@@ -46,8 +46,7 @@ class ConsoleCodes:
 
     @classmethod
     def set_window_title(cls, title: str) -> str:
-        # The title is set twice, once for all terminal emulators that are not konsole and once for konsole
-        return f"{cls.OSC}0;mkosi: {title}{cls.ST}{cls.OSC}30;mkosi: {title}{cls.ST}"
+        return f"{cls.OSC}0;mkosi: {title}{cls.ST}"
 
     @classmethod
     def push_window_title(cls) -> str:


### PR DESCRIPTION
You have to configure
"Menu->Settings->Configure Konsole... ->General->"Show window title on the titlebar" and then konsole will show the window title as expected, so drop the hack.