### PR TITLE
Fix unit tests at package build time

### DIFF
--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,12 +1,45 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+import importlib.util
 import os
+import shutil
+import socket
 import tempfile
 from pathlib import Path
+
+import pytest
 
 from mkosi.run import run
 
 REPO_ROOT = Path(__file__).parent.parent
+
+# tolerate missing tools/prerequisites in some random dev or packaging environment, but enforce them
+# in CI/mkosi box
+SKIP_MISSING_TOOLS = "MKOSI_IN_BOX" not in os.environ
+
+
+def _network_unavailable() -> bool:
+    """Return True if we have no outbound network access (e.g. in an offline package build)."""
+    try:
+        with socket.create_connection(("pypi.org", 443), timeout=5):
+            return False
+    except OSError:
+        return True
+
+
+def _venv_unavailable() -> bool:
+    """Return True if we should skip venv tests because ensurepip or network is missing."""
+    return SKIP_MISSING_TOOLS and (importlib.util.find_spec("ensurepip") is None or _network_unavailable())
+
+
+def _script_missing(script: str) -> bool:
+    """Return True if we should skip the test because the helper script is missing."""
+    return SKIP_MISSING_TOOLS and not (REPO_ROOT / script).exists()
+
+
+def _tool_missing(tool: str) -> bool:
+    """Return True if we should skip the test because tool is missing."""
+    return SKIP_MISSING_TOOLS and shutil.which(tool) is None
 
 
 def test_mkosi_help_direct() -> None:
@@ -14,6 +47,7 @@ def test_mkosi_help_direct() -> None:
     run(["python3", "-m", "mkosi", "-h"], cwd=REPO_ROOT)
 
 
+@pytest.mark.skipif(_venv_unavailable(), reason="ensurepip or network not available")
 def test_venv_installation() -> None:
     """Test mkosi can be installed in a venv."""
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -36,6 +70,7 @@ def test_venv_installation() -> None:
         run([os.fspath(venv / "bin/mkosi"), "-h"], cwd=REPO_ROOT)
 
 
+@pytest.mark.skipif(_venv_unavailable(), reason="ensurepip or network not available")
 def test_editable_venv_installation() -> None:
     """Test mkosi can be installed in editable mode."""
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -57,6 +92,8 @@ def test_editable_venv_installation() -> None:
         run([os.fspath(venv / "bin/mkosi"), "-h"], cwd=REPO_ROOT)
 
 
+@pytest.mark.skipif(_script_missing("tools/generate-zipapp.sh"), reason="tools/generate-zipapp.sh not found")
+@pytest.mark.skipif(_tool_missing("man"), reason="man not found")
 def test_zipapp_creation() -> None:
     """Test zipapp generation."""
     run(["./tools/generate-zipapp.sh"], cwd=REPO_ROOT)

--- a/tests/test_linters.py
+++ b/tests/test_linters.py
@@ -40,6 +40,7 @@ def test_ruff_check() -> None:
     )
 
 
+@pytest.mark.skipif(_skip_if_missing("git"), reason="git not found")
 def test_no_tabs_in_code() -> None:
     result = run(["git", "grep", "-P", r"\t", "*.py"], check=False, cwd=REPO_ROOT)
     assert result.returncode != 0, "Found tabs in Python code"
@@ -86,5 +87,9 @@ def test_shellcheck() -> None:
 
 
 @pytest.mark.skipif(_skip_if_missing("pandoc"), reason="pandoc not found")
+@pytest.mark.skipif(
+    SKIP_MISSING_TOOLS and not (REPO_ROOT / "tools/make-man-page.sh").exists(),
+    reason="tools/make-man-page.sh not found",
+)
 def test_man_page_generation() -> None:
     run(["tools/make-man-page.sh"], cwd=REPO_ROOT)


### PR DESCRIPTION
Unit tests are broken as they expect a CI environment, but they are also ran at package build time. Skip gracefully when the CI tools are not available.

[   59s] ERROR    root:run.py:162 "/tmp/tmp1x492nlw/testvenv/bin/python3 -m pip install --upgrade setuptools wheel pip" returned non-zero exit code 1.
...
[   59s] ERROR    root:log.py:32 git not found.
...
[   59s] FAILED tests/test_install.py::test_venv_installation - subprocess.CalledProce...
[   59s] FAILED tests/test_install.py::test_editable_venv_installation - subprocess.Ca...
[   59s] FAILED tests/test_linters.py::test_no_tabs_in_code

Follow-up for b0f9525c2c74401fc4280c48233aa9831ced60d5