### PR TITLE
Add zram and nfnetlink to default initrd 

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -135,3 +135,5 @@ KernelModules=
         xhci-pci-renesas
         /fs/nls/
         crypto/
+        zram      # for early/systemd-zram-setup
+        nfnetlink # for firewalld.service


### PR DESCRIPTION
zram-generator has been on by default in fedora
since fc33 (2020) and runs during early boot.
If the zram module is missing, users are hit with a nasty
45s systemd timeout.

firewalld.service is also on by default and fails to start
without nfnetlink.

Let's make sure an image built with `KernelModules=default`,
which pulls in the default mkosi-initrd modules, brings up
a fedora system in a non-degraded state

Before:
52038188 fedora.initrd

After:
52105776 fedora.initrd