### PR TITLE
Silence swtpm SHA1 signature deprecation warning

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -6040,6 +6040,21 @@ def want_selinux_relabel(
     return setfiles, policy, fc, binpolicy
 
 
+def swtpm_setup_version(sandbox: SandboxProtocol = nosandbox) -> GenericVersion:
+    version = GenericVersion(
+        run(
+            ["swtpm_setup", "--version"],
+            stdout=subprocess.PIPE,
+            sandbox=sandbox(),
+            success_exit_status=(0, 1),
+        ).stdout.split()[-1]
+    )
+
+    logging.debug(f"Version reported by swtpm_setup is {version}")
+
+    return version
+
+
 def systemd_tool_version(*tool: PathString, sandbox: SandboxProtocol = nosandbox) -> GenericVersion:
     version = GenericVersion(
         run(

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -43,6 +43,7 @@ from mkosi.config import (
     VsockCID,
     finalize_term,
     format_bytes,
+    swtpm_setup_version,
     systemd_pty_forward,
     systemd_tool_version,
     want_selinux_relabel,
@@ -271,6 +272,11 @@ def start_swtpm(config: Config) -> Iterator[Path]:
                 "--pcr-banks",
                 "sha256",
                 "--config", "/dev/null",
+                *(
+                    ["--profile-name=custom", "--profile-remove-disabled=check"]
+                    if swtpm_setup_version() >= "0.10.0" 
+                    else []
+                 ),
             ],
             sandbox=config.sandbox(options=["--bind", state, workdir(Path(state))]),
             stdout=None if ARG_DEBUG.get() else subprocess.DEVNULL,


### PR DESCRIPTION
When launching `mkosi vm`, the following warning appears:
```
swtpm: Warning: Profile-enabled algorithms contain disabled 'RSA-1024-sign(SHA1, pkcs1-pss)'
swtpm: Warning: Setting OPENSSL_ENABLE_SHA1_SIGNATURES=1
```

This is due to the default profile of swtpm including support for SHA1 signatures, which are deprecated in OpenSSL.

According to swtpm(8), the swtpm options
```
--profile-name=custom  --profile-remove-disabled=check
```
will do the following:
```
- remove camellia, tdes, and rsaes (RSA encryption with PKCS#1 v1.5 padding)
- disable signature support (RSA and EC) over SHA1
- disable unpadded RSA encryption
- set the minimum size for RSA keys to 2048 bits
- set the minimum size for EC keys to 224 bits
```

These options are sufficient to silence the warning, and has the benefit/risk of automatically removing similarly deprecated algorithms in the future, as libtpms/swtpm evolves.

Since the mkosi invocation of `swtpm setup` restricts PCR banks to SHA256, mkosi is already opinionated about the TPM provided to the TPM. It seems reasonable to go ahead and just prune dead crypto algorithms.

If in the future users need more control over the swtpm configuration, the sensible solution is probably the addition of a TPMProfile= option, which provides a suitable swtpm profile in JSON format.

But for now, just make the warning go away.

You can look at the built-in swtpm profiles using:
```
$ swtpm_setup --tpm2 --print-profiles | jq
```