### PR TITLE
tests: Move unit tests from GitHub workflow into pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,88 +29,11 @@ jobs:
 
           mkosi -f box -- true
 
-      - name: Run ruff format
-        run: |
-          mkosi box -- ruff --version
-          if ! mkosi box -- ruff format --check --quiet mkosi/ tests/ kernel-install/*.install
-          then
-              echo "Please run 'ruff format' on the above files or apply the diffs below manually"
-              mkosi box -- ruff format --check --quiet --diff mkosi/ tests/ kernel-install/*.install
-          fi
-
-      - name: Run ruff check
-        run: |
-          mkosi box -- ruff --version
-          mkosi box -- ruff check --output-format=github mkosi/ tests/ kernel-install/*.install
-
-      - name: Check that tabs are not used in code
-        run: sh -c '! git grep -P "\\t" "*.py"'
-
-      - name: Spell Checking (codespell)
-        run: |
-          mkosi box -- codespell --version
-          mkosi box -- codespell $(git ls-files) --skip docs/style.css
-
-      - name: License Checking (reuse)
-        run: |
-          mkosi box -- reuse --version
-          if ! mkosi box -- reuse lint
-          then
-              echo "Hint: If the above output lists unlicensed files tracked in git you might need to adjust REUSE.toml"
-              exit 1
-          fi
-
-      - name: Type Checking (mypy)
-        run: |
-          mkosi box -- mypy --version
-          mkosi box -- mypy mkosi/ kernel-install/*.install
-          mkosi box -- mypy --python-version 3.10 mkosi/ tests/ kernel-install/*.install
-
-      - name: Type Checking (pyright)
-        run: |
-          mkosi box -- pyright --version
-          mkosi box -- pyright mkosi/ tests/ kernel-install/*.install
-
-      - name: Unit Tests
-        run: |
-          mkosi box -- python3 -m pytest --version
-          mkosi box -- python3 -m pytest -sv tests/
-
-      - name: Test execution from current working directory
-        run: python3 -m mkosi -h
+      - name: Run unit tests
+        run: mkosi box -- python3 -m pytest -sv
 
       - name: Test execution from current working directory (sudo call)
         run: sudo python3 -m mkosi -h
-
-      - name: Test venv installation
-        run: |
-          python3 -m venv testvenv
-          testvenv/bin/python3 -m pip install --upgrade setuptools wheel pip
-          testvenv/bin/python3 -m pip install .
-          testvenv/bin/mkosi -h
-          rm -rf testvenv
-
-      - name: Test editable venv installation
-        run: |
-          python3 -m venv testvenv
-          testvenv/bin/python3 -m pip install --upgrade setuptools wheel pip
-          testvenv/bin/python3 -m pip install --editable .
-          testvenv/bin/mkosi -h
-          rm -rf testvenv
-
-      - name: Test zipapp creation
-        run: |
-          ./tools/generate-zipapp.sh
-          ./builddir/mkosi -h
-          ./builddir/mkosi documentation
-
-      - name: Run shellcheck on scripts
-        run: |
-          bash -c 'shopt -s globstar; mkosi box -- shellcheck bin/mkosi tools/*.sh'
-          mkosi completion bash | mkosi box -- shellcheck -
-
-      - name: Test man page generation
-        run: mkosi box -- tools/make-man-page.sh
 
   integration-test:
     runs-on: ${{ matrix.runner }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,6 @@
 *.cache-pre-dev
 *.cache-pre-inst
 .cache
-.mkosi.1
-.mkosi-addon.1
-.mkosi-initrd.1
-.mkosi-sandbox.1
 .mypy_cache/
 .project
 .pydevproject
@@ -14,6 +10,8 @@
 /SHA256SUMS
 /SHA256SUMS.gpg
 /build
+# Generated zipapp
+/builddir/
 /dist
 /mkosi.build
 /mkosi.egg-info
@@ -23,6 +21,7 @@
 /mkosi.rootpw
 mkosi.local
 mkosi.local.conf
+mkosi/resources/man/*.[17]
 mkosi.tools
 mkosi.tools.manifest
 /mkosi.key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,12 +11,13 @@ Always consult these files as needed:
 
 ## Build and Test Commands
 
-- `mypy mkosi tests kernel-install/*.install` to run mypy
-- `ruff format mkosi tests kernel-install/*.install` to format code
-- `ruff check --fix mkosi tests kernel-install/*.install` to run ruff
-- `python3 -m pytest ...` to run unit tests.
-- `python3 -m pytest -m integration ...` to run integration tests. No need to run these by
-  default.
+- Running tests: See the "Hacking on mkosi" section in `README.md` for complete instructions.
+- `bin/mkosi box -- pytest` to run all unit tests including linters and type checkers
+- append usual pytest options like `-k test_mypy` to run a specific check
+- `bin/mkosi box -- ruff format mkosi tests kernel-install/*.install` to format code
+- `bin/mkosi box -- ruff check --fix mkosi tests kernel-install/*.install` to fix ruff issues
+- `python3 -m pytest -m integration ...` to run integration tests. No need to run these by default.
+
 - Never invent your own build commands or try to optimize the build process.
 - Never use `head`, `tail`, or pipe (`|`) the output of build or test commands. Always let the full output
 display. This is critical for diagnosing build and test failures.

--- a/README.md
+++ b/README.md
@@ -123,11 +123,29 @@ modifications.
 
 # Hacking on mkosi
 
-To hack on mkosi itself you will also need
-[mypy](https://github.com/python/mypy), for type checking, and
-[pytest](https://github.com/pytest-dev/pytest), to run tests. We check
-tests and typing in CI (see `.github/workflows`), but you can run the
-tests locally as well.
+To hack on mkosi itself, you can run the full test suite locally, just
+like CI does. The tests include linting, type checking, and unit tests,
+all runnable via [pytest](https://github.com/pytest-dev/pytest).
+
+All linters such as `ruff` or `mypy` are run inside `mkosi box`
+(i.e. from inside `mkosi.tools/`) for a consistent environment. Build that with:
+
+```sh
+bin/mkosi -f box -- true
+```
+
+Then run the full test suite inside the tools tree:
+
+```bash
+bin/mkosi box -- pytest
+```
+
+You can use [pytest options](https://docs.pytest.org/en/stable/how-to/usage.html) to only run a subset, for
+example only run the linters:
+
+```sh
+bin/mkosi box -- pytest -k test_linters
+```
 
 # References
 

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -235,6 +235,7 @@ def run(
     success_exit_status: Sequence[int] = (0,),
     setup: Sequence[PathString] = (),
     sandbox: AbstractContextManager[Sequence[PathString]] = nosandbox(),
+    cwd: Optional[PathString] = None,
 ) -> CompletedProcess:
     if input is not None:
         assert stdin is None  # stdin and input cannot be specified together
@@ -251,6 +252,7 @@ def run(
         success_exit_status=success_exit_status,
         setup=setup,
         sandbox=sandbox,
+        cwd=cwd,
     ) as process:
         out, err = process.communicate(input)
 
@@ -305,6 +307,7 @@ def spawn(
     success_exit_status: Sequence[int] = (0,),
     setup: Sequence[PathString] = (),
     sandbox: AbstractContextManager[Sequence[PathString]] = nosandbox(),
+    cwd: Optional[PathString] = None,
 ) -> Iterator[Popen]:
     cmd = [os.fspath(x) for x in cmdline]
 
@@ -362,6 +365,7 @@ def spawn(
                 group=group,
                 pass_fds=pass_fds,
                 env=env if not sbx or not apply_sandbox_in_preexec else None,
+                cwd=os.fspath(cwd) if cwd is not None else None,
                 preexec_fn=(
                     functools.partial(
                         _preexec,

--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -880,6 +880,10 @@ def userns_acquire_empty() -> int:
 
 
 def chase(root: str, path: str, *, nofollow: bool = False) -> str:
+    # pyright hack around `reportPossiblyUnboundVariable`; it doesn't understand
+    # that it's defined/used only if `nofollow` is True
+    parent = ""
+    base = ""
     if nofollow:
         parent = os.path.dirname(path) or "/"
         base = os.path.basename(path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,3 +104,4 @@ markers = [
     "integration: mark a test as an integration test."
 ]
 addopts = "-m \"not integration\""
+testpaths = ["tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,3 +63,16 @@ def ci_sections(request: Any) -> Iterator[None]:
 @pytest.fixture(scope="session", autouse=True)
 def logging() -> None:
     log_setup()
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item: Any, call: Any) -> Iterator[None]:
+    """Suppress tracebacks for test_linters.py tests.
+
+    These are not helpful and just noise.
+    """
+    outcome = yield
+    report = outcome.get_result()  # type: ignore
+
+    if item.parent.name == "test_linters.py" and report.failed and call.excinfo is not None:
+        report.longrepr = str(call.excinfo.value)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+import tempfile
+from pathlib import Path
+
+from mkosi.run import run
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def test_mkosi_help_direct() -> None:
+    """Test mkosi can be run from current directory."""
+    run(["python3", "-m", "mkosi", "-h"], cwd=REPO_ROOT)
+
+
+def test_venv_installation() -> None:
+    """Test mkosi can be installed in a venv."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        venv = Path(tmpdir) / "testvenv"
+
+        # Create venv
+        run(["python3", "-m", "venv", os.fspath(venv)], cwd=REPO_ROOT)
+        pip = venv / "bin/python3"
+
+        # Upgrade pip, setuptools, wheel
+        run(
+            [os.fspath(pip), "-m", "pip", "install", "--upgrade", "setuptools", "wheel", "pip"],
+            cwd=REPO_ROOT,
+        )
+
+        # Install mkosi
+        run([os.fspath(pip), "-m", "pip", "install", "."], cwd=REPO_ROOT)
+
+        # Test that mkosi works
+        run([os.fspath(venv / "bin/mkosi"), "-h"], cwd=REPO_ROOT)
+
+
+def test_editable_venv_installation() -> None:
+    """Test mkosi can be installed in editable mode."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        venv = Path(tmpdir) / "testvenv"
+
+        run(["python3", "-m", "venv", os.fspath(venv)], cwd=REPO_ROOT)
+        pip = venv / "bin/python3"
+
+        # Upgrade pip, setuptools, wheel
+        run(
+            [os.fspath(pip), "-m", "pip", "install", "--upgrade", "setuptools", "wheel", "pip"],
+            cwd=REPO_ROOT,
+        )
+
+        # Install mkosi in editable mode
+        run([os.fspath(pip), "-m", "pip", "install", "--editable", "."], cwd=REPO_ROOT)
+
+        # Test that mkosi works
+        run([os.fspath(venv / "bin/mkosi"), "-h"], cwd=REPO_ROOT)
+
+
+def test_zipapp_creation() -> None:
+    """Test zipapp generation."""
+    run(["./tools/generate-zipapp.sh"], cwd=REPO_ROOT)
+
+    run(["./builddir/mkosi", "-h"], cwd=REPO_ROOT)
+    run(["./builddir/mkosi", "documentation"], cwd=REPO_ROOT)

--- a/tests/test_linters.py
+++ b/tests/test_linters.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mkosi.run import run
+
+# tolerate missing tools in some random dev environment, but enforce them in CI/mkosi box
+SKIP_MISSING_TOOLS = "MKOSI_IN_BOX" not in os.environ
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def kernel_install_files() -> list[str]:
+    """Get list of kernel-install/*.install files."""
+    return [os.fspath(p) for p in (REPO_ROOT / "kernel-install").glob("*.install")]
+
+
+def _skip_if_missing(tool: str) -> bool:
+    """Return True if we should skip the test because tool is missing."""
+    return SKIP_MISSING_TOOLS and shutil.which(tool) is None
+
+
+@pytest.mark.skipif(_skip_if_missing("ruff"), reason="ruff not found")
+def test_ruff_format_check() -> None:
+    """Check that code is formatted with ruff format."""
+    run(["ruff", "format", "--check", "--diff", "mkosi/", "tests/", *kernel_install_files()], cwd=REPO_ROOT)
+
+
+@pytest.mark.skipif(_skip_if_missing("ruff"), reason="ruff not found")
+def test_ruff_check() -> None:
+    """Check code quality with ruff."""
+    run(
+        ["ruff", "check", "--output-format=github", "mkosi/", "tests/", *kernel_install_files()],
+        cwd=REPO_ROOT,
+    )
+
+
+def test_no_tabs_in_code() -> None:
+    result = run(["git", "grep", "-P", r"\t", "*.py"], check=False, cwd=REPO_ROOT)
+    assert result.returncode != 0, "Found tabs in Python code"
+
+
+@pytest.mark.skipif(_skip_if_missing("codespell"), reason="codespell not found")
+def test_codespell() -> None:
+    run(["codespell", "--version"], cwd=REPO_ROOT)
+    files = run(["git", "ls-files"], stdout=subprocess.PIPE, cwd=REPO_ROOT).stdout.strip().split("\n")
+    # Filter out files we want to skip
+    files_to_check = [f for f in files if f != "docs/style.css"]
+    run(["codespell", *files_to_check], cwd=REPO_ROOT)
+
+
+@pytest.mark.skipif(_skip_if_missing("reuse"), reason="reuse not found")
+def test_reuse_lint() -> None:
+    run(["reuse", "lint"], cwd=REPO_ROOT)
+
+
+@pytest.mark.skipif(_skip_if_missing("mypy"), reason="mypy not found")
+def test_mypy() -> None:
+    run(["mypy", "mkosi/", *kernel_install_files()], cwd=REPO_ROOT)
+
+
+@pytest.mark.skipif(_skip_if_missing("mypy"), reason="mypy not found")
+def test_mypy_python310() -> None:
+    run(["mypy", "--python-version", "3.10", "mkosi/", "tests/", *kernel_install_files()], cwd=REPO_ROOT)
+
+
+@pytest.mark.skipif(_skip_if_missing("pyright"), reason="pyright not found")
+def test_pyright() -> None:
+    run(["pyright", "mkosi/", "tests/", *kernel_install_files()], cwd=REPO_ROOT)
+
+
+@pytest.mark.skipif(_skip_if_missing("shellcheck"), reason="shellcheck not found")
+def test_shellcheck() -> None:
+    # Check bin/mkosi and tools/*.sh
+    tools_scripts = [os.fspath(p) for p in (REPO_ROOT / "tools").glob("*.sh")]
+    run(["shellcheck", "bin/mkosi", *tools_scripts], cwd=REPO_ROOT)
+
+    # Also check bash completion script
+    completion = run(["bin/mkosi", "completion", "bash"], stdout=subprocess.PIPE, cwd=REPO_ROOT).stdout
+    run(["shellcheck", "-"], input=completion, cwd=REPO_ROOT)
+
+
+@pytest.mark.skipif(_skip_if_missing("pandoc"), reason="pandoc not found")
+def test_man_page_generation() -> None:
+    run(["tools/make-man-page.sh"], cwd=REPO_ROOT)


### PR DESCRIPTION
Extract all CI linter/formatter/install checks from the GitHub workflow
into pytest tests. Workflows are hard to reproduce locally, and it's
much more convenient to reproduce what CI does with a simple `pytest`
command. Update the documentation and also stop recommending locally
installed `mypy` and friends -- let's always use the version from
`mkosi box` to get something halfway reproducible.

Keep the `sudo mkosi -h` test in the workflow, though -- it cannot run
inside `mkosi box` as that doesn't have `sudo`.

---

I'm still not 100% happy about this, e.g. it's mysterious what the `- uses: ./` step does. I'd also like to get rid of the `Install` step, but I have a gut feeling it interacts with the `uses: ./` magic. But anyway, this is enough to make the linter failures reproducible and consistent. I'd like to get your (in particular @daandemeyer 's) opinion what you think about the general direction.

After this, I'd like to do the same treatment to the integration test (I didn't yet try to run them locally), and then finally towards actually fixing the two current failures (arch distro+debian tools, and arch+fedora).