### PR TITLE
Use proper constants for ansi colors

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -35,7 +35,7 @@ from mkosi.distribution import Distribution, detect_distribution
 from mkosi.log import ARG_DEBUG, ARG_DEBUG_SANDBOX, ARG_DEBUG_SHELL, complete_step, die
 from mkosi.pager import page
 from mkosi.run import SandboxProtocol, find_binary, nosandbox, run, sandbox_cmd, workdir
-from mkosi.sandbox import Style, __version__
+from mkosi.sandbox import ANSI_BLUE, ANSI_BOLD, ANSI_RESET, __version__
 from mkosi.user import INVOKING_USER
 from mkosi.util import (
     PathString,
@@ -4387,7 +4387,7 @@ def create_argument_parser(chdir: bool = True) -> argparse.ArgumentParser:
                 mkosi [options…] {b}help{e}
                 mkosi -h | --help
                 mkosi --version
-        """).format(b=Style.bold, e=Style.reset),
+        """).format(b=ANSI_BOLD, e=ANSI_RESET),
         add_help=False,
         allow_abbrev=False,
         argument_default=argparse.SUPPRESS,
@@ -5536,7 +5536,7 @@ def format_octal_or_default(oct_value: Optional[int]) -> str:
 
 
 def bold(s: Any) -> str:
-    return f"{Style.bold}{s}{Style.reset}"
+    return f"{ANSI_BOLD}{s}{ANSI_RESET}"
 
 
 def cat_config(images: Sequence[Config]) -> str:
@@ -5551,7 +5551,7 @@ def cat_config(images: Sequence[Config]) -> str:
             # Display the paths as relative to ., if underneath.
             if path.is_relative_to(Path.cwd()):
                 path = path.relative_to(Path.cwd())
-            print(f"{Style.blue}# {path}{Style.reset}", file=c)
+            print(f"{ANSI_BLUE}# {path}{ANSI_RESET}", file=c)
             print(path.read_text(), file=c)
 
     return c.getvalue()

--- a/mkosi/log.py
+++ b/mkosi/log.py
@@ -8,7 +8,7 @@ import sys
 from collections.abc import Iterator
 from typing import Any, NoReturn, Optional
 
-from mkosi.sandbox import Style, terminal_is_dumb
+from mkosi.sandbox import ANSI_BOLD, ANSI_GRAY, ANSI_RED, ANSI_RESET, ANSI_YELLOW, terminal_is_dumb
 
 # This global should be initialized after parsing arguments
 ARG_DEBUG = contextvars.ContextVar("debug", default=False)
@@ -75,11 +75,11 @@ def log_step(text: str) -> None:
     else:
         if not terminal_is_dumb():
             print(ConsoleCodes.set_window_title(text), file=sys.stderr, end="")
-        logging.info(f"{prefix}{Style.bold}{text}{Style.reset}")
+        logging.info(f"{prefix}{ANSI_BOLD}{text}{ANSI_RESET}")
 
 
 def log_notice(text: str) -> None:
-    logging.info(f"{Style.bold}{text}{Style.reset}")
+    logging.info(f"{ANSI_BOLD}{text}{ANSI_RESET}")
 
 
 @contextlib.contextmanager
@@ -105,11 +105,11 @@ class Formatter(logging.Formatter):
         fmt = fmt or "%(message)s"
 
         self.formatters = {
-            logging.DEBUG:    logging.Formatter(f"‣ {Style.gray}{fmt}{Style.reset}"),
+            logging.DEBUG:    logging.Formatter(f"‣ {ANSI_GRAY}{fmt}{ANSI_RESET}"),
             logging.INFO:     logging.Formatter(f"‣ {fmt}"),
-            logging.WARNING:  logging.Formatter(f"‣ {Style.yellow}{fmt}{Style.reset}"),
-            logging.ERROR:    logging.Formatter(f"‣ {Style.red}{fmt}{Style.reset}"),
-            logging.CRITICAL: logging.Formatter(f"‣ {Style.red}{Style.bold}{fmt}{Style.reset}"),
+            logging.WARNING:  logging.Formatter(f"‣ {ANSI_YELLOW}{fmt}{ANSI_RESET}"),
+            logging.ERROR:    logging.Formatter(f"‣ {ANSI_RED}{fmt}{ANSI_RESET}"),
+            logging.CRITICAL: logging.Formatter(f"‣ {ANSI_RED}{ANSI_BOLD}{fmt}{ANSI_RESET}"),
         }  # fmt: skip
 
         super().__init__(fmt, *args, **kwargs)

--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -142,19 +142,18 @@ def terminal_is_dumb() -> bool:
     return not sys.stdout.isatty() or not sys.stderr.isatty() or os.getenv("TERM", "") == "dumb"
 
 
-class Style:
-    # fmt: off
-    bold: str   = "\033[0;1;39m"     if not terminal_is_dumb() else ""
-    blue: str   = "\033[0;1;34m"     if not terminal_is_dumb() else ""
-    gray: str   = "\033[0;38;5;245m" if not terminal_is_dumb() else ""
-    red: str    = "\033[31;1m"       if not terminal_is_dumb() else ""
-    yellow: str = "\033[33;1m"       if not terminal_is_dumb() else ""
-    reset: str  = "\033[0m"          if not terminal_is_dumb() else ""
-    # fmt: on
+# fmt: off
+ANSI_BOLD   = "\033[0;1;39m"     if not terminal_is_dumb() else ""
+ANSI_BLUE   = "\033[0;1;34m"     if not terminal_is_dumb() else ""
+ANSI_GRAY   = "\033[0;38;5;245m" if not terminal_is_dumb() else ""
+ANSI_RED    = "\033[31;1m"       if not terminal_is_dumb() else ""
+ANSI_YELLOW = "\033[33;1m"       if not terminal_is_dumb() else ""
+ANSI_RESET  = "\033[0m"          if not terminal_is_dumb() else ""
+# fmt: on
 
 
 ENOSYS_MSG = f"""\
-{Style.red}mkosi was unable to invoke the {{syscall}}() system call.{Style.reset}
+{ANSI_RED}mkosi was unable to invoke the {{syscall}}() system call.{ANSI_RESET}
 This probably means either the system call is not implemented by the running kernel version ({{kver}}) or the
 system call is prohibited via seccomp if mkosi is being executed inside a containerized environment.\
 """
@@ -1027,7 +1026,7 @@ See the mkosi-sandbox(1) man page for details.\
 
 
 UNSHARE_EPERM_MSG = f"""\
-{Style.red}mkosi was forbidden to unshare namespaces{Style.reset}.
+{ANSI_RED}mkosi was forbidden to unshare namespaces{ANSI_RESET}.
 This probably means your distribution has restricted unprivileged user namespaces.
 Please consult the REQUIREMENTS section of the mkosi man page, e.g. via "mkosi
 documentation", for workarounds.\


### PR DESCRIPTION
I was playing around with mypyc again and it did not like class attributes like the Style ones. While mypyc ended up not working for other reasons, let's switch to something it is happy with which is just regular constants named identically to how they're named in systemd. It's arguably not uglier than the Style namespace class.