### PR TITLE
zypper: Use --oldpackage when downgrading packages is allowed

### DIFF
--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -150,7 +150,7 @@ class Zypper(PackageManager):
         ]  # fmt: skip
 
         if allow_downgrade:
-            arguments += ["--allow-downgrade"]
+            arguments += ["--allow-downgrade", "--oldpackage"]
 
         arguments += [*packages]
 


### PR DESCRIPTION
Commit 78f155bb ("Add support for downgrading when installing volatile packages") introduced the `allow_downgrade` parameter to the `PackageManager.install()` method. The motivation for adding this parameter was to ensure that when updating volatile packages, mkosi can install a local package even if it is older that what the distribution provides.

For zypper, the parameter was implemented by adding the `--allow-downgrade` option to the tool's install command. However, this doesn't work fully and volatiles packages might not be properly updated. The issue is that even though the `--allow-downgrade` option allows the solver to downgrade installed packages, zypper rejects the operation if the selected package is not the latest version available in the repositories.

To force the installation of an older package, zypper additionally provides the `--oldpackage` option. Use this option in `Zypper.install()` for correctly updating volatile packages.

---

The following output shows the current behavior when the version of a local systemd package is set to 257.9, whereas the distribution repository contains version 258.4:

```
‣  Installing volatile packages for openSUSE
Warning: Enforced setting: $releasever=tumbleweed
Temporarily enabling repository 'non-oss'. [--plus-content]
Loading repository data...
Reading installed packages...
'systemd' is already installed.
There is an update candidate for 'systemd', but it comes from a repository with a lower priority. Use 'zypper install systemd-258.4-1.1.x86_64' to install this candidate.
'systemd-network' not found in package names. Trying capabilities.
'udev' is already installed.
There is an update candidate for 'udev', but it comes from a repository with a lower priority. Use 'zypper install udev-258.4-1.1.x86_64' to install this candidate.
'libsystemd0' is already installed.
There is an update candidate for 'libsystemd0', but it comes from a repository with a lower priority. Use 'zypper install libsystemd0-258.4-1.1.x86_64' to install this candidate.
'libudev1' is already installed.
There is an update candidate for 'libudev1', but it comes from a repository with a lower priority. Use 'zypper install libudev1-258.4-1.1.x86_64' to install this candidate.
Resolving package dependencies...

The following 3 NEW packages are going to be installed:
  systemd-container systemd-experimental systemd-networkd

3 new packages to install.
[...]
```

New behavior:

```
‣  Installing volatile packages for openSUSE
Warning: Enforced setting: $releasever=tumbleweed
Temporarily enabling repository 'non-oss'. [--plus-content]
Loading repository data...
Reading installed packages...
There is an update candidate for 'systemd', but it comes from a repository with a lower priority. Use 'zypper install systemd-258.4-1.1.x86_64' to install this candidate.
'systemd-network' not found in package names. Trying capabilities.
There is an update candidate for 'udev', but it comes from a repository with a lower priority. Use 'zypper install udev-258.4-1.1.x86_64' to install this candidate.
There is an update candidate for 'libsystemd0', but it comes from a repository with a lower priority. Use 'zypper install libsystemd0-258.4-1.1.x86_64' to install this candidate.
There is an update candidate for 'libudev1', but it comes from a repository with a lower priority. Use 'zypper install libudev1-258.4-1.1.x86_64' to install this candidate.
Resolving package dependencies...

The following 4 packages are going to be reinstalled:
  libsystemd0 libudev1 systemd udev

The following 3 NEW packages are going to be installed:
  systemd-container systemd-experimental systemd-networkd

3 new packages to install, 4 to reinstall.
[...]
(1/7) Installing: libsystemd0-257.9-00.x86_64 [done]
(2/7) Installing: libudev1-257.9-00.x86_64 [done]
(3/7) Installing: systemd-257.9-00.x86_64 [done]
(4/7) Installing: udev-257.9-00.x86_64 [done]
(5/7) Installing: systemd-networkd-257.9-00.x86_64 [done]
(6/7) Installing: systemd-experimental-257.9-00.x86_64 [done]
(7/7) Installing: systemd-container-257.9-00.x86_64 [done]
```