### PR TITLE
Compare contents before deduplicating against base tree

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import datetime
+import filecmp
 import functools
 import getpass
 import hashlib
@@ -225,8 +226,17 @@ def mount_base_trees(context: Context) -> Iterator[None]:
                     die(f"/{rel} is a directory in the overlay but not in the base tree")
                 shutil.copystat(q, p)
             else:
-                logging.info(f"Removing duplicate path /{rel} from overlay")
-                p.unlink()
+                # Only remove files from the overlay that are truly identical to the base tree.
+                # Symlinks must have the same target and regular files must have the same contents.
+                if p.is_symlink() != q.is_symlink():
+                    continue
+                if p.is_symlink():
+                    same = os.readlink(p) == os.readlink(q)
+                else:
+                    same = filecmp.cmp(p, q, shallow=False)
+                if same:
+                    logging.info(f"Removing duplicate path /{rel} from overlay")
+                    p.unlink()
 
 
 def remove_files(context: Context) -> None:


### PR DESCRIPTION
The overlay deduplication unconditionally removed any non-directory file
present in both the upper layer and the base tree, even when the overlay
file had different contents. This is visible on Alpine/postmarketOS
where busybox and coreutils both install symlinks at the same paths in
/usr/bin but with different targets. Installing coreutils in a sysext
replaces the busybox symlinks in the overlay, but the deduplication
removed them, leaving the old busybox targets visible at runtime.

This compares symlink targets and file contents before removing them.

Signed-off-by: Clayton Craft <clayton@craftyguy.net>