### PR TITLE
sandbox: handle case where dev node for tty doesn't exist better

### DIFF
--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -52,6 +52,7 @@ EFD_CLOEXEC = 0x80000
 ENAMETOOLONG = 36
 EPERM = 1
 ENOENT = 2
+ENODEV = 19
 ENOSYS = 38
 F_DUPFD = 0
 F_GETFD = 1
@@ -1458,7 +1459,9 @@ def enter(argv: list[str]) -> list[str]:
 
     try:
         ttyname = os.ttyname(2) if os.isatty(2) else ""
-    except FileNotFoundError:
+    except OSError as exc:
+        if exc.errno not in (ENOENT, ENODEV):
+            raise
         ttyname = ""
 
     while argv:


### PR DESCRIPTION
In cec6ae1d ("sandbox: handle case where dev node for tty doesn't exist"), code was added to try to deal with a device node not existing. For whatever reason, a FileNotFoundError with errno=2 was raised back then, and I get a more generic OSError with errno=19.

    $ python3 -c "import os; os.ttyname(2)"
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
        import os; os.ttyname(2)
                   ~~~~~~~~~~^^^
    OSError: [Errno 19] No such device

Let's just handle both cases.