### PR TITLE
Make full $PATH available when building tools tree

### DIFF
--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -423,7 +423,7 @@ def finalize_path(
     root = root or Path("/")
     path = [os.fspath(p) for p in extra]
 
-    if relaxed:
+    if relaxed or root == Path("/"):
         path += [
             s
             for s in os.environ["PATH"].split(":")
@@ -688,6 +688,7 @@ def sandbox_cmd(
                 # still use sandbox.py, so we make sure it is available inside the sandbox so it can be
                 # executed there as well.
                 "--ro-bind", module / "sandbox.py", "/sandbox.py",
+                "--ro-bind", "/home", "/home",
             ]  # fmt: skip
 
             if devices:


### PR DESCRIPTION
There's no risk of issues where stuff from $PATH expects
/usr from the host when building the tools tree or not using
it at all, so make the full $PATH available in that case.

This allows stuff like downloading apk to ~/.local/bin and 
building postmarketos images.

To make this work we also have to mount /home into the sandbox.
This shouldn't be an issue generally. We don't expect tools to
accidentally pick stuff up from /home unless actually intended.
