### PR TITLE
feature: Add Bootloader=uki_prebuilt for distro-shipped UKIs

### DIFF
--- a/mkosi.conf.d/fedora/mkosi.conf.d/arm64-uki-signed.conf
+++ b/mkosi.conf.d/fedora/mkosi.conf.d/arm64-uki-signed.conf
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Architecture=arm64
+Bootloader=uki-signed
+
+[Content]
+# kernel-uki-virt ships a pre-built UKI for virtual machines, needed to test
+# Bootloader=uki-signed. Not available on all Fedora architectures (e.g. ppc64le),
+# so kept in arch-specific configs and gated on Bootloader=uki-signed. A separate
+# file is needed to match both Architecture= and Bootloader= simultaneously.
+Packages=
+        kernel-uki-virt

--- a/mkosi.conf.d/fedora/mkosi.conf.d/x86_64-uki-signed.conf
+++ b/mkosi.conf.d/fedora/mkosi.conf.d/x86_64-uki-signed.conf
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Architecture=x86-64
+Bootloader=uki-signed
+
+[Content]
+# kernel-uki-virt ships a pre-built UKI for virtual machines, needed to test
+# Bootloader=uki-signed. Not available on all Fedora architectures (e.g. ppc64le),
+# so kept in arch-specific configs and gated on Bootloader=uki-signed. A separate
+# file is needed to match both Architecture= and Bootloader= simultaneously.
+Packages=
+        kernel-uki-virt

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -83,6 +83,7 @@ from mkosi.config import (
     summary,
     systemd_tool_version,
     want_kernel,
+    want_prebuilt_uki,
     want_selinux_relabel,
     yes_no,
 )
