### PR TITLE
run.py: always log the sandbox when a command fails

### DIFF
--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -125,10 +125,7 @@ def log_process_failure(sandbox: Sequence[str], cmdline: Sequence[str], returnco
         else:
             logging.error(f"{cmdline[0]} not found.")
     else:
-        logging.error(
-            f'"{shlex.join([*sandbox, *cmdline])}"'
-            f" returned non-zero exit code {returncode}."
-        )
+        logging.error(f'"{shlex.join([*sandbox, *cmdline])}" returned non-zero exit code {returncode}.')
 
 
 def run(


### PR DESCRIPTION
The main focus of commit https://github.com/systemd/mkosi/commit/7e7a3c71696d66d1774abff3eff80d5032612c88 ("Don't log sandbox for every
command") was to reduce verbosity in the --debug case and it did just
that. To avoid losing the sandbox completely, that commit said "... but
still log the full sandbox if a command fails" and it did that too in
`__init__.py`; for both the --debug and non-debug cases.

However, what happened in run.py was a bit different: there, commit
https://github.com/systemd/mkosi/commit/7e7a3c71696d66d1774abff3eff80d5032612c88 showed the sandox on failure but only in the --debug
case!? Make run.py consistent with `__init__.py` and always show the
sandbox on failure in run.py, in _both_ --debug and non-debug case.

This helps with issue https://github.com/systemd/mkosi/issues/3948: hiding that bind mounts exist is especially
confusing on fatal "disk full" failures because that leaves only
misleading paths in the error message! On failure, showing such critical
sandbox information must not require --debug.

Not concealing the sandbox on failure is useful in any case, not
just https://github.com/systemd/mkosi/issues/3948

Signed-off-by: Marc Herbert <marc.herbert@intel.com>