### PR TITLE
Add linux-firmware package to default initrd conf

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -16,6 +16,7 @@ Packages=
         bash                      # for emergency logins
         less                      # this makes 'systemctl' much nicer to use ;)
         gzip                      # For compressed keymap unpacking by loadkeys
+        linux-firmware            # mkosi will remove unused blobs during build
 
 RemoveFiles=
         # we don't need this after the binary catalogs have been built


### PR DESCRIPTION
When installing a kernel, we generally want the firmware to be there as well. mkosi prunes unused blobs during build anyway (in `process_kernel_modules`).