### PR TITLE
Add log_step call in build_kernel_modules_initrd

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1523,6 +1523,8 @@ def build_kernel_modules_initrd(context: Context, kver: str) -> Path:
     if kmods.exists():
         return kmods
 
+    log_step("Building kernel modules initrd")
+
     make_cpio(
         context.root,
         kmods,


### PR DESCRIPTION
The logs shows
```
    Building default-initrd image
    Building main image
```

but there's an unexplained second call to resolve kmods, which isn't explained by the visible steps in the current log. Add a `log_step` to make it clear what's going on.