### PR TITLE
config: Pull repository keys on Debian by default

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -1087,11 +1087,14 @@ def config_default_repository_key_fetch(namespace: dict[str, Any]) -> bool:
         if d == "nixos":
             return True
 
-        return d == Distribution.ubuntu and needs_repository_key_fetch(namespace["distribution"])
+        return d in (Distribution.ubuntu, Distribution.debian) and needs_repository_key_fetch(
+            namespace["distribution"]
+        )
 
-    return namespace["tools_tree_distribution"] == Distribution.ubuntu and needs_repository_key_fetch(
-        namespace["distribution"]
-    )
+    return namespace["tools_tree_distribution"] in (
+        Distribution.ubuntu,
+        Distribution.debian,
+    ) and needs_repository_key_fetch(namespace["distribution"])
 
 
 def config_default_source_date_epoch(namespace: dict[str, Any]) -> Optional[int]:

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -588,8 +588,9 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
 `RepositoryKeyFetch=`, `--repository-key-fetch=`
 :   Controls whether **mkosi** will fetch distribution GPG keys remotely. Enabled by
-    default on Ubuntu when not using a tools tree or when using Ubuntu tools trees to build
-    Arch Linux or RPM-based distributions. Disabled by default on all other distributions.
+    default on Debian and Ubuntu when not using a tools tree or when using Debian or Ubuntu
+    tools trees to build Arch Linux or RPM-based distributions. Disabled by default on all
+    other distributions.
     When disabled, the distribution GPG keys for the target distribution have to be installed
     locally on the host system alongside the package manager for that distribution.
 


### PR DESCRIPTION
Debian's `archlinux-keyring` is lagging behind by more than half a year by now, and contains expired developer keys
(https://bugs.debian.org/1138819). This has broken the build of arch with a Debian tool box since May 09.

Even if/when the above Debian update happens, this is a recurring problem. Give in, and download the keys at build time just like we do on Ubuntu.

Fixes #4347