### PR TITLE
mkosi-initrd: Trim orphaned GPU/audio modules, add ACPI platform attrs

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -61,21 +61,19 @@ KernelModules=
         dm-raid
         dm-verity
         dmi-sysfs
-        drm_buddy
-        drm_display_helper
         edac_mce_amd
         efi-pstore
         efivarfs
         erofs
         evdev
         ext4
+        firmware_attributes_class
         hid-generic
         i2c-algo-bit
         i2c_hid_acpi
         i2c-mux
         i2c-smbus
         i8042
-        intel-gtt
         intel_pmc_ssram_telemetry
         intel_rapl_common
         intel-uncore-frequency-common
@@ -85,11 +83,11 @@ KernelModules=
         loop
         mdio_devres
         mei
-        mxm-wmi
         nvme
         nvmet-tcp
         overlay
         parport
+        platform_profile
         pmt_telemetry
         qemu_fw_cfg
         raid[0-9]*
@@ -100,22 +98,16 @@ KernelModules=
         serio
         sg
         skx_edac_common
-        snd-intel-dspcfg
-        snd-soc-hda-codec
         squashfs
         thunderbolt_net
         tpm_tis
         tpm_vtpm_proxy
-        ttm
         typec_ucsi
         ucsi_acpi
         usbhid
         usb-storage
-        uvc
         vfat
         video
-        videobuf2-v4l2
-        videobuf2-vmalloc
         virtio_balloon
         virtio_blk
         virtio_console


### PR DESCRIPTION
The DRM and sound helpers (drm_buddy, drm_display_helper, ttm, intel-gtt,
mxm-wmi, snd-intel-dspcfg, snd-soc-hda-codec) had no actual KMS/audio
driver in the include list to pull them in, and there is no audio/GPU
userspace running in the initrd anyway. uvc and videobuf2-* are USB
webcam plumbing, also unused. Add firmware_attributes_class and
platform_profile so udev does not log autoload failures for those on
modern laptops.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>