### PR TITLE
kmod: actually ignore missing module deps

### DIFF
--- a/mkosi/kmod.py
+++ b/mkosi/kmod.py
@@ -317,7 +317,7 @@ def resolve_module_dependencies(
 
             mods.add(name)
             firmware.update(depinfo.firmware)
-            todo += [m for m in depinfo.modules if m not in mods]
+            todo += [m for m in depinfo.modules if m not in mods and m in nametofile]
 
     return set(nametofile[m] for m in mods if m in nametofile), set(firmware)
 


### PR DESCRIPTION
Prior to f9e7527e, IIUC modules in todo were ignored when they were popped and `moddep.get(m)` returned None for any modules that were missin. After f9e7527e, missing modules aren't actually ignored, which leads to e.g.:

```
‣ aes is a dependency of cifs but is not installed, ignoring
‣ nls is a dependency of cifs but is not installed, ignoring
‣ aead2 is a dependency of cifs but is not installed, ignoring
modinfo: ERROR: Module name nls not found.
```

(nls.ko doesn't exist, and shouldn't exist in recent (6.19-ish) kernel trees)