### PR TITLE
mkosi-tools: Install Debian bootstrap packages on Fedora

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.profiles/runtime/mkosi.conf.d/fedora.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/runtime/mkosi.conf.d/fedora.conf
@@ -5,6 +5,8 @@ Distribution=fedora
 
 [Content]
 Packages=
+        apt-utils
+        debian-keyring
         qemu-system-aarch64-core
         qemu-system-ppc-core
         qemu-system-s390x-core


### PR DESCRIPTION
Building Debian based OSes on Fedora requires `apt` and they Debian keyring.

---

In clean checkout of current particleos.git (9e3fc044fe6ce88fe8049) on a Fedora 44 host:
```
../mkosi/bin/mkosi --distribution debian
‣ [tools]  Running prepare script /tmp/tmpcl60_2ke/resources/mkosi-tools/mkosi.prepare…
+ mkdir -p /buildroot/usr/share/p11-kit/modules
+ echo 'module: opensc-pkcs11.so'
‣ [tools]  /home/martin/upstream/particleos/mkosi.tools size is 1.5G.
‣ [tools] Running clean script /home/martin/upstream/particleos/mkosi.clean…
‣ [tools] Validating certificates and keys
‣ [tools] Syncing package manager metadata: no incremental image has a cache manifest
‣ [tools] Keyring for repo http://deb.debian.org/debian not found at /usr/share/keyrings/debian-archive-keyring.gpg
‣ [tools] (Make sure the right keyring package (e.g. debian-archive-keyring, kali-archive-keyring or ubuntu-keyring) is installed)
```