### PR TITLE
dnf: Give advanced users some control over plugins

### DIFF
--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -169,6 +169,11 @@ class Dnf(PackageManager):
             "--setopt=persistdir=/buildroot/var/lib/dnf",
         ]
 
+        if plugins := context.config.environment.get("MKOSI_DNF_DISABLE_PLUGINS"):
+            cmdline += [f"--disableplugin={plugins}"]
+        if plugins := context.config.environment.get("MKOSI_DNF_ENABLE_PLUGINS"):
+            cmdline += [f"--enableplugin={plugins}"]
+
         if ARG_DEBUG.get():
             cmdline += ["--setopt=debuglevel=10"]
 

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -3127,6 +3127,12 @@ repository.
 * `$MKOSI_DNF` can be used to override the executable used as **dnf**.
   This is particularly useful to select between **dnf** and **dnf5**.
 
+* `$MKOSI_DNF_DISABLE_PLUGINS` can be used to disable dnf plugins. The value
+  is forwarded to dnf's `--disableplugin=` option.
+
+* `$MKOSI_DNF_ENABLE_PLUGINS` can be used to enable dnf plugins. The value
+  is forwarded to dnf's `--enableplugin=` option.
+
 * `$EPEL_MIRROR` can be used to override the default mirror location
   used for the epel repositories when `Mirror=` is used. By default
   **mkosi** looks for the epel repositories in the `fedora` subdirectory of


### PR DESCRIPTION
Let's add some environment variables to control plugins for cases where users have some dnf plugin they can't touch on their host system which doesn't behave properly in mkosi-sandbox and which they can't remove themselves.