### PR TITLE
Bookworm tools trees fixes

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.profiles/runtime/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/virtiofsd.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/runtime/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/virtiofsd.conf
@@ -3,6 +3,7 @@
 [TriggerMatch]
 Distribution=debian
 Release=!bullseye
+Release=!bookworm
 
 [TriggerMatch]
 Distribution=ubuntu


### PR DESCRIPTION
I bumped the mkosi commit for an older project and the default tools tree failed to build with `ToolsTreeRelease=bookworm`, which it is unfortunately still using. This fixes one more package movements.