### PR TITLE
sandbox: Drop all capabilities that don't make sense in userns

### DIFF
--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -349,6 +349,7 @@ def start_virtiofsd(
         "--sandbox=chroot",
         f"--inode-file-handles={'prefer' if os.getuid() == 0 and not uidmap else 'never'}",
         "--log-level=error",
+        "--modcaps=-mknod",
     ]  # fmt: skip
 
     if selinux:


### PR DESCRIPTION
When unsharing a user namespace, we get a full set of capabilities, of which a ton don't make sense to keep. Why drop them? Because it's possible that other tools check if they have the required capabilities to run, like systing now checking if it is invoked with CAP_BPF. If we don't drop CAP_BPF, systing will think it's able to attach BPF programs even though in reality it can't as CAP_BPF in a user namespace doesn't actually allow you to attach BPF programs.

While we're at it, let's be a bit more thorough with the capability logic and make sure we modify all capability sets to only contain the capabilities we want to keep.