### PR TITLE
Copy repart definitions to staging directory

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2477,7 +2477,7 @@ def copy_repart_definitions(context: Context) -> None:
         return
 
     for d in definitions:
-        copy_tree(d, context.config.output_dir_or_cwd() / context.config.output_split_repart_definitions)
+        copy_tree(d, context.staging / context.config.output_split_repart_definitions)
 
 
 def calculate_sha256sum(context: Context) -> None:


### PR DESCRIPTION
We should always use the staging directory while the image is being built, at the end everything is moved to the output directory.