### PR TITLE
Fix unit tests for package builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Run unit tests
         run: mkosi box -- python3 -m pytest -sv
 
+      - name: Run installation tests
+        run: mkosi box -- python3 -m pytest -sv -m install
+
       - name: Test execution from current working directory (sudo call)
         run: sudo python3 -m mkosi -h
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Always consult these files as needed:
 - `bin/mkosi box -- ruff format mkosi tests kernel-install/*.install` to format code
 - `bin/mkosi box -- ruff check --fix mkosi tests kernel-install/*.install` to fix ruff issues
 - `python3 -m pytest -m integration ...` to run integration tests. No need to run these by default.
+- `bin/mkosi box -- pytest -m install` to run installation tests (venv/pip/zipapp). Skipped by default as they install from the network. No need to run these by default.
 
 - Never invent your own build commands or try to optimize the build process.
 - Never use `head`, `tail`, or pipe (`|`) the output of build or test commands. Always let the full output

--- a/README.md
+++ b/README.md
@@ -147,6 +147,14 @@ example only run the linters:
 bin/mkosi box -- pytest -k test_linters
 ```
 
+Installation tests (venv, editable and zipapp installs) are marked with the
+`install` marker and are skipped by default, as they create virtual
+environments and install packages from the network. Run them explicitly with:
+
+```sh
+bin/mkosi box -- pytest -m install
+```
+
 When a tool that mkosi runs inside its sandbox fails, see
 [Debugging failing sandboxed commands](docs/debugging.md) for how to replay the command by hand.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,8 @@ extend-immutable-calls = ["mkosi.run.nosandbox"]
 
 [tool.pytest.ini_options]
 markers = [
-    "integration: mark a test as an integration test."
+    "integration: mark a test as an integration test.",
+    "install: mark a test as an installation test (venv/pip/zipapp).",
 ]
-addopts = "-m \"not integration\""
+addopts = "-m \"not integration and not install\""
 testpaths = ["tests"]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -4,9 +4,13 @@ import os
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from mkosi.run import run
 
 REPO_ROOT = Path(__file__).parent.parent
+
+pytestmark = pytest.mark.install
 
 
 def test_mkosi_help_direct() -> None:

--- a/tests/test_linters.py
+++ b/tests/test_linters.py
@@ -40,6 +40,7 @@ def test_ruff_check() -> None:
     )
 
 
+@pytest.mark.skipif(skip_if_missing("git"), reason="git not found")
 def test_no_tabs_in_code() -> None:
     result = run(["git", "grep", "-P", r"\t", "*.py"], check=False, cwd=REPO_ROOT)
     assert result.returncode != 0, "Found tabs in Python code"
@@ -86,5 +87,9 @@ def test_shellcheck() -> None:
 
 
 @pytest.mark.skipif(skip_if_missing("pandoc"), reason="pandoc not found")
+@pytest.mark.skipif(
+    SKIP_MISSING_TOOLS and not (REPO_ROOT / "tools/make-man-page.sh").exists(),
+    reason="tools/make-man-page.sh not found",
+)
 def test_man_page_generation() -> None:
     run(["tools/make-man-page.sh"], cwd=REPO_ROOT)

--- a/tests/test_linters.py
+++ b/tests/test_linters.py
@@ -20,18 +20,18 @@ def kernel_install_files() -> list[str]:
     return [os.fspath(p) for p in (REPO_ROOT / "kernel-install").glob("*.install")]
 
 
-def _skip_if_missing(tool: str) -> bool:
+def skip_if_missing(tool: str) -> bool:
     """Return True if we should skip the test because tool is missing."""
     return SKIP_MISSING_TOOLS and shutil.which(tool) is None
 
 
-@pytest.mark.skipif(_skip_if_missing("ruff"), reason="ruff not found")
+@pytest.mark.skipif(skip_if_missing("ruff"), reason="ruff not found")
 def test_ruff_format_check() -> None:
     """Check that code is formatted with ruff format."""
     run(["ruff", "format", "--check", "--diff", "mkosi/", "tests/", *kernel_install_files()], cwd=REPO_ROOT)
 
 
-@pytest.mark.skipif(_skip_if_missing("ruff"), reason="ruff not found")
+@pytest.mark.skipif(skip_if_missing("ruff"), reason="ruff not found")
 def test_ruff_check() -> None:
     """Check code quality with ruff."""
     run(
@@ -45,7 +45,7 @@ def test_no_tabs_in_code() -> None:
     assert result.returncode != 0, "Found tabs in Python code"
 
 
-@pytest.mark.skipif(_skip_if_missing("codespell"), reason="codespell not found")
+@pytest.mark.skipif(skip_if_missing("codespell"), reason="codespell not found")
 def test_codespell() -> None:
     run(["codespell", "--version"], cwd=REPO_ROOT)
     files = run(["git", "ls-files"], stdout=subprocess.PIPE, cwd=REPO_ROOT).stdout.strip().split("\n")
@@ -54,27 +54,27 @@ def test_codespell() -> None:
     run(["codespell", *files_to_check], cwd=REPO_ROOT)
 
 
-@pytest.mark.skipif(_skip_if_missing("reuse"), reason="reuse not found")
+@pytest.mark.skipif(skip_if_missing("reuse"), reason="reuse not found")
 def test_reuse_lint() -> None:
     run(["reuse", "lint"], cwd=REPO_ROOT)
 
 
-@pytest.mark.skipif(_skip_if_missing("mypy"), reason="mypy not found")
+@pytest.mark.skipif(skip_if_missing("mypy"), reason="mypy not found")
 def test_mypy() -> None:
     run(["mypy", "mkosi/", *kernel_install_files()], cwd=REPO_ROOT)
 
 
-@pytest.mark.skipif(_skip_if_missing("mypy"), reason="mypy not found")
+@pytest.mark.skipif(skip_if_missing("mypy"), reason="mypy not found")
 def test_mypy_python310() -> None:
     run(["mypy", "--python-version", "3.10", "mkosi/", "tests/", *kernel_install_files()], cwd=REPO_ROOT)
 
 
-@pytest.mark.skipif(_skip_if_missing("pyright"), reason="pyright not found")
+@pytest.mark.skipif(skip_if_missing("pyright"), reason="pyright not found")
 def test_pyright() -> None:
     run(["pyright", "mkosi/", "tests/", *kernel_install_files()], cwd=REPO_ROOT)
 
 
-@pytest.mark.skipif(_skip_if_missing("shellcheck"), reason="shellcheck not found")
+@pytest.mark.skipif(skip_if_missing("shellcheck"), reason="shellcheck not found")
 def test_shellcheck() -> None:
     # Check bin/mkosi and tools/*.sh
     tools_scripts = [os.fspath(p) for p in (REPO_ROOT / "tools").glob("*.sh")]
@@ -85,6 +85,6 @@ def test_shellcheck() -> None:
     run(["shellcheck", "-"], input=completion, cwd=REPO_ROOT)
 
 
-@pytest.mark.skipif(_skip_if_missing("pandoc"), reason="pandoc not found")
+@pytest.mark.skipif(skip_if_missing("pandoc"), reason="pandoc not found")
 def test_man_page_generation() -> None:
     run(["tools/make-man-page.sh"], cwd=REPO_ROOT)


### PR DESCRIPTION
My alternate proposal for #4339

I kept the `test_linters.py` as the first commit from @bluca, and handled the install tests through a marker. I think this is simpler, more robust, and more predictable. WDYT?