### PR TITLE
obs: enable PR CI workflow

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -8,3 +8,14 @@ rebuild:
     branches:
       only:
         - main
+ci:
+  steps:
+    - branch_package:
+        source_project: system:systemd
+        source_package: mkosi
+        target_project: system:systemd:ci
+  filters:
+    event: pull_request
+    branches:
+      only:
+        - main


### PR DESCRIPTION
Build packages on OBS against the PR and reports status back to Github. This just builds the mkosi package for now, next step is to also build particleos images.