### PR TITLE
finalize_scripts: tighten the PATH-strip condition to actual self-exec

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -594,10 +594,21 @@ def finalize_scripts(config: Config, scripts: Mapping[str, Sequence[PathString]]
         for name, script in scripts.items():
             # Make sure we don't end up in a recursive loop when we name a script after the binary
             # it execs by removing the scripts directory from the PATH when we execute a script.
+            #
+            # Recursion is only possible when some unqualified token in the exec'd command line is
+            # exactly "name" -- in that case the shell would resolve it back to "/scripts/<name>"
+            # via PATH. Checking "config.find_binary(name)" instead is a broader condition: it
+            # triggers PATH-strip whenever the script name happens to exist somewhere in the
+            # search path, including for scripts that exec a different binary entirely. For
+            # example, "mkosi-install" execs "dnf install", but the strip causes the wrapped
+            # "/scripts/dnf" to be hidden from PATH, so the raw system dnf runs without the
+            # wrapper's "--installroot", "--use-host-config", and "--setopt=" flags.
+            same_name_recursion = any("/" not in (s := os.fspath(arg)) and s == name for arg in script)
+
             with (Path(d) / name).open("w") as f:
                 f.write("#!/bin/sh\n")
 
-                if config.find_binary(name):
+                if same_name_recursion:
                     f.write(
                         textwrap.dedent(
                             """\


### PR DESCRIPTION
The PATH-strip prelude exists to prevent `/scripts/<name>` from recursing into itself when the script execs a binary named `<name>` via PATH lookup. The current heuristic, `config.find_binary(name)`, checks a broader condition: whether *some* binary called `<name>` exists in the search path. That produces false positives for scripts that exec a different binary entirely.

In particular, `mkosi-install` execs `dnf install $@`, expecting `dnf` to resolve to the wrapped `/scripts/dnf` (which adds `--installroot=…`, `--use-host-config`, `--setopt=…`). When the prelude gets emitted for `mkosi-install` too, it strips `/scripts` from PATH before the exec, so `dnf` resolves to the raw system binary and is invoked with none of the wrapper's overrides.

Tighten the check: emit the prelude only when one of the exec'd argv tokens is the unqualified string `name`, which is the only case where PATH lookup could resolve back to `/scripts/<name>`.

Reproducer:

```
$ mkdir /tmp/repro && cd /tmp/repro
$ cat > mkosi.conf <<'EOF'
[Distribution]
Distribution=fedora
EOF
$ cat > mkosi.prepare <<'EOF'
mkosi-install --dump-main-config bash 2>&1 | grep '^installroot ' EOF
$ chmod +x mkosi.prepare
$ mkosi -ff build
```

Before: installroot = /
After: installroot = /buildroot
