### PR TITLE
installer: Auto-retry package index download failures

### DIFF
--- a/mkosi/installer/apk.py
+++ b/mkosi/installer/apk.py
@@ -186,6 +186,8 @@ class Apk(PackageManager):
             + ["update", *(["--update-cache"] if force else [])],
             sandbox=context.sandbox(network=True, options=options),
             env=env,
+            # Downloading repository metadata often fails with transient network errors
+            num_retries=3,
         )
         rmtree(tmp)
 

--- a/mkosi/installer/apt.py
+++ b/mkosi/installer/apt.py
@@ -227,6 +227,7 @@ class Apt(PackageManager):
         apivfs: bool = False,
         options: Sequence[PathString] = (),
         stdout: _FILE = None,
+        retry: bool = False,
     ) -> CompletedProcess:
         with umask(~0o755):
             # TODO: Drop once apt 2.5.4 is widely available.
@@ -240,6 +241,8 @@ class Apt(PackageManager):
             sandbox=cls.sandbox(context, apivfs=apivfs, options=options),
             env=cls.finalize_environment(context),
             stdout=stdout,
+            # Downloading repository metadata often fails with transient network errors
+            num_retries=3 if retry else 0,
         )
 
     @classmethod
@@ -284,7 +287,7 @@ class Apt(PackageManager):
 
     @classmethod
     def sync(cls, context: Context, force: bool) -> None:
-        cls.invoke(context, "update")
+        cls.invoke(context, "update", retry=True)
 
     @classmethod
     def createrepo(cls, context: Context) -> None:

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -227,6 +227,7 @@ class Dnf(PackageManager):
         apivfs: bool = False,
         stdout: _FILE = None,
         cached_metadata: bool = True,
+        retry: bool = False,
     ) -> CompletedProcess:
         try:
             return run(
@@ -234,6 +235,8 @@ class Dnf(PackageManager):
                 sandbox=cls.sandbox(context, apivfs=apivfs),
                 env=cls.finalize_environment(context),
                 stdout=stdout,
+                # Downloading repository metadata often fails with transient network errors
+                num_retries=3 if retry else 0,
             )
         finally:
             # dnf interprets the log directory relative to the install root so there's nothing we can do but
@@ -266,12 +269,13 @@ class Dnf(PackageManager):
         cls.invoke(context, "remove", packages, apivfs=True)
 
     @classmethod
-    def sync(cls, context: Context, force: bool, arguments: Sequence[str] = ()) -> None:
+    def sync(cls, context: Context, force: bool, arguments: Sequence[str] = (), retry: bool = True) -> None:
         cls.invoke(
             context,
             "makecache",
             arguments=[*(["--refresh"] if force else []), *arguments],
             cached_metadata=False,
+            retry=retry,
         )
 
     @classmethod
@@ -294,4 +298,5 @@ class Dnf(PackageManager):
             )
         )
 
-        cls.sync(context, force=True, arguments=["--disablerepo=*", "--enablerepo=mkosi"])
+        # The local repository never fails transiently, so don't retry.
+        cls.sync(context, force=True, arguments=["--disablerepo=*", "--enablerepo=mkosi"], retry=False)

--- a/mkosi/installer/pacman.py
+++ b/mkosi/installer/pacman.py
@@ -178,6 +178,7 @@ class Pacman(PackageManager):
         *,
         apivfs: bool = False,
         stdout: _FILE = None,
+        retry: bool = False,
     ) -> CompletedProcess:
         with umask(~0o755):
             (context.root / "var/lib/pacman/local").mkdir(parents=True, exist_ok=True)
@@ -191,6 +192,8 @@ class Pacman(PackageManager):
             sandbox=cls.sandbox(context, apivfs=apivfs),
             env=cls.finalize_environment(context),
             stdout=stdout,
+            # Downloading repository metadata often fails with transient network errors
+            num_retries=3 if retry else 0,
         )
 
     @classmethod
@@ -256,7 +259,7 @@ class Pacman(PackageManager):
 
     @classmethod
     def sync(cls, context: Context, force: bool) -> None:
