### PR TITLE
Forbid AI attribution in commit messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,11 @@
 This file provides guidance to AI coding agents when working with code in this repository. Only add
 instructions to this file if you've seen an AI agent mess up that particular bit of logic in practice.
 
+## Legal
+
+ - Only human beings can ever be credited within commit messages. This means no Co-Developed-By or
+   Co-Authored-By or anything similar that lists an AI model instead of a human being.
+
 ## Key Documentation
 
 Always consult these files as needed:
@@ -27,9 +32,3 @@ display. This is critical for diagnosing build and test failures.
 ## Pull Request Review Instructions
 
 - Always check out the PR in a git worktree in `worktrees/`, review it locally and remove the worktree when finished.
-
-## AI Contribution Disclosure
-
-Per project policy: if you use AI code generation tools, you **must disclose** this in commit messages by
-adding e.g. `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`. All AI-generated output requires
-thorough human review before submission.


### PR DESCRIPTION
Adopt systemd's policy: only human beings can be credited within commit
messages. Drop the previous AI Contribution Disclosure section that
required a Co-Authored-By trailer.
