### PR TITLE
Updated man page to mention "gui" not being part of default set

### DIFF
--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1466,7 +1466,7 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 :   Set the profiles to enable for the default tools tree. Takes a
     comma-delimited list consisting of `devel`, `misc`,
     `package-manager` and `runtime`. By default, all profiles except
-    `devel` are enabled.
+    `devel` and `gui` are enabled.
 
     The `devel` profile contains tools required to build (C/C++)
     projects. The `misc` profile contains various useful tools that are
@@ -1474,7 +1474,8 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     contains package managers and related tools other than those native
     to the tools tree distribution. The `runtime` profile contains the
     tools required to boot images in a systemd-nspawn container or in a
-    virtual machine.
+    virtual machine. The `gui` profile contains tools required to boot
+    images in a virtual machine with audio and graphics support.
 
 `ToolsTreeMirror=`, `--tools-tree-mirror=`
 :   Set the mirror to use for the default tools tree. By default, the


### PR DESCRIPTION
This PR addresses the issue: https://github.com/systemd/mkosi/issues/3941

The issue appears that the `qemu-*` and other various packages related to executing `mkosi vm` doesn't exist in the tools tree. And the [man page mentions](https://github.com/systemd/mkosi/blob/b1dffe1c3c4060225d758698fa5970af066a18ba/mkosi/resources/man/mkosi.1.md?plain=1#L1465-L1469) that all profiles are enabled except `devel`, which does not appear to be true unless GUI is added as done in this PR *(as far as we understand)*. This should be a problem on other distro's too, but I've tested on Arch and this solves the issue there at least.

Here's an excerpt from the man page:

> `ToolsTreeProfiles=`, `--tools-tree-profile=`
> :   Set the profiles to enable for the default tools tree. Takes a
>     comma-delimited list consisting of `devel`, `misc`,
>     `package-manager` and `runtime`. By default, all profiles except
>     `devel` are enabled.

Strange thing is that the [gui](https://github.com/systemd/mkosi/blob/b1dffe1c3c4060225d758698fa5970af066a18ba/mkosi/resources/mkosi-tools/mkosi.profiles/gui/mkosi.conf.d/arch.conf) profile is some what undocumented and not mentioned in many places. So we add that to the man pages too, to highlight it's existance.

A workaround until a new release is out is also to do in `mkosi.conf`:

```ini
[Build]
ToolsTree=default
ToolsTreeDistribution=arch
ToolsTreeProfiles=devel,misc,package-manager,runtime,gui
```

Or in the case of Arch at least, in `mkosi.conf` do:
```ini
[Build]
ToolsTreePackages=qemu-full,pipewire
```

From a user experience perspective, it makes more sense for `mkosi vm --console=gui` to work. And if smaller images are desired, then overriding the `ToolsTreeProfiles=` to remove `gui` and other large profiles makes more sense.