### PR TITLE
Rename mkosi 'ssh' service to 'mkosi-sshd'

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2860,7 +2860,7 @@ def configure_ssh(context: Context) -> None:
         unitdir.mkdir(parents=True, exist_ok=True)
 
     with umask(~0o644):
-        (unitdir / "ssh.socket").write_text(
+        (unitdir / "mkosi-sshd.socket").write_text(
             textwrap.dedent(
                 """\
                 [Unit]
@@ -2878,7 +2878,7 @@ def configure_ssh(context: Context) -> None:
             )
         )
 
-        (unitdir / "ssh@.service").write_text(
+        (unitdir / "mkosi-sshd@.service").write_text(
             textwrap.dedent(
                 """\
                 [Unit]
@@ -2903,7 +2903,7 @@ def configure_ssh(context: Context) -> None:
     with umask(~0o755):
         preset.parent.mkdir(parents=True, exist_ok=True)
     with umask(~0o644):
-        preset.write_text("enable ssh.socket\n")
+        preset.write_text("enable mkosi-sshd.socket\n")
 
 
 def configure_initrd(context: Context) -> None:

--- a/mkosi/resources/man/mkosi.news.7.md
+++ b/mkosi/resources/man/mkosi.news.7.md
@@ -6,6 +6,8 @@
 
 ## v26
 
+- The name of the systemd service created by `--ssh=yes` has been renamed
+  from `ssh.service` to `mkosi-sshd.service`.
 - Extra options to commands invoked by mkosi (e.g. when using `mkosi boot`
   or `mkosi shell`) should now be delimited from regular options using
   `--`. Options passed after the verb without using the `--` delimiter


### PR DESCRIPTION
Since It's `sshd` not `ssh`. Also distinguish it from system `sshd`, and from systemd's `sshd-vsock`.