### PR TITLE
Default Machine= to the current working directory name

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -4177,6 +4177,7 @@ SETTINGS: list[ConfigSetting[Any]] = [
         metavar="NAME",
         section="Runtime",
         help="Set the machine name to use when booting the image",
+        default_factory=lambda ns: ns["directory"].name if ns["directory"] else None,
         scope=SettingScope.main,
     ),
     ConfigSetting(

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -2066,6 +2066,8 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     Note that `Ephemeral=` has to be enabled to start multiple instances
     of the same image.
 
+    Defaults to the current working directory name.
+
 `Register=`, `--register=`
 :   Takes a boolean value or `auto`. Specifies whether to register the
     vm/container with systemd-machined. If enabled, mkosi will fail if


### PR DESCRIPTION
It makes a lot more sense for the systemd machine name to be systemd rather than main.