### PR TITLE
Tracking ty compatibility

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5199,12 +5199,12 @@ def run_verb(args: Args, tools: Optional[Config], images: Sequence[Config], *, r
         if any((c := config).is_incremental() and not have_cache(config) for config in images):
             if args.rerun_build_scripts:
                 die(
-                    f"Cannot use --rerun-build-scripts as the cache for image {c.image} is out-of-date",
+                    f"Cannot use --rerun-build-scripts as the cache for image {c.image} is out-of-date",  # ty: ignore[unresolved-reference]
                     hint="Rebuild the image to update the image cache",
                 )
             else:
                 die(
-                    f"Strict incremental mode is enabled and cache for image {c.image} is out-of-date",
+                    f"Strict incremental mode is enabled and cache for image {c.image} is out-of-date",  # ty: ignore[unresolved-reference]
                     hint="Build once with '-i yes' to update the image cache",
                 )
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1907,7 +1907,7 @@ class Args:
         if isinstance(s, str):
             j = json.loads(s)
         elif isinstance(s, dict):
-            j = s
+            j = s  # ty: ignore[invalid-assignment]
         elif hasattr(s, "read"):
             j = json.load(s)
         else:
@@ -2483,7 +2483,7 @@ class Config:
         if isinstance(s, str):
             j = json.loads(s)
         elif isinstance(s, dict):
-            j = s
+            j = s  # ty: ignore[invalid-assignment]
         elif hasattr(s, "read"):
             j = json.load(s)
         else:
@@ -4611,7 +4611,7 @@ def create_argument_parser(chdir: bool = True) -> argparse.ArgumentParser:
             last_section = s.section
 
         if s.short and s.const is not None:
-            group.add_argument(  # type: ignore  # needed by pyright
+            group.add_argument(  # type: ignore  # ty: ignore[unused-ignore-comment]  # needed by pyright
                 s.short,
                 metavar="",
                 dest=s.dest,
@@ -4624,7 +4624,7 @@ def create_argument_parser(chdir: bool = True) -> argparse.ArgumentParser:
         for long in [s.long, *s.compat_longs]:
             opts = [s.short, long] if s.short and long == s.long and s.const is None else [long]
 
-            group.add_argument(  # type: ignore  # needed by pyright
+            group.add_argument(  # type: ignore  # ty: ignore[unused-ignore-comment]  # needed by pyright
                 *opts,
                 dest=s.dest,
                 choices=s.choices,
@@ -4643,7 +4643,7 @@ def resolve_deps(images: Sequence[Config], include: Sequence[str]) -> list[Confi
     graph = {config.image: config.dependencies for config in images}
 
     if any((missing := i) not in graph for i in include):
-        die(f"No image found with name {missing}")
+        die(f"No image found with name {missing}")  # ty: ignore[unresolved-reference]
 
     deps = set()
     queue = [*include]
@@ -4823,13 +4823,13 @@ class ParseContext:
             # so we ignore the return-value error for it.
             if isinstance(v, list):
                 assert isinstance(cfg_value, type(v))
-                return cfg_value + v  # type: ignore[return-value]  # needed by mypy
+                return cfg_value + v  # type: ignore[return-value]  # ty: ignore[unused-ignore-comment]  # needed by mypy
             elif isinstance(v, dict):
                 assert isinstance(cfg_value, type(v))
-                return cfg_value | v  # type: ignore[return-value]  # needed by mypy
+                return cfg_value | v  # type: ignore[return-value]  # ty: ignore[unused-ignore-comment]  # needed by mypy
             elif isinstance(v, set):
                 assert isinstance(cfg_value, type(v))
-                return cfg_value | v  # type: ignore[return-value]  # needed by mypy
+                return cfg_value | v  # type: ignore[return-value]  # ty: ignore[unused-ignore-comment]  # needed by mypy
             else:
                 return v
 


### PR DESCRIPTION
ty is a new checker from the people that brought us ruff and uv. Since it is written in Rust, it is vastly faster than mypy or pyright. It is not yet fully features, but the recent release has removed about 80% of the false positives it had before. This allows us to annotate the remaining false positives with ignore comments for ty specifically and add two type annotations that also make the intent clearer to the human reader.

At the same time, ty complains about type ignore comments, that are needed for either mypy or pyright. Unfortunately there is no syntax for type checker specific ignores, but we can silence those errors for ty. This also adds comments on which type checker makes a specific type ignore comment necessary.

Unfortunately the tests cannot yet be properly type checked with ty due to [1].

[1] https://github.com/astral-sh/ty/issues/2797