### PR TITLE
Fix SplitArtifacts=repart-definitions for addons

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2464,7 +2464,7 @@ def copy_repart_definitions(context: Context) -> None:
 
     if context.config.output_format == OutputFormat.esp:
         definitions = [context.workspace / "esp-definitions"]
-    elif context.config.output_format.is_extension_or_portable_image():
+    elif context.config.output_format in (OutputFormat.sysext, OutputFormat.confext, OutputFormat.portable):
         definitions = [extension_or_portable_image_repart_definitions(context)]
     elif (d := context.workspace / "repart-definitions").exists():
         definitions = [d]


### PR DESCRIPTION
is_extension_or_portable_image() includes addon images, which should be skipped in copy_repart_definitions(), so list the formats individually instead.

Follow up for 1acab18874433b504b080dcf8753826c8b0d5bd9