### PR TITLE
opensuse: do not install xfsprogs in the initrd

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/opensuse.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/opensuse.conf
@@ -22,9 +22,10 @@ Packages=
         libtss2-tcti-device0
 
         # File system checkers for supported root file systems
+        # xfsprogs pulls in Python on openSUSE, since XFS is usually used for
+        # /home, we can avoid installing it in the initrd.
         btrfsprogs
         e2fsprogs
-        xfsprogs
         dosfstools
 
         procps


### PR DESCRIPTION
`xfsprogs` is pulling `python313-base` in the initrd, similar to what happens in Debian.
Since the common use of XFS is `/home`, avoid installing it and save ~13M in the final compressed cpio.

Spotted in the systemd CI:

```
2026-03-02T22:17:14.5811013Z ‣ Building default-initrd image
...
2026-03-02T22:17:17.0691008Z ‣  Installing openSUSE
...
2026-03-02T22:17:18.9640788Z The following 151 NEW packages are going to be installed:
2026-03-02T22:17:18.9652848Z   aaa_base bash bash-sh branding-openSUSE btrfsprogs btrfsprogs-udev-rules coreutils crypto-policies dbus-1 dbus-1-common dbus-1-tools dbus-broker dbus-broker-block-restart device-mapper diffutils dosfstools e2fsprogs fillup findutils glibc grep gzip kbd kmod krb5 less libacl1 libattr1 libaudit1 libblkid1 libbrotlicommon1 libbrotlidec1 libbz2-1 libcap-ng0 libcap2 libcbor0_13 libcom_err2 libcrypt1 libcryptsetup12 libcurl4 libdbus-1-3 libdevmapper-event1_03 libdevmapper1_03 libeconf0 libedit0 libefivar1 libexpat1 libext2fs2 libfdisk1 libffi8 libfido2-1 libgcc_s1 libgcrypt20 libgmp10 libgpg-error0 libhidapi-hidraw0 libidn2-0 libinih0 libjitterentropy3 libjson-c5 libkbdfile1 libkeymap1 libkeyutils1 libkfont0 libkmod2 libldap2 liblua5_4-5 liblzma5 liblzo2-2 libmount1 libmpdec4 libncurses6 libnghttp2-14 libnghttp3-9 libnss_usrfiles2 libopenssl3 libpcre2-8-0 libpkgconf7 libpopt0 libproc2-1 libpsl5 libpython3_13-1_0 libreadline8 libsasl2-3 libseccomp2 libselinux1 libsemanage-conf libsemanage2 libsepol2 libsmartcols1 libssh-config libssh4 libstdc++6 libsubid5 libsystemd0 libtss2-esys0 libtss2-fapi-common libtss2-fapi1 libtss2-mu0 libtss2-rc0 libtss2-sys1 libtss2-tcti-device0 libtss2-tctildr0 libudev1 libunistring5 liburcu8 libuuid1 libverto1 libz1 libzstd1 login_defs ncurses-utils netcfg openSUSE-build-key pam pam-config pam-extra patterns-base-minimal_base permctl permissions permissions-config pkgconf pkgconf-m4 pkgconf-pkg-config procps python313-base rpm rpm-config-SUSE sed shadow shadow-pw-mgmt suse-module-tools system-group-hardware system-group-kvm system-user-lp system-user-tss systemd systemd-default-settings systemd-default-settings-branding-openSUSE systemd-presets-branding-openSUSE systemd-presets-common-SUSE systemd-rpm-macros sysuser-shadow tar terminfo-base thin-provisioning-tools tpm2.0-tools udev util-linux xfsprogs xz
...
2026-03-02T22:17:34.2751588Z ‣  Creating cpio archive /mnt/mkosi/tmp/mkosi-workspace-p9mo4h2h/staging/initrd.cpio…
2026-03-02T22:17:37.3383783Z ‣  Compressing /mnt/mkosi/tmp/mkosi-workspace-p9mo4h2h/staging/initrd.cpio with zstd
2026-03-02T22:17:37.9095719Z ‣  /mnt/mkosi/build/mkosi.output/initrd.cpio.zst size is 56.5M, consumes 56.5M.
```