### PR TITLE
Fix #4233: `mkosi` runs into permission errors even when running as root

### DIFF
--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -799,7 +799,7 @@ def acquire_privileges(
         have_effective_cap(CAP_SYS_ADMIN)
         and identity
         and (not foreign or have_effective_cap(CAP_CHOWN))
-        and not delegate
+        and (not delegate or (os.getuid() == 0 and os.getgid() == 0))
         and (not become_root or (os.getuid() == 0 and os.getgid() == 0))
     ):
         return False

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from unittest import mock
+
+from mkosi.sandbox import acquire_privileges
+
+
+def test_acquire_privileges_root_with_delegate_skips_userns() -> None:
+    """Running as root with delegate>0 should not enter a user namespace.
+
+    Regression test for https://github.com/systemd/mkosi/issues/4233:
+    when mkosi runs as root, acquire_privileges(foreign=True, delegate=3)
+    must return False (skip namespace entry) so that subsequent calls to
+    ensure_directories_exist() retain host-root filesystem access.
+    """
+    with (
+        mock.patch("mkosi.sandbox.have_effective_cap", return_value=True),
+        mock.patch("os.getuid", return_value=0),
+        mock.patch("os.getgid", return_value=0),
+    ):
+        result = acquire_privileges(foreign=True, delegate=3)
+    assert result is False


### PR DESCRIPTION
Closes #4233

Skip user namespace entry in `acquire_privileges` when running as real root with a non-zero `delegate` value.

## Changes

**`mkosi/sandbox.py` — `acquire_privileges()`**
The condition on line 802 that gates early-exit (returning `False`, meaning "don't enter a user namespace") previously blocked that exit whenever `delegate` was truthy. It now allows the early exit when both `os.getuid() == 0` and `os.getgid() == 0`, so a real-root process is not forced into a user namespace solely because of a non-zero `delegate` argument.

```python
# before
and not delegate
# after
and (not delegate or (os.getuid() == 0 and os.getgid() == 0))
```

**`tests/test_sandbox.py`** (new file)
Adds `test_acquire_privileges_root_with_delegate_skips_userns`, which mocks `have_effective_cap` to return `True`, patches `os.getuid`/`os.getgid` to return `0`, and asserts that `acquire_privileges(foreign=True, delegate=3)` returns `False`.

## Motivation

When mkosi is invoked as root, the sandbox set up before `ensure_directories_exist()` was entering a user namespace because `delegate` was non-zero. Inside that namespace the process no longer held host-root privileges, making directories under paths like `/home/user/...` (mode `0700`) inaccessible. The result was a `PermissionError: [Errno 13] Permission denied` on a `mkdir` call for the build directory, even though the caller was UID 0 on the host. The regression was introduced in #4160, which added the `delegate` parameter path through `acquire_privileges`.

Real root does not benefit from a user namespace for privilege escalation purposes — it already has the capabilities it needs — so skipping namespace entry when `uid == gid == 0` is both correct and safe.

## Testing

Unit test added in `tests/test_sandbox.py` validates the fixed code path directly:

```
$ python -m pytest tests/test_sandbox.py -v
tests/test_sandbox.py::test_acquire_privileges_root_with_delegate_skips_userns PASSED
```

Manual verification: running `mkosi` as root with a build directory inside a `0700` home directory no longer raises `PermissionError` and proceeds through `ensure_directories_exist()` successfully.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*