### PR TITLE
Fix tar exclude patterns for apivfs paths

### DIFF
--- a/mkosi/archive.py
+++ b/mkosi/archive.py
@@ -13,12 +13,13 @@ from mkosi.util import PathString, chdir
 
 def tar_exclude_apivfs_tmp() -> list[str]:
     return [
-        "--exclude", "./dev/*",
-        "--exclude", "./proc/*",
-        "--exclude", "./sys/*",
-        "--exclude", "./tmp/*",
-        "--exclude", "./run/*",
-        "--exclude", "./var/tmp/*",
+        "--anchored",
+        "--exclude", "./dev/*",     "--exclude", "dev/*",
+        "--exclude", "./proc/*",    "--exclude", "proc/*",
+        "--exclude", "./sys/*",     "--exclude", "sys/*",
+        "--exclude", "./tmp/*",     "--exclude", "tmp/*",
+        "--exclude", "./run/*",     "--exclude", "run/*",
+        "--exclude", "./var/tmp/*", "--exclude", "var/tmp/*",
     ]  # fmt: skip
 
 


### PR DESCRIPTION
Add `--anchored` and non-prefixed variants of exclude patterns so apivfs directories are properly excluded regardless of whether tar entries are prefixed with `./`.

To reproduce the issue, try using BaseTrees with a tarball that doesn't have the `./` prefix, for example, from [Ubuntu Cloud Images](https://cloud-images.ubuntu.com/):
```
[Content]
BaseTrees=cloud-images/ubuntu-26.04-server-cloudimg-amd64v3-root.tar.xz
```

It will not exclude /dev/* and fail to build.