### PR TITLE
tools: move grub-pc-bin to arch-specific drop-in

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
@@ -7,7 +7,6 @@ Distribution=|ubuntu
 
 [Content]
 Packages=
-        ?exact-name(grub-pc-bin)
         apt
         apt-utils
         btrfs-progs

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/x86.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/x86.conf
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Architecture=|x86
+Architecture=|x86-64
+
+[Content]
+Packages=
+        grub-pc-bin


### PR DESCRIPTION
```
2026-05-26T09:06:43.9842316Z Package grub-pc-bin is not available, but is referred to by another package.
2026-05-26T09:06:43.9842760Z This may mean that the package is missing, has been obsoleted, or
2026-05-26T09:06:43.9843062Z is only available from another source
2026-05-26T09:06:43.9843221Z
2026-05-26T09:06:43.9867449Z E: Package 'grub-pc-bin' has no installation candidate
```

https://github.com/systemd/systemd/actions/runs/26442527598/job/77840339559?pr=42300