### PR TITLE
vmspawn: Set --tpm-state=off

### DIFF
--- a/mkosi/vmspawn.py
+++ b/mkosi/vmspawn.py
@@ -58,6 +58,7 @@ def run_vmspawn(args: Args, config: Config) -> None:
         "--kvm", config.kvm.to_tristate(),
         "--vsock", config.vsock.to_tristate(),
         "--tpm", config.tpm.to_tristate(),
+        "--tpm-state=off",
         "--secure-boot", yes_no(config.secure_boot),
         "--console", str(config.console),
     ]  # fmt: skip


### PR DESCRIPTION
Otherwise we'll leave the tpm state lingering around. For now let's disable tpm state saving.