### PR TITLE
zypper: add --force-resolution flag

### DIFF
--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -37,6 +37,7 @@ class Zypper(PackageManager):
             "install",
             "--download", "in-advance",
             "--recommends" if context.config.with_recommends else "--no-recommends",
+            "--force-resolution",
         ]  # fmt: skip
 
         return {
@@ -146,6 +147,7 @@ class Zypper(PackageManager):
         arguments = [
             "--download", "in-advance",
             "--recommends" if context.config.with_recommends else "--no-recommends",
+            "--force-resolution",
         ]  # fmt: skip
 
         if allow_downgrade:


### PR DESCRIPTION
With zypper it's easy to end up in situations where the dependency resolver requires user input.

For instance take this minimal example:
```
[Distribution]
Distribution=opensuse
Release=tumbleweed

[Content]
BuildPackages=patterns-devel-base-devel_basis
Packages=busybox-xz
```

When build (with an mkosi.build script present) you get the following:
```
Problem: 1: nothing provides 'this-is-only-for-build-envs' needed by the to be installed gettext-tools-mini-0.26-3.2.x86_64
 Solution 1: deinstallation of busybox-xz-1.37.0-41.1.noarch
 Solution 2: do not install patterns-devel-base-devel_basis-20170319-13.2.x86_64
 Solution 3: break gettext-tools-mini-0.26-3.2.x86_64 by ignoring some of its dependencies

Choose from above solutions by number or cancel [1/2/3/c/d/?] (c): c
‣ "zypper --installroot=/buildroot --cache-dir=/var/cache/zypp --non-interactive --no-refresh --releasever=tumbleweed install --download in-advance --no-recommends patterns-devel-base-devel_basis" returned non-zero exit code 4.
```

Zypper will choose a solution by itself if you use the `--force-resolution` flag. In this case it would opt for deleting `busybox-xz`. Furthermore, `--solver-focus` may be used to steer the resolution. See [zyppper(8)](https://manpages.opensuse.org/Tumbleweed/zypper/zypper.8.en.html).

As a workaround you can add flags to the packages list like so:
```
[Distribution]
Distribution=opensuse
Release=tumbleweed

[Content]
BuildPackages=patterns-devel-base-devel_basis,--solver-focus,Update,--force-resolution
Packages=busybox-xz
```

But that's obviously not ideal. 

This PR ensures that zypper is always run with `--force-resolution` so it doesn't prevent configurations like these from running.
