### PR TITLE
dnf: Tighten repo_gpgcheck, work around librepo bug

### DIFF
--- a/mkosi/distribution/centos.py
+++ b/mkosi/distribution/centos.py
@@ -169,16 +169,20 @@ class Installer(DistributionInstaller, distribution=Distribution.centos):
                 subdir += f"/CentOS-Stream-{context.config.release}-{context.config.snapshot}/compose"
 
             if repo == "extras":
+                # extras-common signs its metadata with the CentOS SIG key, not the main key we
+                # configure, so we can't verify its metadata signature.
                 yield RpmRepository(
                     repo.lower(),
                     f"baseurl={join_mirror(mirror, f'{subdir}/{repo}/$basearch/extras-common')}",
                     gpgurls,
+                    repo_gpgcheck=False,
                 )
                 yield RpmRepository(
                     f"{repo.lower()}-source",
                     f"baseurl={join_mirror(mirror, f'{subdir}/{repo}/source/extras-common')}",
                     gpgurls,
                     enabled=False,
+                    repo_gpgcheck=False,
                 )
             else:
                 yield RpmRepository(
@@ -206,12 +210,14 @@ class Installer(DistributionInstaller, distribution=Distribution.centos):
                     repo.lower(),
                     f"{url}?arch=$basearch&repo=centos-extras-sig-extras-common-$stream",
                     gpgurls,
+                    repo_gpgcheck=False,
                 )
                 yield RpmRepository(
                     f"{repo.lower()}-source",
                     f"{url}?arch=source&repo=centos-extras-sig-extras-common-source-$stream",
                     gpgurls,
                     enabled=False,
+                    repo_gpgcheck=False,
                 )
             else:
                 yield RpmRepository(
@@ -299,18 +305,21 @@ class Installer(DistributionInstaller, distribution=Distribution.centos):
                     f"baseurl={url}/{dir}/{reldir}/Everything/$basearch",
                     gpgurls,
                     enabled=False,
+                    repo_gpgcheck=False,
                 )
                 yield RpmRepository(
                     f"{repo}-debuginfo",
                     f"baseurl={url}/{dir}/{reldir}/Everything/$basearch/debug",
                     gpgurls,
                     enabled=False,
+                    repo_gpgcheck=False,
                 )
                 yield RpmRepository(
                     f"{repo}-source",
                     f"baseurl={url}/{dir}/{reldir}/Everything/source/tree",
                     gpgurls,
                     enabled=False,
+                    repo_gpgcheck=False,
                 )
         else:
             if GenericVersion(context.config.release) >= 10:
@@ -322,18 +331,21 @@ class Installer(DistributionInstaller, distribution=Distribution.centos):
                     f"{url}?repo=epel{z}-{release}&arch=$basearch",
                     gpgurls,
                     enabled=False,
+                    repo_gpgcheck=False,
                 )
                 yield RpmRepository(
                     "epel-debuginfo",
                     f"{url}?repo=epel{z}-debug-{release}&arch=$basearch",
                     gpgurls,
                     enabled=False,
+                    repo_gpgcheck=False,
                 )
                 yield RpmRepository(
                     "epel-source",
                     f"{url}?repo=epel{z}-source-{release}&arch=source",
                     gpgurls,
                     enabled=False,
+                    repo_gpgcheck=False,
                 )
 
                 yield RpmRepository(
@@ -341,18 +353,21 @@ class Installer(DistributionInstaller, distribution=Distribution.centos):
                     f"{url}?repo=epel{z}-testing-{release}&arch=$basearch",
                     gpgurls,
                     enabled=False,
+                    repo_gpgcheck=False,
                 )
                 yield RpmRepository(
                     "epel-testing-debuginfo",
                     f"{url}?repo=epel{z}-testing-debug-{release}&arch=$basearch",
                     gpgurls,
                     enabled=False,
+                    repo_gpgcheck=False,
                 )
                 yield RpmRepository(
                     "epel-testing-source",
                     f"{url}?repo=epel{z}-testing-source-{release}&arch=source",
                     gpgurls,
                     enabled=False,
+                    repo_gpgcheck=False,
                 )
             else:
                 url = "metalink=https://mirrors.fedoraproject.org/metalink?arch=$basearch"
