### PR TITLE
tests: fix running pytest on undetected distro

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,12 +15,13 @@ from . import ImageConfig, ci_group
 
 
 def pytest_addoption(parser: Any) -> None:
+    distribution = detect_distribution()[0]
     parser.addoption(
         "-D",
         "--distribution",
         metavar="DISTRIBUTION",
         help="Run the integration tests for the given distribution.",
-        default=detect_distribution()[0],
+        default=distribution if isinstance(distribution, Distribution) else None,
         type=Distribution,
         choices=[Distribution(d) for d in Distribution.values()],
     )


### PR DESCRIPTION
63ae86e changed detect_distribution so that if it can't find the distribution it now just returns the string instead of returning None. This breaks conftest.py when trying to run tests on a distribution that's not detected (e.g. when packaging mkosi for Alpine Linux)

Fixes #4162