### PR TITLE
config: exclude multiple inheritance from JSON loading typing

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1906,9 +1906,9 @@ class Args:
         j: dict[str, Any]
         if isinstance(s, str):
             j = json.loads(s)
-        elif isinstance(s, dict):
+        elif isinstance(s, dict) and not hasattr(s, "read"):
             j = s
-        elif hasattr(s, "read"):
+        elif hasattr(s, "read") and not isinstance(s, dict):
             j = json.load(s)
         else:
             raise ValueError(
@@ -2482,9 +2482,9 @@ class Config:
         j: dict[str, Any]
         if isinstance(s, str):
             j = json.loads(s)
-        elif isinstance(s, dict):
+        elif isinstance(s, dict) and not hasattr(s, "read"):
             j = s
-        elif hasattr(s, "read"):
+        elif hasattr(s, "read") and not isinstance(s, dict):
             j = json.load(s)
         else:
             raise ValueError(


### PR DESCRIPTION
As pointed out in [1], the reason that ty cannot infer that the assignment of the dict instance s to the dict j when loading JSON after checking that s is instance of dict, is because multiple inheritance is a thing and the passed in object could be a dict that doesn't have string keys, but does have a read method. So let's be explicit and disallow these unhandled cases. This also fixes that the order of these branches is not stable against reordering with pyright and type checking fails if e.g. the check for the read attribute is moved above the dict instance check.

[1] https://github.com/astral-sh/ty/issues/1475#issuecomment-3916505245
[2] https://github.com/astral-sh/ty/issues/1578