@@ -363,18 +378,21 @@ class Installer(DistributionInstaller, distribution=Distribution.centos):
                         f"{url}&repo={repo}-{release}",
                         gpgurls,
                         enabled=False,
+                        repo_gpgcheck=False,
                     )
                     yield RpmRepository(
                         f"{repo}-debuginfo",
                         f"{url}&repo={repo}-debug-{release}",
                         gpgurls,
                         enabled=False,
+                        repo_gpgcheck=False,
                     )
                     yield RpmRepository(
                         f"{repo}-source",
                         f"{url}&repo={repo}-source-{release}",
                         gpgurls,
                         enabled=False,
+                        repo_gpgcheck=False,
                     )
 
                 yield RpmRepository(
@@ -382,18 +400,21 @@ class Installer(DistributionInstaller, distribution=Distribution.centos):
                     f"{url}&repo=testing-epel{release}",
                     gpgurls,
                     enabled=False,
+                    repo_gpgcheck=False,
                 )
                 yield RpmRepository(
                     "epel-testing-debuginfo",
                     f"{url}&repo=testing-debug-epel{release}",
                     gpgurls,
                     enabled=False,
+                    repo_gpgcheck=False,
                 )
                 yield RpmRepository(
                     "epel-testing-source",
                     f"{url}&repo=testing-source-epel{release}",
                     gpgurls,
                     enabled=False,
+                    repo_gpgcheck=False,
                 )
 
                 yield RpmRepository(
@@ -401,18 +422,21 @@ class Installer(DistributionInstaller, distribution=Distribution.centos):
                     f"{url}&repo=epel-testing-next-{release}",
                     gpgurls,
                     enabled=False,
+                    repo_gpgcheck=False,
                 )
                 yield RpmRepository(
                     "epel-next-testing-debuginfo",
                     f"{url}&repo=epel-testing-next-debug-{release}",
                     gpgurls,
                     enabled=False,
+                    repo_gpgcheck=False,
                 )
                 yield RpmRepository(
                     "epel-next-testing-source",
                     f"{url}&repo=epel-testing-next-source-{release}",
                     gpgurls,
                     enabled=False,
+                    repo_gpgcheck=False,
                 )
 
     @classmethod

--- a/mkosi/distribution/fedora.py
+++ b/mkosi/distribution/fedora.py
@@ -149,6 +149,7 @@ class Installer(DistributionInstaller, distribution=Distribution.fedora):
 
     @classmethod
     def repositories(cls, context: Context) -> Iterable[RpmRepository]:
+        # Fedora doesn't sign its repository metadata (no repomd.xml.asc), so disable repo_gpgcheck.
         gpgurls = find_fedora_rpm_gpgkeys(context)
 
         mirror = context.config.mirror
@@ -165,7 +166,9 @@ class Installer(DistributionInstaller, distribution=Distribution.fedora):
             )
 
         if context.config.local_mirror:
-            yield RpmRepository("fedora", f"baseurl={context.config.local_mirror}", gpgurls)
+            yield RpmRepository(
+                "fedora", f"baseurl={context.config.local_mirror}", gpgurls, repo_gpgcheck=False
+            )
             return
 
         if context.config.release == "eln":
@@ -173,11 +176,21 @@ class Installer(DistributionInstaller, distribution=Distribution.fedora):
 
             for repo in ("AppStream", "BaseOS", "Extras", "CRB"):
                 url = f"baseurl={join_mirror(mirror, repo)}"
