### PR TITLE
Configure default tools tree with ToolsTree=yes

### DIFF
--- a/blog/content/a-reintroduction-to-mkosi.md
+++ b/blog/content/a-reintroduction-to-mkosi.md
@@ -275,7 +275,7 @@ mkosi depends on very recent versions of various systemd tools (v254 or
 newer). To support older distributions, we implemented so called tools
 trees. In short, `mkosi` can first build a tools image for you that
 contains all required tools to build the actual image. This can be
-enabled by adding `ToolsTree=default` to your mkosi configuration.
+enabled by adding `ToolsTree=yes` to your mkosi configuration.
 Building a tools image does not require a recent version of systemd.
 
 In the systemd mkosi configuration, we automatically use a tools tree if

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -13,7 +13,7 @@ Format=directory
 OutputDirectory=mkosi.output
 
 [Build]
-ToolsTree=default
+ToolsTree=yes
 Incremental=yes
 BuildSources=.
 

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2727,7 +2727,7 @@ def check_systemd_tool(
     if v < version:
         die(
             f"Found '{tool}' with version {v} but version {version} or newer is required to {reason}.",
-            hint=f"Use ToolsTree=default to get a newer version of '{tools[0]}'.",
+            hint=f"Use ToolsTree=yes to get a newer version of '{tools[0]}'.",
         )
 
 
@@ -2743,7 +2743,7 @@ def check_ukify(
     if v < version:
         die(
             f"Found '{ukify}' with version {v} but version {version} or newer is required to {reason}.",
-            hint="Use ToolsTree=default to get a newer version of 'ukify'.",
+            hint="Use ToolsTree=yes to get a newer version of 'ukify'.",
         )
 
 
@@ -2763,7 +2763,7 @@ def check_tools(config: Config, verb: Verb) -> None:
                     else "257"
                 ),
                 reason="build unified kernel image profiles",
-                hint=("Use ToolsTree=default to download most required tools including ukify automatically"),
+                hint=("Use ToolsTree=yes to download most required tools including ukify automatically"),
             )
         elif want_efi(config) and config.unified_kernel_images.enabled():
             check_ukify(
@@ -2771,7 +2771,7 @@ def check_tools(config: Config, verb: Verb) -> None:
                 version="254",
                 reason="build bootable images",
                 hint=(
-                    "Use ToolsTree=default to download most required tools including ukify "
+                    "Use ToolsTree=yes to download most required tools including ukify "
                     "automatically or use Bootable=no to create a non-bootable image which doesn't "
                     "require ukify"
                 ),

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1052,7 +1052,7 @@ def config_default_repository_key_fetch(namespace: dict[str, Any]) -> bool:
     def needs_repository_key_fetch(distribution: Distribution) -> bool:
         return distribution == Distribution.arch or distribution.is_rpm_distribution()
 
-    if namespace["tools_tree"] != Path("default"):
+    if namespace["tools_tree"] not in (Path("default"), Path("yes")):
         return (
             detect_distribution(namespace["tools_tree"] or Path("/"))[0] == Distribution.ubuntu
             and needs_repository_key_fetch(namespace["distribution"])
@@ -3606,7 +3606,7 @@ SETTINGS: list[ConfigSetting[Any]] = [
         dest="tools_tree",
         metavar="PATH",
         section="Build",
-        parse=config_make_path_parser(constants=("default",)),
+        parse=config_make_path_parser(constants=("default", "yes", "no")),
         path_suffixes=("tools",),
         help="Look up programs to execute inside the given tree",
         scope=SettingScope.universal,
@@ -5318,12 +5318,14 @@ def parse_config(
         Path(".mkosi-private/history/latest.json").write_text(dump_json(Config.to_partial_dict(cli)))
 
     tools = None
-    if config.get("tools_tree") == Path("default"):
+    if config.get("tools_tree") in (Path("default"), Path("yes")):
         if in_box():
             config["tools_tree"] = Path(os.environ["MKOSI_DEFAULT_TOOLS_TREE_PATH"])
         else:
             tools = finalize_default_tools(context, config, configdir=configdir, resources=resources)
             config["tools_tree"] = tools.output_dir_or_cwd() / tools.output
+    elif config.get("tools_tree") == Path("no"):
+        config["tools_tree"] = None
 
     images = []
 

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1404,7 +1404,7 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     this might result in failures when trying to execute binaries from
     any of the extra search paths.
 
-    If set to `default`, **mkosi** will automatically add an extra tools tree
+    If set to `yes`, **mkosi** will automatically add an extra tools tree
     image and use it as the tools tree. This image can be further configured
     using the settings below or with `mkosi.tools.conf` which can either be a
     file or directory containing extra configuration for the default tools tree.
@@ -2882,7 +2882,7 @@ builds more reproducible, but also allows to use newer tooling, that is not yet 
 distribution running mkosi.
 
 Tools trees can be provided via the `ToolsTree=` option, the `mkosi.tools` directory or built automatically
-by mkosi if set to `ToolsTree=default`. For most use cases setting it is sufficient to use the default tools
+by mkosi if set to `ToolsTree=yes`. For most use cases setting it is sufficient to use the default tools
 trees and the use of a tools tree is recommended.
 
 Fully custom tools trees can be built like any other mkosi image, but mkosi provides a builtin include

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -442,7 +442,7 @@ def test_override_default(tmp_path: Path) -> None:
         """\
         [Build]
         Environment=MY_KEY=MY_VALUE
-        ToolsTree=default
+        ToolsTree=yes
         """
     )
 


### PR DESCRIPTION
ToolsTree=default has always been rather weird, let's use ToolsTree=yes instead (but keep compat ofc)