### PR TITLE
Use userdbd creds instead of manual useradd call for mkosi user

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -37,6 +37,7 @@ path = [
     "**.yaml",
     "**.yml",
     "**.zsh",
+    "mkosi.credentials/*",
     "mkosi/resources/pandoc/*.lua",
 ]
 precedence = "aggregate"

--- a/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
+++ b/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
@@ -10,4 +10,4 @@ Packages=
         openssh-client
         openssh-server
         python3
-        passwd
+        systemd-userdbd

--- a/mkosi.credentials/userdb.group.mkosi
+++ b/mkosi.credentials/userdb.group.mkosi
@@ -1,0 +1,5 @@
+{
+    "groupName": "mkosi",
+    "gid": 4711,
+    "disposition": "regular"
+}

--- a/mkosi.credentials/userdb.user.mkosi
+++ b/mkosi.credentials/userdb.user.mkosi
@@ -1,0 +1,10 @@
+{
+    "userName": "mkosi",
+    "uid": 4711,
+    "disposition": "regular",
+    "enforcePasswordPolicy": false,
+    "shell": "/bin/bash",
+    "privileged": {
+        "hashedPassword": ["$1$.iBhENSq$/a.G1fbNy4uPqvrVx36bl0"]
+    }
+}

--- a/mkosi.postinst
+++ b/mkosi.postinst
@@ -2,14 +2,4 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 set -ex
 
-mkosi-chroot \
-    useradd \
-    --user-group \
-    --create-home \
-    --password "$(openssl passwd -1 mkosi)" \
-    --groups systemd-journal \
-    --shell /bin/bash \
-    --uid 4711 \
-    mkosi
-
 systemctl --root="$BUILDROOT" mask lvm2-monitor.service


### PR DESCRIPTION
This helps dogfooding one more bit of systemd, and also makes it resilient to a factory reset.
userdbd was introduced in v245 in 2019, so should be fine to use.

https://systemd.io/USER_RECORD/