### PR TITLE
Revert "Add Incremental=relaxed"

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4718,10 +4718,7 @@ def run_clean(args: Args, config: Config, repository_metadata_needs_sync: bool =
         remove_image_cache = args.force > 0
         remove_package_cache = args.force > 1
     else:
-        # Rely on the fact that True is 1 and False is 0 in numeric contexts.
-        remove_outputs = args.force > (config.incremental == Incremental.relaxed) or (
-            config.is_incremental() and not have_cache(config)
-        )
+        remove_outputs = args.force > 0 or (config.is_incremental() and not have_cache(config))
         remove_build_cache = args.force > 1 or args.wipe_build_dir
         remove_image_cache = args.force > 1 or not have_cache(config) or repository_metadata_needs_sync
         remove_package_cache = args.force > 2
@@ -5239,16 +5236,12 @@ def run_verb(args: Args, tools: Optional[Config], images: Sequence[Config], *, r
             ikd = imd = None
 
             for config in images:
-                # If the output format is "none" and there are no build scripts, there's nothing to do so
-                # exit early.
-                if config.output_format == OutputFormat.none and not config.build_scripts:
-                    continue
-
-                # If the image already exists and we're not rerunning build scripts, there's nothing to do so
-                # exit early.
-                if (config.output_dir_or_cwd() / config.output).exists() and (
-                    not args.rerun_build_scripts or not config.build_scripts
-                ):
+                # If the output format is "none" or we're rebuilding and there are no build scripts, there's
+                # nothing to do so exit early.
+                if (
+                    config.output_format == OutputFormat.none
+                    or (args.rerun_build_scripts and (config.output_dir_or_cwd() / config.output).exists())
+                ) and not config.build_scripts:
                     continue
 
                 check_tools(config, Verb.build)

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -422,7 +422,6 @@ class Incremental(StrEnum):
     yes = enum.auto()
     no = enum.auto()
     strict = enum.auto()
-    relaxed = enum.auto()
 
     def __bool__(self) -> bool:
         return self != Incremental.no
@@ -3909,7 +3908,7 @@ SETTINGS: list[ConfigSetting[Any]] = [
         parse=config_make_enum_parser_with_boolean(Incremental, yes=Incremental.yes, no=Incremental.no),
         default=Incremental.no,
         help="Make use of and generate intermediary cache images",
-        scope=SettingScope.inherit,
+        scope=SettingScope.universal,
         choices=Incremental.values(),
     ),
     ConfigSetting(

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1589,9 +1589,6 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     If set to `strict`, the build fails if previously built cached image does
     not exist.
 
-    If set to `relaxed`, images are only rebuilt when `-ff` is specified or
-    if the cached imaged is out of date.
-
 `CacheOnly=`, `--cache-only=`
 :   Takes one of `auto`, `metadata`, `always` or `never`. Defaults to
     `auto`. If `always`, the package manager is instructed not to contact


### PR DESCRIPTION
This does not work as a per distribution CacheKey= means that we can switch between distributions without invalidating caches, meaning the output files won't be removed yet will still be those of the previous distribution rather than the new one.

Revert for now until I figure out a better approach.

This reverts commit a97c50044ce19d72e5119cd11af6993c3944ab65.