### PR TITLE
action: don't fail if apk cannot be downloaded

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -100,9 +100,13 @@ runs:
       # scripts (like .github/workflows/ci.yml) clean up /usr/local
       shell: bash
       run: |
-        sudo curl -fsSL -o /usr/bin/apk https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v3.0.6/x86_64/apk.static
-        echo 'f1489e05bace7d7dd0a687fcd38d50b585ac660af4231668b123649bef3718c4  /usr/bin/apk' | sha256sum --check
-        sudo chmod +x /usr/bin/apk
+        if sudo curl -fsSL -o /usr/bin/apk https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v3.0.6/x86_64/apk.static
+        then
+            echo 'f1489e05bace7d7dd0a687fcd38d50b585ac660af4231668b123649bef3718c4  /usr/bin/apk' | sha256sum --check
+            sudo chmod +x /usr/bin/apk
+        else
+            echo "WARNING: Failed to fetch latest apk!"
+        fi
 
     - name: Dependencies
       shell: bash


### PR DESCRIPTION
@craftyguy @bluca requested this, because this was failing CI elsewhere, I assume you don't mind, since  #4364 handles this similary.