### PR TITLE
mkosi-cmd: Add VM-side command channel daemon for mkosi cmd

### DIFF
--- a/mkosi.extra/usr/lib/systemd/system-preset/00-mkosi.preset
+++ b/mkosi.extra/usr/lib/systemd/system-preset/00-mkosi.preset
@@ -23,3 +23,6 @@ disable auditd.service
 
 # systemd-timesyncd is not enabled by default in the default systemd preset so enable it here instead.
 enable systemd-timesyncd.service
+
+# Command channel daemon for host interaction via mkosi cmd
+enable mkosi-cmd-daemon.service

--- a/mkosi.extra/usr/lib/systemd/system/mkosi-cmd-daemon.service
+++ b/mkosi.extra/usr/lib/systemd/system/mkosi-cmd-daemon.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=mkosi command channel daemon (ttyS1)
+After=basic.target
+
+[Service]
+Type=simple
+ExecStart=/bin/bash /usr/local/bin/mkosi-cmd-daemon.sh
+Restart=on-failure
+RestartSec=2
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=basic.target

--- a/mkosi.extra/usr/local/bin/mkosi-cmd-daemon.sh
+++ b/mkosi.extra/usr/local/bin/mkosi-cmd-daemon.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# mkosi-cmd-daemon.sh - VM-side command execution daemon
+#
+# Listens on /dev/ttyS1 for JSON command requests, executes them,
+# and writes JSON responses back. Designed to be driven by the
+# host-side mkosi-cmd script via a QEMU unix socket chardev.
+#
+# Protocol:
+#   Request:  {"id": "...", "cmd": "..."}\n
+#   Response: {"id": "...", "stdout": "...", "stderr": "...", "rc": N}\n
+
+SERIAL="/dev/ttyS1"
+TIMEOUT=30
+
+# Wait for the serial device to appear (give up after TIMEOUT seconds)
+elapsed=0
+while [ ! -e "$SERIAL" ]; do
+    if [ "$elapsed" -ge "$TIMEOUT" ]; then
+        echo "mkosi-cmd-daemon: $SERIAL not found after ${TIMEOUT}s, exiting" >&2
+        exit 0
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+done
+
+# Configure serial port: raw mode, no echo
+stty -F "$SERIAL" raw -echo -echoe -echok -echoctl
+
+# Open serial port for read/write
+exec 3<>"$SERIAL"
+
+while IFS= read -r line <&3; do
+    # Skip empty lines
+    [ -z "$line" ] && continue
+
+    # Strip any trailing carriage return
+    line="${line%$'\r'}"
+
+    # Parse JSON request
+    id=$(printf '%s' "$line" | jq -r '.id // empty' 2>/dev/null)
+    cmd=$(printf '%s' "$line" | jq -r '.cmd // empty' 2>/dev/null)
+
+    # Skip malformed requests
+    if [ -z "$id" ] || [ -z "$cmd" ]; then
+        continue
+    fi
+
+    # Execute the command, capturing stdout and stderr separately
+    stderr_file=$(mktemp)
+    stdout=$(bash -c "$cmd" 2>"$stderr_file")
+    rc=$?
+    stderr=$(cat "$stderr_file")
+    rm -f "$stderr_file"
+
+    # Build and send JSON response (monochrome, no ANSI colors)
+    jq -Mnc \
+        --arg id "$id" \
+        --arg stdout "$stdout" \
+        --arg stderr "$stderr" \
+        --argjson rc "$rc" \
+        '{id: $id, stdout: $stdout, stderr: $stderr, rc: $rc}' >&3
+
+done

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -112,6 +112,7 @@ from mkosi.qemu import (
     finalize_credentials,
     finalize_kernel_command_line_extra,
     join_initrds,
+    run_cmd,
     run_qemu,
     run_ssh,
     start_journal_remote,
@@ -5141,6 +5142,7 @@ def run_verb(args: Args, tools: Optional[Config], images: Sequence[Config], *, r
     if args.verb.needs_tools():
         return {
             Verb.ssh: run_ssh,
+            Verb.cmd: run_cmd,
             Verb.journalctl: run_journalctl,
             Verb.coredumpctl: run_coredumpctl,
             Verb.box: run_box,

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -78,6 +78,7 @@ class Verb(StrEnum):
     vm = enum.auto()
     qemu = enum.auto()
     ssh = enum.auto()
+    cmd = enum.auto()
     serve = enum.auto()
     bump = enum.auto()
     help = enum.auto()
@@ -102,6 +103,7 @@ class Verb(StrEnum):
             Verb.vm,
             Verb.qemu,
             Verb.ssh,
+            Verb.cmd,
             Verb.journalctl,
             Verb.coredumpctl,
             Verb.burn,
@@ -120,6 +122,7 @@ class Verb(StrEnum):
             Verb.journalctl,
             Verb.coredumpctl,
             Verb.ssh,
+            Verb.cmd,
             Verb.latest_snapshot,
         )
 
@@ -1879,6 +1882,7 @@ class Args:
     json: bool
     wipe_build_dir: bool
     rerun_build_scripts: bool
+    cmd_timeout: int
 
     @classmethod
     def default(cls) -> "Args":
@@ -4577,6 +4581,13 @@ def create_argument_parser(chdir: bool = True) -> argparse.ArgumentParser:
         help="Run build scripts even if the image is not rebuilt",
         action="store_true",
         default=False,
+    )
+    parser.add_argument(
+        "--cmd-timeout",
+        metavar="SECONDS",
+        help="Timeout in seconds for mkosi cmd (default: 30)",
+        type=int,
+        default=30,
     )
     # These can be removed once mkosi v15 is available in LTS distros and compatibility with <= v14
     # is no longer needed in build infrastructure (e.g.: OBS).

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -14,6 +14,7 @@ import logging
 import os
 import queue
 import random
+import re
 import resource
 import shutil
 import socket
@@ -747,7 +748,11 @@ def finalize_initrd(config: Config) -> Iterator[Optional[Path]]:
 
 
 @contextlib.contextmanager
-def finalize_state(config: Config, cid: int) -> Iterator[None]:
+def finalize_state(
+    config: Config,
+    cid: Optional[int] = None,
+    cmd_socket: Optional[str] = None,
+) -> Iterator[None]:
     statedir = INVOKING_USER.runtime_dir() / "mkosi/machine"
     statedir.mkdir(parents=True, exist_ok=True)
 
@@ -766,8 +771,9 @@ def finalize_state(config: Config, cid: int) -> Iterator[None]:
                 {
                     "Machine": config.machine_or_name(),
                     "Pid": os.getpid(),
-                    "ProxyCommand": f"socat - VSOCK-CONNECT:{cid}:%p",
+                    "ProxyCommand": f"socat - VSOCK-CONNECT:{cid}:%p" if cid is not None else None,
                     "SshKey": os.fspath(config.ssh_key) if config.ssh_key else None,
+                    "CmdSocket": cmd_socket,
                 },
                 sort_keys=True,
                 indent=4,
@@ -1125,6 +1131,8 @@ def run_qemu(args: Args, config: Config) -> None:
             "-device", f"vhost-vsock-pci,guest-cid={cid},vhostfd={qemu_device_fds[QemuDeviceNode.vhost_vsock]}",  # noqa: E501
         ]  # fmt: skip
 