-                yield RpmRepository(repo.lower(), f"{url}/$basearch/os", gpgurls)
+                yield RpmRepository(repo.lower(), f"{url}/$basearch/os", gpgurls, repo_gpgcheck=False)
                 yield RpmRepository(
-                    f"{repo.lower()}-debuginfo", f"{url}/$basearch/debug/tree", gpgurls, enabled=False
+                    f"{repo.lower()}-debuginfo",
+                    f"{url}/$basearch/debug/tree",
+                    gpgurls,
+                    enabled=False,
+                    repo_gpgcheck=False,
                 )
-                yield RpmRepository(f"{repo.lower()}-source", f"{url}/source/tree", gpgurls, enabled=False)
+                yield RpmRepository(
+                    f"{repo.lower()}-source",
+                    f"{url}/source/tree",
+                    gpgurls,
+                    enabled=False,
+                    repo_gpgcheck=False,
+                )
         elif mirror:
             # Snapshot= implies the koji compose URL layout (compose/<release>/
             # Fedora-<Release>-<snapshot>/compose/Everything/...), regardless
@@ -194,62 +207,108 @@ class Installer(DistributionInstaller, distribution=Distribution.fedora):
                 subdir += "/$releasever"
 
             url = f"baseurl={join_mirror(mirror, f'{subdir}/Everything')}"
-            yield RpmRepository("fedora", f"{url}/$basearch/os", gpgurls)
-            yield RpmRepository("fedora-debuginfo", f"{url}/$basearch/debug/tree", gpgurls, enabled=False)
-            yield RpmRepository("fedora-source", f"{url}/source/tree", gpgurls, enabled=False)
+            yield RpmRepository("fedora", f"{url}/$basearch/os", gpgurls, repo_gpgcheck=False)
+            yield RpmRepository(
+                "fedora-debuginfo",
+                f"{url}/$basearch/debug/tree",
+                gpgurls,
+                enabled=False,
+                repo_gpgcheck=False,
+            )
+            yield RpmRepository(
+                "fedora-source", f"{url}/source/tree", gpgurls, enabled=False, repo_gpgcheck=False
+            )
 
             # Snapshot= pins to a frozen koji compose, which has no separate
             # linux/updates/ tree, so skip the updates repos in that case.
             if context.config.release != "rawhide" and not context.config.snapshot:
                 url = f"baseurl={join_mirror(mirror, 'linux/updates/$releasever/Everything')}"
-                yield RpmRepository("updates", f"{url}/$basearch", gpgurls)
-                yield RpmRepository("updates-debuginfo", f"{url}/$basearch/debug", gpgurls, enabled=False)
-                yield RpmRepository("updates-source", f"{url}/source/tree", gpgurls, enabled=False)
+                yield RpmRepository("updates", f"{url}/$basearch", gpgurls, repo_gpgcheck=False)
+                yield RpmRepository(
+                    "updates-debuginfo",
+                    f"{url}/$basearch/debug",
+                    gpgurls,
+                    enabled=False,
+                    repo_gpgcheck=False,
+                )
+                yield RpmRepository(
+                    "updates-source", f"{url}/source/tree", gpgurls, enabled=False, repo_gpgcheck=False
+                )
 
                 url = f"baseurl={join_mirror(mirror, 'linux/updates/testing/$releasever/Everything')}"
-                yield RpmRepository("updates-testing", f"{url}/$basearch", gpgurls, enabled=False)
                 yield RpmRepository(
-                    "updates-testing-debuginfo", f"{url}/$basearch/debug", gpgurls, enabled=False
+                    "updates-testing", f"{url}/$basearch", gpgurls, enabled=False, repo_gpgcheck=False
                 )
-                yield RpmRepository("updates-testing-source", f"{url}/source/tree", gpgurls, enabled=False)
+                yield RpmRepository(
+                    "updates-testing-debuginfo",
+                    f"{url}/$basearch/debug",
+                    gpgurls,
+                    enabled=False,
+                    repo_gpgcheck=False,
+                )
+                yield RpmRepository(
+                    "updates-testing-source",
+                    f"{url}/source/tree",
+                    gpgurls,
+                    enabled=False,
+                    repo_gpgcheck=False,
+                )
         else:
             url = "metalink=https://mirrors.fedoraproject.org/metalink?arch=$basearch"
