### PR TITLE
 Add wireless-regdb package to initrd default conf for fedora

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -16,6 +16,7 @@ Packages=
         bash                      # for emergency logins
         less                      # this makes 'systemctl' much nicer to use ;)
         gzip                      # For compressed keymap unpacking by loadkeys
+        wireless-regdb            # fw dep of kmod cfg80211
 
 RemoveFiles=
         # we don't need this after the binary catalogs have been built


### PR DESCRIPTION
Debugging logs in #4017 warn that cfg80211 needs the wifi regulatory database as a firmware dependency (to set transmit strengths and such).
```
 6328 Oct 11 03:00 /usr/lib/firmware/regulatory.db
1085 Oct 11 03:00 /usr/lib/firmware/regulatory.db.p7s
```
It's a 50k package. Add it.

Why does early init need wifi? it isn't in /boot/initramfs on fedora. 
