### PR TITLE
Only add pacman packages for expected architecture

### DIFF
--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import dataclasses
+import logging
+import os
 import shutil
+import subprocess
 import textwrap
 from collections.abc import Sequence
 from contextlib import AbstractContextManager
@@ -266,7 +269,11 @@ class Pacman(PackageManager):
                 "--quiet",
                 workdir(context.repository / "mkosi.db.tar"),
                 *sorted(
-                    (workdir(p) for p in context.repository.glob("*.pkg.tar*")),
+                    (
+                        workdir(p)
+                        for p in context.repository.glob("*.pkg.tar*")
+                        if cls.parse_pkg_pkginfo(p)[3] in ("any", cls.architecture(context))
+                    ),
                     key=lambda p: GenericVersion(Path(p).name),
                 ),
             ],
@@ -286,6 +293,32 @@ class Pacman(PackageManager):
 
         # pacman can't sync a single repository, so we go behind its back and do it ourselves.
         shutil.move(context.repository / "mkosi.db.tar", context.metadata_dir / "lib/pacman/sync/mkosi.db")
+
+    @classmethod
+    def parse_pkg_pkginfo(cls, path: Path) -> tuple[str, str, str, str]:
+        name = version = base = arch = ""
+        pkginfo = run(["bsdtar", "-xOqf", os.fspath(path), ".PKGINFO"], check=False, stdout=subprocess.PIPE)
+        if pkginfo.returncode != 0:
+            logging.debug(f"{path} was not a valid package file")
+        else:
+            for line in pkginfo.stdout.splitlines():
+                line = line.split("#", 1)[0].strip()
+                parts = line.split("=", 1)
+                if len(parts) == 1:
+                    continue
+                key, val = parts
+                key = key.strip()
+                val = val.strip()
+                if key == "pkgname":
+                    name = val
+                elif key == "pkgver":
+                    version = val
+                elif key == "pkgbase":
+                    base = val
+                elif key == "arch":
+                    arch = val
+
+        return name, version, base, arch
 
     @classmethod
     def parse_pkg_desc(cls, path: Path) -> tuple[str, str, str, str]:


### PR DESCRIPTION
Right now, `repo-add` will just add all valid packages to the repo regardless of their architecture, which can cause problems when the package files in question are for the wrong architecture; this will simply fail to install things if one of the required packages ends up being for the wrong architecture, or if the wrong-architecture package gets sorted after the correct-architecture one in the command.

We could rely on the standard filename structure for pacman packages and expect, for example, `pkgname-pkgver-pkgrel-arch.pkg.tar.ext`, but this would prevent the user from including valid packages which do not adopt this naming convention.

Instead, this PR relies on processing the metadata inside the package files similar to how `repo-add` does before adding packages. On my system, this currently results in only ~3s overhead when processing a directory with ~200 packages, so, the performance seems reasonable. In general, pacman packages should put the `.PKGINFO` file at the very beginning of the file, and tarfile will stop once it finds the correct member.