### PR TITLE
ukify: Support multiple PCR signing keys to sign phases separately

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -63,6 +63,7 @@ from mkosi.config import (
     ManifestFormat,
     Network,
     OutputFormat,
+    PcrSigner,
     SecureBootSignTool,
     ShimBootloader,
     Ssh,
@@ -1583,8 +1584,10 @@ def want_signed_pcrs(config: Config) -> bool:
     return config.sign_expected_pcr == ConfigFeature.enabled or (
         config.sign_expected_pcr == ConfigFeature.auto
         and config.find_binary("systemd-measure", "/usr/lib/systemd/systemd-measure") is not None
-        and bool(config.sign_expected_pcr_key)
-        and bool(config.sign_expected_pcr_certificate)
+        and (
+            (bool(config.sign_expected_pcr_key) and bool(config.sign_expected_pcr_certificate))
+            or bool(config.sign_expected_pcr_with_phases)
+        )
     )
 
 
@@ -1755,73 +1758,98 @@ def build_uki(
 
         arguments += ["--sign-kernel"]
 
-    if want_signed_pcrs(context.config):
-        assert context.config.sign_expected_pcr_key
-        assert context.config.sign_expected_pcr_certificate
+    seen_bind_paths: set[Path] = set()
 
+    if want_signed_pcrs(context.config):
         arguments += [
             # SHA1 might be disabled in OpenSSL depending on the distro so we opt to not sign
             # for SHA1 to avoid having to manage a bunch of configuration to re-enable SHA1.
             "--pcr-banks", "sha256",
         ]  # fmt: skip
 
-        if (
-            systemd_tool_version(
-                python_binary(context.config),
-                ukify,
-                sandbox=context.sandbox,
-            )
-            >= "258"
-        ):
+        ukify_version = systemd_tool_version(
+            python_binary(context.config),
+            ukify,
+            sandbox=context.sandbox,
+        )
+
+        if ukify_version >= "258":
             cert_parameter = "--pcr-certificate"
         else:
             cert_parameter = "--pcr-public-key"
 
-        # If we're providing the private key via an engine or provider, we have to pass in a X.509
-        # certificate via --pcr-certificate as well.
-        if context.config.sign_expected_pcr_key_source.type != KeySourceType.file:
-            if context.config.sign_expected_pcr_certificate_source.type == CertificateSourceType.provider:
-                arguments += [
-                    "--certificate-provider",
-                    f"provider:{context.config.sign_expected_pcr_certificate_source.source}",
-                ]
-
-            options += ["--bind", "/run", "/run"]
-
-            if context.config.sign_expected_pcr_certificate.exists():
-                arguments += [
-                    cert_parameter, workdir(context.config.sign_expected_pcr_certificate),
-                ]  # fmt: skip
-                options += [
-                    "--ro-bind", context.config.sign_expected_pcr_certificate, workdir(context.config.sign_expected_pcr_certificate),  # noqa: E501
-                ]  # fmt: skip
-            else:
-                arguments += [cert_parameter, context.config.sign_expected_pcr_certificate]
-
-        if context.config.sign_expected_pcr_key_source.type == KeySourceType.engine:
-            arguments += ["--signing-engine", context.config.sign_expected_pcr_key_source.source]
-        elif context.config.sign_expected_pcr_key_source.type == KeySourceType.provider:
-            arguments += ["--signing-provider", context.config.sign_expected_pcr_key_source.source]
-
-        if context.config.sign_expected_pcr_key.exists():
-            arguments += ["--pcr-private-key", workdir(context.config.sign_expected_pcr_key)]
-            options += [
-                "--ro-bind", context.config.sign_expected_pcr_key, workdir(context.config.sign_expected_pcr_key),  # noqa: E501
-            ]  # fmt: skip
+        if context.config.sign_expected_pcr_with_phases:
+            signers = context.config.sign_expected_pcr_with_phases
+            if ukify_version < "253":
+                die(f"ukify {ukify_version} does not support --phases (need >= 253)")
         else:
-            arguments += ["--pcr-private-key", context.config.sign_expected_pcr_key]
+            assert context.config.sign_expected_pcr_key
+            assert context.config.sign_expected_pcr_certificate
+            signers = [
+                PcrSigner(
+                    key=context.config.sign_expected_pcr_key,
+                    certificate=context.config.sign_expected_pcr_certificate,
+                    phases=[],
+                    key_source=context.config.sign_expected_pcr_key_source,
+                    certificate_source=context.config.sign_expected_pcr_certificate_source,
+                )
+            ]
+
+        need_run_bind = False
+
+        for signer in signers:
+            # If we're providing the private key via an engine or provider, we have to pass in
+            # a X.509 certificate via --pcr-certificate as well.
+            if signer.key_source.type != KeySourceType.file:
+                if signer.certificate_source.type == CertificateSourceType.provider:
+                    arguments += [
+                        "--certificate-provider", f"provider:{signer.certificate_source.source}",
+                    ]  # fmt: skip
+
+                need_run_bind = True
+
+                if signer.certificate.exists():
+                    arguments += [cert_parameter, workdir(signer.certificate)]
+                    seen_bind_paths.add(signer.certificate)
+                else:
+                    arguments += [cert_parameter, signer.certificate]
+
+            if signer.key_source.type == KeySourceType.engine:
+                arguments += ["--signing-engine", signer.key_source.source]
+            elif signer.key_source.type == KeySourceType.provider:
+                arguments += ["--signing-provider", signer.key_source.source]
+
+            if signer.key.exists():
+                arguments += ["--pcr-private-key", workdir(signer.key)]
+                seen_bind_paths.add(signer.key)
+            else:
+                arguments += ["--pcr-private-key", signer.key]
+
+            if signer.phases:
+                arguments += ["--phases", " ".join(signer.phases)]
+
+        if need_run_bind:
+            options += ["--bind", "/run", "/run"]
     elif ArtifactOutput.pcrs in context.config.split_artifacts:
         assert context.config.sign_expected_pcr_certificate
 
         json_out = True
+        cert = context.config.sign_expected_pcr_certificate
         arguments += [
             "--policy-digest",
             "--pcr-banks", "sha256",
-            "--pcr-certificate", workdir(context.config.sign_expected_pcr_certificate),
+            "--pcr-certificate", workdir(cert),
         ]  # fmt: skip
-        options += [
-            "--ro-bind", context.config.sign_expected_pcr_certificate, workdir(context.config.sign_expected_pcr_certificate),  # noqa: E501
-        ]  # fmt: skip
+        seen_bind_paths.add(cert)
+
+    if (pcrpkey := context.config.sign_expected_pcr_uki_public_key) is not None:
+        if not pcrpkey.exists():
+            die(f"SignExpectedPcrUKIPublicKey={pcrpkey} does not exist")
+        arguments += ["--pcrpkey", workdir(pcrpkey)]
+        seen_bind_paths.add(pcrpkey)
+
+    for file in seen_bind_paths:
+        options += ["--ro-bind", file, workdir(file)]
 
     if microcodes:
         # new .ucode section support?
@@ -2723,25 +2751,39 @@ def check_inputs(config: Config) -> None:
             hint="Run mkosi genkey to generate a key/certificate pair",
         )
 
-    if config.sign_expected_pcr == ConfigFeature.enabled and not config.sign_expected_pcr_key:
+    if (
+        config.sign_expected_pcr == ConfigFeature.enabled
+        and not config.sign_expected_pcr_with_phases
+        and not config.sign_expected_pcr_key
+    ):
         die(
             "SignExpectedPcr= is enabled but no private key is configured",
             hint="Run mkosi genkey to generate a key/certificate pair",
         )
 
-    if config.sign_expected_pcr == ConfigFeature.enabled and not config.sign_expected_pcr_certificate:
+    if (
+        config.sign_expected_pcr == ConfigFeature.enabled
+        and not config.sign_expected_pcr_with_phases
+        and not config.sign_expected_pcr_certificate
+    ):
         die(
             "SignExpectedPcr= is enabled but no certificate is configured",
             hint="Run mkosi genkey to generate a key/certificate pair",
         )
 
-    if config.secure_boot_key_source != config.sign_expected_pcr_key_source:
-        die("Secure boot key source and expected PCR signatures key source have to be the same")
+    # When SignExpectedPcrWithPhases= is used the key/certificate sources live per-entry, so the
+    # scalar sign_expected_pcr_{key,certificate}_source fields default to "file" regardless of
+    # what the per-signer sources are. Comparing those scalars against secure boot's sources
+    # would be meaningless, so skip the check in that case and rely on ukify to reject
+    # inconsistent sources at invocation time.
+    if not config.sign_expected_pcr_with_phases:
+        if config.secure_boot_key_source != config.sign_expected_pcr_key_source:
+            die("Secure boot key source and expected PCR signatures key source have to be the same")
 
-    if config.secure_boot_certificate_source != config.sign_expected_pcr_certificate_source:
-        die(
-            "Secure boot certificate source and expected PCR signatures certificate source have to be the same"  # noqa: E501
-        )  # fmt: skip
+        if config.secure_boot_certificate_source != config.sign_expected_pcr_certificate_source:
+            die(
+                "Secure boot certificate source and expected PCR signatures certificate source have to be the same"  # noqa: E501
+            )  # fmt: skip
 
     if config.verity == Verity.signed and not config.verity_key:
         die(

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1733,6 +1733,88 @@ def config_parse_certificate_source(
     return CertificateSource(type=type, source=source)
 
 
+@dataclasses.dataclass(frozen=True)
+class PcrSigner:
+    key: Path
+    certificate: Path
+    phases: list[str]
+    key_source: KeySource = KeySource(type=KeySourceType.file)
+    certificate_source: CertificateSource = CertificateSource(type=CertificateSourceType.file)
+
+
+def parse_pcr_signer(value: str) -> PcrSigner:
+    # Fields are whitespace-separated with shell-style quoting (values containing spaces can be
+    # quoted with " or '). Line continuation with trailing backslash is folded by the list parser
+    # before we see the value, so each invocation sees exactly one logical entry.
+    try:
+        parts = shlex.split(value)
+    except ValueError as e:
+        die(f"Failed to parse SignExpectedPcrWithPhases= entry '{value}': {e}")
+
+    if not 3 <= len(parts) <= 5:
+        die(
+            "SignExpectedPcrWithPhases= entry must have 3 to 5 whitespace-separated fields "
+            f"(KEY CERT PHASES [KEYSOURCE [CERTSOURCE]]), got: '{value}'"
+        )
+
+    key_str, cert_str, phases_str, *rest = parts
+
+    if not key_str:
+        die(f"SignExpectedPcrWithPhases= entry has empty KEY field: '{value}'")
+    if not cert_str:
+        die(f"SignExpectedPcrWithPhases= entry has empty CERT field: '{value}'")
+
+    key = config_parse_key(key_str, None)
+    cert = config_parse_certificate(cert_str, None)
+    assert key is not None
+    assert cert is not None
+
+    # "-" means "no --phases argument emitted" (ukify uses its default phase paths).
+    phases = [] if phases_str == "-" else [p for p in phases_str.split(",") if p]
+
+    key_source = (
+        config_parse_key_source(rest[0], None) if len(rest) > 0 else KeySource(type=KeySourceType.file)
+    )
+    cert_source = (
+        config_parse_certificate_source(rest[1], None)
+        if len(rest) > 1
+        else CertificateSource(type=CertificateSourceType.file)
+    )
+    assert key_source is not None
+    assert cert_source is not None
+
+    return PcrSigner(
+        key=key,
+        certificate=cert,
+        phases=phases,
+        key_source=key_source,
+        certificate_source=cert_source,
+    )
+
+
+def config_parse_pcr_signers(
+    value: Optional[str],
+    old: Optional[list[PcrSigner]],
+) -> Optional[list[PcrSigner]]:
+    new = old.copy() if old else []
+
+    if value is None:
+        return []
+
+    # Fold shell-style backslash line continuations so entries formatted to span multiple
+    # lines (for readability of long PKCS#11 URIs and phase path lists) are treated as one.
+    folded = re.sub(r"\\\n[ \t]*", " ", value)
+
+    values = folded.split("\n")
+
+    # Empty value resets the list
+    if values in ([], [""]):
+        return None
+
+    new += [parse_pcr_signer(v) for v in values if v.strip()]
+    return new
+
+
 def config_parse_artifact_output_list(
     value: Optional[str], old: Optional[list[ArtifactOutput]]
 ) -> Optional[list[ArtifactOutput]]:
@@ -2190,6 +2272,8 @@ class Config:
     sign_expected_pcr_key_source: KeySource
     sign_expected_pcr_certificate: Optional[Path]
     sign_expected_pcr_certificate_source: CertificateSource
+    sign_expected_pcr_with_phases: list[PcrSigner]
+    sign_expected_pcr_uki_public_key: Optional[Path]
     passphrase: Optional[Path]
     checksum: bool
     sign: bool
@@ -3747,6 +3831,23 @@ SETTINGS: list[ConfigSetting[Any]] = [
         parse=config_parse_certificate_source,
         default=CertificateSource(type=CertificateSourceType.file),
         help="The source to use to retrieve the expected PCR signing certificate",
+        scope=SettingScope.inherit,
+    ),
+    ConfigSetting(
+        dest="sign_expected_pcr_with_phases",
+        metavar="KEY CERT PHASES [KEYSRC [CERTSRC]]",
+        section="Validation",
+        parse=config_parse_pcr_signers,
+        help="Sign expected PCR values with multiple keys bound to specific UKI phase paths",
+        scope=SettingScope.inherit,
+    ),
+    ConfigSetting(
+        dest="sign_expected_pcr_uki_public_key",
+        name="SignExpectedPcrUKIPublicKey",
+        metavar="PATH",
+        section="Validation",
+        parse=config_parse_certificate,
+        help="PEM-encoded public key to embed in the UKI's .pcrpkey section",
         scope=SettingScope.inherit,
     ),
     ConfigSetting(
@@ -5430,6 +5531,63 @@ def finalize_historydir(args: Args) -> Path:
     return (configdir or Path.cwd()) / ".mkosi-private/history"
 
 
+def validate_pcr_signing(config: Config) -> None:
+    if config.sign_expected_pcr_with_phases:
+        # Only flag the scalar settings whose corresponding key/certificate is actually set.
+        # SignExpectedPcrKeySource=/SignExpectedPcrCertificateSource= are scope=inherit, so a
+        # main image that sets them (for use with the legacy scalars) would otherwise trip the
+        # check in a subimage that only uses SignExpectedPcrWithPhases=; those sources are
+        # harmless without a paired key/certificate, so skip them in that case.
+        conflicts = []
+        if config.sign_expected_pcr_key is not None:
+            conflicts.append("SignExpectedPcrKey=")
+            if config.sign_expected_pcr_key_source.type != KeySourceType.file:
+                conflicts.append("SignExpectedPcrKeySource=")
+        if config.sign_expected_pcr_certificate is not None:
+            conflicts.append("SignExpectedPcrCertificate=")
+            if config.sign_expected_pcr_certificate_source.type != CertificateSourceType.file:
+                conflicts.append("SignExpectedPcrCertificateSource=")
+
+        if conflicts:
+            msg = (
+                "SignExpectedPcrWithPhases= cannot be combined with "
+                + ", ".join(conflicts)
+                + "; specify per-signer key, certificate and sources in each "
+                "SignExpectedPcrWithPhases= entry instead"
+            )
+            # mkosi.key/mkosi.crt in the config directory are auto-picked-up by
+            # SignExpectedPcrKey=/SignExpectedPcrCertificate= and easy to overlook. Detection
+            # works for both top-level and mkosi/ subfolder layouts because Path.name only
+            # looks at the basename.
+            clears = []
+            if config.sign_expected_pcr_key is not None and config.sign_expected_pcr_key.name == "mkosi.key":
+                clears.append("SignExpectedPcrKey=")
+            if (
+                config.sign_expected_pcr_certificate is not None
+                and config.sign_expected_pcr_certificate.name == "mkosi.crt"
+            ):
+                clears.append("SignExpectedPcrCertificate=")
+            hint = None
+            if clears:
+                hint = (
+                    "mkosi.key/mkosi.crt in the config directory are picked up automatically; "
+                    "delete the file(s) or clear the pickup by adding to [Validation]: " + ", ".join(clears)
+                )
+            die(msg, hint=hint)
+
+    # When SignExpectedPcr=enabled is set explicitly, either the legacy scalars or the new
+    # list-valued setting must be configured; otherwise we'd hit an assertion failure later
+    # when running ukify.
+    if config.sign_expected_pcr == ConfigFeature.enabled and not (
+        config.sign_expected_pcr_with_phases
+        or (config.sign_expected_pcr_key and config.sign_expected_pcr_certificate)
+    ):
+        die(
+            "SignExpectedPcr=yes requires either SignExpectedPcrKey= and "
+            "SignExpectedPcrCertificate=, or SignExpectedPcrWithPhases= to be set"
+        )
+
+
 def parse_config(
     argv: Sequence[str] = (),
     *,
@@ -5627,6 +5785,9 @@ def parse_config(
     main = Config.from_dict(config)
     subimages = [Config.from_dict(ns) for ns in images]
 
+    for image in [main, *subimages]:
+        validate_pcr_signing(image)
+
     if any(want_default_initrd(image) for image in subimages + [main]):
         initrd = finalize_default_initrd(maincontext, config, configdir=configdir, resources=resources)
 
@@ -5714,6 +5875,10 @@ def none_to_default(s: Optional[object]) -> str:
 
 def line_join_list(array: Iterable[object]) -> str:
     return "\n                                     ".join(str(item) for item in array) if array else "none"
+
+
+def format_pcr_signers(signers: list[PcrSigner]) -> str:
+    return line_join_list([f"{s.key} -> {','.join(s.phases) if s.phases else '-'}" for s in signers])
 
 
 def format_bytes(num_bytes: int) -> str:
@@ -5924,6 +6089,8 @@ def summary(config: Config) -> str:
            Expected PCRs Key Source: {config.sign_expected_pcr_key_source}
           Expected PCRs Certificate: {none_to_none(config.sign_expected_pcr_certificate)}
    Expected PCRs Certificate Source: {config.sign_expected_pcr_certificate_source}
+     Sign Expected PCRs With Phases: {format_pcr_signers(config.sign_expected_pcr_with_phases)}
+       Expected PCRs UKI Public Key: {none_to_none(config.sign_expected_pcr_uki_public_key)}
                          Passphrase: {none_to_none(config.passphrase)}
                            Checksum: {yes_no(config.checksum)}
                                Sign: {yes_no(config.sign)}
@@ -6144,6 +6311,27 @@ def json_type_transformer(refcls: Union[type[Args], type[Config]]) -> Callable[[
             for d in creds
         ]
 
+    def pcr_signer_transformer(
+        signers: list[dict[str, Any]],
+        fieldtype: type[list[PcrSigner]],
+    ) -> list[PcrSigner]:
+        return [
+            PcrSigner(
+                key=Path(d["Key"]),
+                certificate=Path(d["Certificate"]),
+                phases=d.get("Phases", []),
+                key_source=KeySource(
+                    type=KeySourceType(d["KeySource"]["Type"]),
+                    source=d["KeySource"].get("Source", ""),
+                ),
+                certificate_source=CertificateSource(
+                    type=CertificateSourceType(d["CertificateSource"]["Type"]),
+                    source=d["CertificateSource"].get("Source", ""),
+                ),
+            )
+            for d in signers
+        ]
+
     # The type of this should be
     # dict[
     #     type,
@@ -6193,6 +6381,7 @@ def json_type_transformer(refcls: Union[type[Args], type[Config]]) -> Callable[[
         ConsoleMode: enum_transformer,
         Verity: enum_transformer,
         list[Credential]: credential_transformer,
+        list[PcrSigner]: pcr_signer_transformer,
     }
 
     def json_transformer(key: str, val: Any) -> Any:

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1456,9 +1456,92 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 :   The source of the corresponding private key, to support OpenSSL engines and providers,
     e.g. `--secure-boot-key-source=engine:pkcs11` or `--secure-boot-key-source=provider:pkcs11`.
 
+    `SecureBootKeySource=` and `SignExpectedPcrKeySource=` must use the same
+    mechanism when both Secure Boot signing and PCR signing are enabled because
+    **ukify** relies on a single global `--signing-engine`/`--signing-provider`
+    that applies to all signing operations in one invocation. Mixing sources
+    thus would not work. When `SignExpectedPcrWithPhases=` is used this
+    check is skipped because each signer carries its own source. In that
+    case it is the user's responsibility to keep sources consistent across
+    signers and with `SecureBootKeySource=`.
+
 `SecureBootCertificateSource=`, `--secure-boot-certificate-source=`, `VerityCertificateSource=`, `--verity-certificate-source=`, `SignExpectedPcrCertificateSource=`, `--sign-expected-certificate-source=`
 :   The source of the corresponding certificate, to support OpenSSL providers,
     e.g. `--secure-boot-certificate-source=provider:pkcs11`. Note that engines are not supported.
+
+    The key source mechanism constraint to be the same for all keys from
+    `*KeySource=` also applies to `SecureBootCertificateSource=` and
+    `SignExpectedPcrCertificateSource=`.
+
+`SignExpectedPcrWithPhases=`, `--sign-expected-pcr-with-phases=`
+:   Sign the expected PCR values with multiple keys, each signing only a specific
+    set of UKI boot phases. This option is an alternative to `SignExpectedPcrKey=`
+    and cannot be combined with `SignExpectedPcrKey=`, `SignExpectedPcrCertificate=`,
+    `SignExpectedPcrKeySource=` or `SignExpectedPcrCertificateSource=`.
+
+    Accepts one entry per logical line, with each entry containing
+    3 to 5 whitespace-separated fields:
+
+    `KEY CERTIFICATE PHASES [KEYSOURCE [CERTIFICATESOURCE]]`
+
+    - `KEY`: path to the PEM-encoded private key, or a PKCS#11 URI when
+      `KEYSOURCE` is `engine:…` or `provider:…`.
+    - `CERTIFICATE`: path to the X.509 certificate.
+    - `PHASES`: comma-separated list of colon-separated phase paths
+      (e.g. `enter-initrd:leave-initrd,enter-initrd:leave-initrd:sysinit`).
+      Use the special value `-` to omit `--phases` entirely, letting
+      **ukify** apply its default phase path list.
+    - `KEYSOURCE` (optional): same as `SignExpectedPcrKeySource=`,
+      defaults to `file`.
+    - `CERTIFICATESOURCE` (optional): same as `SignExpectedPcrCertificateSource=`,
+      defaults to `file`.
+
+    Entries are separated by newlines. Fields within an entry are
+    whitespace-separated with shell-style quoting, so values
+    containing spaces can be quoted with `"` or `'`. A trailing `\`
+    continues the entry on the next line.
+
+    Requires **ukify** version 253 or newer.
+
+    When multiple entries are configured, **ukify** will not embed a
+    `.pcrpkey` PE section in the UKI by default. It only does so when
+    exactly one signing key is supplied. Set `SignExpectedPcrUKIPublicKey=`
+    to explicitly control what goes into the `.pcrpkey` section.
+
+    Because **ukify** relies on a single global `--signing-engine`/
+    `--signing-provider` per invocation, all signer entries must use the
+    same mechanism for their `KEYSOURCE` (and `CERTIFICATESOURCE`) fields,
+    and the same mechanism as `SecureBootKeySource=`/`SecureBootCertificateSource=`
+    when Secure Boot signing is also enabled.
+
+    Note that `mkosi.key` and `mkosi.crt` in the config directory are
+    automatically picked up by `SignExpectedPcrKey=` and `SignExpectedPcrCertificate=`
+    respectively. When switching to `SignExpectedPcrWithPhases=`, either
+    delete/rename those files or explicitly clear the legacy scalars by
+    adding `SignExpectedPcrKey=` and `SignExpectedPcrCertificate=` (with
+    empty values) to your config. Otherwise the mutual-exclusion check
+    will reject the configuration.
+
+    Example reproducing the "Example 3" invocation from the **ukify**(1)
+    manual page (using X.509 certificates, as expected by **ukify** ≥ 258):
+
+    ```
+    [Validation]
+    SignExpectedPcrWithPhases=
+        /keys/tpm2-pcr-initrd-private-key.pem /keys/tpm2-pcr-initrd.crt enter-initrd
+        /keys/tpm2-pcr-system-private-key.pem /keys/tpm2-pcr-system.crt enter-initrd:leave-initrd,enter-initrd:leave-initrd:sysinit,enter-initrd:leave-initrd:sysinit:ready
+    SignExpectedPcrUKIPublicKey=/keys/tpm2-pcr-initrd-public-key.pem
+    ```
+
+`SignExpectedPcrUKIPublicKey=`, `--sign-expected-pcr-uki-public-key=`
+:   Path to a PEM-encoded public key to embed in the UKI's `.pcrpkey` PE
+    section, forwarded to **ukify** as `--pcrpkey=`. The file is embedded
+    verbatim by **ukify**. An X.509 certificate is *not* accepted here and
+    you have to convert it with `openssl x509 -in mkosi.crt -pubkey -noout`.
+    When not set, **ukify** derives the section contents from the
+    sole signing key if exactly one is provided. When multiple signing
+    keys are configured via `SignExpectedPcrWithPhases=`, **ukify** omits
+    the section entirely unless this setting is used.
 
 `Passphrase=`, `--passphrase=`
 :   Specify the path to a file containing the passphrase to use for LUKS
@@ -3181,6 +3264,8 @@ down to subimages but can be overridden:
 - `SignExpectedPcrKeySource=`
 - `SignExpectedPcrCertificate=`
 - `SignExpectedPcrCertificateSource=`
+- `SignExpectedPcrWithPhases=`
+- `SignExpectedPcrUKIPublicKey=`
 
 Additionally, there are various settings that can only be configured in
 the main image but which are not passed down to subimages:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,16 +14,20 @@ from mkosi import expand_kernel_specifiers
 from mkosi.config import (
     Architecture,
     ArtifactOutput,
+    CertificateSourceType,
     Compression,
     Config,
     ConfigFeature,
     ConfigTree,
+    KeySourceType,
     OutputFormat,
     Verb,
     config_parse_bytes,
+    config_parse_pcr_signers,
     in_box,
     parse_config,
     parse_ini,
+    parse_pcr_signer,
 )
 from mkosi.distribution import Distribution, detect_distribution
 from mkosi.util import chdir, resource_path
@@ -1992,3 +1996,105 @@ def test_history_empty_list(tmp_path: Path) -> None:
         _, _, [main] = parse_config(["summary"])
 
     assert main.package_directories == []
+
+
+def test_parse_pcr_signer_minimal() -> None:
+    s = parse_pcr_signer("/keys/a.key /keys/a.crt enter-initrd")
+    assert s.key == Path("/keys/a.key")
+    assert s.certificate == Path("/keys/a.crt")
+    assert s.phases == ["enter-initrd"]
+    assert s.key_source.type == KeySourceType.file
+    assert s.certificate_source.type == CertificateSourceType.file
+
+
+def test_parse_pcr_signer_multiple_phase_paths() -> None:
+    s = parse_pcr_signer(
+        "/keys/a.key /keys/a.crt "
+        "enter-initrd:leave-initrd,enter-initrd:leave-initrd:sysinit,enter-initrd:leave-initrd:sysinit:ready"
+    )
+    assert s.phases == [
+        "enter-initrd:leave-initrd",
+        "enter-initrd:leave-initrd:sysinit",
+        "enter-initrd:leave-initrd:sysinit:ready",
+    ]
+
+
+def test_parse_pcr_signer_phases_sentinel() -> None:
+    s = parse_pcr_signer("/keys/a.key /keys/a.crt -")
+    assert s.phases == []
+
+
+def test_parse_pcr_signer_with_sources() -> None:
+    s = parse_pcr_signer(
+        "pkcs11:token=foo;object=bar;type=private /keys/a.crt enter-initrd engine:pkcs11 file"
+    )
+    assert str(s.key) == "pkcs11:token=foo;object=bar;type=private"
+    assert s.key_source.type == KeySourceType.engine
+    assert s.key_source.source == "pkcs11"
+    assert s.certificate_source.type == CertificateSourceType.file
+
+
+def test_parse_pcr_signer_quoting() -> None:
+    s = parse_pcr_signer('"/path with space/a.key" /keys/a.crt enter-initrd')
+    assert s.key == Path("/path with space/a.key")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "/keys/a.key",
+        "/keys/a.key /keys/a.crt",
+        "/keys/a.key /keys/a.crt - file file extra",
+    ],
+)
+def test_parse_pcr_signer_wrong_field_count(value: str) -> None:
+    with pytest.raises(SystemExit):
+        parse_pcr_signer(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        '"" /keys/a.crt -',
+        '/keys/a.key "" -',
+    ],
+)
+def test_parse_pcr_signer_empty_field(value: str) -> None:
+    with pytest.raises(SystemExit):
+        parse_pcr_signer(value)
+
+
+def test_config_parse_pcr_signers_backslash_newline() -> None:
+    value = "/keys/a.key \\\n    /keys/a.crt \\\n    enter-initrd"
+    result = config_parse_pcr_signers(value, None)
+    assert result is not None
+    assert len(result) == 1
+    assert result[0].key == Path("/keys/a.key")
+    assert result[0].certificate == Path("/keys/a.crt")
+    assert result[0].phases == ["enter-initrd"]
+
+
+def test_config_parse_pcr_signers_multiple_entries() -> None:
+    value = (
+        "/keys/initrd.key /keys/initrd.crt enter-initrd\n"
+        "/keys/system.key /keys/system.crt enter-initrd:leave-initrd"
+    )
+    result = config_parse_pcr_signers(value, None)
+    assert result is not None
+    assert len(result) == 2
+    assert result[0].phases == ["enter-initrd"]
+    assert result[1].phases == ["enter-initrd:leave-initrd"]
+
+
+def test_config_parse_pcr_signers_accumulates() -> None:
+    initial = config_parse_pcr_signers("/keys/a.key /keys/a.crt enter-initrd", None)
+    result = config_parse_pcr_signers("/keys/b.key /keys/b.crt -", initial)
+    assert result is not None
+    assert len(result) == 2
+
+
+def test_config_parse_pcr_signers_empty_resets() -> None:
+    initial = config_parse_pcr_signers("/keys/a.key /keys/a.crt enter-initrd", None)
+    assert initial
+    assert config_parse_pcr_signers("", initial) is None

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -35,6 +35,7 @@ from mkosi.config import (
     ManifestFormat,
     Network,
     OutputFormat,
+    PcrSigner,
     QemuDiskType,
     SecureBootSignTool,
     ShimBootloader,
@@ -385,6 +386,40 @@ def test_config() -> None:
                 "Source": "",
                 "Type": "file"
             },
+            "SignExpectedPcrUKIPublicKey": "/keys/initrd.crt",
+            "SignExpectedPcrWithPhases": [
+                {
+                    "Certificate": "/keys/initrd.crt",
+                    "CertificateSource": {
+                        "Source": "",
+                        "Type": "file"
+                    },
+                    "Key": "/keys/initrd.key",
+                    "KeySource": {
+                        "Source": "",
+                        "Type": "file"
+                    },
+                    "Phases": [
+                        "enter-initrd"
+                    ]
+                },
+                {
+                    "Certificate": "/keys/system.crt",
+                    "CertificateSource": {
+                        "Source": "",
+                        "Type": "file"
+                    },
+                    "Key": "pkcs11:token=PCRPolicyDevel;object=system;type=private",
+                    "KeySource": {
+                        "Source": "pkcs11",
+                        "Type": "engine"
+                    },
+                    "Phases": [
+                        "enter-initrd:leave-initrd",
+                        "enter-initrd:leave-initrd:sysinit"
+                    ]
+                }
+            ],
             "SkeletonTrees": [
                 {
                     "Source": "/foo/bar",
@@ -610,6 +645,20 @@ def test_config() -> None:
         sign_expected_pcr_certificate=Path("/my/cert"),
         sign_expected_pcr_key_source=KeySource(type=KeySourceType.file),
         sign_expected_pcr_key=Path("/my/key"),
+        sign_expected_pcr_uki_public_key=Path("/keys/initrd.crt"),
+        sign_expected_pcr_with_phases=[
+            PcrSigner(
+                key=Path("/keys/initrd.key"),
+                certificate=Path("/keys/initrd.crt"),
+                phases=["enter-initrd"],
+            ),
+            PcrSigner(
+                key=Path("pkcs11:token=PCRPolicyDevel;object=system;type=private"),
+                certificate=Path("/keys/system.crt"),
+                phases=["enter-initrd:leave-initrd", "enter-initrd:leave-initrd:sysinit"],
+                key_source=KeySource(type=KeySourceType.engine, source="pkcs11"),
+            ),
+        ],
         sign_expected_pcr=ConfigFeature.disabled,
         sign=False,
         skeleton_trees=[ConfigTree(Path("/foo/bar"), Path("/")), ConfigTree(Path("/bar/baz"), Path("/qux"))],


### PR DESCRIPTION
To be able to bind a secret against a signed PCR policy so that it only unlocks in the initrd but not the final system one has to sign the policies with separate keys because that's what one actually binds to. This is supported in ukify as "phases" and ukify accepts the PCR signing keys specified multiple times together with the phase they are for. We can't extend the existing config setting for this scheme, so instead we have to add a new setting which can hold the configuration entries. Also, we need a new setting to specify which PCR pub key goes into the .pcrpkey UKI section because when we have many, ukify won't add any by default.
Add SignExpectedPcrWithPhases= as alternative to SignExpectedPcrKey=/ SignExpectedPcrCertificate=/*Source= where we can now specify the phase signing configuration one line each. A line contains KEY CERT PHASES [KEYSRC [CERTSRC]] where KEYSRC/CERTSRC defaults to "file". One can also set "-" for PHASES to omit --phases for ukify so that it chooses the defaults. Also add SignExpectedPcrUKIPublicKey= to be able to specify the key for the .pcrpkey UKI section.

Closes https://github.com/systemd/mkosi/issues/4109