### PR TITLE
Don't discard ordering of include/exclude entries in KernelModules=

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1514,7 +1514,8 @@ def finalize_kernel_modules_include(context: Context, *, include: Sequence[str],
         else:
             final.append(p)
 
-    return final
+    # deduplicate while maintaining ordering
+    return list({k: None for k in final})
 
 
 def build_kernel_modules_initrd(context: Context, kver: str) -> Path:


### PR DESCRIPTION
Since eecf8b3b5 `KernelModules=` supports both inclusion and exclusion of kmods. When resolving kmod presets like "default" and "host" (and perhaps others in the future) it's important to retain the ordering of entries, so that the user can add a preset and then subtract only specific modules from the working set.

`filter_kernel_modules` relies on this ordering to do its job.