### PR TITLE
installer: Only mount configured state subdirs into sandbox

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4726,6 +4726,10 @@ def sync_repository_metadata(
     for d in ("cache", "lib"):
         (metadata_dir / d / subdir).mkdir(parents=True, exist_ok=True)
 
+    src = metadata_dir / "lib" / subdir
+    for p in last.distribution.installer.package_manager(last).state_subdirs():
+        (src / p).mkdir(parents=True, exist_ok=True)
+
     (last.package_cache_dir_or_default() / "cache" / subdir).mkdir(parents=True, exist_ok=True)
 
     # Sync repository metadata unless explicitly disabled.
@@ -4753,7 +4757,6 @@ def sync_repository_metadata(
                     context,
                     force=context.args.force > 1 or context.config.cacheonly == Cacheonly.never,
                 )
-
         src = metadata_dir / "cache" / subdir
         dst = last.package_cache_dir_or_default() / "cache" / subdir
 

--- a/mkosi/installer/__init__.py
+++ b/mkosi/installer/__init__.py
@@ -30,7 +30,7 @@ class PackageManager:
         return []
 
     @classmethod
-    def state_subdirs(cls, state: Path) -> list[Path]:
+    def state_subdirs(cls) -> list[Path]:
         return []
 
     @classmethod
@@ -85,7 +85,12 @@ class PackageManager:
         subdir = context.config.distribution.installer.package_manager(context.config).subdir(context.config)
 
         src = context.metadata_dir / "lib" / subdir
-        mounts += ["--bind", src, Path("/var/lib") / subdir]
+        mounts += flatten(
+            ("--bind", src / state_subdir, Path("/var/lib") / subdir / state_subdir)
+            for state_subdir in context.config.distribution.installer.package_manager(
+                context.config
+            ).state_subdirs()
+        )
 
         src = context.metadata_dir / "cache" / subdir
         caches = context.config.distribution.installer.package_manager(context.config).package_subdirs(src)

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -64,8 +64,8 @@ class Apt(PackageManager):
         return ["*.deb", "*.ddeb"]
 
     @classmethod
-    def state_subdirs(cls, state: Path) -> list[Path]:
-        return [state / "lists"]
+    def state_subdirs(cls) -> list[Path]:
+        return [Path("lists")]
 
     @classmethod
     def dpkg_cmd(cls, command: str) -> list[PathString]:

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -43,8 +43,8 @@ class Pacman(PackageManager):
         return ["*.pkg.tar*"]
 
     @classmethod
-    def state_subdirs(cls, state: Path) -> list[Path]:
-        return [state / "sync"]
+    def state_subdirs(cls) -> list[Path]:
+        return [Path("sync")]
 
     @classmethod
     def scripts(cls, context: Context) -> dict[str, list[PathString]]:


### PR DESCRIPTION
This got lost somewhere with the countless refactorings. Let's not mount a state directory to /var/lib unless one is configured. Most package managers don't actually store anything there that we care about and if we use PackageCacheDirectory=/var, we might end up mounting too much state there, such as the pacman host db lock file.

Fixes #3985