### PR TITLE
Fix #4173: Adding repositories with local config broken on Arch

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4870,14 +4870,13 @@ def sync_repository_metadata(
 
             install_sandbox_trees(context.config, context.sandbox_tree)
             context.config.distribution.installer.setup(context)
+            context.config.distribution.installer.keyring(context)
 
             with complete_step("Syncing package manager metadata"):
                 context.config.distribution.installer.package_manager(context.config).sync(
                     context,
                     force=context.args.force > 1 or context.config.cacheonly == Cacheonly.never,
                 )
-
-            context.config.distribution.installer.keyring(context)
 
         src = metadata_dir / "cache" / subdir
         dst = last.package_cache_dir_or_default() / "cache" / subdir


### PR DESCRIPTION
Closes #4173

Moves the `keyring()` call before `sync()` in `sync_repository_metadata()` (`mkosi/__init__.py`) so the pacman keyring is initialized prior to database synchronization. This restores the ordering that existed before #4093, fixing a regression where repositories added via local config profiles (e.g., OBS repos) would fail with "key is unknown" / "keyring is not writable" errors because pacman attempted to verify repository signatures before the keyring was set up.

- `mkosi/__init__.py`: in `sync_repository_metadata()`, moved `context.config.distribution.installer.keyring(context)` from after the `complete_step("Syncing package manager metadata")` block to immediately after `installer.setup(context)`.

Verified by running `mkosi -B -f` on an Arch-based host with an OBS repository configured via `mkosi.local.conf`; package database synchronization now completes successfully without keyring errors.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*