### PR TITLE
Improve logging messages for kmod/fw resolution

### DIFF
--- a/mkosi/kmod.py
+++ b/mkosi/kmod.py
@@ -85,10 +85,11 @@ def filter_kernel_modules(
     include: Iterable[str],
     exclude: Iterable[str],
 ) -> list[str]:
+    log_step("Applying kernel modules include/exclude configuration")
     if include:
-        logging.debug(f"Kernel modules include: {' '.join(include)}")
+        logging.debug(f"Kernel modules include directives: {' '.join(include)}")
     if exclude:
-        logging.debug(f"Kernel modules exclude: {' '.join(exclude)}")
+        logging.debug(f"Kernel modules exclude directives: {' '.join(exclude)}")
 
     modulesd = Path("usr/lib/modules") / kver
     with chdir(root):
@@ -137,7 +138,7 @@ def filter_kernel_modules(
         # If no exclude patterns are specified, only keep the specified kernel modules.
         modules = {modulesd / m for m in keep}
 
-    logging.debug(f"Including {len(modules)}/{n_modules} kernel modules.")
+    logging.debug(f"Passing {len(modules)}/{n_modules} kernel modules on to dependency resolution.")
 
     return sorted(module_path_to_name(m) for m in modules)
 
@@ -149,10 +150,11 @@ def filter_firmware(
     include: Iterable[str],
     exclude: Iterable[str],
 ) -> set[Path]:
+    log_step("Applying firmware include/exclude configuration")
     if include:
-        logging.debug(f"Firmware include: {' '.join(include)}")
+        logging.debug(f"Firmware include directives: {' '.join(include)}")
     if exclude:
-        logging.debug(f"Firmware exclude: {' '.join(exclude)}")
+        logging.debug(f"Firmware exclude directives: {' '.join(exclude)}")
 
     firmwared = Path("usr/lib/firmware")
 
@@ -185,7 +187,7 @@ def filter_firmware(
             if (patterns and regex.search(rel)) or globs_match_firmware(rel, globs):
                 firmware.add(f)
 
-    logging.debug(f"Including {len(firmware)} firmware files")
+    logging.debug(f"A total of {len(firmware)} firmware files will be included in the image")
 
     return firmware
 


### PR DESCRIPTION
- Disambiguate use of the term "include" (include directive/include in image)
- Add logged steps with clearer descriptions: inclusion/exclusion, dep resolution, final count, and debuglog sorted lists whee appropriate

To make the log clearer, and provide information in --debug to help someone fine-tuning KernelModules=+- to see what's happening along the pipeline, without waiting for the final image to build.

Complements #4017.