### PR TITLE
Match KernelModules= globs relative to modules root dir

### DIFF
--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1163,15 +1163,29 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     The modules that were last matched by a positive pattern are included in the image,
     as well as their module and firmware dependencies.
 
-    The module paths are taken relative to the `/usr/lib/modules/<kver>/<subdir>/kernel/` directory,
-    and the `.ko` suffix and compression suffix are ignored during matching.
-    The patterns may include just the basename (e.g. `loop`),
+    The `.ko` suffix and compression suffix are ignored during matching.
+
+    Globs are matched against module paths relative to `/usr/lib/module/<kver>`,
+    e.g. the module at `/usr/lib/module/<kver>/kernel/foo/bar.ko.xz`
+    becomes `kernel/foo/bar` for matching purposes.
+
+    Globs beginning with "/" are treated specially. The glob is *first* matched
+    against a path relative to `/usr/lib/module/<kver>/kernel`, and only then against
+    `/usr/lib/module/<kver>/`. This is a convenience, since usually only the in-tree
+    modules under `kernel/` are of interest.
+
+    For example, the module at`/usr/lib/module/<kver>/kernel/foo/bar.ko.xz`
+    can be matched by either `/foo/bar` or `/kernel/foo/bar`.
+
+    The glob patterns may include just the basename (e.g. `loop`),
     which must match the basename of the module,
     the relative path (e.g. `block/loop`),
     which must match the final components of the module path up to the basename,
     or an absolute path (e.g. `/drivers/block/loop`),
     which must match the full path to the module.
+
     When suffixed with `/`, the pattern will match all modules underneath that directory.
+
     The patterns may include shell-style globs (`*`, `?`, `[…-…]`).
 
     If the special value `default` is used, the default kernel modules

--- a/tests/test_kmod.py
+++ b/tests/test_kmod.py
@@ -40,6 +40,15 @@ def test_globs_match_module() -> None:
     assert not kmod.globs_match_module("drivers/ata/ahci.ko.zst", ["-*"])
     assert not kmod.globs_match_module("drivers/ata/ahci.ko.xz", ["-*"])
 
+    # absolute glob behavior unchanged when paths are relative to /lib/module/<kver>
+    assert kmod.globs_match_module("kernel/drivers/ata/ahci.ko", ["drivers/*"])
+    assert kmod.globs_match_module("kernel/drivers/ata/ahci.ko", ["/drivers/*"])
+    assert not kmod.globs_match_module("kernel/drivers/ata/ahci.ko.xz", ["/ata/*"])
+
+    # absolute globs match both relative to kernel/ and module_dir root
+    assert kmod.globs_match_module("kernel/drivers/ata/ahci.ko.xz", ["/drivers/ata/ahci"])
+    assert kmod.globs_match_module("kernel/drivers/ata/ahci.ko.xz", ["/kernel/drivers/ata/ahci"])
+
 
 def test_normalize_module_glob() -> None:
     assert kmod.normalize_module_glob("raid[0-9]") == "raid[0-9]"


### PR DESCRIPTION
**Update:** folded in the reverted changes from #4025

#4025 broke back-compat and was reverted. My bad.

The old code, matched globs relative to `/lib/modules/KVER/kernel`. I didn't realize #4025 changed this behavior and now matches relative to `/lib/modules/KVER` . 
This broke absolute globs like `/drivers/mmc/host`.

One could argue that the behavior is #2025 is more correct.
Although the old convention saves us from prepending `/kernel` to every absolute globs, it ignores the fact that `kernel/` only holds *in-tree* modules. out-of-tree modules (DKMS, BSPs for embedded)  generally live in sibling directories like `updates/` or `extra/` or `vendor/`. 

Also, If you cat `/lib/modules/$(uname -r)/modules.dep`,  you'll see that it treats modules on the system relative to  `/lib/modules/KVER`, not `/lib/modules/KVER/kernel`. That's the text equivalent of what `modprobe` looks at. 

This patch reapplies #4025, originally meant as a code style issue, and adds a condition to `globs_match_filename` that tries to match absolute globs under `kernel/` first so that existing configs continue to work without modification. This should be fine since generally there will be no collisions (e.g. there is no `kernel/updates` or `kernel/extra`).

Note: in this case as well, adding the extra logging from #4017 and #4020 were very helpful.
