### PR TITLE
Add ansi module for ANSI definitions.

### DIFF
--- a/mkosi/ansi.py
+++ b/mkosi/ansi.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+
+def terminal_is_dumb() -> bool:
+    return not sys.stdout.isatty() or not sys.stderr.isatty() or os.getenv("TERM", "") == "dumb"
+
+
+# fmt: off
+ANSI_BOLD      = "\033[0;1;39m"     if not terminal_is_dumb() else ""
+ANSI_BLUE      = "\033[0;1;34m"     if not terminal_is_dumb() else ""
+ANSI_GRAY      = "\033[0;38;5;245m" if not terminal_is_dumb() else ""
+ANSI_RED       = "\033[31;1m"       if not terminal_is_dumb() else ""
+ANSI_YELLOW    = "\033[33;1m"       if not terminal_is_dumb() else ""
+ANSI_RESET     = "\033[0m"          if not terminal_is_dumb() else ""
+# fmt: on

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -32,11 +32,12 @@ from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import Any, Callable, ClassVar, Generic, Optional, Protocol, TypeVar, Union, cast
 
+from mkosi.ansi import ANSI_BLUE, ANSI_BOLD, ANSI_RESET
 from mkosi.distribution import Distribution, detect_distribution
 from mkosi.log import ARG_DEBUG, ARG_DEBUG_SANDBOX, ARG_DEBUG_SHELL, ARG_DEBUG_TIMING, complete_step, die
 from mkosi.pager import page
 from mkosi.run import SandboxProtocol, find_binary, nosandbox, run, sandbox_cmd, workdir
-from mkosi.sandbox import ANSI_BLUE, ANSI_BOLD, ANSI_RESET, __version__
+from mkosi.sandbox import __version__
 from mkosi.user import INVOKING_USER
 from mkosi.util import (
     PathString,

--- a/mkosi/log.py
+++ b/mkosi/log.py
@@ -9,7 +9,7 @@ import time
 from collections.abc import Iterator
 from typing import Any, NoReturn, Optional
 
-from mkosi.sandbox import (
+from mkosi.ansi import (
     ANSI_BLUE,
     ANSI_BOLD,
     ANSI_GRAY,

--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -13,6 +13,8 @@ import os
 import sys
 import warnings  # noqa: F401 (loaded lazily by os.execvp() which happens too late)
 
+from mkosi.ansi import ANSI_BOLD, ANSI_RED, ANSI_RESET
+
 __version__ = "27~devel"
 
 # The following constants are taken from the Linux kernel headers.
@@ -145,20 +147,6 @@ libc.capget.argtypes = (ctypes.c_void_p, ctypes.c_void_p)
 libc.capset.argtypes = (ctypes.c_void_p, ctypes.c_void_p)
 libc.fcntl.argtypes = (ctypes.c_int, ctypes.c_int, ctypes.c_int)
 libc.setns.argtypes = (ctypes.c_int, ctypes.c_int)
-
-
-def terminal_is_dumb() -> bool:
-    return not sys.stdout.isatty() or not sys.stderr.isatty() or os.getenv("TERM", "") == "dumb"
-
-
-# fmt: off
-ANSI_BOLD   = "\033[0;1;39m"     if not terminal_is_dumb() else ""
-ANSI_BLUE   = "\033[0;1;34m"     if not terminal_is_dumb() else ""
-ANSI_GRAY   = "\033[0;38;5;245m" if not terminal_is_dumb() else ""
-ANSI_RED    = "\033[31;1m"       if not terminal_is_dumb() else ""
-ANSI_YELLOW = "\033[33;1m"       if not terminal_is_dumb() else ""
-ANSI_RESET  = "\033[0m"          if not terminal_is_dumb() else ""
-# fmt: on
 
 
 ENOSYS_MSG = f"""\
@@ -1247,13 +1235,10 @@ class OverlayOperation(FSOperation):
         mount("overlayfs", dst, "overlay", 0, ",".join(options))
 
 
-ANSI_HIGHLIGHT = "\x1b[0;1;39m" if os.isatty(2) else ""
-ANSI_NORMAL = "\x1b[0m" if os.isatty(2) else ""
-
 HELP = f"""\
 mkosi-sandbox [OPTIONS...] COMMAND [ARGUMENTS...]
 
-{ANSI_HIGHLIGHT}Run the specified command in a custom sandbox.{ANSI_NORMAL}
+{ANSI_BOLD}Run the specified command in a custom sandbox.{ANSI_RESET}
 
   -h --help                       Show this help
      --version                    Show package version


### PR DESCRIPTION
Also removes duplicate ANSI definitions which were identical to `ANSI_BOLD` and `ANSI_RESET` respectively, but used `os.isatty(2)` instead of `terminal_is_dumb()` for terminal detection.