### PR TITLE
Making sure 'kerneltype' is updated to uki when appropriate

### DIFF
--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -987,6 +987,7 @@ def run_qemu(args: Args, config: Config) -> None:
                 f"Kernel or UKI not found at {kernel}, please install a kernel in the image "
                 "or provide a -kernel argument to mkosi vm"
             )
+        kerneltype = KernelType.identify(config, kernel)
 
     ovmf = find_ovmf_firmware(config, firmware)
 


### PR DESCRIPTION
This should fix https://github.com/systemd/mkosi/issues/4292

Tested against:
```ini
[Output]
Format=uki
```
With:
- mkosi d2b798d00c90eb87846725f47b7b19bea9efe94e
- Qemu 11.0.0
- edk2-ovmf 202602-3