+    cmd_sock_path: Optional[str] = None
+
     if config.console == ConsoleMode.gui:
         if config.architecture.is_arm_variant():
             cmdline += ["-device", "virtio-gpu-pci"]
@@ -1144,7 +1152,15 @@ def run_qemu(args: Args, config: Config) -> None:
             "-nodefaults",
         ]  # fmt: skip
 
-        if config.console != ConsoleMode.headless:
+        if config.console == ConsoleMode.headless:
+            cmd_sock_path = f"/tmp/mkosi-cmd-{config.machine_or_name()}.sock"
+            cmdline += [
+                "-chardev", "file,id=serial0,path=/tmp/mkosi-serial.log",
+                "-serial", "chardev:serial0",
+                "-chardev", f"socket,id=cmdchan,path={cmd_sock_path},server=on,wait=off",
+                "-serial", "chardev:cmdchan",
+            ]  # fmt: skip
+        else:
             cmdline += [
                 "-chardev", "stdio,mux=on,id=console,signal=off",
                 "-device", "virtio-serial-pci,id=mkosi-virtio-serial-pci",
@@ -1366,8 +1382,7 @@ def run_qemu(args: Args, config: Config) -> None:
         cmdline += config.qemu_args
         cmdline += args.cmdline
 
-        if cid is not None:
-            stack.enter_context(finalize_state(config, cid))
+        stack.enter_context(finalize_state(config, cid=cid, cmd_socket=cmd_sock_path))
 
         # Reopen stdin, stdout and stderr to give qemu a private copy of them.  This is a mitigation for the
         # case when running mkosi under meson and one or two of the three are redirected and their pipe might
@@ -1467,3 +1482,87 @@ def run_ssh(args: Args, config: Config) -> None:
             options=["--same-dir", "--become-root"],
         ),
     )
