### PR TITLE
config: Don't export MKOSI_DNF into a tools tree

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2310,7 +2310,7 @@ class Config:
             env["GIT_PROXY_SSL_CERT"] = "/proxy.clientcert"
         if self.proxy_client_key:
             env["GIT_PROXY_SSL_KEY"] = "/proxy.clientkey"
-        if dnf := os.getenv("MKOSI_DNF"):
+        if (dnf := os.getenv("MKOSI_DNF")) and not self.tools_tree:
             env["MKOSI_DNF"] = dnf
         if gnupghome := os.getenv("GNUPGHOME"):
             env["GNUPGHOME"] = os.fspath(Path(gnupghome).absolute())

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -3223,7 +3223,10 @@ repository.
   **mkosi** to page output.
 
 * `$MKOSI_DNF` can be used to override the executable used as **dnf**.
-  This is particularly useful to select between **dnf** and **dnf5**.
+  This is particularly useful to select between **dnf** and **dnf5**. Note that
+  this variable is only honoured when no tools tree is in use; when a
+  tools tree is active, the dnf executable is autodetected from within
+  the tools tree.
 
 * `$MKOSI_DNF_DISABLE_PLUGINS` can be used to disable dnf plugins. The value
   is forwarded to dnf's `--disableplugin=` option.


### PR DESCRIPTION
When a tools tree is in use, the dnf executable runs from inside the tools tree sandbox, not from the host. Propagating $MKOSI_DNF from the host environment into the tools tree leads to unpredictable results as the dnf executable may not exist inside the tools tree. 

Fixes #4280