-        cls.invoke(context, "--sync", ["--refresh", *(["--refresh"] if force else [])])
+        cls.invoke(context, "--sync", ["--refresh", *(["--refresh"] if force else [])], retry=True)
 
     @classmethod
     def createrepo(cls, context: Context) -> None:

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -126,12 +126,15 @@ class Zypper(PackageManager):
         options: Sequence[str] = (),
         apivfs: bool = False,
         stdout: _FILE = None,
+        retry: bool = False,
     ) -> CompletedProcess:
         return run(
             cls.cmd(context) + [*options, operation, *arguments],
             sandbox=cls.sandbox(context, apivfs=apivfs),
             env=cls.finalize_environment(context),
             stdout=stdout,
+            # Downloading repository metadata often fails with transient network errors
+            num_retries=3 if retry else 0,
         )
 
     @classmethod
@@ -161,12 +164,13 @@ class Zypper(PackageManager):
         cls.invoke(context, "remove", ["--clean-deps", *packages], apivfs=True, options=["--ignore-unknown"])
 
     @classmethod
-    def sync(cls, context: Context, force: bool, arguments: Sequence[str] = ()) -> None:
+    def sync(cls, context: Context, force: bool, arguments: Sequence[str] = (), retry: bool = True) -> None:
         cls.invoke(
             context,
             "refresh",
             [*(["--force"] if force else []), *arguments],
             options=["--gpg-auto-import-keys"] if context.config.repository_key_fetch else [],
+            retry=retry,
         )
 
     @classmethod
@@ -190,4 +194,5 @@ class Zypper(PackageManager):
             )
         )
 
-        cls.sync(context, force=True, arguments=["mkosi"])
+        # The local repository never fails transiently, so don't retry.
+        cls.sync(context, force=True, arguments=["mkosi"], retry=False)

--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -15,6 +15,7 @@ import signal
 import subprocess
 import sys
 import threading
+import time
 import uuid
 from collections.abc import Awaitable, Collection, Iterator, Mapping, Sequence
 from contextlib import AbstractContextManager
@@ -238,27 +239,50 @@ def run(
     setup: Sequence[PathString] = (),
     sandbox: AbstractContextManager[Sequence[PathString]] = nosandbox(),
     cwd: Optional[PathString] = None,
+    num_retries: int = 0,
 ) -> CompletedProcess:
+    """
+    Run the command in cmdline and return the completed process.
+
+    If num_retries is larger than zero, a failing command is retried up to that many additional times,
+    with a cubically growing delay (1, 8, 27, ... seconds). Use this for commands that can fail transiently.
+    Retrying only applies to failures covered by check=True and success_exit_status.
+    """
     if input is not None:
         assert stdin is None  # stdin and input cannot be specified together
         stdin = subprocess.PIPE
 
-    with spawn(
-        cmdline,
-        check=check,
-        stdin=stdin,
-        stdout=stdout,
-        stderr=stderr,
-        env=env,
-        log=log,
-        success_exit_status=success_exit_status,
-        setup=setup,
-        sandbox=sandbox,
-        cwd=cwd,
-    ) as process:
-        out, err = process.communicate(input)
+    # The sandbox context manager can only be entered once, so enter it here and pass the entered
+    # options to each spawn() attempt.
+    with sandbox as sbx:
+        attempt = 0
+        while True:
+            try:
+                with spawn(
+                    cmdline,
+                    check=check,
+                    stdin=stdin,
+                    stdout=stdout,
+                    stderr=stderr,
+                    env=env,
+                    log=log,
+                    success_exit_status=success_exit_status,
+                    setup=setup,
+                    sandbox=contextlib.nullcontext(sbx),
+                    cwd=cwd,
+                ) as process:
+                    out, err = process.communicate(input)
 
