### PR TITLE
initialise keyring earlier in the sandbox lifecycle

### DIFF
--- a/mkosi/distribution/arch.py
+++ b/mkosi/distribution/arch.py
@@ -82,6 +82,7 @@ class Installer(DistributionInstaller, distribution=Distribution.arch):
     @classmethod
     def setup(cls, context: Context) -> None:
         Pacman.setup(context, list(cls.repositories(context)))
+        Pacman.keyring(context)
 
     @classmethod
     def install(cls, context: Context) -> None:

--- a/mkosi/distribution/arch.py
+++ b/mkosi/distribution/arch.py
@@ -82,6 +82,9 @@ class Installer(DistributionInstaller, distribution=Distribution.arch):
     @classmethod
     def setup(cls, context: Context) -> None:
         Pacman.setup(context, list(cls.repositories(context)))
+        # pacman's keyring needs to be initialized and pre-seeded with any drop-in keys prior
+        # to its first sync, otherwise it'll refuse to continue when using custom repositories
+        # due to missing signatures.
         Pacman.keyring(context)
 
     @classmethod


### PR DESCRIPTION
#4093 moved the keyring initialisation later in the setup lifecycle as part of normalising arch/pacman setup. if any custom repositories are used, pacman requires the keys to exist for all configured repositories from the get-go or exits immediately. let's set this up earlier in the sandbox lifecycle to provide the requisite keys.

i haven't verified if this breaks any distro other than arch, but i couldn't find any rationale for moving it in the git commit logs so i don't know if it was moved intentionally or incidentally.

original cut of this simply had the pacman installer run `pacman-key` twice (once at setup, and once where it currently runs), but that's is basically begging for hysteresis and i couldn't find any other example of that sort of special casing in the codebase.

marked as draft because i'll check other distributions this weekend. if i'm operating on a bad assumption here i can rework this as required.