### PR TITLE
fix(ubuntu-kali-debian, tools-trees): add `passwd` into debian/ubuntu tools trees

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.profiles/misc/mkosi.conf.d/debian-kali-ubuntu.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/misc/mkosi.conf.d/debian-kali-ubuntu.conf
@@ -7,6 +7,7 @@ Distribution=|ubuntu
 
 [Content]
 Packages=
+        passwd
         git-core
         libnss-resolve
         libnss-myhostname


### PR DESCRIPTION
This fixes an issue where `/usr/lib/rpm/sysusers.sh` would fail to run on a debian/ubuntu system due to `usermod`, `groupadd` and `useradd` not being present in the tools tree. RPM seems to run this specific script on the "host" (tools tree) and this missing makes it so fedora-based image builds that include any package with sysupdate scripts fails to build.

## Reproduction

```bash
tee mkosi.conf <<EOF
[Config]
MinimumVersion=27~devel

[Distribution]
Distribution=fedora
Release=44

[Build]
ToolsTree=default
ToolsTreeDistribution=debian

[Content]
Packages=dbus-common # this package includes sysupdate scripts as of f44

[Output]
OutputDirectory=mkosi.output
EOF
mkosi build
```

This should output normal build output for any fedora image, then it should fail with the following RPM scriptlet errors:

```bash
>>> Running sysusers scriptlet: setup-0:2.15.0-28.fc44.noarch
>>> Finished sysusers scriptlet: setup-0:2.15.0-28.fc44.noarch
>>> Scriptlet output:
>>> /usr/lib/rpm/sysusers.sh: line 107: groupadd: command not found
>>> /usr/lib/rpm/sysusers.sh: line 107: groupadd: command not found
>>> /usr/lib/rpm/sysusers.sh: line 107: groupadd: command not found
>>> /usr/lib/rpm/sysusers.sh: line 107: groupadd: command not found
[7/9] Installing fedora-release-0:44-18.noarch                                  100% |   1.0 KiB/s | 124.0   B |  00m00s
>>> Running sysusers scriptlet: setup-0:2.15.0-28.fc44.noarch
>>> Finished sysusers scriptlet: setup-0:2.15.0-28.fc44.noarch
>>> Scriptlet output:
>>> /usr/lib/rpm/sysusers.sh: line 107: groupadd: command not found
>>> /usr/lib/rpm/sysusers.sh: line 107: groupadd: command not found
>>> /usr/lib/rpm/sysusers.sh: line 107: groupadd: command not found
>>> /usr/lib/rpm/sysusers.sh: line 107: groupadd: command not found
>>> /usr/lib/rpm/sysusers.sh: line 107: groupadd: command not found
>>> /usr/lib/rpm/sysusers.sh: line 107: groupadd: command not found
>>> /usr/lib/rpm/sysusers.sh: line 107: groupadd: command not found
>>> /usr/lib/rpm/sysusers.sh: line 107: groupadd: command not found
>>> /usr/lib/rpm/sysusers.sh: line 107: groupadd: command not found
>>> /usr/lib/rpm/sysusers.sh: line 107: groupadd: command not found
>>> /usr/lib/rpm/sysusers.sh: line 107: groupadd: command not found
>>> /usr/lib/rpm/sysusers.sh: line 107: groupadd: command not found
>>> /usr/lib/rpm/sysusers.sh: line 107: groupadd: command not found
>>> /usr/lib/rpm/sysusers.sh: line 107: groupadd: command not found
# ...
```

## Real world 

- https://github.com/zirconium-dev/zirconium/actions/runs/28683154628
- https://github.com/zirconium-dev/zirconium/actions/runs/28459381411
- https://github.com/zirconium-dev/zirconium/actions/runs/28683154628

These image builds have been failing on the ubuntu runners because they depend on a NetworkManager package that fails if the sysupdate scripts do not work.