### PR TITLE
nspawn: do not fail if --forward-journal is not available

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -14,6 +14,7 @@ import resource
 import shlex
 import shutil
 import signal
+import socket
 import stat
 import subprocess
 import sys
@@ -113,6 +114,7 @@ from mkosi.qemu import (
     join_initrds,
     run_qemu,
     run_ssh,
+    start_journal_remote,
 )
 from mkosi.run import (
     Popen,
@@ -4363,13 +4365,31 @@ def run_shell(args: Args, config: Config) -> None:
             cmdline += ["--bind-user", getpass.getuser(), "--bind-user-group=wheel"]
 
         if args.verb == Verb.boot and config.forward_journal:
-            cmdline += [
-                "--forward-journal", config.forward_journal,
-                "--forward-journal-max-use=1T",
-                "--forward-journal-keep-free=1G",
-                "--forward-journal-max-file-size=4G",
-                f"--forward-journal-max-files={1 if config.forward_journal.suffix == '.journal' else 100}",
-            ]  # fmt: skip
+            if systemd_tool_version("systemd-nspawn", sandbox=config.sandbox) >= "261~devel":
+                cmdline += [
+                    "--forward-journal", config.forward_journal,
+                    "--forward-journal-max-use=1T",
+                    "--forward-journal-keep-free=1G",
+                    "--forward-journal-max-file-size=4G",
+                    f"--forward-journal-max-files={1 if config.forward_journal.suffix == '.journal' else 100}",  # noqa: E501
+                ]  # fmt: skip
+            else:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+                    addr = (
+                        Path(os.getenv("TMPDIR", "/tmp"))
+                        / f"mkosi-journal-remote-unix-{uuid.uuid4().hex[:16]}"
+                    )
+                    sock.bind(os.fspath(addr))
+                    stack.callback(addr.unlink, missing_ok=True)
+                    sock.listen()
+                    if config.output_format == OutputFormat.directory and (st := os.stat(fname)).st_uid != 0:
+                        os.chown(addr, st.st_uid, st.st_gid)
+                    stack.enter_context(start_journal_remote(config, sock.fileno()))
+                    uidmap = "rootidmap" if addr.stat().st_uid != 0 else "noidmap"
+                    cmdline += [
+                        f"--bind={addr}:/run/host/journal/socket:{uidmap}",
+                        "--set-credential=journal.forward_to_socket:/run/host/journal/socket",
+                    ]
 
         if args.verb == Verb.boot:
             # Add nspawn options first since systemd-nspawn ignores all options after the first argument.


### PR DESCRIPTION
--forward-journal is only available in 261, which means we cannot use the current mkosi main in the systemd stable branches. Check the version and fallback to the previous implementation if it's older.

Follow-up for 2518468c650b3e4f4c457810255464003e923479