### PR TITLE
Add support for using the foreign UID range for directory images

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import datetime
+import errno
 import functools
 import getpass
 import hashlib
@@ -124,32 +125,21 @@ from mkosi.run import (
     finalize_interpreter,
     finalize_passwd_symlinks,
     find_binary,
-    fork_and_wait,
     run,
     spawn,
     workdir,
 )
 from mkosi.sandbox import (
-    CAP_SYS_ADMIN,
     CLONE_NEWNS,
-    MOUNT_ATTR_NODEV,
-    MOUNT_ATTR_NOEXEC,
-    MOUNT_ATTR_NOSUID,
-    MOUNT_ATTR_RDONLY,
-    MS_REC,
-    MS_SLAVE,
     __version__,
     acquire_privileges,
-    have_effective_cap,
     join_new_session_keyring,
-    mount,
-    mount_bind,
     umask,
     unshare,
     userns_has_single_user,
 )
 from mkosi.sysupdate import run_sysupdate
-from mkosi.tree import copy_tree, make_tree, move_tree, rmtree
+from mkosi.tree import copy_tree, is_foreign_uid_tree, make_tree, move_tree, rmtree
 from mkosi.user import INVOKING_USER, become_root_cmd
 from mkosi.util import (
     PathString,
@@ -4137,6 +4127,28 @@ def build_image(context: Context) -> None:
     elif context.config.output_format == OutputFormat.directory:
         context.root.rename(context.staging / context.config.output_with_format)
 
+        if context.config.foreign_uid_range:
+            with complete_step("Changing ownership to the foreign UID range"):
+                run(
+                    [
+                        "systemd-dissect",
+                        "--shift",
+                        workdir(context.staging / context.config.output_with_format),
+                        "foreign",
+                    ],
+                    sandbox=context.sandbox(
+                        options=[
+                            # systemd-dissect --shift maps root to foreign uid root so we have to pretend the
+                            # files on disk are owned by root to get it to shift UIDs correctly.
+                            "--become-root",
+                            "--map-foreign",
+                            "--bind",
+                            context.staging / context.config.output_with_format,
+                            workdir(context.staging / context.config.output_with_format),
+                        ],
+                    ),
+                )
+
     if context.config.output_size and context.config.output_format == OutputFormat.disk:
         output = context.staging / context.config.output_with_format
         current_size = output.stat().st_size
@@ -4303,17 +4315,7 @@ def run_shell(args: Args, config: Config) -> None:
                 stack.callback((config.output_dir_or_cwd() / f"{name}.nspawn").unlink, missing_ok=True)
             copyfile2(config.nspawn_settings, config.output_dir_or_cwd() / f"{name}.nspawn")
 
-        # If we're booting a directory image that wasn't built by root, we always make an ephemeral
-        # copy to avoid ending up with files not owned by the directory image owner in the
-        # directory image.
-        if config.ephemeral or (
-            config.output_format == OutputFormat.directory
-            and args.verb == Verb.boot
-            and (config.output_dir_or_cwd() / config.output).stat().st_uid != 0
-        ):
-            fname = stack.enter_context(copy_ephemeral(config, config.output_dir_or_cwd() / config.output))
-        else:
-            fname = stack.enter_context(flock_or_die(config.output_dir_or_cwd() / config.output))
+        fname = stack.enter_context(copy_ephemeral(config, config.output_dir_or_cwd() / config.output))
 
         if config.output_format == OutputFormat.disk and args.verb == Verb.boot:
             run(
@@ -4337,26 +4339,7 @@ def run_shell(args: Args, config: Config) -> None:
                 setup=become_root_cmd(),
             )  # fmt: skip
 
-        if config.output_format == OutputFormat.directory:
-            cmdline += ["--directory", fname]
-
-            owner = os.stat(fname).st_uid
-            if owner != 0:
-                # Let's allow running a shell in a non-ephemeral image but in that case only map a
-                # single user into the image so it can't get polluted with files or directories
-                # owned by other users.
-                if (
-                    args.verb == Verb.shell
-                    and config.output_format == OutputFormat.directory
-                    and not config.ephemeral
-                ):
-                    range = 1
-                else:
-                    range = 65536
-
-                cmdline += [f"--private-users={owner}:{range}"]
-        else:
-            cmdline += ["--image", fname]
+        cmdline += ["--directory" if fname.is_dir() else "--image", fname]
 
         if config.runtime_build_sources:
             for t in config.build_sources:
@@ -4436,22 +4419,12 @@ def run_shell(args: Args, config: Config) -> None:
                 relaxed=True,
                 options=["--same-dir"],
             ),
-            setup=become_root_cmd(),
         )
 
 
 def run_systemd_tool(tool: str, args: Args, config: Config) -> None:
     if config.output_format not in (OutputFormat.disk, OutputFormat.directory):
         die(f"{config.output_format} images cannot be inspected with {tool}")
-
-    if (
-        args.verb in (Verb.journalctl, Verb.coredumpctl)
-        and config.output_format == OutputFormat.disk
-        and os.getuid() != 0
-    ):
-        need_root = True
-    else:
-        need_root = False
 
     if (tool_path := config.find_binary(tool)) is None:
         die(f"Failed to find {tool}")
@@ -4471,12 +4444,7 @@ def run_systemd_tool(tool: str, args: Args, config: Config) -> None:
         stdout=sys.stdout,
         env=os.environ | config.finalize_environment(),
         log=False,
-        sandbox=config.sandbox(
-            network=True,
-            devices=config.output_format == OutputFormat.disk,
-            relaxed=True,
-        ),
-        setup=become_root_cmd() if need_root else [],
+        sandbox=config.sandbox(network=True, relaxed=True),
     )
 
 
@@ -4731,17 +4699,6 @@ def needs_build(args: Args, config: Config, force: int = 1) -> bool:
     )
 
 
