### PR TITLE
mkosi-tools: Add libfido2

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/arch.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/arch.conf
@@ -9,6 +9,7 @@ Packages=
         btrfs-progs
         erofs-utils
         grub
+        libfido2
         libseccomp
         libmicrohttpd
         pacman

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/azure-centos-fedora/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/azure-centos-fedora/mkosi.conf
@@ -11,6 +11,7 @@ Distribution=|azure
 [Content]
 Packages=
         createrepo_c
+        libfido2
         libseccomp
         policycoreutils
         python3

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
@@ -14,6 +14,7 @@ Packages=
         erofs-utils
         grub-common
         libcryptsetup12
+        libfido2-1
         libseccomp2
         libtss2-dev
         policycoreutils

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/opensuse/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/opensuse/mkosi.conf
@@ -11,6 +11,7 @@ Packages=
         distribution-gpg-keys
         erofs-utils
         grub2-common
+        libfido2
         libseccomp2
         pkcs11-provider
         policycoreutils

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/postmarketos.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/postmarketos.conf
@@ -12,6 +12,7 @@ Packages=
         erofs-utils
         # NOTE: grub disabled because package trigger fails
         # grub
+        libfido2
         libseccomp
         p11-kit
         sbsigntool


### PR DESCRIPTION
Required for interaction with hardware keys.
