### PR TITLE
mkosi-initrd: Add libfdisk to PostmarketOS

### DIFF
--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/postmarketos.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/postmarketos.conf
@@ -9,3 +9,6 @@ Packages=
         kbd
         libseccomp
         util-linux
+
+        # systemd-repart dependency
+        libfdisk


### PR DESCRIPTION
Commit 327644ececcabd3b left that out as I couldn't find it in the package search. But the package is inherited from Alpine.

Thanks to Clayton Craft for pointing this out!

----

Follow-up from https://github.com/systemd/mkosi/pull/4322#issuecomment-4509619194 thanks @craftyguy !