### PR TITLE
Add SparseOutput= setting to convert disk images to Android sparse format

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2779,6 +2779,9 @@ def check_inputs(config: Config) -> None:
             ),
         )
 
+    if config.sparse_output and config.output_format != OutputFormat.disk:
+        die("SparseOutput=yes can only be used with Format=disk")
+
     if config.is_incremental() and config.cacheonly == Cacheonly.never:
         die("Incremental=yes cannot be used with CacheOnly=never")
 
@@ -4186,6 +4189,24 @@ def build_image(context: Context) -> None:
                 f"Can't change the output size because the image is already larger ({format_bytes(current_size)}) than requested"  # noqa: E501
             )
 
+    if context.config.sparse_output:
+        if not context.config.find_binary("img2simg"):
+            die("SparseOutput=yes was requested but img2simg was not found")
+
+        output = context.staging / context.config.output_with_format
+
+        with complete_step("Converting disk image to Android sparse image…"):
+            tmp = output.parent / f"{output.name}.tmp"
+            run(
+                ["img2simg", workdir(output), workdir(tmp)],
+                sandbox=context.sandbox(
+                    options=[
+                        "--bind", context.staging, workdir(context.staging),
+                    ],
+                ),
+            )
+            tmp.rename(output)
+
     if context.config.output_format.use_outer_compression():
         maybe_compress(
             context,
@@ -4305,6 +4326,8 @@ def run_shell(args: Args, config: Config) -> None:
         die(f"Cannot {opname} {config.output_format} images with systemd-nspawn")
     if config.output_format.use_outer_compression() and config.compress_output:
         die(f"Cannot {opname} compressed {config.output_format} images with systemd-nspawn")
+    if config.sparse_output:
+        die(f"Cannot {opname} sparse images with systemd-nspawn")
 
     cmdline: list[PathString] = ["systemd-nspawn", "--quiet", "--link-journal=no", "--suppress-sync=yes"]
 

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2101,6 +2101,7 @@ class Config:
     sysupdate_dir: Optional[Path]
     sector_size: Optional[int]
     overlay: bool
+    sparse_output: bool
     seed: uuid.UUID
     el_torito: ConfigFeature
     el_torito_system: Optional[str]
@@ -3030,6 +3031,13 @@ SETTINGS: list[ConfigSetting[Any]] = [
         section="Output",
         parse=config_parse_boolean,
         help="Only output the additions on top of the given base trees",
+    ),
+    ConfigSetting(
+        dest="sparse_output",
+        metavar="BOOL",
+        section="Output",
+        parse=config_parse_boolean,
+        help="Convert the disk image to Android sparse format",
     ),
     ConfigSetting(
         dest="seed",
@@ -5808,6 +5816,7 @@ def summary(config: Config) -> str:
                  Repart Directories: {line_join_list(config.repart_dirs)}
                         Sector Size: {none_to_default(config.sector_size)}
                             Overlay: {yes_no(config.overlay)}
+                      Sparse Output: {yes_no(config.sparse_output)}
                                Seed: {none_to_random(config.seed)}
                           El Torito: {config.el_torito}
                    El Torito System: {none_to_none(config.el_torito_system)}

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -902,6 +902,8 @@ def run_qemu(args: Args, config: Config) -> None:
         OutputFormat.directory,
     ):
         die(f"{config.output_format} images cannot be booted in qemu")
+    if config.sparse_output:
+        die("Sparse images cannot be booted in qemu")
 
     if (
         config.output_format in (OutputFormat.cpio, OutputFormat.uki, OutputFormat.esp)

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -790,6 +790,12 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
     This option may be used to create [systemd *system extensions*](https://uapi-group.org/specifications/specs/extension_image).
 
+`SparseOutput=`, `--sparse-output=`
+:   Takes a boolean value. If enabled, the output disk image is converted
+    to Android sparse format using **img2simg**. This is useful for flashing
+    images via **fastboot**. Can only be used with `Format=disk`. Defaults
+    to `no`.
+
 `Seed=`, `--seed=`
 :   Takes a UUID as argument or the special value `random`.
     Overrides the seed that **systemd-repart**

--- a/mkosi/vmspawn.py
+++ b/mkosi/vmspawn.py
@@ -41,6 +41,8 @@ def run_vmspawn(args: Args, config: Config) -> None:
         OutputFormat.uki,
     ):
         die(f"{config.output_format} images cannot be booted in systemd-vmspawn")
+    if config.sparse_output:
+        die("Sparse images cannot be booted in systemd-vmspawn")
 
     kernel = config.expand_linux_specifiers() if config.linux else None
     firmware = finalize_firmware(config, kernel)


### PR DESCRIPTION
This uses img2simg on the raw disk image after partition splitting but before compression, so split partition artifacts remain usable and the sparse image can still be compressed with CompressOutput=. This is useful for producing images that can be flashed via fastboot. Requires img2simg from android-tools.

I decided to use a new separate option for toggling this, rather than using Format=, because the build pipeline is identical to Format=disk and adding a new format would require updating every OutputFormat.disk check across the codebase. It's also not a CompressOutput= value since sparse is a format conversion, not compression, and users may want to compress the sparse image afterwards.