### PR TITLE
mkosi-tools: Add cryptsetup-libs to centos/fedora/opensuse

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/azure-centos-fedora/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/azure-centos-fedora/mkosi.conf
@@ -11,6 +11,7 @@ Distribution=|azure
 [Content]
 Packages=
         createrepo_c
+        cryptsetup-libs
         libfido2
         libseccomp
         policycoreutils


### PR DESCRIPTION
With upcoming changes in systemd it might not be pulled in by default anymore, add it explicitly hence.