### PR TITLE
Add glob in default initrd to exclude some exotic drivers

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -135,5 +135,7 @@ KernelModules=
         xhci-pci-renesas
         /fs/nls/
         crypto/
+        -/drivers/crypto/ # exclude specialized hardware
+        ccp_crypto # AMD crypto accelerator available in ryzen
         zram      # for early/systemd-zram-setup
         nfnetlink # for firewalld.service


### PR DESCRIPTION
Drop these.  qat is a Xeon-only crypto accelerator. Atmel makes microcontrollers. chelsio and cavium make high-end hardware. virtio_crypto gives VM access to hardware crypto accelerators. All of which don't belong in the default initrd.

Intel QAT drivers requires firmware that isn't installed by the current default Packages=, so they are useless anyway. Extra logging in #4020 and #4017  was very helpful when pruning the list.
```
./drivers/crypto/atmel-ecc.ko.xz
./drivers/crypto/atmel-i2c.ko.xz
./drivers/crypto/atmel-sha204a.ko.xz
./drivers/crypto/cavium/nitrox/n5pf.ko.xz
./drivers/crypto/chelsio/chcr.ko.xz
./drivers/crypto/intel/iaa/iaa_crypto.ko.xz
./drivers/crypto/intel/qat/qat_420xx/qat_420xx.ko.xz
./drivers/crypto/intel/qat/qat_4xxx/qat_4xxx.ko.xz
./drivers/crypto/intel/qat/qat_6xxx/qat_6xxx.ko.xz
./drivers/crypto/intel/qat/qat_c3xxx/qat_c3xxx.ko.xz
./drivers/crypto/intel/qat/qat_c3xxxvf/qat_c3xxxvf.ko.xz
./drivers/crypto/intel/qat/qat_c62x/qat_c62x.ko.xz
./drivers/crypto/intel/qat/qat_c62xvf/qat_c62xvf.ko.xz
./drivers/crypto/intel/qat/qat_common/intel_qat.ko.xz
./drivers/crypto/intel/qat/qat_dh895xcc/qat_dh895xcc.ko.xz
./drivers/crypto/intel/qat/qat_dh895xccvf/qat_dh895xccvf.ko.xz
./drivers/crypto/padlock-aes.ko.xz
./drivers/crypto/padlock-sha.ko.xz
./drivers/crypto/virtio/virtio_crypto.ko.xz
./drivers/net/ethernet/chelsio/inline_crypto/ch_ipsec/ch_ipsec.ko.xz
./drivers/net/ethernet/chelsio/inline_crypto/ch_ktls/ch_ktls.ko.xz
./crypto/async_tx/async_memcpy.ko.xz
./crypto/async_tx/async_pq.ko.xz
./crypto/async_tx/async_raid6_recov.ko.xz
./crypto/async_tx/async_tx.ko.xz
./crypto/async_tx/async_xor.ko.xz
```
Keep these (ccp is AMD'd crypto coprocessor available in Ryzen, which is reasonable to include, since we include intel aesni drivers)
```
/drivers/crypto/ccp/ccp-crypto.ko.xz 
./arch/x86/crypto/aegis128-aesni.ko.xz
./arch/x86/crypto/blowfish-x86_64.ko.xz
./arch/x86/crypto/camellia-aesni-avx-x86_64.ko.xz
./arch/x86/crypto/camellia-aesni-avx2.ko.xz
./arch/x86/crypto/camellia-x86_64.ko.xz
./arch/x86/crypto/cast5-avx-x86_64.ko.xz
./arch/x86/crypto/cast6-avx-x86_64.ko.xz
./arch/x86/crypto/curve25519-x86_64.ko.xz
./arch/x86/crypto/des3_ede-x86_64.ko.xz
./arch/x86/crypto/ghash-clmulni-intel.ko.xz
./arch/x86/crypto/nhpoly1305-avx2.ko.xz
./arch/x86/crypto/nhpoly1305-sse2.ko.xz
./arch/x86/crypto/polyval-clmulni.ko.xz
./arch/x86/crypto/serpent-avx-x86_64.ko.xz
./arch/x86/crypto/serpent-avx2.ko.xz
./arch/x86/crypto/serpent-sse2-x86_64.ko.xz
./arch/x86/crypto/twofish-avx-x86_64.ko.xz
./arch/x86/crypto/twofish-x86_64-3way.ko.xz
./arch/x86/crypto/twofish-x86_64.ko.xz
./crypto/adiantum.ko.xz
./crypto/aegis128.ko.xz
./crypto/aes_ti.ko.xz
./crypto/ansi_cprng.ko.xz
./crypto/asymmetric_keys/pkcs8_key_parser.ko.xz
./crypto/blowfish_common.ko.xz
./crypto/blowfish_generic.ko.xz
./crypto/camellia_generic.ko.xz
./crypto/cast5_generic.ko.xz
./crypto/cast6_generic.ko.xz
./crypto/cast_common.ko.xz
./crypto/chacha.ko.xz
./crypto/chacha20poly1305.ko.xz
./crypto/crc32-cryptoapi.ko.xz
./crypto/crypto_engine.ko.xz
./crypto/crypto_user.ko.xz
./crypto/curve25519-generic.ko.xz
./crypto/des_generic.ko.xz
./crypto/echainiv.ko.xz
./crypto/ecrdsa_generic.ko.xz
./crypto/essiv.ko.xz
./crypto/fcrypt.ko.xz
./crypto/hctr2.ko.xz
./crypto/krb5/krb5.ko.xz
./crypto/krb5enc.ko.xz
./crypto/lz4.ko.xz
./crypto/lz4hc.ko.xz
./crypto/md4.ko.xz
./crypto/michael_mic.ko.xz
./crypto/nhpoly1305.ko.xz
./crypto/pcbc.ko.xz
./crypto/pcrypt.ko.xz
./crypto/polyval-generic.ko.xz
./crypto/rmd160.ko.xz
./crypto/serpent_generic.ko.xz
./crypto/streebog_generic.ko.xz
./crypto/tcrypt.ko.xz
./crypto/twofish_common.ko.xz
./crypto/twofish_generic.ko.xz
./crypto/wp512.ko.xz
./crypto/xcbc.ko.xz
./crypto/xctr.ko.xz
./crypto/zstd.ko.xz
./lib/crypto/libarc4.ko.xz
./lib/crypto/libcurve25519-generic.ko.xz
./lib/crypto/libcurve25519.ko.xz
./lib/crypto/libdes.ko.xz
./lib/crypto/libpoly1305-generic.ko.xz
```