### PR TITLE
make_image: log systemd-repart *.conf files at the --debug level

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3390,6 +3390,15 @@ def make_image(
     ):
         env["SYSTEMD_REPART_MKFS_EXT4_OPTIONS"] = "-O ^orphan_file"
 
+    if ARG_DEBUG.get():
+        for dir in definitions:
+            for c in dir.glob("*.conf"):
+                # Do not spam the logs in case something goes wrong
+                logging.debug(f"# {c} (truncated to 100 lines)")
+                with open(c) as f:
+                    for line in itertools.islice(f, 100):
+                        logging.debug(line.strip())
+
     with complete_step(msg):
         output = json.loads(
             run_systemd_sign_tool(


### PR DESCRIPTION
As discussed in #3948, systemd-repart *.conf files have default values which is convenient until this fails with some dreaded "disk full" error \- then it becomes very mysterious. To considerably speed up the investigation about what exactly is full, show the configuration files in use when using --debug.