### PR TITLE
nixos: Use repository key fetching by default on nixos

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3446,8 +3446,8 @@ def make_image(
         cmdline += ["--definitions", workdir(d)]
         opts += ["--ro-bind", d, workdir(d)]
 
-    def can_orphan_file(distribution: Optional[Distribution], release: Optional[str]) -> bool:
-        if distribution is None:
+    def can_orphan_file(distribution: Union[Distribution, str, None], release: Optional[str]) -> bool:
+        if not isinstance(distribution, Distribution):
             return True
 
         return not (

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from mkosi.config import Config
 from mkosi.context import Context
-from mkosi.distribution import detect_distribution
+from mkosi.distribution import Distribution, detect_distribution
 from mkosi.installer import PackageManager
 from mkosi.log import complete_step
 from mkosi.run import CompletedProcess, run, workdir
@@ -234,6 +234,7 @@ class Pacman(PackageManager):
 
         if (
             (d := detect_distribution(context.config.tools())[0])
+            and isinstance(d, Distribution)
             and d.is_apt_distribution()
             and (context.sandbox_tree / "usr/share/pacman/keyrings").exists()
         ):

--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -185,7 +185,7 @@ class StrEnum(enum.Enum):
 
     @classmethod
     def values(cls) -> list[str]:
-        return list(s.replace("_", "-") for s in map(str, cls.__members__))
+        return [d.value for d in cls.__members__.values()]
 
     @classmethod
     def choices(cls) -> list[str]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1514,7 +1514,7 @@ def test_tools(tmp_path: Path) -> None:
         _, tools, _ = parse_config(argv, resources=resources)
         assert tools
         host = detect_distribution()[0]
-        if host:
+        if isinstance(host, Distribution):
             assert tools.distribution == (
                 host.installer.default_tools_tree_distribution() or tools.distribution
             )


### PR DESCRIPTION
nixos generally won't have any keys in the expected locations so let's use repository key fetching by default if we're building from a nixos host (or tools tree).