### PR TITLE
tests: Run distro=arch / tools=fedora on Fedora 44 to evade pacman bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,12 @@ jobs:
           - distro: ubuntu
             tools: opensuse
         include:
+          # Fedora rawhide's pacman 7.1.0 deadlocks with curl 8.20 when installing packages
+          # (https://github.com/curl/curl/issues/21466, https://gitlab.archlinux.org/pacman/pacman/-/merge_requests/360)
+          # use the latest stable release instead, until https://src.fedoraproject.org/rpms/pacman/pull-request/5# lands
+          - distro: arch
+            tools: fedora
+            tools_release: "44"
           # low rate limit on s390x/ppc64le/arm64 workers
           - distro: debian
             tools: debian
@@ -136,6 +142,7 @@ jobs:
 
           [Build]
           ToolsTreeDistribution=${{ matrix.tools }}
+          ToolsTreeRelease=${{ matrix.tools_release }}
           Environment=SYSTEMD_REPART_MKFS_OPTIONS_EROFS="--quiet"
 
           [Runtime]


### PR DESCRIPTION
Fedora Rawhide's pacman 7.1.0 deadlocks with curl 8.20.0 when installing packages. Pin the tools tree to the latest stable Fedora release for this test run combination until the pacman fix lands in Rawhide.

curl issue (closed, libcurl is not fork-safe by design): https://github.com/curl/curl/issues/21466

pacman fix (not yet merged):
https://gitlab.archlinux.org/pacman/pacman/-/merge_requests/360

See issue #4344 for the full analysis.

---

This is clearly a hack, but I don't really want to push for adding an unmerged upstream pacman patch into the Fedora package. All in all I think this is better than a prolonged red integration test, though.