### PR TITLE
config / qemu: add Console=headless

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -376,6 +376,7 @@ class ConsoleMode(StrEnum):
     read_only = enum.auto()
     native = enum.auto()
     gui = enum.auto()
+    headless = enum.auto()
 
 
 class Network(StrEnum):

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1818,11 +1818,13 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     kernel command line arguments.
 
 `Console=`, `--console=`
-:   Configures how to set up the console of the VM. Takes one of `interactive`, `read-only`, `native`, or
-    `gui`. Defaults to `interactive`. `interactive` provides an interactive terminal interface to the VM.
-    `read-only` is similar, but is strictly read-only, i.e. does not accept any input from the user.
-    `native` also provides a TTY-based interface, but uses **qemu**'s native implementation (which means the **qemu**
-    monitor is available). `gui` shows the **qemu** graphical UI.
+:   Configures how to set up the console of the VM. Takes one of `interactive`, `read-only`, `native`,
+    `gui`, or `headless`. Defaults to `interactive`. `interactive` provides an interactive terminal interface
+    to the VM. `read-only` is similar, but is strictly read-only, i.e. does not accept any input from the
+    user. `native` also provides a TTY-based interface, but uses **qemu**'s native implementation (which means
+    the **qemu** monitor is available). `gui` shows the **qemu** graphical UI. `headless` runs the VM without
+    any console attached, useful for fully automated or scripted VM usage. `headless` is only supported by
+    the `qemu` verb.
 
 `CPUs=`, `--cpus=`
 :   Configures the number of CPU cores to assign to the guest when booting a virtual machine.

--- a/mkosi/vmspawn.py
+++ b/mkosi/vmspawn.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from mkosi.config import (
     Args,
     Config,
+    ConsoleMode,
     Firmware,
     Network,
     OutputFormat,
@@ -35,6 +36,9 @@ def run_vmspawn(args: Args, config: Config) -> None:
 
     if config.firmware_variables and config.firmware_variables != Path("microsoft"):
         die("mkosi vmspawn does not support FirmwareVariables=")
+
+    if config.console == ConsoleMode.headless:
+        die("Console=headless is not supported by vmspawn")
 
     kernel = config.expand_linux_specifiers() if config.linux else None
     firmware = finalize_firmware(config, kernel)


### PR DESCRIPTION
Add a headless option for Console so automation can run the qemu instance in a background task.  In the current modes, qemu just exits on boot because the console has nothing to attach to.