### PR TITLE
mkosi-initrd: Add libfdisk1

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/arch.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/arch.conf
@@ -15,6 +15,9 @@ Packages=
         libseccomp
         tpm2-tss
 
+        # systemd-repart needs libfdisk.so
+        util-linux-libs
+
         procps-ng
         util-linux
 

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/azure-centos-fedora.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/azure-centos-fedora.conf
@@ -15,6 +15,9 @@ Packages=
         libseccomp
         tpm2-tss
 
+        # systemd-repart dependency
+        libfdisk
+
         # File system checkers for supported root file systems
         e2fsprogs
         xfsprogs

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/debian-ubuntu.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/debian-ubuntu.conf
@@ -1,0 +1,8 @@
+[Match]
+Distribution=|debian
+Distribution=|ubuntu
+
+[Content]
+Packages =
+        # systemd-repart dependency
+        libfdisk1

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/opensuse.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/opensuse.conf
@@ -22,6 +22,9 @@ Packages=
         libtss2-rc0
         libtss2-tcti-device0
 
+        # systemd-repart dependency
+        libfdisk1
+
         # File system checkers for supported root file systems
         btrfsprogs
         e2fsprogs


### PR DESCRIPTION
systemd-repart otherwise crashes on Debian with

> libfdisk.so.1 is not available

For consistency, add it to the other OSes, too.

---

Fixes first boot after installing Debian:

<img width="4032" height="3024" alt="2026-05-21-09-49-21-970" src="https://github.com/user-attachments/assets/b39f912c-ac3d-4b1a-a7fb-0b7e640b0bc4" />
