### PR TITLE
Add support for building UKIProfiles initrds with extra packages

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1935,6 +1935,7 @@ class UKIProfile:
     profile: dict[str, str]
     cmdline: list[str]
     sign_expected_pcr: bool
+    packages: list[str]
 
 
 def make_simple_config_parser(
@@ -2636,6 +2637,13 @@ UKI_PROFILE_SETTINGS: list[ConfigSetting[Any]] = [
         section="UKIProfile",
         parse=config_parse_boolean,
         default=True,
+    ),
+    ConfigSetting(
+        dest="packages",
+        metavar="PACKAGE",
+        section="UKIProfile",
+        parse=config_make_list_parser(delimiter=",", key=package_sort_key),
+        help="Add an additional package to the UKI Profile's initrd",
     ),
 ]
 
@@ -5948,6 +5956,7 @@ def json_type_transformer(refcls: Union[type[Args], type[Config]]) -> Callable[[
             UKIProfile(
                 profile=profile["Profile"],
                 cmdline=profile["Cmdline"],
+                packages=profile["Packages"],
                 sign_expected_pcr=profile["SignExpectedPcr"],
             )
             for profile in profiles

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -2266,6 +2266,13 @@ settings can be specified in the `UKIProfile` section:
     `.cmdline` section and the extra kernel command line arguments
     specified with this setting.
 
+`Packages=`
+:   Install the specified distribution packages (i.e. RPM, deb, …) in the
+    initrd, on top of the base profile's initrd. Takes a comma-separated list
+    of package specifications. This option may be used multiple times in which
+    case the specified package lists are combined. The types and syntax is the
+    same as the `Content` section's `Packages=` setting.
+
 `SignExpectedPcr=`
 :   Sign expected PCR measurements for this UKI profile. Takes a boolean.
     Enabled by default.

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -397,6 +397,9 @@ def test_config() -> None:
                     "Cmdline": [
                         "key=value"
                     ],
+                    "Packages": [
+                        "mypackage"
+                    ],
                     "Profile": {
                         "key": "value"
                     },
@@ -596,6 +599,7 @@ def test_config() -> None:
             UKIProfile(
                 profile={"key": "value"},
                 cmdline=["key=value"],
+                packages=["mypackage"],
                 sign_expected_pcr=True,
             )
         ],


### PR DESCRIPTION
If Packages= is specifed under a UKI profile, take the 'main' initrd and add the new packages on top of it, and use that as the profile's initrd. Profile's sections are complete replacements, they are not additive, so it needs to be the full thing.