### PR TITLE
Add details to KernelModulesInitrd= doc

### DIFF
--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1186,10 +1186,16 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     the host system are included as well.
 
 `KernelModulesInitrd=`, `--kernel-modules-initrd=`
-:   Boolean value, enabled (true) by default. If enabled, when building a bootable image, **mkosi** will generate
-    an extra initrd for each unified kernel image it assembles. This initrd contains only modules for
-    the specific kernel version, and will be appended to the prebuilt initrd. This allows generating kernel
-    independent initrds which are augmented with the necessary modules when the UKI is assembled.
+:   Boolean value, enabled (true) by default. If enabled, when building a bootable image,
+    **mkosi** will generate an extra initrd for each unified kernel image it assembles.
+    This initrd contains only modules and possibly firmware, and is then appended to the
+    base initrd to form the final initrd file. This keeps the base initrd kernel independent,
+    and only augments it with the necessary kernel-version specific modules when the UKI
+    is assembled.
+
+    If disabled, no extra initrd is generated. Note that the kernel modules will still **not**
+    be included in the base initrd, which remains kernel independent. Instead, it is assumed
+    the user provides the necessary modules, if any, via an additional custom initrd.
 
 `KernelInitrdModules=`, `--kernel-modules-initrd-include=`
 :   Like `KernelModules=`, but specifies the kernel modules to include in the initrd.


### PR DESCRIPTION
`initrd` is an overloaded term and this can get confusing. 
in mkosi parlance, an initrd can be:
1. the initrd file used for booting, or embded in a UKI
2. a single cpio archive which is included inside the initrd file.
3. a "default initrd" which is a file that groups the early user-space as a cpio archive. Compressed by default.
4. a "kernel modules initrd" which groups  the modules (and actually, also firmware) as a single cpio archive. Not compressed by default.
5. a custom mkosi image/config/build target.
6. files in a mkosi.initrd directory which contains custom initrd archive for inclusion in the initrd fie


This PR does nothing to address the confusion.

It only clarifies that setting `KernelModulesInitrd=no` does **not** mean the kernel modules will be included in the base initrd. Rather, it's a way to tell `mkosi` that you will provide them independently in a (extra) custom initrd.

I hope I got this right.