### PR TITLE
mkosi-addon: drop Output=addon, addon.py already has a default

### DIFF
--- a/mkosi/resources/mkosi-addon/mkosi.conf
+++ b/mkosi/resources/mkosi-addon/mkosi.conf
@@ -4,7 +4,6 @@
 Distribution=custom
 
 [Output]
-Output=addon
 Format=addon
 ManifestFormat=
 SplitArtifacts=


### PR DESCRIPTION
addon.py already passes mkosi-local.addon.efi by default if nothing else is given, so it's not necessary to override it here. And it makes it impossible to give custom names via Output= in your own config.