### PR TITLE
Make OUTPUT variable available in postoutput scripts

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1130,6 +1130,7 @@ def run_postoutput_scripts(context: Context) -> None:
         ),
         SRCDIR="/work/src",
         OUTPUTDIR="/work/out",
+        OUTPUT=context.config.output,
         MKOSI_UID=str(os.getuid()),
         MKOSI_GID=str(os.getgid()),
         MKOSI_CONFIG="/work/config.json",


### PR DESCRIPTION
This patch makes the variable OUTPUT available in postoutput scripts.

In my use case i wanted to add an symlink to the generated image. But in the outputdir are two entries: The image itself (with the output extension) and the symlink to it (without the extention). So a simple: 
`ln -s ${OUTPUTDIR}/* <location>` will not work since * matches two files. So i ended up doing `ln -s ${OUTPUTDIR}/*.img <location>`. But that's a foot gun: As soon as i change the configured OutputExtension from "img" to something elses this script would fail.

With the new OUTPUT variable i can simply write  `ln -s ${OUTPUTDIR}/$OUTPUT <location>` (for using the symlink) or `ln -s ${OUTPUTDIR}/${OUTPUT}.* <location>` (for the image itself) .