### PR TITLE
Do not attempt to copy non-existent repart definitions

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2477,7 +2477,8 @@ def copy_repart_definitions(context: Context) -> None:
         return
 
     for d in definitions:
-        copy_tree(d, context.staging / context.config.output_split_repart_definitions)
+        if d.exists():
+            copy_tree(d, context.staging / context.config.output_split_repart_definitions)
 
 
 def calculate_sha256sum(context: Context) -> None:


### PR DESCRIPTION
```
‣ + cp --recursive --no-dereference --preserve=mode,links,timestamps,ownership,xattr --reflink=auto --copy-contents /tmp/tmpsdcskbl6/resources/repart/definitions/addon-unsigned.repart.d /home/bluca/.cache/mkosi/mkosi-workspace-n8snet9l/staging/pi3__x86-64.repart.d
cp: cannot stat '/tmp/tmpsdcskbl6/resources/repart/definitions/addon-unsigned.repart.d': No such file or directory
```

Follow-up for 1acab18874433b504b080dcf8753826c8b0d5bd9