### PR TITLE
opensuse: More GPG key handling fixes

### DIFF
--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -111,7 +111,6 @@ class Zypper(PackageManager):
             "--non-interactive",
             "--no-refresh",
             f"--releasever={context.config.release}",
-            *(["--gpg-auto-import-keys"] if context.config.repository_key_fetch else []),
             *(["--no-gpg-checks"] if not context.config.repository_key_check else []),
             *([f"--plus-content={repo}" for repo in context.config.repositories]),
             *(["-vv"] if ARG_DEBUG.get() else []),
@@ -163,7 +162,12 @@ class Zypper(PackageManager):
 
     @classmethod
     def sync(cls, context: Context, force: bool, arguments: Sequence[str] = ()) -> None:
-        cls.invoke(context, "refresh", [*(["--force"] if force else []), *arguments])
+        cls.invoke(
+            context,
+            "refresh",
+            [*(["--force"] if force else []), *arguments],
+            options=["--gpg-auto-import-keys"] if context.config.repository_key_fetch else [],
+        )
 
     @classmethod
     def createrepo(cls, context: Context) -> None:


### PR DESCRIPTION
- Pass GPG keys to rpm --import as paths inside the sandbox. This
  makes sure that overrides from mkosi.sandbox are taken into account.
  e.g. atm we pass mkosi.tools/usr/share/distribution-gpg-keys/... whereas
  now we pass /usr/share/distribution-gpg-keys/...
- Make sure we figure out keys once when using zypper. zypper downloads
  GPG keys (when fetching is enabled) when refreshing repositories. These
  keys are stored in the rpm database in the temporary root we use when
  syncing repository metadata. To make sure they are not lost, we extract
  the keys using rpmkeys and store them in the keyring directory which we
  use from then onwards. For all image builds we then simply import the
  keys from the keyring directory.