### PR TITLE
vmspawn: Forward journal-remote settings to vmspawn

### DIFF
--- a/mkosi/vmspawn.py
+++ b/mkosi/vmspawn.py
@@ -167,7 +167,13 @@ def run_vmspawn(args: Args, config: Config) -> None:
             cmdline += ["--image-disk-type", str(config.disk_type)]
 
         if config.forward_journal:
-            cmdline += ["--forward-journal", config.forward_journal]
+            cmdline += [
+                "--forward-journal", config.forward_journal,
+                "--forward-journal-max-use=1T",
+                "--forward-journal-keep-free=1G",
+                "--forward-journal-max-file-size=4G",
+                f"--forward-journal-max-files={1 if config.forward_journal.suffix == '.journal' else 100}",
+            ]  # fmt: skip
 
         cmdline += [
             *args.cmdline,


### PR DESCRIPTION
Pass the same MaxUse/KeepFree/MaxFileSize/MaxFiles settings to vmspawn via its new --forward-journal-* options that we configure in systemd-journal-remote.conf for qemu.