### PR TITLE
tests: ignore masked units in check-and-shutdown

### DIFF
--- a/mkosi.extra/usr/lib/systemd/mkosi-check-and-shutdown.sh
+++ b/mkosi.extra/usr/lib/systemd/mkosi-check-and-shutdown.sh
@@ -2,7 +2,11 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 set -eux
 
-systemctl --failed --no-legend | tee /failed-services
+# Ignore masked units (in particular lvm2-monitor.service,, see mkosi.postinst); these
+# are not a real image failure
+systemctl --failed --no-legend --plain |
+    awk '$2 != "masked"' |
+    tee /failed-services
 
 # Exit with non-zero EC if the /failed-services file is not empty (we have -e set)
 [[ ! -s /failed-services ]]

--- a/mkosi.postinst
+++ b/mkosi.postinst
@@ -2,4 +2,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 set -ex
 
+# Enabled in the initrd (which has lvm2) and can fail there when udev activation races dmeventd.
+# That failed state is inherited across switch-root into the main image, where lvm2 isn't even
+# installed, surfacing as not-found/failed noise. Mask it so mkosi-check-and-shutdown.sh ignores it.
 systemctl --root="$BUILDROOT" mask lvm2-monitor.service


### PR DESCRIPTION
Masking lvm2-monitor.service in 899dfbd45 did not actually stop it from tripping the boot check: a masked unit that udev pulls in when scanning a disk image's partitions still fails to start and is listed by `systemctl --failed` with ACTIVE=failed. Masking only changed the LOAD column from `not-found` to `masked`.

A masked unit failing to start is noise, not a real service failure in the image, so filter masked units out of the failed-services check.

Also explain mkosi.postinst *why* lvm2-monitor.service even fails in the first place: It's only installed in the initrd, not the main image. That may or may not be a bug, but it's uninteresting for the "failed services?" check.

----

Helps with [this flake](https://github.com/systemd/mkosi/actions/runs/27721694120/job/82008778934?pr=4297#step:8:30058), which I've seen several times now. This complements PR #3399 from last year.

This might be a bit contentious/bikeshedd-y, so submitting it as a separate PR. @behrmann as author of #3399 you might have an opinion on this? Thanks!