### PR TITLE
kmod: Stop retrieving dependency info of all modules

### DIFF
--- a/mkosi/kmod.py
+++ b/mkosi/kmod.py
@@ -27,7 +27,7 @@ def loaded_modules() -> list[str]:
 def all_modules(modulesd: Path) -> Iterator[Path]:
     # The glob may match additional paths.
     # Narrow this down to *.ko, *.ko.gz, *.ko.xz, *.ko.zst.
-    return (m for m in modulesd.rglob("*.ko*") if m.name.endswith((".ko", ".ko.gz", ".ko.xz", ".ko.zst")))
+    return (m for m in modulesd.rglob("*.ko*") if m.name.endswith((".ko.zst", ".ko.xz", ".ko.gz", ".ko")))
 
 
 def globs_match_filename(name: str, globs: Sequence[str], *, match_default: bool = False) -> bool:


### PR DESCRIPTION
Instead of running modinfo once to retrieve the dependency information
of all modules, let's only retrieve the dependency information of the
modules that are to be included in the image and their transitive
dependencies. This means we have to run modinfo multiple times, but with
far fewer modules than before. This ends up being faster than retrieving
the dependency information of all modules, especially after the optimization
from https://github.com/systemd/mkosi/commit/e276dac87a530efac4376a5059b980f2d43460f5.

For the mkosi default image build on Arch Linux this reduces the time for
calculating the required kernel modules and firmware on my laptop from 5s
to 0.5s.