### PR TITLE
verity: do not copy signing cert in addons/portables/extensions

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -512,6 +512,10 @@ def configure_verity_certificate(context: Context) -> None:
     if context.config.verity_certificate_source.type != CertificateSourceType.file:
         return
 
+    # Makes no sense to ship this in extensions/addons/etc, it's for the rootfs
+    if context.config.output_format.is_extension_or_portable_image():
+        return
+
     veritydir = context.root / "usr/lib/verity.d"
     with umask(~0o755):
         veritydir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
It makes no sense to include these in portables or addons or extensions, it's for the rootfs so pid1 can use it

Follow-up for 4bdb47b6dafec4f258a2dca446d67ee662dbedd4