### PR TITLE
debian: support additional suites

### DIFF
--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -587,7 +587,8 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 `Repositories=`, `--repositories=`
 :   Enable package repositories that are disabled by default. This can be used to enable the EPEL repos for
-    CentOS or different components of the Debian/Kali/Ubuntu repositories.
+    CentOS or different components of the Debian/Kali/Ubuntu repositories.  Debian suites can be specified
+    ahead of the component, separated by a ":" (colon) character, e.g. `trixie-backports:main`.
 
 ### [Output] Section
 


### PR DESCRIPTION
This is a proposed solution to the ability to specify a repository suite in the Debian configuration, in addition to the components currently specified.  The optional suite is specified as a prefix to the component name in the `Repositories=` config setting, e.g.

```
Repositories=
    non-free-firmware
    trixie-backports:main
    trixie-backports:non-free-firmware
``` 

The `trixie-backports:` lines above would generate the following content in the resulting `trixie.sources` file:
```
Types: deb deb-src
URIs: http://deb.debian.org/debian
Suites: trixie-backports
Components: main non-free-firmware
Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
```

Fixes #1755