### PR TITLE
Fix #4249: unshare --map-auto --map-current-user --setuid 0 --setgid ...

### DIFF
--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -3439,7 +3439,7 @@ For other systems, try researching the `kernel.unprivileged_userns_clone` or
   If this behavior causes applications running in your image to misbehave, you
   can consider running **mkosi** as root which avoids this problem. Alternatively,
   if running **mkosi** as root is not desired, you can use
-  `unshare --map-auto --map-current-user --setuid 0 --setgid 0` to become root in
+  `unshare --map-auto --map-root-user` to become root in
   a user namespace with more than one user assuming the UID/GID mappings in
   `/etc/subuid` and `/etc/subgid` are configured correctly. Note that running mkosi
   as root or with `unshare` means that all output files produced by **mkosi** will not


### PR DESCRIPTION
Closes #4249

## Motivation

The `unshare` invocation documented in `mkosi.1.md` (`--map-auto --map-current-user --setuid 0 --setgid 0`) fails on recent kernels (6.18.10+ on aarch64/Fedora) because `--map-current-user` and `--setuid 0 --setgid 0` conflict when combined with `--map-auto`.

## Changes

- `mkosi/resources/man/mkosi.1.md`, line 3442: Replace the broken `unshare --map-auto --map-current-user --setuid 0 --setgid 0` invocation with the simpler `unshare --map-auto --map-root-user`, which achieves the same result (becoming UID/GID 0 inside a user namespace with full subuid/subgid mappings) without the conflicting flags.

## Testing

Manually verified that `unshare --map-auto --map-root-user pipx run --spec git+https://github.com/systemd/mkosi.git mkosi --debug` completes successfully on Fedora 43 with kernel 6.18.10+ on aarch64, where the previous invocation failed. Confirmed that `id` inside the namespace reports `uid=0(root) gid=0(root)` and that `/etc/subuid`/`/etc/subgid` mappings are applied correctly.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*