### PR TITLE
Fix #4206: cp: setting attribute 'security.ima' for 'security.ima': O...

### DIFF
--- a/mkosi/tree.py
+++ b/mkosi/tree.py
@@ -103,6 +103,12 @@ def tree_has_selinux_xattr(path: Path) -> bool:
     )
 
 
+def tree_has_ima_xattr(path: Path) -> bool:
+    return any(
+        "security.ima" in os.listxattr(p, follow_symlinks=False) for p in (path, *path.rglob("*"))
+    )
+
+
 def copy_tree(
     src: Path,
     dst: Path,
@@ -125,7 +131,10 @@ def copy_tree(
         attrs += ",timestamps,ownership"
 
         # Trying to copy selinux xattrs to overlayfs fails with "Operation not supported" in containers.
-        if statfs(os.fspath(dst.parent)) != OVERLAYFS_SUPER_MAGIC or not tree_has_selinux_xattr(src):
+        # Trying to copy security.ima xattrs fails with "Operation not permitted" when non-root.
+        if (statfs(os.fspath(dst.parent)) != OVERLAYFS_SUPER_MAGIC or not tree_has_selinux_xattr(src)) and (
+            os.getuid() == 0 or not tree_has_ima_xattr(src)
+        ):
             attrs += ",xattr"
 
     def copy() -> None:

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from pathlib import Path
+from unittest.mock import patch
+
+from mkosi.tree import tree_has_ima_xattr, tree_has_selinux_xattr
+
+
+def test_tree_has_ima_xattr_present() -> None:
+    with patch("os.listxattr", return_value=["security.ima", "security.selinux"]):
+        with patch.object(Path, "rglob", return_value=[]):
+            assert tree_has_ima_xattr(Path("/fake")) is True
+
+
+def test_tree_has_ima_xattr_absent() -> None:
+    with patch("os.listxattr", return_value=["security.selinux", "user.foo"]):
+        with patch.object(Path, "rglob", return_value=[]):
+            assert tree_has_ima_xattr(Path("/fake")) is False
+
+
+def test_tree_has_selinux_xattr_present() -> None:
+    with patch("os.listxattr", return_value=["security.selinux"]):
+        with patch.object(Path, "rglob", return_value=[]):
+            assert tree_has_selinux_xattr(Path("/fake")) is True
+
+
+def test_tree_has_selinux_xattr_absent() -> None:
+    with patch("os.listxattr", return_value=["security.ima", "user.foo"]):
+        with patch.object(Path, "rglob", return_value=[]):
+            assert tree_has_selinux_xattr(Path("/fake")) is False


### PR DESCRIPTION
Closes #4206

## Motivation

When building as non-root, `cp --preserve=xattr` fails with `Operation not permitted` if source files carry `security.ima` xattrs (e.g. `/etc/crypto-policies/back-ends/*` on Fedora with IMA enabled). The existing xattr guard in `copy_tree` only suppresses xattr copying on overlayfs destinations to work around SELinux issues, leaving the IMA case unhandled.

## Changes

**`mkosi/tree.py`**

- Adds `tree_has_ima_xattr(path: Path) -> bool` (mirrors the existing `tree_has_selinux_xattr`): walks `path` and all descendants via `rglob`, checking `os.listxattr(..., follow_symlinks=False)` for `"security.ima"`.
- In `copy_tree`, the condition that appends `",xattr"` to the `attrs` string (line ~134) is extended with a second guard: `os.getuid() == 0 or not tree_has_ima_xattr(src)`. xattr copying is now skipped when running as non-root and the source tree contains IMA xattrs, regardless of the filesystem type of the destination.

**`tests/test_tree.py`** (new file)

- `test_tree_has_ima_xattr_present` / `test_tree_has_ima_xattr_absent`: verify `tree_has_ima_xattr` returns the correct boolean when `os.listxattr` is mocked to include or exclude `"security.ima"`.
- `test_tree_has_selinux_xattr_present` / `test_tree_has_selinux_xattr_absent`: equivalent coverage for the pre-existing `tree_has_selinux_xattr` function, which had no unit tests.

## Testing

Unit tests added in `tests/test_tree.py` cover both the positive and negative cases for `tree_has_ima_xattr` and `tree_has_selinux_xattr` using `unittest.mock.patch` on `os.listxattr` and `Path.rglob`.

Manual verification: running `mkosi build` with `ToolsTreeDistribution=debian` / `ToolsTreeRelease=trixie` as a non-root user on a Fedora 43 host with IMA xattrs present on `/etc/crypto-policies/back-ends/*` no longer produces `cp: setting attribute 'security.ima' ... Operation not permitted` errors and completes successfully.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*