### PR TITLE
Rework sandbox globbing and exist checks

### DIFF
--- a/mkosi/distribution/rhel.py
+++ b/mkosi/distribution/rhel.py
@@ -31,7 +31,7 @@ class Installer(centos.Installer, distribution=Distribution.rhel):
         if context.config.mirror:
             return None
 
-        path = Path("/etc/rhsm/ca/redhat-uep.pem")
+        path = Path("etc/rhsm/ca/redhat-uep.pem")
         if not exists_in_sandbox(path, sandbox=context.sandbox()):
             die(
                 f"redhat-uep.pem certificate not found in sandbox at {path}",
@@ -45,7 +45,7 @@ class Installer(centos.Installer, distribution=Distribution.rhel):
         if context.config.mirror:
             return None
 
-        glob = "/etc/pki/entitlement/*-key.pem"
+        glob = "etc/pki/entitlement/*-key.pem"
         paths = glob_in_sandbox(glob, sandbox=context.sandbox())
         if not paths:
             die(
@@ -60,7 +60,7 @@ class Installer(centos.Installer, distribution=Distribution.rhel):
         if context.config.mirror:
             return None
 
-        glob = "/etc/pki/entitlement/*.pem"
+        glob = "etc/pki/entitlement/*.pem"
         paths = [p for p in glob_in_sandbox(glob, sandbox=context.sandbox()) if "-key.pem" not in p.name]
         if not paths:
             die(

--- a/mkosi/installer/rpm.py
+++ b/mkosi/installer/rpm.py
@@ -54,8 +54,8 @@ def find_rpm_gpgkey(
     # We assume here that GPG keys will only ever be relative symlinks and never absolute symlinks.
 
     paths = glob_in_sandbox(
-        f"/usr/share/distribution-gpg-keys/*/{key}*",
-        f"/etc/pki/rpm-gpg/{key}*",
+        f"usr/share/distribution-gpg-keys/*/{key}",
+        f"etc/pki/rpm-gpg/{key}",
         sandbox=context.sandbox(),
     )
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import contextlib
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mkosi.run import fork_and_wait
+
+
+def test_fork_and_wait_returns_value() -> None:
+    result = fork_and_wait(lambda: 42)
+    assert result == 42
+
+
+def test_fork_and_wait_returns_none() -> None:
+    result = fork_and_wait(lambda: None)
+    assert result is None
+
+
+def test_fork_and_wait_returns_string() -> None:
+    result = fork_and_wait(lambda: "hello world")
+    assert result == "hello world"
+
+
+def test_fork_and_wait_returns_complex_type() -> None:
+    result = fork_and_wait(lambda: {"key": [1, 2, 3], "nested": {"a": True}})
+    assert result == {"key": [1, 2, 3], "nested": {"a": True}}
+
+
+def test_fork_and_wait_passes_args() -> None:
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    result = fork_and_wait(add, 3, 4)
+    assert result == 7
+
+
+def test_fork_and_wait_passes_kwargs() -> None:
+    def greet(name: str, greeting: str = "Hello") -> str:
+        return f"{greeting}, {name}!"
+
+    result = fork_and_wait(greet, "world", greeting="Hi")
+    assert result == "Hi, world!"
+
+
+def test_fork_and_wait_child_failure() -> None:
+    def fail() -> None:
+        raise RuntimeError("boom")
+
+    with pytest.raises(subprocess.CalledProcessError):
+        fork_and_wait(fail)
+
+
+def test_fork_and_wait_sandbox(tmp_path: Path) -> None:
+    (tmp_path / "abc").mkdir()
+
+    def exists() -> bool:
+        return Path("/abc").exists()
+
+    result = fork_and_wait(exists, sandbox=contextlib.nullcontext(["--bind", os.fspath(tmp_path), "/"]))
+    assert result


### PR DESCRIPTION
Using bash to glob in the sandbox is rather primitive. Let's do better by taking advantage of the fact that we can run mkosi-sandbox without executing another binary. We beef up fork_and_wait() to allow passing in a sandbox and use a pipe to send the pickled result of the target function back to the parent process so we can return it from fork_and_wait(). This allows us to rewrite glob_in_sandbox() and exists_in_sandbox() to be much simpler.

At the same time, make sure we show proper stacktraces when using uncaught_exception_handler() after fork. To achieve this, we have to make sure it logs all frames, including the parent's ones, as we have to log the exception from the forked process as we can't pickle exceptions and send them to the parent.

Additionally, try to populate the line cache as early as possible as we might not be able to access source files after sandboxing ourselves.

While we're at it, we switch _preexec() over to using uncaught_exception_handler() as well.