### PR TITLE
Make Ruff check for dangling whitespace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ scripts_are_modules = true
 [tool.ruff]
 target-version = "py39"
 line-length = 109
-lint.select = ["E", "F", "I", "UP"]
+lint.select = ["E", "F", "I", "UP", "W291"]
 
 [tool.pytest.ini_options]
 markers = [


### PR DESCRIPTION
In particular, when reviewers use GH code review to suggest a change, neither the editor nor the diff seem to flag this issue. it's then easy for the contributor to miss these by simply accepting the changes. 

Make CI catch it.
 