-            yield RpmRepository("fedora", f"{url}&repo=fedora-$releasever", gpgurls)
+            yield RpmRepository("fedora", f"{url}&repo=fedora-$releasever", gpgurls, repo_gpgcheck=False)
             yield RpmRepository(
-                "fedora-debuginfo", f"{url}&repo=fedora-debug-$releasever", gpgurls, enabled=False
+                "fedora-debuginfo",
+                f"{url}&repo=fedora-debug-$releasever",
+                gpgurls,
+                enabled=False,
+                repo_gpgcheck=False,
             )
             yield RpmRepository(
-                "fedora-source", f"{url}&repo=fedora-source-$releasever", gpgurls, enabled=False
+                "fedora-source",
+                f"{url}&repo=fedora-source-$releasever",
+                gpgurls,
+                enabled=False,
+                repo_gpgcheck=False,
             )
 
             if context.config.release != "rawhide":
-                yield RpmRepository("updates", f"{url}&repo=updates-released-f$releasever", gpgurls)
+                yield RpmRepository(
+                    "updates", f"{url}&repo=updates-released-f$releasever", gpgurls, repo_gpgcheck=False
+                )
                 yield RpmRepository(
                     "updates-debuginfo",
                     f"{url}&repo=updates-released-debug-f$releasever",
                     gpgurls,
                     enabled=False,
+                    repo_gpgcheck=False,
                 )
                 yield RpmRepository(
                     "updates-source",
                     f"{url}&repo=updates-released-source-f$releasever",
                     gpgurls,
                     enabled=False,
+                    repo_gpgcheck=False,
                 )
                 yield RpmRepository(
-                    "updates-testing", f"{url}&repo=updates-testing-f$releasever", gpgurls, enabled=False
+                    "updates-testing",
+                    f"{url}&repo=updates-testing-f$releasever",
+                    gpgurls,
+                    enabled=False,
+                    repo_gpgcheck=False,
                 )
                 yield RpmRepository(
                     "updates-testing-debuginfo",
                     f"{url}&repo=updates-testing-debug-f$releasever",
                     gpgurls,
                     enabled=False,
+                    repo_gpgcheck=False,
                 )
                 yield RpmRepository(
                     "updates-testing-source",
                     f"{url}&repo=updates-testing-source-f$releasever",
                     gpgurls,
                     enabled=False,
+                    repo_gpgcheck=False,
                 )
 
     @classmethod

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -119,6 +119,7 @@ class Dnf(PackageManager):
                             name={repo.id}
                             {repo.url}
                             gpgcheck=1
