### PR TITLE
pacman: Make sure hookdir exists before running pacman

### DIFF
--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -181,6 +181,7 @@ class Pacman(PackageManager):
     ) -> CompletedProcess:
         with umask(~0o755):
             (context.root / "var/lib/pacman/local").mkdir(parents=True, exist_ok=True)
+            (context.root / "etc/pacman.d/hooks").mkdir(parents=True, exist_ok=True)
 
         return run(
             cls.cmd(context) + [operation, *arguments],


### PR DESCRIPTION
The latest pacman release seems to fail if the passed hookdir does not exist, so let's make sure it exists before invoking pacman.