### PR TITLE
Don't add El Torito boot catalog for BIOS/grub images by default

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -3478,9 +3478,16 @@ def make_image(
     if tabs and systemd_tool_version("systemd-repart", sandbox=context.sandbox) >= 258:
         cmdline += ["--append-fstab=auto"]
 
+    # grub-bios-setup interprets El Torito/ISO9660 header as a filesystem on the bare
+    # disk and then refuses to embed itself. So only enable it by default when we are
+    # not installing grub for BIOS.
+    el_torito_wanted = context.config.el_torito == ConfigFeature.enabled or (
+        context.config.el_torito == ConfigFeature.auto and not want_grub_bios(context)
+    )
+
     if (
         el_torito
-        and context.config.el_torito != ConfigFeature.disabled
+        and el_torito_wanted
         and systemd_tool_version("systemd-repart", sandbox=context.sandbox) >= "261~devel"
     ):
         cmdline += ["--el-torito=yes"]

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -801,7 +801,9 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 `ElTorito=`, `--el-torito=`
 :   Whether to add an El Torito boot catalog to boot the ESP when building a
-    disk image. Takes a boolean value or `auto`. Defaults to `auto`.
+    disk image. Takes a boolean value or `auto`. Defaults to `auto`. When set to
+    `auto`, an El Torito boot catalog is added unless grub is installed as the
+    BIOS bootloader (as that is incompatible). Requires systemd-repart ≥ v261.
 
 `ElToritoSystem=`, `--el-torito-system=`
 :   Set the system identifier in the ISO 9660 descriptor.

--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -880,6 +880,10 @@ def userns_acquire_empty() -> int:
 
 
 def chase(root: str, path: str, *, nofollow: bool = False) -> str:
+    # pyright hack around `reportPossiblyUnboundVariable`; it doesn't understand
+    # that it's defined/used only if `nofollow` is True
+    parent = ""
+    base = ""
     if nofollow:
         parent = os.path.dirname(path) or "/"
         base = os.path.basename(path)


### PR DESCRIPTION
systemd-repart v261 adds an El Torito boot catalog, which writes an ISO9660 header to the image. grub-bios-setup interprets that header as a filesystem on the bare disk and fails:

> warning: Attempting to install GRUB to a disk with multiple partition labels. This is not supported yet
> Embedding is not possible. GRUB can only be installed in this setup by
. using blocklists. However, blocklists are UNRELIABLE and their use is . discouraged
> error: will not proceed with blocklists

Adjust auto mode to only add the El Torito catalog when grub is not installed as the BIOS bootloader (`Explicit ElTorito=yes` still forces it on). This goes back to the status quo ante until systemd 260 for grub/BIOS.

Fixes #4337

---

See the issue above for detailed analysis and debugging notes. I expect all the Fedora tests to pass again with this. There are still two unrelated failures that already happened before (arch distro+debian tools: missing keyring, and arch+fedora: hangs when installing lsof), these will be treated separately.