### PR TITLE
Skip security.ima xattrs when copying tree as non-root

### DIFF
--- a/mkosi/tree.py
+++ b/mkosi/tree.py
@@ -130,8 +130,11 @@ def copy_tree(
 
         # Trying to copy selinux xattrs to overlayfs fails with "Operation not supported" in containers.
         # Trying to copy security.ima xattrs fails with "Operation not permitted" when non-root.
-        if (statfs(os.fspath(dst.parent)) != OVERLAYFS_SUPER_MAGIC or not tree_has_selinux_xattr(src)) and (
-            os.getuid() == 0 or not tree_has_ima_xattr(src)
+        # Copying SELinux attributes also needs root and it seems unlikely, that copying IMA attributes to
+        # overlayfs should work when SELinux does not.
+        if not (
+            (statfs(os.fspath(dst.parent)) == OVERLAYFS_SUPER_MAGIC or os.getuid() != 0)
+            and (tree_has_selinux_xattr(src) or tree_has_ima_xattr(src))
         ):
             attrs += ",xattr"
 

--- a/mkosi/tree.py
+++ b/mkosi/tree.py
@@ -103,6 +103,10 @@ def tree_has_selinux_xattr(path: Path) -> bool:
     )
 
 
+def tree_has_ima_xattr(path: Path) -> bool:
+    return any("security.ima" in os.listxattr(p, follow_symlinks=False) for p in (path, *path.rglob("*")))
+
+
 def copy_tree(
     src: Path,
     dst: Path,
@@ -125,7 +129,10 @@ def copy_tree(
         attrs += ",timestamps,ownership"
 
         # Trying to copy selinux xattrs to overlayfs fails with "Operation not supported" in containers.
-        if statfs(os.fspath(dst.parent)) != OVERLAYFS_SUPER_MAGIC or not tree_has_selinux_xattr(src):
+        # Trying to copy security.ima xattrs fails with "Operation not permitted" when non-root.
+        if (statfs(os.fspath(dst.parent)) != OVERLAYFS_SUPER_MAGIC or not tree_has_selinux_xattr(src)) and (
+            os.getuid() == 0 or not tree_has_ima_xattr(src)
+        ):
             attrs += ",xattr"
 
     def copy() -> None:


### PR DESCRIPTION
This is a resubmission of #4269 without the tests, that mocked out everything except for `any`, and with the ruff failure fixed. 

Fixes: #4206