@@ -2144,10 +2145,7 @@ def install_uki(
     with umask(~0o700):
         boot_binary.parent.mkdir(parents=True, exist_ok=True)
 
-    if (
-        context.config.bootloader.is_signed()
-        and context.config.unified_kernel_images == UnifiedKernelImage.auto
-    ) or context.config.unified_kernel_images == UnifiedKernelImage.signed:
+    if want_prebuilt_uki(context.config):
         for p in (context.root / "usr/lib/modules" / kver).glob("*.efi"):
             log_step(f"Installing prebuilt UKI at {p} to {boot_binary}")
             copyfile2(p, boot_binary)

--- a/mkosi/bootloader.py
+++ b/mkosi/bootloader.py
@@ -25,6 +25,7 @@ from mkosi.config import (
     SecureBootSignTool,
     ShimBootloader,
     systemd_tool_version,
+    want_prebuilt_uki,
 )
 from mkosi.context import Context
 from mkosi.distribution import Distribution
@@ -680,15 +681,21 @@ def gen_kernel_images(context: Context) -> Iterator[tuple[str, Path]]:
         # scripts in the kernel source tree sometimes do weird stuff. But let's make sure we're not returning
         # UKIs as the UKI on Fedora is named vmlinuz-virt.efi. Also look for uncompressed images (vmlinux) as
         # some architectures ship those. Prefer vmlinuz if both are present.
-        for kimg in kver.glob("vmlinuz*"):
-            if KernelType.identify(context.config, kimg) != KernelType.uki:
-                yield kver.name, kimg
-                break
+        if want_prebuilt_uki(context.config):
+            for kimg in kver.glob("vmlinuz*.efi"):
+                if KernelType.identify(context.config, kimg) == KernelType.uki:
+                    yield kver.name, kimg
+                    break
         else:
-            for kimg in kver.glob("vmlinux*"):
+            for kimg in kver.glob("vmlinuz*"):
                 if KernelType.identify(context.config, kimg) != KernelType.uki:
                     yield kver.name, kimg
                     break
+            else:
+                for kimg in kver.glob("vmlinux*"):
+                    if KernelType.identify(context.config, kimg) != KernelType.uki:
+                        yield kver.name, kimg
+                        break
 
 
 def install_systemd_boot(context: Context) -> None:

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3299,6 +3299,7 @@ SETTINGS: list[ConfigSetting[Any]] = [
         dest="bootloader",
         section="Content",
         parse=config_make_enum_parser(Bootloader),
+        match=config_make_enum_matcher(Bootloader),
         choices=Bootloader.choices(),
         default=Bootloader.systemd_boot,
         help="Specify which UEFI bootloader to use",
@@ -5443,6 +5444,15 @@ def want_kernel(config: Config) -> bool:
 
 def want_default_initrd(config: Config) -> bool:
     return Path("default") in config.initrds
+
+
+def want_prebuilt_uki(config: Config) -> bool:
+    # Returns True when mkosi should use a distro-pre-built signed UKI rather than building one itself.
+    # This happens when a signed bootloader is selected (implying distro UKIs) or when
+    # UnifiedKernelImages=signed is set explicitly.
+    return (
+        config.bootloader.is_signed() and config.unified_kernel_images == UnifiedKernelImage.auto
+    ) or config.unified_kernel_images == UnifiedKernelImage.signed
 
 
 def finalize_historydir(args: Args, output_dir: Optional[Path] = None) -> Path:

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -30,6 +30,7 @@ from typing import Optional
 from mkosi.bootloader import KernelType
 from mkosi.config import (
     Args,
+    Bootloader,
     Config,
     ConfigFeature,
     ConsoleMode,
@@ -1314,9 +1315,16 @@ def run_qemu(args: Args, config: Config) -> None:
         if kernel and (kerneltype != KernelType.uki or not config.architecture.supports_smbios(firmware)):
             cmdline += ["-append", " ".join(config.kernel_command_line + kcl)]
         elif config.architecture.supports_smbios(firmware):
+            # With Bootloader=uki-signed, a UKI built by the distro is used, and we cannot embed
+            # config.kernel_command_line in the UKI. Instead, pass those options through SMBIOS type#11. We
+            # know that this will work because all UEFI systems support SMBIOS and UKIs by construction use
+            # systemd-stub, which reads SMBIOS type#11.
+            stub_kcl = (
+                config.kernel_command_line if config.bootloader == Bootloader.uki_signed else []
+            ) + kcl
             cmdline += [
                 "-smbios",
-                f"type=11,value=io.systemd.stub.kernel-cmdline-extra={' '.join(kcl).replace(',', ',,')}",
+                f"type=11,value=io.systemd.stub.kernel-cmdline-extra={' '.join(stub_kcl).replace(',', ',,')}",  # noqa: E501
                 "-smbios",
                 f"type=11,value=io.systemd.boot.kernel-cmdline-extra={' '.join(kcl).replace(',', ',,')}",
             ]

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -5,7 +5,7 @@ import subprocess
 
 import pytest
 
-from mkosi.config import Bootloader, Firmware, OutputFormat
+from mkosi.config import Architecture, Bootloader, Firmware, OutputFormat
 from mkosi.distribution import Distribution
 from mkosi.run import find_binary, run
 from mkosi.versioncomp import GenericVersion
@@ -59,11 +59,37 @@ def test_format(config: ImageConfig, format: OutputFormat) -> None:
 
 @pytest.mark.parametrize("bootloader", Bootloader)
 def test_bootloader(config: ImageConfig, bootloader: Bootloader) -> None:
-    if config.distribution == Distribution.rhel_ubi or bootloader.is_signed():
+    if config.distribution == Distribution.rhel_ubi or (
+        bootloader.is_signed() and bootloader != Bootloader.uki_signed
+    ):
+        return
+
+    # TODO: want_prebuilt_uki() also fires for UnifiedKernelImage=signed with a non-signed bootloader,
+    # but there is no integration test for that path yet.
+    # uki-signed test matrix:
+    #   x86-64 Fedora  → supports_smbios(uefi)=True,  kernel-uki-virt available → runs
+    #   arm64  Fedora  → supports_smbios(uefi)=True,  kernel-uki-virt available → runs
+    #   ppc64le Fedora → supports_smbios(uefi)=False                             → skipped
+    #   non-Fedora     → no kernel-uki-virt equivalent                           → skipped
+    if bootloader == Bootloader.uki_signed and (
+        config.distribution != Distribution.fedora
+        or not Architecture.native().supports_smbios(Firmware.uefi)
+    ):
         return
 
     firmware = Firmware.linux if bootloader == Bootloader.none else Firmware.auto
 
     with Image(config) as image:
-        image.build(["--format=disk", "--bootloader", str(bootloader)])
+        image.build(
+            [
+                "--format=disk",
+                "--bootloader",
+                str(bootloader),
+                *(
+                    ["--incremental=no", "--cache-key=&d~&r~&a~&I~prebuilt"]
+                    if bootloader == Bootloader.uki_signed
+                    else []
+                ),
+            ]
+        )
         image.vm(["--firmware", str(firmware)])

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -5,7 +5,7 @@ import subprocess
 
 import pytest
 
-from mkosi.config import Bootloader, Firmware, OutputFormat
+from mkosi.config import Architecture, Bootloader, Firmware, OutputFormat
 from mkosi.distribution import Distribution
 from mkosi.run import find_binary, run
 from mkosi.versioncomp import GenericVersion
@@ -59,11 +59,33 @@ def test_format(config: ImageConfig, format: OutputFormat) -> None:
 
 @pytest.mark.parametrize("bootloader", Bootloader)
 def test_bootloader(config: ImageConfig, bootloader: Bootloader) -> None:
-    if config.distribution == Distribution.rhel_ubi or bootloader.is_signed():
+    if config.distribution == Distribution.rhel_ubi or (
+        bootloader.is_signed() and bootloader != Bootloader.uki_signed
+    ):
+        return
+
+    # TODO: want_prebuilt_uki() also fires for UnifiedKernelImage=signed with a non-signed bootloader,
+    # but there is no integration test for that path yet.
+    # uki-signed test matrix:
+    #   x86-64 Fedora  → supports_smbios(uefi)=True,  kernel-uki-virt available → runs
+    #   arm64  Fedora  → supports_smbios(uefi)=True,  kernel-uki-virt available → runs
+    #   ppc64le Fedora → supports_smbios(uefi)=False                             → skipped
+    #   non-Fedora     → no kernel-uki-virt equivalent                           → skipped
+    if bootloader == Bootloader.uki_signed and (
+        config.distribution != Distribution.fedora
+        or not Architecture.native().supports_smbios(Firmware.uefi)
+    ):
         return
 
     firmware = Firmware.linux if bootloader == Bootloader.none else Firmware.auto
 
     with Image(config) as image:
-        image.build(["--format=disk", "--bootloader", str(bootloader)])
+        image.build(
+            [
+                "--format=disk",
+                "--bootloader",
+                str(bootloader),
+                *(["--incremental=no"] if bootloader == Bootloader.uki_signed else []),
+            ]
+        )
         image.vm(["--firmware", str(firmware)])

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -85,7 +85,7 @@ def test_bootloader(config: ImageConfig, bootloader: Bootloader) -> None:
                 "--format=disk",
                 "--bootloader",
                 str(bootloader),
-                *(["--incremental=no"] if bootloader == Bootloader.uki_signed else []),
+                *(["--incremental=yes"] if bootloader == Bootloader.uki_signed else []),
             ]
         )
         image.vm(["--firmware", str(firmware)])


### PR DESCRIPTION
Some distributions (like Fedora) ship their own prebuilt Unified Kernel Images (UKIs). In some use cases, it's helpful to use mkosi to build images that consume these distro-shipped UKIs rather than building a UKI from scratch.

One such use case is testing [cvmutils](https://gitlab.com/vkuznets/cvmutils/-/tree/cvmutils), where the goal is to replace [ad-hoc shell scripts](https://gitlab.com/vkuznets/cvmutils-tests-e2e/-/blob/master/mkimage.sh?ref_type=heads) that handle image building with mkosi. However, doing so currently requires [extra scripts](https://gitlab.com/simsingh/cvmutils/-/tree/mkosi/tests/integration/mkosi/config/fedora?ref_type=heads) to bridge the gap.

This PR fills that gap by allowing mkosi to natively consume prebuilt UKIs, eliminating the need for any additional scripts.

Fixes https://github.com/systemd/mkosi/issues/4174
