### PR TITLE
config: Fix InitrdPackages not being added with default

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -5149,10 +5149,10 @@ def finalize_default_initrd(
                 ns = context.cli
                 if f"{s.dest}_was_none" in main.cli:
                     ns[f"{dest}_was_none"] = main.cli[f"{s.dest}_was_none"]
-            elif s.dest in main.config:
-                ns = context.config
             else:
-                ns = context.defaults
+                # Always use context.config for non-CLI initrd settings to ensure they
+                # merge with mkosi-initrd config during parsing
+                ns = context.config
 
             ns[dest] = copy.deepcopy(finalized[s.dest])
 


### PR DESCRIPTION
The check `s.dest in main.config` in finalize_default_initrd() is unreliable - initrd_packages is often not present in main.config even when specified in configuration files, causing values to fall through to context.defaults.

When mkosi-initrd/mkosi.conf is parsed, the parser only checks context.config (not context.defaults), so user packages are not seen and cannot be merged. Additionally, during finalization, context.config takes priority over context.defaults, causing user packages to be lost.

Fix by always using context.config for non-CLI initrd settings, ensuring they are visible to the parser and get properly merged with the mkosi-initrd default packages via the list parser.

Fixes #4114 