### PR TITLE
arch: Download archlinux-keyring with pacman

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4842,13 +4842,14 @@ def sync_repository_metadata(
             install_sandbox_trees(context.config, context.sandbox_tree)
             context.config.distribution.installer.setup(context)
 
-            context.config.distribution.installer.keyring(context)
-
             with complete_step("Syncing package manager metadata"):
                 context.config.distribution.installer.package_manager(context.config).sync(
                     context,
                     force=context.args.force > 1 or context.config.cacheonly == Cacheonly.never,
                 )
+
+            context.config.distribution.installer.keyring(context)
+
         src = metadata_dir / "cache" / subdir
         dst = last.package_cache_dir_or_default() / "cache" / subdir
 

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -65,7 +65,7 @@ class Pacman(PackageManager):
             "--ro-bind", context.repository, "/var/cache/pacman/mkosi",
         ]  # fmt: skip
 
-        if any(context.keyring_dir.iterdir()):
+        if context.keyring_dir.exists() and any(context.keyring_dir.iterdir()):
             mounts += ["--ro-bind", context.keyring_dir, "/etc/pacman.d/gnupg"]
 
         if (context.root / "var/lib/pacman/local").exists():
@@ -201,13 +201,14 @@ class Pacman(PackageManager):
         *,
         apivfs: bool = True,
         allow_downgrade: bool = False,
+        options: Sequence[str] = (),
     ) -> None:
         arguments = ["--needed", "--assume-installed", "initramfs"]
 
         if allow_downgrade:
             arguments += ["--sysupgrade", "--sysupgrade"]
 
-        arguments += [*packages]
+        arguments += [*options, *packages]
 
         cls.invoke(context, "--sync", arguments, apivfs=apivfs)
 


### PR DESCRIPTION
curl-ing the Arch Linux website fails quite often due to connection issues. Let's try downloading the archlinux-keyring package with Pacman so we go directly to a mirror and avoid hitting the Arch Linux website.