### PR TITLE
PTY forward fixes

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4061,7 +4061,7 @@ def run_box(args: Args, config: Config) -> None:
     cmdline = [*args.cmdline]
 
     if sys.stdin.isatty() and sys.stdout.isatty():
-        cmdline = systemd_pty_forward(config, "48;2;12;51;51", "mkosi-sandbox") + cmdline
+        cmdline = systemd_pty_forward(config, background="48;2;12;51;51", title="mkosi-sandbox") + cmdline
 
     with contextlib.ExitStack() as stack:
         if config.tools() != Path("/"):

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -6038,7 +6038,12 @@ def systemd_tool_version(*tool: PathString, sandbox: SandboxProtocol = nosandbox
     return version
 
 
-def systemd_pty_forward(config: Config, background: str, title: str) -> list[str]:
+def systemd_pty_forward(
+    config: Config,
+    *,
+    background: Optional[str] = None,
+    title: Optional[str] = None,
+) -> list[str]:
     tint_bg = parse_boolean(config.environment.get("SYSTEMD_TINT_BACKGROUND", "1")) and parse_boolean(
         os.environ.get("SYSTEMD_TINT_BACKGROUND", "1")
     )
@@ -6052,8 +6057,8 @@ def systemd_pty_forward(config: Config, background: str, title: str) -> list[str
         return []
 
     cmd = ["systemd-pty-forward"]
-    if tint_bg:
-        cmd += [f"--background={background}"]
-    if adjust_title:
-        cmd += ["--title=", title]
+    if tint_bg and background:
+        cmd += ["--background", background]
+    if adjust_title and title:
+        cmd += ["--title", title]
     return cmd

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -1186,7 +1186,9 @@ def run_qemu(args: Args, config: Config) -> None:
 
     if config.console in (ConsoleMode.interactive, ConsoleMode.read_only):
         cmdline += systemd_pty_forward(
-            config, "48;2;12;51;19", f"Virtual Machine {config.machine_or_name()}"
+            config,
+            background="48;2;12;51;19",
+            title=f"Virtual Machine {config.machine_or_name()}",
         )
 
         if config.console == ConsoleMode.read_only:


### PR DESCRIPTION
--title= and the actual title were passed as two separate arguments. Fix by using --title instead of --title=.

Also only pass arguments if a background or title are provided respectively.

Also do some general cleanups.

Follow up for 8fe5df44005ce0f8c704f2839a44d988fb7d1ebb