### PR TITLE
Add python3-pefile to fedora tools conf

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/fedora/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/fedora/mkosi.conf
@@ -11,3 +11,4 @@ Packages=
         dnf5-plugins
         erofs-utils
         pkcs11-provider
+        python3-pefile


### PR DESCRIPTION
python3-pefile is a dep of `system-ukify` which `mkosi` depends on, so it gets installed indirectly by `dnf install  $(mkosi dependencies)` runs. But mkosi depends on it directly, so make it an explicit dependency.