### PR TITLE
rpm: Set pkgverify_level to digest

### DIFF
--- a/mkosi/installer/rpm.py
+++ b/mkosi/installer/rpm.py
@@ -91,6 +91,10 @@ def setup_rpm(
     if dbbackend:
         (confdir / "macros.db_backend").write_text(f"%_db_backend {dbbackend}")
 
+    # TODO: Drop when zypper and dnf5 correctly disable signature checks for gpgcheck=0 repositories.
+    if not (confdir / "macros.pkgverify_level").exists():
+        (confdir / "macros.pkgverify_level").write_text("%_pkgverify_level digest")
+
     if context.config.distribution == Distribution.opensuse or (
         context.config.distribution.is_centos_variant() and context.config.release == "9"
     ):


### PR DESCRIPTION
This was changed to all in rpm 6.0.0, which means that rpm is checking for signatures from dnf/zypper repos that have gpgcheck=0. dnf5 was updated to deal with this but for some reason the fix isn't working in Arch and zypper doesn't deal with this at all, so revert back to the previous level until package managers can actually deal with this.