### PR TITLE
Pass environment to systemd-sysusers invocation

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3004,6 +3004,7 @@ def run_sysusers(context: Context) -> None:
         run(
             ["systemd-sysusers", "--root=/buildroot"],
             sandbox=context.sandbox(options=context.rootoptions()),
+            env=context.config.finalize_environment(),
         )
 
 


### PR DESCRIPTION
`systemd-sysusers` [honors](https://systemd.io/ENVIRONMENT) `SOURCE_DATE_EPOCH` environment variable when generating a `/etc/shadow`. But mkosi does not pass an environment to the `systemd-sysusers` invocation. Pass the environment to improve builds reproducibility.