### PR TITLE
mkosi-initrd: Also add cryptsetup-libs explicitly to the initrd

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/azure-centos-fedora.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/azure-centos-fedora.conf
@@ -11,6 +11,7 @@ Distribution=|azure
 [Content]
 Packages=
         # Various libraries that are dlopen'ed by systemd
+        cryptsetup-libs
         libseccomp
         tpm2-tss
 

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/opensuse.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/opensuse.conf
@@ -14,6 +14,7 @@ Packages=
         xz
 
         # Various libraries that are dlopen'ed by systemd
+        libcryptsetup12
         libfido2-1
         libseccomp2
         libtss2-esys0

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/postmarketos.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/postmarketos.conf
@@ -5,6 +5,7 @@ Distribution=postmarketos
 
 [Content]
 Packages=
+        cryptsetup-libs
         kbd
         libseccomp
         util-linux

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/opensuse/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/opensuse/mkosi.conf
@@ -11,6 +11,7 @@ Packages=
         distribution-gpg-keys
         erofs-utils
         grub2-common
+        libcryptsetup12
         libfido2
         libseccomp2
         pkcs11-provider


### PR DESCRIPTION
And fix the name of the package on opensuse in the tools tree.
