### PR TITLE
Add pyrightconfig.json

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,11 @@ py_version = "39"
 
 [tool.pyright]
 pythonVersion = "3.9"
+include = [
+    "mkosi/**/*.py",
+    "tests/**/*.py",
+    "kernel-install/*.install"
+]
 
 [tool.mypy]
 python_version = 3.9


### PR DESCRIPTION
Let's configure the files on which pyright should run to avoid long startup times where it tries to check every single file in the workspace directory.