-def remove_cache_entries(config: Config) -> None:
-    if not config.cache_dir:
-        return
-
-    sandbox = functools.partial(config.sandbox, tools=False)
-
-    if any(p.exists() for p in cache_tree_paths(config)):
-        with complete_step(f"Removing cache entries of {config.image} image…"):
-            rmtree(*(p for p in cache_tree_paths(config) if p.exists()), sandbox=sandbox)
-
-
 def run_clean(args: Args, config: Config, repository_metadata_needs_sync: bool = False) -> None:
     # We remove any cached images if either the user used --force twice, or he/she called "clean"
     # with it passed once. Let's also remove the downloaded package cache if the user specified one
@@ -4801,8 +4758,9 @@ def run_clean(args: Args, config: Config, repository_metadata_needs_sync: bool =
         with complete_step(f"Clearing out build directory of {config.image} image…"):
             rmtree(*config.build_subdir.iterdir(), sandbox=sandbox)
 
-    if remove_image_cache and config.cache_dir:
-        remove_cache_entries(config)
+    if remove_image_cache and config.cache_dir and any(p.exists() for p in cache_tree_paths(config)):
+        with complete_step(f"Removing cache entries of {config.image} image…"):
+            rmtree(*(p for p in cache_tree_paths(config) if p.exists()), sandbox=sandbox)
 
     if remove_package_cache and config.cache_dir and config.image in ("main", "tools"):
         with complete_step(f"Clearing out metadata and keyring cache of {config.image} image…"):
@@ -4930,65 +4888,6 @@ def sync_repository_metadata(
     return keyring_dir, metadata_dir
 
 
-def run_build(
-    args: Args,
-    config: Config,
-    *,
-    resources: Path,
-    keyring_dir: Path,
-    metadata_dir: Path,
-    package_dir: Optional[Path] = None,
-) -> None:
-    if not have_effective_cap(CAP_SYS_ADMIN):
-        acquire_privileges()
-        unshare(CLONE_NEWNS)
-    else:
-        unshare(CLONE_NEWNS)
-        mount("", "/", "", MS_SLAVE | MS_REC, "")
-
-    # For extra safety when running as root, remount a bunch of directories read-only unless the output
-    # directory is located in it.
-    if os.getuid() == 0:
-        remount = ["/etc", "/opt", "/boot", "/efi", "/media", "/usr"]
-
-        for d in remount:
-            if not Path(d).exists():
-                continue
-
-            if any(
-                p and p.is_relative_to(d)
-                for p in (
-                    config.workspace_dir_or_default(),
-                    config.package_cache_dir_or_default(),
-                    config.cache_dir,
-                    config.output_dir_or_cwd(),
-                )
-            ):
-                continue
-
-            attrs = MOUNT_ATTR_RDONLY
-            if d in ("/boot", "/efi"):
-                attrs |= MOUNT_ATTR_NOSUID | MOUNT_ATTR_NODEV | MOUNT_ATTR_NOEXEC
-
-            mount_bind(d, d, attrs, recursive=True)
-
-    with (
-        complete_step(f"Building {config.image} image"),
-        setup_workspace(args, config) as workspace,
-    ):
-        build_image(
-            Context(
-                args,
-                config,
-                workspace=workspace,
-                resources=resources,
-                keyring_dir=keyring_dir,
-                metadata_dir=metadata_dir,
-                package_dir=package_dir,
-            )
-        )
-
-
 def ensure_tools_tree_has_etc_resolv_conf(config: Config) -> None:
     if not config.tools_tree:
         return
@@ -5083,6 +4982,28 @@ def run_verb(args: Args, tools: Optional[Config], images: Sequence[Config], *, r
         run_latest_snapshot(args, last)
         return
 
+    try:
+        # Try to get a user namespace with some delegated ranges and the foreign UID range via
+        # systemd-nsresourced if we can.
+        acquire_privileges(foreign=True, delegate=3)
+    except OSError as e:
+        # Don't fail if systemd-nsresourced is too old or not installed, use a regular unpriv user namespace
+        # instead.
+        if isinstance(e, OSError) and e.errno not in (errno.EINVAL, errno.ENOENT):
+            raise
+
+        logging.debug(
+            f"Could not provision user namespace via systemd-nsresourced ({e}), falling back to "
+            "unprivileged user namespace via unshare(CLONE_NEWUSER) and writing /proc/self/uid_map directly"
+        )
+
+        acquire_privileges()
+
+    # Most of our mounts happen in subprocesses these days but the overlay mounts for Overlay=yes still
+    # happen in process so we need to set up a private mount namespace. We don't have any reason to modify
+    # the current one anyway so this doesn't hurt even if it might not always be necessary.
+    unshare(CLONE_NEWNS)
+
     if args.verb == Verb.clean:
         if tools and args.force > 0:
             run_clean(args, tools)
@@ -5120,13 +5041,19 @@ def run_verb(args: Args, tools: Optional[Config], images: Sequence[Config], *, r
                 resources=resources,
                 stack=stack,
             )
-            fork_and_wait(
-                run_build,
-                args,
-                tools,
-                resources=resources,
-                keyring_dir=tkd,
-                metadata_dir=tmd,
+
+            stack.enter_context(complete_step(f"Building {tools.image} image"))
+            workspace = stack.enter_context(setup_workspace(args, tools))
+
+            build_image(
+                Context(
+                    args,
+                    tools,
+                    workspace=workspace,
+                    resources=resources,
+                    keyring_dir=tkd,
+                    metadata_dir=tmd,
+                )
             )
 
         resolv = tools.output_dir_or_cwd() / tools.output / "etc/resolv.conf"
@@ -5302,15 +5229,24 @@ def run_verb(args: Args, tools: Optional[Config], images: Sequence[Config], *, r
                         stack=stack,
                     )
 
-                fork_and_wait(
-                    run_build,
-                    args,
-                    config,
-                    resources=resources,
-                    keyring_dir=ikd,
-                    metadata_dir=imd,
-                    package_dir=package_dir,
-                )
+                assert ikd
+                assert imd
+
+                with (
+                    complete_step(f"Building {config.image} image"),
+                    setup_workspace(args, config) as workspace,
+                ):
+                    build_image(
+                        Context(
+                            args,
+                            config,
+                            workspace=workspace,
+                            resources=resources,
+                            keyring_dir=ikd,
+                            metadata_dir=imd,
+                            package_dir=package_dir,
+                        )
+                    )
 
             if not ikd and not imd:
                 logging.info("All images have already been built and do not have any build scripts")
@@ -5323,14 +5259,10 @@ def run_verb(args: Args, tools: Optional[Config], images: Sequence[Config], *, r
     if args.verb == Verb.build:
         return
 
-    if (
-        last.output_format == OutputFormat.directory
-        and (last.output_dir_or_cwd() / last.output).stat().st_uid == 0
-        and os.getuid() != 0
-    ):
+    if (output := last.output_dir_or_cwd() / last.output).is_dir() and not is_foreign_uid_tree(output):
         die(
-            "Cannot operate on directory images built as root when running unprivileged",
-            hint="Clean the root owned image by running mkosi -ff clean as root and then rebuild the image",
+            "Can only operate on foreign UID range owned directory images",
+            hint="Add ForeignUIDRange=yes to [Build] and rebuild the image to use the foreign UID range",
         )
 
     run_vm = {

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2163,6 +2163,7 @@ class Config:
     proxy_client_certificate: Optional[Path]
     proxy_client_key: Optional[Path]
     make_scripts_executable: bool
+    foreign_uid_range: bool
 
     nspawn_settings: Optional[Path]
     ephemeral: bool
@@ -4060,6 +4061,14 @@ SETTINGS: list[ConfigSetting[Any]] = [
         default=False,
         help="Whether mkosi will try to make build/postinst/finalize scripts executable if they are not",
         scope=SettingScope.multiversal,
+    ),
+    ConfigSetting(
+        dest="foreign_uid_range",
+        name="ForeignUIDRange",
+        section="Build",
+        parse=config_parse_boolean,
+        help="Use the foreign UID range",
+        scope=SettingScope.main,
     ),
     # Runtime section
     ConfigSetting(

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -50,9 +50,9 @@ from mkosi.config import (
 )
 from mkosi.log import ARG_DEBUG, die
 from mkosi.partition import finalize_root, find_partitions
-from mkosi.run import AsyncioThread, find_binary, fork_and_wait, run, spawn, workdir
+from mkosi.run import AsyncioThread, find_binary, run, spawn, workdir
 from mkosi.tree import copy_tree, maybe_make_nocow, rmtree
-from mkosi.user import INVOKING_USER, become_root_in_subuid_range, become_root_in_subuid_range_cmd
+from mkosi.user import INVOKING_USER
 from mkosi.util import (
     PathString,
     StrEnum,
@@ -393,25 +393,11 @@ def start_virtiofsd(
             pass_fds=(sock.fileno(),),
             user=st.st_uid if st else None,
             group=st.st_gid if st else None,
-            # If we're booting from virtiofs and unshare is too old, we use our own function to become root
-            # in the subuid range if needed.
-            # TODO: Drop this as soon as we drop CentOS Stream 9 support and can rely on newer unshare
-            # features.
-            preexec=(
-                become_root_in_subuid_range
-                if not uidmap and os.getuid() != 0 and unshare_version() < "2.38"
-                else None
-            ),
             sandbox=config.sandbox(
                 options=[
-                    "--bind", directory, workdir(directory),
-                    *(["--become-root"] if uidmap else []),
+                    "--bind" if uidmap else "--bind-foreign", directory, workdir(directory),
+                    "--become-root",
                 ],
-            ),
-            setup=(
-                become_root_in_subuid_range_cmd()
-                if not uidmap and os.getuid() != 0 and unshare_version() >= "2.38"
-                else []
             ),
         ) as proc:  # fmt: skip
             yield path
@@ -530,12 +516,7 @@ def copy_ephemeral(config: Config, src: Path) -> Iterator[Path]:
         yield src
         return
 
-    # If we're booting a directory image that was not built as root, we have to make an ephemeral copy. If
-    # we're running as root, we have to make an ephemeral copy so that all the files in the directory tree
-    # are also owned by root. If we're not running as root, we'll be making use of a subuid/subgid user
-    # namespace and we don't want any leftover files from the subuid/subgid user namespace to remain after we
-    # shut down the container or virtual machine.
-    if not config.ephemeral and (config.output_format != OutputFormat.directory or src.stat().st_uid == 0):
+    if not config.ephemeral:
         with flock_or_die(src):
             yield src
 
@@ -548,31 +529,11 @@ def copy_ephemeral(config: Config, src: Path) -> Iterator[Path]:
     tmp = src.parent / f"{src.name}-{uuid.uuid4().hex[:16]}"
 
     try:
-
-        def copy() -> None:
-            copy_tree(
-                src,
-                tmp,
-                preserve=(
-                    config.output_format == OutputFormat.directory
-                    and (os.getuid() != 0 or src.stat().st_uid == 0)
-                ),
-                use_subvolumes=config.use_subvolumes,
-                sandbox=config.sandbox,
-            )
-
         with flock(src, flags=fcntl.LOCK_SH):
-            fork_and_wait(copy)
+            copy_tree(src, tmp, use_subvolumes=config.use_subvolumes, sandbox=config.sandbox)
         yield tmp
     finally:
-
-        def rm() -> None:
-            if config.output_format == OutputFormat.directory:
-                become_root_in_subuid_range()
-
-            rmtree(tmp, sandbox=config.sandbox)
-
-        fork_and_wait(rm)
+        rmtree(tmp, sandbox=config.sandbox)
 
 
 def join_initrds(initrds: Sequence[Path], output: Path) -> Path:
@@ -969,11 +930,8 @@ def run_qemu(args: Args, config: Config) -> None:
     if config.bind_user:
         die("mkosi qemu does not support --bind-user=")
 
-    # After we unshare the user namespace to sandbox qemu, we might not have access to /dev/kvm or related
-    # device nodes anymore as access to these might be gated behind the kvm group and we won't be part of the
-    # kvm group anymore after unsharing the user namespace. To get around this, open all those device nodes
-    # early can pass them as file descriptors to qemu later. Note that we can't pass the kvm file descriptor
-    # to qemu until version 9.0.
+    # Pass various /dev files as fds if we can. This allows us to provide better errors if we can't access
+    # these for whatever reason.
     qemu_device_fds = {
         d: d.open()
         for d in QemuDeviceNode

--- a/mkosi/resources/man/mkosi-sandbox.1.md
+++ b/mkosi/resources/man/mkosi-sandbox.1.md
@@ -66,6 +66,17 @@ from `mkosi.sandbox` is not supported and may break in future versions.
 `--ro-bind-try SRC DST`
 :   Like `--bind-try`, but does a recursive readonly bind mount.
 
+`--bind-foreign SRC DST`
+:   Like `--bind`, but `mkosi-sandbox` will allocate a user namespace and provision it with a transient UID
+    range using `systemd-nsresourced` and then idmap the foreign UID range to this transient UID range using
+    `systemd-mountfsd` for each `--bind-foreign` mount. Finally, `mkosi-sandbox` will join the user namespace
+    just before executing the configure command in the sandbox.
+
+    Using this option requires `systemd-nsresourced` and `systemd-mountfsd` v260 or newer.
+
+`--ro-bind-foreign SRC DST`
+:   Like `--bind-foreign`, but does a readonly mount.
+
 `--symlink SRC DST`
 :   Creates a symlink at `DST` in the sandbox pointing to `SRC`. If `DST` already
     exists and is a file or symlink, a temporary symlink is created and mounted on
@@ -112,6 +123,21 @@ from `mkosi.sandbox` is not supported and may break in future versions.
     sandbox will be able to do bind mounts and other operations.
 
     If `mkosi-sandbox` is invoked as the root user, this option won't do anything.
+
+`--map-foreign`
+:   Map the foreign UID range in the sandbox. For more information on the foreign UID range,
+    see [Users, Groups, UIDs and GIDs on systemd Systems](https://systemd.io/UIDS-GIDS/).
+
+    When running `mkosi-sandbox` unprivileged, this option requires `systemd-nsresourced`
+    v260 or newer.
+
+`--map-delegate N`
+:   Map N additional 64K UID/GID ranges in the sandbox.
+
+    This is needed to execute `systemd-nspawn` or any program that tries to allocate a
+    transient UID range via `systemd-nsresourced` from within the `mkosi-sandbox` environment.
+
+    This option requires `systemd-nsresourced` v260 or newer.
 
 `--suppress-chown`
 :   Specifying this option causes all calls to `chown()` or similar system calls to become a

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -92,12 +92,21 @@ The following command line verbs are known:
     shell in the container. To pass extra options to nspawn, separate them
     from regular options with `--`.
 
+    To use `directory` images with `shell`, the `ForeignUIDRange=` option has to
+    be enabled when building the image.
+
 `boot`
 :   Similar to `shell`, but instead of spawning a shell, it boots systemd in the
     image using **systemd-nspawn**. Extra arguments may be specified after
     the `boot` verb, which are passed as the *kernel command line* to the
     init system in the image. To pass extra options to nspawn, separate them
     from regular options with `--`.
+
+    To use `directory` images with `boot`, the `ForeignUIDRange=` option has to
+    be enabled when building the image.
+
+    To use `disk` images with `boot`, systemd-nsresourced and systemd-mountfsd
+    v260 or newer are required on the host.
 
 `vm`
 :   Similar to `boot`, but uses the configured virtual machine monitor (by
@@ -107,6 +116,9 @@ The following command line verbs are known:
     virtual machine monitor. See `VirtualMachineMonitor=` for more
     information. To pass extra options to the configured virtual machine
     monitor, separate them from regular options with `--`.
+
+    To use `directory` images with `vm`, the `ForeignUIDRange=` option has to
+    be enabled when building the image.
 
 `ssh`
 :   When the image is built with the `Ssh=always` option or if systemd's
@@ -1797,6 +1809,16 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 `MakeScriptsExecutable=`, `--make-scripts-executable=`
 :   If one of the hook scripts (see `SCRIPTS` section) is not marked as executable, attempt to chmod it
     instead of failing outright. Defaults to `no`.
+
+`ForeignUIDRange=`, `--foreign-uid-range=`
+:   If enabled, directory images will be owned by the foreign UID range on disk
+    instead of the user's UID.
+
+    Enabling this option is required to use directory images with `mkosi shell`,
+    `mkosi boot` and `mkosi vm`.
+
+    systemd-nsresourced and systemd-mountfsd v260 or newer are required on the host
+    to make use of this option.
 
 ### [Runtime] Section (previously known as the [Host] section)
 

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -261,12 +261,8 @@ def _preexec(
     cmd: list[str],
     env: dict[str, Any],
     sandbox: list[str],
-    preexec: Optional[Callable[[], None]],
 ) -> None:
     with uncaught_exception_handler(exit=os._exit, fork=True, proceed=True):
-        if preexec:
-            preexec()
-
         if not sandbox:
             return
 
@@ -306,7 +302,6 @@ def spawn(
     pass_fds: Collection[int] = (),
     env: Mapping[str, str] = {},
     log: bool = True,
-    preexec: Optional[Callable[[], None]] = None,
     success_exit_status: Sequence[int] = (0,),
     setup: Sequence[PathString] = (),
     sandbox: AbstractContextManager[Sequence[PathString]] = nosandbox(),
@@ -365,12 +360,15 @@ def spawn(
                 group=group,
                 pass_fds=pass_fds,
                 env=env if not sbx or not apply_sandbox_in_preexec else None,
-                preexec_fn=functools.partial(
-                    _preexec,
-                    cmd=cmd,
-                    env=env,
-                    sandbox=sbx if apply_sandbox_in_preexec else [],
-                    preexec=preexec,
+                preexec_fn=(
+                    functools.partial(
+                        _preexec,
+                        cmd=cmd,
+                        env=env,
+                        sandbox=sbx,
+                    )
+                    if apply_sandbox_in_preexec and sbx
+                    else None
                 ),
             )
         except FileNotFoundError as e:
@@ -402,12 +400,15 @@ def spawn(
                     user=user,
                     group=group,
                     env=env if not sbx or not apply_sandbox_in_preexec else None,
-                    preexec_fn=functools.partial(
-                        _preexec,
-                        cmd=["bash"],
-                        env=env,
-                        sandbox=sbx if apply_sandbox_in_preexec else [],
-                        preexec=preexec,
+                    preexec_fn=(
+                        functools.partial(
+                            _preexec,
+                            cmd=["bash"],
+                            env=env,
+                            sandbox=sbx,
+                        )
+                        if apply_sandbox_in_preexec and sbx
+                        else None
                     ),
                 )
             raise subprocess.CalledProcessError(returncode, cmdline)

--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -58,6 +58,8 @@ FICLONE = 0x40049409
 FS_IOC_GETFLAGS = 0x80086601
 FS_IOC_SETFLAGS = 0x40086602
 FS_NOCOW_FL = 0x00800000
+FOREIGN_UID_MIN = 2147352576
+FOREIGN_UID_MAX = FOREIGN_UID_MIN + 0xFFFF
 LINUX_CAPABILITY_U32S_3 = 2
 LINUX_CAPABILITY_VERSION_3 = 0x20080522
 MNT_DETACH = 2
@@ -89,6 +91,7 @@ SCMP_ACT_ALLOW = 0x7FFF0000
 SCMP_ACT_ERRNO = 0x00050000
 SCMP_FLTATR_API_SYSRAWRC = 9
 SD_LISTEN_FDS_START = 3
+SIGCONT = 18
 SIGSTOP = 19
 
 
@@ -132,6 +135,7 @@ libc = ctypes.CDLL(None, use_errno=True)
 
 libc.syscall.restype = ctypes.c_long
 libc.unshare.argtypes = (ctypes.c_int,)
+libc.setns.argtypes = (ctypes.c_int, ctypes.c_int)
 libc.statfs.argtypes = (ctypes.c_char_p, ctypes.c_void_p)
 libc.eventfd.argtypes = (ctypes.c_int, ctypes.c_int)
 libc.mount.argtypes = (ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_ulong, ctypes.c_char_p)
@@ -140,6 +144,7 @@ libc.umount2.argtypes = (ctypes.c_char_p, ctypes.c_int)
 libc.capget.argtypes = (ctypes.c_void_p, ctypes.c_void_p)
 libc.capset.argtypes = (ctypes.c_void_p, ctypes.c_void_p)
 libc.fcntl.argtypes = (ctypes.c_int, ctypes.c_int, ctypes.c_int)
+libc.setns.argtypes = (ctypes.c_int, ctypes.c_int)
 
 
 def terminal_is_dumb() -> bool:
@@ -178,6 +183,11 @@ def oserror(syscall: str, filename: str = "", errno: int = 0) -> None:
 def unshare(flags: int) -> None:
     if libc.unshare(flags) < 0:
         oserror("unshare")
+
+
+def setns(fd: int, nstype: int) -> None:
+    if libc.setns(fd, nstype) < 0:
+        oserror("setns")
 
 
 def statfs(path: str) -> int:
@@ -587,7 +597,130 @@ class close:
         os.close(self.fd)
 
 
-def become_user(uid: int, gid: int) -> None:
+if sys.version_info >= (3, 10):
+    Json = dict[str, "Json"] | list["Json"] | str | int | float | bool | None
+    FD = int | tuple[str, int]
+else:
+    from typing import Union
+
+    Json = Union[dict[str, "Json"], list["Json"], str, int, float, bool, None]
+    FD = Union[int, tuple[str, int]]
+
+JsonObject = dict[str, Json]
+
+
+class VarlinkError(Exception):
+    """Exception raised when a varlink call returns an error."""
+
+    def __init__(self, error: str, parameters: JsonObject) -> None:
+        self.error = error
+        self.parameters = parameters
+        super().__init__(f"{error}: {parameters}")
+
+
+def varlink(
+    *,
+    path: str,
+    method: str,
+    parameters: JsonObject,
+    fds: tuple[FD, ...] = (),
+) -> tuple[JsonObject, list[int]]:
+    # To do varlink we need a few extra imports. We import these here to avoid slowing down invocations of
+    # mkosi-sandbox that don't need the varlink stuff.
+    import contextlib
+    import errno
+    import json
+    import socket
+
+    with contextlib.ExitStack() as stack:
+        sock = stack.enter_context(socket.socket(socket.AF_UNIX, socket.SOCK_STREAM))
+        sock.connect(os.fspath(path))
+
+        opened_fds = []
+
+        for fd in fds:
+            if isinstance(fd, int):
+                opened_fds += [fd]
+            else:
+                path, flags = fd
+                opened = os.open(path, flags | os.O_CLOEXEC)
+                opened_fds += [stack.enter_context(close(opened))]
+
+        message: JsonObject = {"method": method}
+        if parameters:
+            message["parameters"] = parameters
+
+        request = json.dumps(message).encode() + b"\x00"
+        socket.send_fds(sock, [request], opened_fds)
+        response, reply_fds, _, _ = socket.recv_fds(sock, bufsize=10 * 1024**2, maxfds=10)
+        reply = json.loads(response.decode().rstrip("\0"))
+
+        if "error" in reply:
+            for fd in reply_fds:
+                os.close(fd)
+
+            if "errnoName" in reply.get("parameters", {}):
+                name = reply["parameters"]["errnoName"]
+                num = getattr(errno, name, None)
+                if num is None:
+                    raise OSError(f"Method {method} returned an unknown error name '{name}'")
+
+                raise OSError(num, os.strerror(num))
+
+            if "errno" in reply.get("parameters", {}):
+                raise OSError(reply["parameters"]["errno"], os.strerror(reply["parameters"]["errno"]))
+
+            raise VarlinkError(reply["error"], reply.get("parameters", {}))
+
+        return reply.get("parameters", {}), reply_fds
+
+
+def nsresource_allocate_user_range(
+    userns: FD,
+    type: str = "managed",
+    foreign: bool = False,
+    delegate: int = 0,
+    become_root: bool = False,
+) -> None:
+    import uuid
+
+    varlink(
+        path="/run/systemd/io.systemd.NamespaceResource",
+        method="io.systemd.NamespaceResource.AllocateUserRange",
+        parameters={
+            "name": f"mkosi-{uuid.uuid4().hex[:4]}",
+            "size": 1 if type == "self" else 65536,
+            "userNamespaceFileDescriptor": 0,
+            "type": type,
+            **({"target": 0} if become_root or type != "self" else {}),
+            "mapForeign": foreign,
+            "delegateContainerRanges": delegate,
+        },
+        fds=(userns,),
+    )
+
+
+def mountfsd_mount_directory(directory: str, userns: int, *, readonly: bool) -> int:
+    reply, fds = varlink(
+        path="/run/systemd/io.systemd.MountFileSystem",
+        method="io.systemd.MountFileSystem.MountDirectory",
+        parameters={
+            "directoryFileDescriptor": 0,
+            "userNamespaceFileDescriptor": 1,
+            "mode": "foreign",
+            "readOnly": readonly,
+        },
+        fds=(
+            (directory, os.O_DIRECTORY | os.O_PATH),
+            userns,
+        ),
+    )
+
+    assert isinstance(reply["mountFileDescriptor"], int)
+    return fds[reply["mountFileDescriptor"]]
+
+
+def unprivileged_userns(foreign: bool, become_root: bool) -> None:
     """
     This function implements the required dance to unshare a user namespace and map the current
     user to itself or to root within it. The kernel only allows a process running outside of the
@@ -605,6 +738,8 @@ def become_user(uid: int, gid: int) -> None:
         oserror("prctl")
 
     ppid = os.getpid()
+    uid = 0 if become_root else os.getuid()
+    gid = 0 if become_root else os.getgid()
 
     event = libc.eventfd(0, EFD_CLOEXEC)
     if event < 0:
@@ -618,10 +753,18 @@ def become_user(uid: int, gid: int) -> None:
                 os.close(event)
                 with open(f"/proc/{ppid}/setgroups", "wb") as f:
                     f.write(b"deny\n")
+
+                gidmap = f"{gid} {os.getgid()} 1\n"
+                if foreign:
+                    gidmap += f"{FOREIGN_UID_MIN} {FOREIGN_UID_MIN} 65536\n"
                 with open(f"/proc/{ppid}/gid_map", "wb") as f:
-                    f.write(f"{gid} {os.getgid()} 1\n".encode())
+                    f.write(gidmap.encode())
+
+                uidmap = f"{uid} {os.getuid()} 1\n"
+                if foreign:
+                    uidmap += f"{FOREIGN_UID_MIN} {FOREIGN_UID_MIN} 65536\n"
                 with open(f"/proc/{ppid}/uid_map", "wb") as f:
-                    f.write(f"{uid} {os.getuid()} 1\n".encode())
+                    f.write(uidmap.encode())
             except OSError as e:
                 os._exit(e.errno or 1)
             except BaseException:
@@ -644,14 +787,42 @@ def become_user(uid: int, gid: int) -> None:
         raise OSError(rc, os.strerror(rc))
 
 
-def acquire_privileges(*, become_root: bool = False, network: bool = False) -> bool:
-    if have_effective_cap(CAP_SYS_ADMIN) and (os.getuid() == 0 or not become_root):
+def acquire_privileges(
+    *,
+    identity: bool = True,
+    foreign: bool = False,
+    delegate: int = 0,
+    become_root: bool = False,
+    network: bool = False,
+) -> bool:
+    if (
+        have_effective_cap(CAP_SYS_ADMIN)
+        and identity
+        and (not foreign or have_effective_cap(CAP_CHOWN))
+        and not delegate
+        and (not become_root or (os.getuid() == 0 and os.getgid() == 0))
+    ):
         return False
 
-    if become_root:
-        become_user(0, 0)
+    if not identity or (foreign and not have_effective_cap(CAP_CHOWN)) or delegate:
+        # nsresource_allocate_user_range() might fail for various reasons and we don't want to leave
+        # the process in an empty user namespace if that's the case. Hence we don't unshare our own
+        # user namespace but get ourselves a child user namespace which we pass to nsresourced. We only
+        # enter the child user namespace if nsresourced can successfully provision it.
+        with close(userns_acquire_empty()) as userns_fd:
+            nsresource_allocate_user_range(
+                userns_fd,
+                "self" if identity else "managed",
+                foreign,
+                delegate,
+                become_root,
+            )
+            setns(userns_fd, CLONE_NEWUSER)
+        if become_root:
+            os.setresgid(0, 0, 0)
+            os.setresuid(0, 0, 0)
     else:
-        become_user(os.getuid(), os.getgid())
+        unprivileged_userns(foreign, become_root)
 
     fix_userns_capabilities(network=network)
 
@@ -666,6 +837,38 @@ def userns_has_single_user() -> bool:
         return False
 
     return len(lines) == 1 and int(lines[0].split()[-1]) == 1
+
+
+def userns_acquire_empty() -> int:
+    pid = os.fork()
+    if pid == 0:
+        try:
+            unshare(CLONE_NEWUSER)
+            os.kill(os.getpid(), SIGSTOP)
+        except OSError as e:
+            os._exit(e.errno or 1)
+        except BaseException:
+            os._exit(1)
+        else:
+            os._exit(0)
+
+    try:
+        result = os.waitid(os.P_PID, pid, os.WEXITED | os.WSTOPPED | os.WNOWAIT)
+        if result and result.si_code != os.CLD_STOPPED:
+            rc = os.waitstatus_to_exitcode(result.si_status)
+            raise OSError(rc, os.strerror(rc))
+
+        userns_fd = os.open(f"/proc/{pid}/ns/user", os.O_RDONLY | os.O_CLOEXEC)
+    finally:
+        os.kill(pid, SIGCONT)
+        _, status = os.waitpid(pid, 0)
+
+    rc = os.waitstatus_to_exitcode(status)
+    if rc != 0:
+        os.close(userns_fd)
+        raise OSError(rc, os.strerror(rc))
+
+    return userns_fd
 
 
 def chase(root: str, path: str) -> str:
@@ -819,10 +1022,14 @@ class FSOperation:
 
 
 class BindOperation(FSOperation):
-    def __init__(self, src: str, dst: str, *, readonly: bool, required: bool, relative: bool) -> None:
+    def __init__(
+        self, src: str, dst: str, *, readonly: bool, required: bool, foreign: bool, relative: bool
+    ) -> None:
         self.src = src
         self.readonly = readonly
         self.required = required
+        self.foreign = foreign
+        self.mappedfd = -EBADF
         super().__init__(dst, relative=relative)
 
     def __hash__(self) -> int:
@@ -856,7 +1063,11 @@ class BindOperation(FSOperation):
                 else:
                     os.mkdir(dst)
 
-        mount_bind(src, dst, attrs=MOUNT_ATTR_RDONLY if self.readonly else 0, recursive=True)
+        if self.mappedfd >= 0:
+            move_mount(self.mappedfd, "", AT_FDCWD, dst, MOVE_MOUNT_F_EMPTY_PATH)
+            os.close(self.mappedfd)
+        else:
+            mount_bind(src, dst, attrs=MOUNT_ATTR_RDONLY if self.readonly else 0, recursive=True)
 
 
 class DevOperation(FSOperation):
@@ -1053,6 +1264,8 @@ mkosi-sandbox [OPTIONS...] COMMAND [ARGUMENTS...]
      --bind-try SRC DST           Bind mount the host path SRC to DST if it exists
      --ro-bind SRC DST            Bind mount the host path SRC to DST read-only
      --ro-bind-try SRC DST        Bind mount the host path SRC to DST read-only if it exists
+     --bind-foreign SRC DST       Like --bind, but idmaps the foreign UID range to a transient UID range
+     --ro-bind-foreign SRC DST    Like --ro-bind, but idmaps the foreign UID range to a transient UID range
      --symlink SRC DST            Create a symlink at DST pointing to SRC
      --write DATA DST             Write DATA to DST
      --overlay-lowerdir DIR       Add a lower directory for the next overlayfs mount
@@ -1063,7 +1276,9 @@ mkosi-sandbox [OPTIONS...] COMMAND [ARGUMENTS...]
      --setenv NAME VALUE          Set the environment variable with name NAME to VALUE
      --chdir DIR                  Change the working directory in the sandbox to DIR
      --same-dir                   Change the working directory in the sandbox to $PWD
-     --become-root                Map the current user/group to root:root in the sandbox
+     --become-root                Become root:root in the sandbox
+     --map-foreign                Map the foreign UID range in the sandbox
+     --map-delegate N             Map N additional 64K UID/GID ranges in the sandbox
      --suppress-chown             Make chown() syscalls in the sandbox a noop
      --suppress-sync              Make sync() syscalls in the sandbox a noop
      --unshare-net                Unshare the network namespace if possible
@@ -1093,7 +1308,14 @@ def main(argv: list[str] = sys.argv[1:]) -> None:
     upperdir = ""
     workdir = ""
     chdir = None
-    become_root = suppress_chown = suppress_sync = unshare_net = unshare_ipc = pack_fds = False
+    become_root = False
+    suppress_chown = False
+    suppress_sync = False
+    unshare_net = False
+    unshare_ipc = False
+    pack_fds = False
+    map_foreign = False
+    map_delegate = 0
 
     try:
         ttyname = os.ttyname(2) if os.isatty(2) else ""
@@ -1118,16 +1340,26 @@ def main(argv: list[str] = sys.argv[1:]) -> None:
             fsops.append(DevOperation(ttyname, os.path.abspath(argv.pop())))
         elif arg == "--dir":
             fsops.append(DirOperation(os.path.abspath(argv.pop())))
-        elif arg in ("--bind", "--ro-bind", "--bind-try", "--ro-bind-try"):
+        elif arg in (
+            "--bind",
+            "--ro-bind",
+            "--bind-try",
+            "--ro-bind-try",
+            "--bind-foreign",
+            "--ro-bind-foreign",
+        ):
             readonly = arg.startswith("--ro")
             required = not arg.endswith("-try")
+            foreign = arg.endswith("-foreign")
             src = argv.pop()
+
             fsops.append(
                 BindOperation(
                     os.path.abspath(src.removeprefix("+")),
                     os.path.abspath(argv.pop()),
                     readonly=readonly,
                     required=required,
+                    foreign=foreign,
                     relative=src.startswith("+"),
                 )
             )
@@ -1165,6 +1397,10 @@ def main(argv: list[str] = sys.argv[1:]) -> None:
             chdir = os.getcwd()
         elif arg == "--become-root":
             become_root = True
+        elif arg == "--map-foreign":
+            map_foreign = True
+        elif arg == "--map-delegate":
+            map_delegate = int(argv.pop())
         elif arg == "--suppress-chown":
             suppress_chown = True
         elif arg == "--suppress-sync":
@@ -1209,7 +1445,26 @@ def main(argv: list[str] = sys.argv[1:]) -> None:
     if unshare_ipc:
         namespaces |= CLONE_NEWIPC
 
-    userns = acquire_privileges(become_root=become_root, network=bool(namespaces & CLONE_NEWNET))
+    network = bool(namespaces & CLONE_NEWNET)
+    foreign = any(fsop.foreign for fsop in fsops if isinstance(fsop, BindOperation))
+
+    userns = acquire_privileges(
+        identity=True,
+        foreign=map_foreign,
+        delegate=(map_delegate + int(foreign)),
+        become_root=(not foreign and become_root),
+        network=network,
+    )
+
+    transient_userns_fd = -EBADF
+    if foreign:
+        transient_userns_fd = userns_acquire_empty()
+        nsresource_allocate_user_range(transient_userns_fd)
+
+        for op in fsops:
+            if isinstance(op, BindOperation) and op.foreign:
+                # Will be closed in BindOperation.execute().
+                op.mappedfd = mountfsd_mount_directory(op.src, transient_userns_fd, readonly=op.readonly)
 
     seccomp_suppress(
         # If we're root in a user namespace with a single user, we're still not going to be able to
@@ -1289,6 +1544,18 @@ def main(argv: list[str] = sys.argv[1:]) -> None:
 
     if chdir:
         os.chdir(chdir)
+
+    if transient_userns_fd >= 0:
+        if libc.setns(transient_userns_fd, CLONE_NEWUSER) < 0:
+            oserror("setns")
+
+        os.close(transient_userns_fd)
+
+        if become_root:
+            os.setresgid(0, 0, 0)
+            os.setresuid(0, 0, 0)
+
+        fix_userns_capabilities(network=network)
 
     if pack_fds:
         nfds = pack_file_descriptors()

--- a/mkosi/tree.py
+++ b/mkosi/tree.py
@@ -15,6 +15,7 @@ from mkosi.log import die
 from mkosi.run import SandboxProtocol, nosandbox, run, workdir
 from mkosi.sandbox import (
     BTRFS_SUPER_MAGIC,
+    FOREIGN_UID_MIN,
     FS_NOCOW_FL,
     OVERLAYFS_SUPER_MAGIC,
     btrfs_subvol_create,
@@ -30,6 +31,10 @@ from mkosi.versioncomp import GenericVersion
 
 def is_subvolume(path: Path) -> bool:
     return path.is_dir() and path.stat().st_ino == 256 and statfs(os.fspath(path)) == BTRFS_SUPER_MAGIC
+
+
+def is_foreign_uid_tree(path: Path) -> bool:
+    return path.is_dir() and path.stat().st_uid == FOREIGN_UID_MIN
 
 
 def cp_version(*, sandbox: SandboxProtocol = nosandbox) -> GenericVersion:

--- a/mkosi/vmspawn.py
+++ b/mkosi/vmspawn.py
@@ -100,14 +100,7 @@ def run_vmspawn(args: Args, config: Config) -> None:
             ):
                 cmdline += ["--initrd", initrd]
 
-        if config.output_format == OutputFormat.directory:
-            cmdline += ["--directory", fname]
-
-            owner = os.stat(fname).st_uid
-            if owner != 0:
-                cmdline += [f"--private-users={str(owner)}"]
-        else:
-            cmdline += ["--image", fname]
+        cmdline += ["--directory" if fname.is_dir() else "--image", fname]
 
         if config.forward_journal:
             cmdline += ["--forward-journal", config.forward_journal]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -14,8 +14,7 @@ from typing import Any, Optional
 import pytest
 
 from mkosi.distribution import Distribution
-from mkosi.run import CompletedProcess, fork_and_wait, run
-from mkosi.sandbox import acquire_privileges
+from mkosi.run import CompletedProcess, run
 from mkosi.tree import rmtree
 from mkosi.user import INVOKING_USER
 from mkosi.util import _FILE, PathString
@@ -48,11 +47,7 @@ class Image:
         value: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> None:
-        def clean() -> None:
-            acquire_privileges()
-            rmtree(self.output_dir)
-
-        fork_and_wait(clean)
+        rmtree(self.output_dir)
 
     def mkosi(
         self,

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -202,6 +202,7 @@ def test_config() -> None:
                 "ath3k-1"
             ],
             "FirmwareVariables": "/foo/bar",
+            "ForeignUIDRange": false,
             "Format": "uki",
             "ForwardJournal": "/mkosi.journal",
             "History": true,
@@ -482,6 +483,7 @@ def test_config() -> None:
         firmware_include=["ath3k-1"],
         firmware_variables=Path("/foo/bar"),
         firmware=Firmware.linux,
+        foreign_uid_range=False,
         forward_journal=Path("/mkosi.journal"),
         history=True,
         hostname=None,


### PR DESCRIPTION
systemd recently introduced the foreign UID range to enable unprivileged
nspawn containers using directory rootfs trees. Let's get rid of all our
hacks to get directory images booting in nspawn and qemu and instead insist
on the foreign UID range when booting directory images.

Because the foreign UID range is rather new, we don't insist on using it
to build images. The new ForeignUIDRange= option has to be enabled to make
use of the foreign UID range. When enabled, we'll enter a user namespace
with the foreign UID range mapped into it when building an image and use
systemd-dissect at the end of the image build to recursively chown the
directory image to the foreign UID range.

run_clean() now needs access to the foreign UID range to remove directory
trees owned by the foreign UID range so we run it with fork_and_wait() as
well now.

To get access to the foreign UID range, we use a few extensions to
AllocateUserRange() from systemd-nsresourced which means we add a minimal
varlink implementation to sandbox.py.

To boot directory images with systemd-nspawn and systemd-vmspawn, we have
to delegate a transient UID range to the mkosi sandbox so that it can be
allocated to systemd-nspawn as a transient UID range by systemd-nsresourced.

For mkosi qemu, we have to set things up for virtiofsd ourselves which we
do with the new --bind-foreign option for mkosi-sandbox in which case it does
the same setup that vmspawn does for virtiofsd itself.

All the foreign UID range functionality will require systemd v260 or newer,
specifically the following PRs:
- https://github.com/systemd/systemd/pull/40212
- https://github.com/systemd/systemd/pull/40564
- https://github.com/systemd/systemd/pull/40415