### PR TITLE
util: don't drop single-character variable names in read_env_file

### DIFF
--- a/mkosi/util.py
+++ b/mkosi/util.py
@@ -92,7 +92,7 @@ def read_env_file(path: PathString) -> Iterator[tuple[str, str]]:
             line = line.rstrip()
             if not line or line.startswith("#"):
                 continue
-            if m := re.match(r"([a-zA-Z_][a-zA-Z_0-9]+)=(.*)", line):
+            if m := re.match(r"([a-zA-Z_][a-zA-Z_0-9]*)=(.*)", line):
                 name, val = m.groups()
                 if val and val[0] in "\"'":
                     val = ast.literal_eval(val)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from mkosi.util import parents_below
+from mkosi.util import parents_below, read_env_file
 
 
 def test_parents_below_basic() -> None:
@@ -50,3 +50,11 @@ def test_parents_below_below_is_child_raises() -> None:
     below = Path("/a/b/c")
     with pytest.raises(ValueError):
         parents_below(path, below)
+
+
+def test_read_env_file(tmp_path: Path) -> None:
+    # Single-character variable names are valid in os-release/env files and in the shell, so they
+    # must not be silently dropped.
+    p = tmp_path / "env"
+    p.write_text("A=1\nBC=2\n_=3\nX=\n")
+    assert read_env_file(p) == {"A": "1", "BC": "2", "_": "3", "X": ""}


### PR DESCRIPTION
The regexp used to parse environment/os-release files required the variable name to consist of at least two characters ([a-zA-Z_][a-zA-Z_0-9]+), so a line with a single-character name such as "A=1" or "_=3" did not match and was silently discarded as a bad line.

Single-character names are valid both in os-release files and in the shell, so allow them by using '*' instead of '+' for the trailing character class.

Add a regression test covering single-character names.