### PR TITLE
nspawn: Add --suppress-sync=yes by default

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4260,7 +4260,7 @@ def run_shell(args: Args, config: Config) -> None:
     if config.output_format.use_outer_compression() and config.compress_output:
         die(f"Cannot {opname} compressed {config.output_format} images with systemd-nspawn")
 
-    cmdline: list[PathString] = ["systemd-nspawn", "--quiet", "--link-journal=no"]
+    cmdline: list[PathString] = ["systemd-nspawn", "--quiet", "--link-journal=no", "--suppress-sync=yes"]
 
     if config.runtime_network == Network.user:
         cmdline += ["--resolv-conf=auto"]


### PR DESCRIPTION
We're doing development containers, so making sure changes actually hit the disk isn't all that important. Let's add --suppress-sync=yes by default to speed things up. This prevents
systemd-machine-id-commit.service from delaying the boot by 5s every first boot of a container.