### PR TITLE
pacman: Drop support for package downgrades

### DIFF
--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -203,13 +203,7 @@ class Pacman(PackageManager):
         allow_downgrade: bool = False,
         options: Sequence[str] = (),
     ) -> None:
-        arguments = ["--needed", "--assume-installed", "initramfs"]
-
-        if allow_downgrade:
-            arguments += ["--sysupgrade", "--sysupgrade"]
-
-        arguments += [*options, *packages]
-
+        arguments = ["--needed", "--assume-installed", "initramfs"] + [*options, *packages]
         cls.invoke(context, "--sync", arguments, apivfs=apivfs)
 
     @classmethod


### PR DESCRIPTION
--sysupgrade --sysupgrade might enable package downgrades but it also enables package upgrades, meaning we end up upgrading the entire system rather than just installing the requested packages. Hence let's drop support for package downgrades, since upgrading the system is worse then not being able to downgrade packages.