### PR TITLE
ci: add postmarketOS to integration testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           - debian
           - fedora
           - opensuse
+          - postmarketos
           - ubuntu
         tools:
           - arch
@@ -80,6 +81,13 @@ jobs:
             tools: opensuse
           - distro: ubuntu
             tools: opensuse
+          # apk is not packaged in Debian, Ubuntu, or EPEL.
+          - distro: postmarketos
+            tools: centos
+          - distro: postmarketos
+            tools: debian
+          - distro: postmarketos
+            tools: ubuntu
         include:
           # low rate limit on s390x/ppc64le/arm64 workers
           - distro: debian
@@ -103,6 +111,10 @@ jobs:
           - distro: debian
             tools: debian
             runner: ubuntu-24.04-s390x
+          # build pmOS using pmOS tools tree
+          - distro: postmarketos
+            tools: postmarketos
+            runner: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/action.yaml
+++ b/action.yaml
@@ -95,11 +95,14 @@ runs:
     - name: Install apk
       # ubuntu-24.04 doesn't package apk, so fetch the official statically-linked binary from
       # upstream so mkosi can use it to populate the postmarketOS tools tree.
+      #
+      # NOTE: apk is dropped into /usr/bin and not /usr/local/bin because later CI
+      # scripts (like .github/workflows/ci.yml) clean up /usr/local
       shell: bash
       run: |
-        sudo curl -fsSL -o /usr/local/bin/apk https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v3.0.6/x86_64/apk.static
-        echo 'f1489e05bace7d7dd0a687fcd38d50b585ac660af4231668b123649bef3718c4  /usr/local/bin/apk' | sha256sum --check
-        sudo chmod +x /usr/local/bin/apk
+        sudo curl -fsSL -o /usr/bin/apk https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v3.0.6/x86_64/apk.static
+        echo 'f1489e05bace7d7dd0a687fcd38d50b585ac660af4231668b123649bef3718c4  /usr/bin/apk' | sha256sum --check
+        sudo chmod +x /usr/bin/apk
 
     - name: Dependencies
       shell: bash

--- a/mkosi.conf.d/postmarketos.conf
+++ b/mkosi.conf.d/postmarketos.conf
@@ -5,6 +5,8 @@ Distribution=postmarketos
 
 [Content]
 Packages=
+        grub
+        grub-efi
         openssh-server
         openssh-server-pam-systemd
 

--- a/mkosi.tools.conf/mkosi.conf.d/postmarketos.conf
+++ b/mkosi.tools.conf/mkosi.conf.d/postmarketos.conf
@@ -6,4 +6,5 @@ Distribution=postmarketos
 [Content]
 Packages=
         py3-codespell
+        py3-pytest
         ruff

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/postmarketos.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/postmarketos.conf
@@ -6,9 +6,11 @@ Distribution=postmarketos
 [Content]
 Packages=
         cryptsetup-libs
+        device-mapper
         kbd
         libseccomp
         util-linux
+        util-linux-login
 
         # systemd-repart dependency
         libfdisk

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/postmarketos.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/postmarketos.conf
@@ -8,14 +8,22 @@ Packages=
         abuild
         apk-tools
         btrfs-progs
+        cryptsetup
         distribution-gpg-keys
         erofs-utils
-        # NOTE: grub disabled because package trigger fails
-        # grub
+        grub
+        grub-efi
         libfido2
         libseccomp
         p11-kit
         sbsigntool
+        sfdisk
         squashfs-tools
         ukify
         xz
+
+        # These replace the busybox applets, which don't support the full set of
+        # features that mkosi needs
+        losetup
+        mount
+        umount

--- a/mkosi/resources/mkosi-tools/mkosi.profiles/package-manager/mkosi.conf.d/arch.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/package-manager/mkosi.conf.d/arch.conf
@@ -5,6 +5,7 @@ Distribution=arch
 
 [Content]
 Packages=
+        apk-tools
         apt
         debian-archive-keyring
         createrepo_c

--- a/mkosi/resources/mkosi-tools/mkosi.profiles/package-manager/mkosi.conf.d/opensuse.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/package-manager/mkosi.conf.d/opensuse.conf
@@ -5,5 +5,6 @@ Distribution=opensuse
 
 [Content]
 Packages=
+        apk-tools
         dnf5
         dnf5-plugins

--- a/mkosi/resources/mkosi-tools/mkosi.profiles/package-manager/mkosi.conf.d/postmarketos.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/package-manager/mkosi.conf.d/postmarketos.conf
@@ -6,6 +6,7 @@ Distribution=postmarketos
 [Content]
 Packages=
         apt
+        archlinux-keyring
         pacman
         debian-archive-keyring
         ubuntu-archive-keyring

--- a/mkosi/resources/mkosi-vm/mkosi.conf.d/postmarketos.conf
+++ b/mkosi/resources/mkosi-vm/mkosi.conf.d/postmarketos.conf
@@ -14,6 +14,7 @@ Packages=
         postmarketos-base
         postmarketos-base-systemd
         systemd-boot
+        systemd-efistub
         systemd-networkd
         systemd-udevd
         tpm2-tools


### PR DESCRIPTION
apk-tools isn't packaged in Ubuntu, so the scope of testing is limited quite a bit to only a handful of distros/tools trees that have apk available. This also means we're not able to test building images for other distros in a pmOS tools tree since the base distro is... 🥁... Ubuntu and it's unable to build a pmOS tools tree because it doesn't have apk-tools.