### PR TITLE
sandbox: fix console-script entrypoint not being able to execute commands

### DIFF
--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -167,9 +167,11 @@ This probably means either the system call is not implemented by the running ker
 system call is prohibited via seccomp if mkosi is being executed inside a containerized environment.\
 """
 
+_entrypoint: bool = False
+
 
 def is_main() -> bool:
-    return __name__ == "__main__"
+    return __name__ == "__main__" or _entrypoint
 
 
 def oserror(syscall: str, filename: str = "", errno: int = 0) -> None:
@@ -1573,6 +1575,12 @@ def main(argv: list[str] = sys.argv[1:]) -> None:
                 sys.exit(127)
 
             raise
+
+
+def entrypoint() -> None:
+    global _entrypoint
+    _entrypoint = True
+    main()
 
 
 if is_main():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ bootable = [
 [project.scripts]
 mkosi = "mkosi.__main__:main"
 mkosi-initrd = "mkosi.initrd:main"
-mkosi-sandbox = "mkosi.sandbox:main"
+mkosi-sandbox = "mkosi.sandbox:entrypoint"
 mkosi-addon = "mkosi.addon:main"
 
 [tool.setuptools]


### PR DESCRIPTION
When installed via pip/pipx/Nix, the mkosi-sandbox console-script calls main() directly, so __name__ is "mkosi.sandbox" rather than "__main__". This causes is_main() to return False, which raises a ValueError when a command is passed after -- and prevents os.execvp() from running. Fix this by introducing an entrypoint() wrapper that sets a module-level _entrypoint flag before calling main(), and update is_main() to also check that flag. Point the console-script at entrypoint() instead of main(). Library calls from run.py are unaffected since they call main() directly without going through entrypoint().
Fixes: https://github.com/systemd/mkosi/issues/4303