### PR TITLE
Fix reproducibility for microcode initrd and gzip compression

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2349,7 +2349,7 @@ def compressor_command(context: Context, compression: Compression) -> list[PathS
     """Returns a command suitable for compressing archives."""
 
     if compression == Compression.gz:
-        return [gzip_binary(context), f"-{context.config.compress_level}", "--stdout", "-"]
+        return [gzip_binary(context), "--no-name", f"-{context.config.compress_level}", "--stdout", "-"]
     elif compression == Compression.xz:
         return ["xz", "--check=crc32", f"-{context.config.compress_level}", "-T0", "--stdout", "-"]
     elif compression == Compression.zstd:


### PR DESCRIPTION
Some minor improvements to reproducibility, impacting the UKIs and compressed archive outputs (i.e. OCIs).  

I have not confirmed whether this fixes reproducibility for other output formats or other use-cases, but it does in my particular case.

For the compression, I don't believe xz or zstd require changes as their default configurations are reproducible.  gzip is the only one that stores the timestamps in the headers.

With the updated configuration from this MR, plus some additional generalisation required in dnf environments (see below), I was able to produce fully reproducible OCI images built via mkosi.

```
RPMDB="/usr/lib/sysimage/rpm/rpmdb.sqlite"
if [ -f "$RPMDB" ]; then
    sqlite3 "$RPMDB" "PRAGMA journal_mode = DELETE;"
    rm -f /usr/lib/sysimage/rpm/.rpm.lock
fi

rm -rf /usr/lib/sysimage/libdnf5 \
 /var/cache/* \
 /etc/machine-id \
 /etc/group- \
 /etc/gshadow- \
 /etc/passwd- \
 /etc/shadow-
```

---

When building the microcode initrd, files are created in a temporary
directory with current timestamps. These timestamps are then embedded
in the CPIO archive, causing non-reproducible builds even when
SourceDateEpoch is set.

Fix this by normalizing the modification times of all files in the
microcode root directory to source_date_epoch before creating the
CPIO archive.

---

The gzip format includes an MTIME field in its header that stores the
modification time of the original file. This causes compressed archives
to differ between builds even when the uncompressed content is identical.

Add the --no-name flag to gzip which suppresses storing the original
filename and timestamp, making gzip output reproducible.


