### PR TITLE
Eliminate `btrfs subvolume delete` errors when building as non-root

### DIFF
--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -252,3 +252,14 @@ def mandatory_variable(name: str) -> str:
         return os.environ[name]
     except KeyError:
         die(f"${name} must be set in the environment")
+
+
+def have_host_uid0() -> bool:
+    result = False
+    regex = rf"\s*{os.geteuid()}\s*{0}\s*(\d+)$"
+    with open("/proc/self/uid_map") as f:
+        for line in f.read().split("\n"):
+            if re.match(regex, line):
+                result = True
+
+    return result


### PR DESCRIPTION
Eliminate these misleading errors when non-root runs `mkosi build --debug`:
```
ERROR: Could not destroy subvolume/snapshot: Operation not permitted
WARNING: deletion failed with EPERM, you don't have permissions or send
may be in progress or the subvolume is set as default
```

The errors stem from `btrfs subvolume delete` requiring either running as root, or the `user_subvol_rm_allowed` mount option.
  
Since kernel 4.18+ (2018), btrfs has allowed deletion of subvolumes via the rmdir(2) syscall. So in practice, we almost always can just use `rm -rf` to remove a subolume.

~~Version 1:  sniff `sysfs` for the btrfs `rmdir_subvol` feature and if it's present, we don't have to special case the subvolume delete and just use `rm`.~~

Version 2: check if we have root privileges or volume has magic mount option before running `btrfs subvolume delete` .