### PR TITLE
qemu: Register with systemd-machined in user session

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -111,7 +111,6 @@ from mkosi.qemu import (
     copy_ephemeral,
     finalize_credentials,
     finalize_kernel_command_line_extra,
-    finalize_register,
     join_initrds,
     run_qemu,
     run_ssh,
@@ -4228,7 +4227,7 @@ def run_shell(args: Args, config: Config) -> None:
 
     # Underscores are not allowed in machine names so replace them with hyphens.
     name = config.machine_or_name().replace("_", "-")
-    cmdline += ["--machine", name, "--register", yes_no(finalize_register(config))]
+    cmdline += ["--machine", name, "--register", yes_no(config.register != ConfigFeature.disabled)]
 
     with contextlib.ExitStack() as stack:
         for f in finalize_credentials(config, stack).iterdir():

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -2029,6 +2029,10 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     systemd-machined. If `auto`, mkosi will register the vm/container
     with systemd-machined if it is available. Defaults to `auto`.
 
+    Note that mkosi will try to register the machine with
+    systemd-machined in the user session. systemd v259 or newer is
+    required to have systemd-machined be available in user sessions.
+
 `ForwardJournal=`, `--forward-journal=`
 :   Specify the path to which journal logs from containers and virtual
     machines should be forwarded. If the path has the `.journal`

--- a/mkosi/vmspawn.py
+++ b/mkosi/vmspawn.py
@@ -21,7 +21,6 @@ from mkosi.qemu import (
     finalize_firmware,
     finalize_initrd,
     finalize_kernel_command_line_extra,
-    finalize_register,
 )
 from mkosi.run import run
 from mkosi.util import PathString
@@ -56,7 +55,6 @@ def run_vmspawn(args: Args, config: Config) -> None:
         "--vsock", config.vsock.to_tristate(),
         "--tpm", config.tpm.to_tristate(),
         "--secure-boot", yes_no(config.secure_boot),
-        "--register", yes_no(finalize_register(config)),
         "--console", str(config.console),
     ]  # fmt: skip
 


### PR DESCRIPTION
Now that machine registration works unprivileged
since systemd v259, let's switch to unconditionally registering machines with the user session
systemd-machined instance.

This breaks compat but the previous implementation arguably wasn't useful or used, since registration would only be done when running as root or if the
Register= feature was explicitly enabled. And if
not running as root, you'd have to authenticate
every time when booting the image to register it
which is arguably too annoying that anyone actually bothered with it.

As vmspawn doesn't yet support registering with the user machined instance, we stop registering vmspawn machines for now. https://github.com/systemd/systemd/pull/40185 will add support for user machined regisration to
vmspawn.

For nspawn we stick with system machined registration for now.