+                            repo_gpgcheck={int(repo.repo_gpgcheck)}
                             enabled={int(repo.enabled)}
                             """
                         )

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+import logging
 import textwrap
 from collections.abc import Sequence
 from pathlib import Path
@@ -7,6 +8,7 @@ from typing import Optional
 
 from mkosi.config import Cacheonly, Config
 from mkosi.context import Context
+from mkosi.distribution import detect_distribution
 from mkosi.installer import PackageManager
 from mkosi.installer.rpm import RpmRepository, rpm_cmd
 from mkosi.log import ARG_DEBUG
@@ -107,6 +109,20 @@ class Dnf(PackageManager):
                 )
             )
 
+        # TODO: librepo rejects valid repository metadata GPG signatures with gpgme 2.1 ("Bad GPG
+        # signature"): https://github.com/rpm-software-management/librepo/issues/376
+        # This happens a lot when building a distro which signs its repos (CentOS) on newer distros like
+        # Arch, Debian testing, or openSUSE Tumbleweed, with their newer gpgme.
+        # Thus until this is fixed, only validate repo GPG signatures when the distributions match. We can
+        # assume that distros test their own dnf repos :-)
+        # Revert once librepo gets fixed and into the distros.
+        repo_gpgcheck_broken = detect_distribution(context.config.tools())[0] != context.config.distribution
+        if repo_gpgcheck_broken:
+            logging.info(
+                "Disabling repository metadata GPG signature check: "
+                "https://github.com/rpm-software-management/librepo/issues/376"
+            )
+
         repofile = context.sandbox_tree / "etc/yum.repos.d/mkosi.repo"
         if not repofile.exists():
             repofile.parent.mkdir(exist_ok=True, parents=True)
@@ -119,7 +135,7 @@ class Dnf(PackageManager):
                             name={repo.id}
                             {repo.url}
                             gpgcheck=1
-                            repo_gpgcheck={int(repo.repo_gpgcheck)}
+                            repo_gpgcheck={int(repo.repo_gpgcheck and not repo_gpgcheck_broken)}
                             enabled={int(repo.enabled)}
                             """
                         )

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -270,7 +270,14 @@ class Dnf(PackageManager):
         cls.invoke(
             context,
             "makecache",
-            arguments=[*(["--refresh"] if force else []), *arguments],
+            arguments=[
+                *(["--refresh"] if force else []),
+                # Some distros enable this, which is annoying: despite failed GPG verification, sync() would
+                # succeed; the later package installation then fails on the unusable cache. Fail right here
+                # to make the root cause visible.
+                "--setopt=skip_if_unavailable=0",
+                *arguments,
+            ],
             cached_metadata=False,
         )
 

--- a/mkosi/installer/rpm.py
+++ b/mkosi/installer/rpm.py
@@ -23,6 +23,11 @@ class RpmRepository:
     sslclientcert: Optional[Path] = None
     priority: Optional[int] = None
 
+    # True if the repository metadata (repomd.xml) is GPG-signed with a key we configure (e.g. CentOS).
+    # False for repositories that don't publish a repomd signature (e.g. Fedora, EPEL) or sign it with
+    # a key we don't have. rpm signatures (gpgcheck) are always verified.
+    repo_gpgcheck: bool = True
+
 
 @overload
 def find_rpm_gpgkey(


### PR DESCRIPTION
For a while now we've had a lot of GPG repo signature test failures with the `opensuse` tools image, like [this](https://github.com/systemd/mkosi/actions/runs/27507702208/job/81302020690?pr=4360) or [this](https://github.com/systemd/mkosi/actions/runs/27507702208/job/81302020722?pr=4360). Initially this looked transient, so I first tried to mitigate that with retries (#4346). But turns out this doesn't help at all. The root cause is a bug in openSUSE's librepo, triggered by updating gnupg to a development release. I reported that to https://bugzilla.opensuse.org/show_bug.cgi?id=1268271 with a standalone reproducer and added a workaround.

This also uncovered some unpredictability with how we handle repository signatures in the first place -- mostly, it depended on the defaults in the *tools* image, not the *target distro*.

This series fixes these cases.

There is one more failure mode left, like [this](https://github.com/martinpitt/mkosi/actions/runs/27535189841/job/81383028780#step:7:3039):

> Repository 'oss' is invalid.
> [oss|https://download.opensuse.org/tumbleweed/repo/oss] Failed to retrieve new repository metadata. History:
>  Timeout exceeded when accessing 'https://cdn.opensuse.org/tumbleweed/repo/oss/repodata/29117db410d8ea1fdb5f93c866f048524e7ee8e4458df9db5389b4f02c9227d922fc963f5d8df558997e769713c96fdd78d66fe674c08ba74067352216a22315-appdata.xml.gz'.
>   Timeout reached Curl error (28)

This is "throw hands into the air". This URL *absolutely works* when I download it from my laptop (in Germany) even *while the test is hanging*. I suspect that either the SUSE CDN rate-limits GitHub (and possibly other origins) for scraper defense, or there is some geolocation going on and one of the mirrors is actually broken.