### PR TITLE
mkosi-tools: add libarchive-tools to tools tree.

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
@@ -21,3 +21,4 @@ Packages=
         python3-pefile
         squashfs-tools
         xz-utils
+        libarchive-tools


### PR DESCRIPTION
Fix Arch image build failure due to missing bsdtar. Fixes discussions/4135.