-    return CompletedProcess(cmdline, process.returncode, out, err)
+                return CompletedProcess(cmdline, process.returncode, out, err)
+            except subprocess.CalledProcessError:
+                if attempt >= num_retries:
+                    raise
+
+                attempt += 1
+                # Retry immediately, then back off quickly: 1, 8, 27, ... seconds
+                delay = attempt**3
+                logging.info(f"Retrying in {delay} seconds ({attempt}/{num_retries})")
+                time.sleep(delay)
 
 
 def _preexec(

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -3,11 +3,12 @@
 import contextlib
 import os
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
 
-from mkosi.run import fork_and_wait
+from mkosi.run import fork_and_wait, run
 
 
 def test_fork_and_wait_returns_value() -> None:
@@ -62,3 +63,72 @@ def test_fork_and_wait_sandbox(tmp_path: Path) -> None:
 
     result = fork_and_wait(exists, sandbox=contextlib.nullcontext(["--bind", os.fspath(tmp_path), "/"]))
     assert result
+
+
+def attempts_cmd(counter: Path, succeed_on: int) -> list[str]:
+    # Append a line to the counter file on every invocation and fail until it has been invoked
+    # succeed_on times.
+    return ["sh", "-ec", f"echo x >>{counter}; [ $(wc -l <{counter}) -ge {succeed_on} ]"]
+
+
+def attempts(counter: Path) -> int:
+    return len(counter.read_text().splitlines())
+
+
+@pytest.fixture
+def sleeps(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    durations: list[float] = []
+    # Don't actually sleep during the test, but record durations
+    monkeypatch.setattr(time, "sleep", durations.append)
+    return durations
+
+
+def test_run_no_retry_by_default(tmp_path: Path, sleeps: list[float]) -> None:
+    counter = tmp_path / "counter"
+
+    with pytest.raises(subprocess.CalledProcessError):
+        run(attempts_cmd(counter, succeed_on=2), log=False)
+
+    assert attempts(counter) == 1
+    assert sleeps == []
+
+
+def test_run_retry_eventually_succeeds(tmp_path: Path, sleeps: list[float]) -> None:
+    counter = tmp_path / "counter"
+
+    result = run(attempts_cmd(counter, succeed_on=3), log=False, num_retries=3)
+
+    assert result.returncode == 0
+    assert attempts(counter) == 3
+    assert sleeps == [1, 8]
+
+
+def test_run_retry_exhausted(tmp_path: Path, sleeps: list[float]) -> None:
+    counter = tmp_path / "counter"
+
+    with pytest.raises(subprocess.CalledProcessError):
+        # num_retries=2 means 3 attempts in total, so succeeding on the 4th is just out of reach
+        run(attempts_cmd(counter, succeed_on=4), log=False, num_retries=2)
+
+    assert attempts(counter) == 3
+    assert sleeps == [1, 8]
+
+
+def test_run_retry_immediate_success_does_not_sleep(tmp_path: Path, sleeps: list[float]) -> None:
+    counter = tmp_path / "counter"
+
+    result = run(attempts_cmd(counter, succeed_on=1), log=False, num_retries=3)
+
+    assert result.returncode == 0
+    assert attempts(counter) == 1
+    assert sleeps == []
+
+
+def test_run_no_retry_without_check(tmp_path: Path, sleeps: list[float]) -> None:
+    counter = tmp_path / "counter"
+
+    result = run(attempts_cmd(counter, succeed_on=2), check=False, log=False, num_retries=3)
+
+    assert result.returncode == 1
+    assert attempts(counter) == 1
+    assert sleeps == []


### PR DESCRIPTION
These are notoriously prone to transient network errors, and every CI
system in the world eventually grows an auto-retry for these. Now it's
mkosi's time!

The local repository set up by createrepo() never fails transiently, so
opt out of retrying there. apk's createrepo() keeps retrying, as its
sync refreshes all configured repositories including remote ones.

Don't apply this to other operations yet -- e.g. downloading actual
packages is much more expensive, and at least `dnf` has some basic retry
already built in (trying different mirrors). Let's add more of these
carefully only when they become a problem. E.g. zypper's
`--download in-advance` is a good candidate.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

----

I saw [this failure](https://github.com/systemd/mkosi/actions/runs/26898232399/job/79344908553?pr=4345#step:10:15) at least twice now.