### PR TITLE
kmod: Only add fully resolved fw path if it exists

### DIFF
--- a/mkosi/kmod.py
+++ b/mkosi/kmod.py
@@ -414,7 +414,8 @@ def gen_required_kernel_modules(
             current = current.parent
 
         # Finally, add the actual fully resolved path to the firmware file.
-        firmware.add(current.relative_to(context.root))
+        if current.exists():
+            firmware.add(current.relative_to(context.root))
 
     yield from sorted(
         itertools.chain(


### PR DESCRIPTION
The symlinks in /usr/lib/firmware might be
dangling and we shouldn't try to add the target of a dangling symlink to the list of firmware as cpio will error out later because it can't find the
file or directory.

Replaces #4053