### PR TITLE
sandbox: Default FSOperation.execute oldroot/newroot to /

### DIFF
--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -1060,7 +1060,7 @@ class FSOperation:
         self.dst = dst
         self.relative = relative
 
-    def execute(self, oldroot: str, newroot: str) -> None:
+    def execute(self, oldroot: str = "/", newroot: str = "/") -> None:
         raise NotImplementedError()
 
     def describe(self) -> str:
@@ -1142,7 +1142,7 @@ class BindOperation(FSOperation):
         suffix = f" [{', '.join(flags)}]" if flags else ""
         return f"bind {self.src} -> {self.dst}{suffix}"
 
-    def execute(self, oldroot: str, newroot: str) -> None:
+    def execute(self, oldroot: str = "/", newroot: str = "/") -> None:
         src = chase(newroot if self.relative else oldroot, self.src, nofollow=self.nofollow)
 
         exists = os.path.lexists if self.nofollow else os.path.exists
@@ -1188,7 +1188,7 @@ class DevOperation(FSOperation):
     def describe(self) -> str:
         return f"dev at {self.dst}" + (f" (tty={self.ttyname})" if self.ttyname else "")
 
-    def execute(self, oldroot: str, newroot: str) -> None:
+    def execute(self, oldroot: str = "/", newroot: str = "/") -> None:
         # We don't put actual devices in /dev, just the API stuff in there that all manner of
         # things depend on, like /dev/null.
         dst = chase(newroot, self.dst)
@@ -1233,7 +1233,7 @@ class TmpfsOperation(FSOperation):
     def describe(self) -> str:
         return f"tmpfs at {self.dst}"
 
-    def execute(self, oldroot: str, newroot: str) -> None:
+    def execute(self, oldroot: str = "/", newroot: str = "/") -> None:
         dst = chase(newroot, self.dst)
         with umask(~0o755):
             os.makedirs(dst, exist_ok=True)
@@ -1246,7 +1246,7 @@ class DirOperation(FSOperation):
     def describe(self) -> str:
         return f"mkdir {self.dst}"
 
-    def execute(self, oldroot: str, newroot: str) -> None:
+    def execute(self, oldroot: str = "/", newroot: str = "/") -> None:
         dst = chase(newroot, self.dst)
         with umask(~0o755):
             os.makedirs(os.path.dirname(dst), exist_ok=True)
@@ -1265,7 +1265,7 @@ class SymlinkOperation(FSOperation):
     def describe(self) -> str:
         return f"symlink {self.dst} -> {self.src}"
 
-    def execute(self, oldroot: str, newroot: str) -> None:
+    def execute(self, oldroot: str = "/", newroot: str = "/") -> None:
         dst = joinpath(newroot, self.dst)
         try:
             return os.symlink(self.src, dst)
@@ -1291,7 +1291,7 @@ class WriteOperation(FSOperation):
     def describe(self) -> str:
         return f"write {len(self.data)} bytes to {self.dst}"
 
-    def execute(self, oldroot: str, newroot: str) -> None:
+    def execute(self, oldroot: str = "/", newroot: str = "/") -> None:
         dst = chase(newroot, self.dst)
         with umask(~0o755):
             os.makedirs(os.path.dirname(dst), exist_ok=True)
@@ -1312,12 +1312,12 @@ class OverlayOperation(FSOperation):
     # This supports being used as a context manager so we can reuse the logic for mount_overlay()
     # in mounts.py.
     def __enter__(self) -> None:
-        self.execute("/", "/")
+        self.execute()
 
     def __exit__(self, *args: object, **kwargs: object) -> None:
         umount2(self.dst)
 
-    def execute(self, oldroot: str, newroot: str) -> None:
+    def execute(self, oldroot: str = "/", newroot: str = "/") -> None:
         lowerdirs = tuple(chase(oldroot, p) for p in self.lowerdirs)
         upperdir = (
             chase(oldroot, self.upperdir) if self.upperdir and self.upperdir != "tmpfs" else self.upperdir


### PR DESCRIPTION
This lets OverlayOperation reuse execute() without passing "/" for both
roots explicitly when used as a context manager.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
