### PR TITLE
action: Make apk installation configurable and reliable again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./
+        with:
+          # Bootstrapping a postmarketOS tools tree on the Ubuntu host needs apk; all other
+          # tools trees install apk-tools from th tools distro's own repo
+          apk: ${{ matrix.tools == 'postmarketos' }}
 
       # Freeing up disk space with rm -rf can take multiple minutes. Since we don't need the extra free space
       # immediately, we remove the files in the background. However, we first move them to a different location so that

--- a/action.yaml
+++ b/action.yaml
@@ -1,6 +1,12 @@
 name: setup-mkosi
 description: Install mkosi
 
+inputs:
+  apk:
+    description: Install the apk package manager (required to bootstrap a postmarketOS tools tree)
+    required: false
+    default: "false"
+
 runs:
   using: composite
   steps:
@@ -98,15 +104,12 @@ runs:
       #
       # NOTE: apk is dropped into /usr/bin and not /usr/local/bin because later CI
       # scripts (like .github/workflows/ci.yml) clean up /usr/local
+      if: ${{ inputs.apk == 'true' }}
       shell: bash
       run: |
-        if sudo curl -fsSL -o /usr/bin/apk https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v3.0.6/x86_64/apk.static
-        then
-            echo 'f1489e05bace7d7dd0a687fcd38d50b585ac660af4231668b123649bef3718c4  /usr/bin/apk' | sha256sum --check
-            sudo chmod +x /usr/bin/apk
-        else
-            echo "WARNING: Failed to fetch latest apk!"
-        fi
+        sudo curl -fsSL -o /usr/bin/apk https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v3.0.6/x86_64/apk.static
+        echo 'f1489e05bace7d7dd0a687fcd38d50b585ac660af4231668b123649bef3718c4  /usr/bin/apk' | sha256sum --check
+        sudo chmod +x /usr/bin/apk
 
     - name: Dependencies
       shell: bash


### PR DESCRIPTION
Commit 5ef262bc53c was a quick-fix to unbreak systemd's CI, but it's not a long-term fix: it makes the apk installation unreliable and unpredictable.

Revert it, and instead add an explicit `apk` action option to install it explicitly. As 5ef262bc53c landed, let it default to false (as arguably it's not needed for most test runs).

Enable it in the test matrix when building a postmarketos tools tree, as we need `apk` on the Ubuntu host to bootstrap it. For any other test scenario, apk will be installed into and run from the tools tree.