+
+
+def run_cmd(args: Args, config: Config) -> None:
+    statedir = INVOKING_USER.runtime_dir() / "mkosi/machine"
+    statedir.mkdir(parents=True, exist_ok=True)
+
+    with flock(statedir):
+        if not (p := statedir / f"{config.machine_or_name()}.json").exists():
+            die(
+                f"{p} not found, cannot execute command in virtual machine {config.machine_or_name()}",
+                hint="Is the machine running with Console=headless?",
+            )
+
+        state = json.loads(p.read_text())
+
+    cmd_socket = state.get("CmdSocket")
+    if not cmd_socket:
+        die(
+            "No command channel configured for this virtual machine",
+            hint="The command channel is only available when Console=headless",
+        )
+
+    if not args.cmdline:
+        die("No command specified", hint="Usage: mkosi cmd -- <command>")
+
+    command = " ".join(args.cmdline)
+    timeout = args.cmd_timeout
+    request_id = f"req_{os.getpid()}_{uuid.uuid4().hex[:8]}"
+    request = json.dumps({"id": request_id, "cmd": command}) + "\n"
+
+    try:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(cmd_socket)
+        sock.settimeout(timeout)
+    except (ConnectionRefusedError, FileNotFoundError) as e:
+        die(f"Cannot connect to command channel at {cmd_socket}: {e}")
+
+    try:
+        sock.sendall(request.encode())
+
+        # Read response lines until we find our request ID
+        buf = b""
+        response = None
+        while True:
+            try:
+                data = sock.recv(4096)
+            except socket.timeout:
+                die(f"Timed out waiting for response from VM (after {timeout}s)")
+
+            if not data:
+                die("Connection closed by VM before receiving a response")
+
+            buf += data
+            while b"\n" in buf:
+                line, buf = buf.split(b"\n", 1)
+                line_str = line.decode(errors="replace")
+                # Strip ANSI escape sequences
+                line_str = re.sub(r"\x1b\[[0-9;]*m", "", line_str)
+                try:
+                    parsed = json.loads(line_str)
+                except json.JSONDecodeError:
+                    continue
+                if parsed.get("id") == request_id:
+                    response = parsed
+                    break
+            if response is not None:
+                break
+    finally:
+        sock.close()
+
+    stdout = response.get("stdout", "")
+    stderr = response.get("stderr", "")
+    rc = response.get("rc", 1)
+
+    if stdout:
+        sys.stdout.write(stdout)
+        if not stdout.endswith("\n"):
+            sys.stdout.write("\n")
+    if stderr:
+        sys.stderr.write(stderr)
+        if not stderr.endswith("\n"):
+            sys.stderr.write("\n")
+
+    raise SystemExit(rc)

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -24,6 +24,8 @@ mkosi — Build Bespoke OS Images
 
 `mkosi [options…] ssh [-- command line…]`
 
+`mkosi [options…] cmd [-- command line…]`
+
 `mkosi [options…] journalctl [-- command line…]`
 
 `mkosi [options…] coredumpctl [-- command line…]`
@@ -126,6 +128,16 @@ The following command line verbs are known:
     hostname when booting it which can later be used to **ssh** into the image
     (e.g. `mkosi --machine=mymachine vm` followed by
     `mkosi --machine=mymachine ssh`).
+
+`cmd`
+:   Executes a command in a running virtual machine via the command channel.
+    The VM must have been started with `Console=headless`. Any arguments
+    specified after the `cmd` verb and separated by `--` from the regular
+    options are concatenated and executed in the VM. The exit code of
+    **mkosi** will match the exit code of the executed command.
+
+    The `Machine=` option can be used to select which running VM to
+    connect to when multiple VMs are running.
 
 `journalctl`
 :   Uses **journalctl** to inspect the journal inside the image.
@@ -315,6 +327,10 @@ Those settings cannot be configured in the configuration files.
     version you are using, depending on how you installed **mkosi**. `auto`, which is
     the default, will try all methods in the order `man`, `pandoc`, `markdown`,
     `system`.
+
+`--cmd-timeout=`
+:   Timeout in seconds when waiting for a response from the VM when using
+    the `cmd` verb. Defaults to 30 seconds.
 
 `--json`
 :   Show the summary output as JSON-SEQ.

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -54,6 +54,7 @@ def test_args(path: Optional[Path]) -> None:
         f"""\
         {{
             "AutoBump": false,
+            "CmdTimeout": 30,
             "Cmdline": [
                 "foo",
                 "bar"
@@ -93,6 +94,7 @@ def test_args(path: Optional[Path]) -> None:
         rerun_build_scripts=True,
         verb=Verb.build,
         wipe_build_dir=True,
+        cmd_timeout=30,
     )
 
     assert dump_json(args.to_dict()) == dump.rstrip()


### PR DESCRIPTION
Some automation cannot use typical network sockets (vsock and standard sockets), but can use unix domain sockets.  This requires a QEMU serial device attached to a host domain socket and a daemon running in the guest which provides the terminal access.

The 'mkosi cmd' feature provides this interface for VMs running with Console=headless mode, allowing automation to interact with the guest without running into network jailing issues.

Along with the command addition (in config) we ship:
    - The daemon script
    - systemd service setup
    - preset to launch the service by default

The daemon exist cleanly after 30s if no serial device appears (e.g. Console != headless).

When in headless mode, add two serial devices:
    - One writes kmsg/dmesg output to /tmp/mkosi-serial.log
    - One is the mkosi-cmd unix domain socket for interactions

Signed-off-by: Gregory Price <gourry@gourry.net