### PR TITLE
Revert "Put build history into the output directory"

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -5445,15 +5445,7 @@ def want_default_initrd(config: Config) -> bool:
     return Path("default") in config.initrds
 
 
-def finalize_historydir(args: Args, output_dir: Optional[Path] = None) -> Path:
-    # When an output dir is given on the CLI, store the build history there so that concurrent builds with
-    # different output dirs don't clobber a shared history. Don't check the finalized OutputDirectory=
-    # config, only the CLI value: the former isn't known yet here (config files and includes are
-    # parsed later) and vm/boot can't see it anyway since they recover the config from the history instead of
-    # parsing it. An output dir set only in config files keeps the history in the config dir.
-    if output_dir is not None:
-        return output_dir / ".mkosi-private/history"
-
+def finalize_historydir(args: Args) -> Path:
     configdir = finalize_configdir(args.directory)
     return (configdir or Path.cwd()) / ".mkosi-private/history"
 
@@ -5510,7 +5502,7 @@ def parse_config(
         return args, None, ()
 
     configdir = finalize_configdir(args.directory)
-    historydir = finalize_historydir(args, context.cli.get("output_dir"))
+    historydir = finalize_historydir(args)
 
     if have_history(args, historydir):
         history = Config.from_partial_json((historydir / "latest.json").read_text())

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -126,13 +126,12 @@ class Image:
                 "--register=no",
                 "--machine",
                 self.machine,
-                "--output-directory", self.output_dir,
                 *options,
             ],
             args,
             stdin=sys.stdin if sys.stdin.isatty() else None,
             check=False,
-        )  # fmt: skip
+        )
 
         if result.returncode != 123:
             raise subprocess.CalledProcessError(result.returncode, result.args, result.stdout, result.stderr)
@@ -159,13 +158,12 @@ class Image:
                 "--register=no",
                 "--machine",
                 self.machine,
-                "--output-directory", self.output_dir,
                 *options,
             ],
             args,
             stdin=sys.stdin if sys.stdin.isatty() else None,
             check=False,
-        )  # fmt: skip
+        )
 
         if result.returncode != 123:
             raise subprocess.CalledProcessError(result.returncode, result.args, result.stdout, result.stderr)


### PR DESCRIPTION
Breaks the systemd CI, and also seems to make passing --output-directory mandatory on the command line if it is defined in the config, which is just horrible UX:

‣ /home/runner/work/systemd/systemd/mkosi/mkosi.local.conf: Setting OutputDirectory specified by specifier '%O' in %O/ovmf_vars_shim.fd is not yet set, ignoring
‣ /home/runner/work/systemd/systemd/mkosi/mkosi.local.conf: Setting OutputDirectory specified by specifier '%O' in %O/ovmf_vars_shim.fd is not yet set, ignoring
‣ Firmware variables file /ovmf_vars_shim.fd does not exist

https://github.com/systemd/systemd/actions/runs/28126107457/job/83290221148?pr=42739

This reverts commit da49fe976c7398524202cfedf93c8ff332d4eaf2.