### PR TITLE
Warn user when installing a kernel package without linux-firmware package

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -5450,6 +5450,15 @@ def parse_config(
 
     subimages = resolve_deps(subimages, main.dependencies)
 
+    for config in tuple(subimages + [main]):
+        if "linux-firmware" not in config.packages and any(
+            config.distribution.installer.is_kernel_package(p)
+            for p in itertools.chain(config.packages, config.volatile_packages)
+        ):
+            logging.warning(
+                "This config installs a kernel in the image. You probably want to add `linux-firmware` to Packages=."
+            )
+            break
     return args, tools, tuple(subimages + [main])
 
 


### PR DESCRIPTION
When users build a main image, they may use a blank config. If they install kernel packages, `run_depmod` detects a valid module directory and kicks off processing of kmod and dw dependencies. The user almost certainly wants the firmware to be available for whatever kmods they will include, and mkosi will remove any unused blobs anyway.

Detect this situation and warn the user.

This doesn't cover all firmware  since some of it is scattered in distro-specific packages. But this sufficiently informs them that they need to think about installing firmware packages.