### PR TITLE
opensuse: fix Leap 16.0 build

### DIFF
--- a/mkosi/distribution/opensuse.py
+++ b/mkosi/distribution/opensuse.py
@@ -56,7 +56,12 @@ class Installer(DistributionInstaller, distribution=Distribution.opensuse):
     def install(cls, context: Context) -> None:
         packages = ["filesystem"]
         if not any(p.endswith("-release") for p in context.config.packages):
-            packages += ["openSUSE-release"]
+            if context.config.release in ("current", "stable", "leap") or (
+                context.config.release != "tumbleweed" and GenericVersion(context.config.release) >= 16
+            ):
+                packages += ["Leap-release"]
+            else:
+                packages += ["openSUSE-release"]
 
         cls.install_packages(context, packages, apivfs=False)
 


### PR DESCRIPTION
Regarding the first commit, see https://en.opensuse.org/Package_repositories#Update

```
Update

Repository of official security and bugfix updates for OSS packages.

Version: Tumbleweed http://download.opensuse.org/update/tumbleweed/
Version: Leap 16.0 No dedicated update repository as we use repo-oss for updates as well.
Version: Leap 15.6 http://download.opensuse.org/update/leap/15.6/oss/
```

I confirmed the change of the 2nd commit internally, but I haven't found any announcement.