### PR TITLE
Force white foreground color

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -4253,7 +4253,7 @@ def run_box(args: Args, config: Config) -> None:
     cmdline = [*args.cmdline]
 
     if sys.stdin.isatty() and sys.stdout.isatty():
-        cmdline = systemd_pty_forward(config, background="48;2;12;51;51", title="mkosi-sandbox") + cmdline
+        cmdline = systemd_pty_forward(config, background="48;2;12;51;51;38;5;15", title="mkosi-sandbox") + cmdline
 
     with contextlib.ExitStack() as stack:
         if config.tools() != Path("/"):

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -1014,7 +1014,7 @@ def run_qemu(args: Args, config: Config) -> None:
     if config.console in (ConsoleMode.interactive, ConsoleMode.read_only):
         cmdline += systemd_pty_forward(
             config,
-            background="48;2;12;51;19",
+            background="48;2;12;51;19;38;5;15",
             title=f"Virtual Machine {config.machine_or_name()}",
         )
 


### PR DESCRIPTION
By default, mkosi sets a dark green background color but doesn't touch
the foreground color. This is completely unreadable on light themed
terminals where the foreground is black.

Add the foreground color specifier to white.
