### PR TITLE
distribution: report the actual architecture in unsupported-arch errors

### DIFF
--- a/mkosi/distribution/arch.py
+++ b/mkosi/distribution/arch.py
@@ -143,7 +143,7 @@ class Installer(DistributionInstaller, distribution=Distribution.arch):
         }.get(arch)  # fmt: skip
 
         if not a:
-            die(f"Architecture {a} is not supported by Arch Linux")
+            die(f"Architecture {arch} is not supported by Arch Linux")
 
         return a
 

--- a/mkosi/distribution/azure.py
+++ b/mkosi/distribution/azure.py
@@ -107,6 +107,6 @@ class Installer(fedora.Installer, distribution=Distribution.azure):
         }.get(arch)  # fmt: skip
 
         if not a:
-            die(f"Architecture {a} is not supported by {cls.pretty_name()}")
+            die(f"Architecture {arch} is not supported by {cls.pretty_name()}")
 
         return a

--- a/mkosi/distribution/centos.py
+++ b/mkosi/distribution/centos.py
@@ -91,7 +91,7 @@ class Installer(DistributionInstaller, distribution=Distribution.centos):
         }.get(arch)  # fmt: skip
 
         if not a:
-            die(f"Architecture {a} is not supported by {cls.pretty_name()}")
+            die(f"Architecture {arch} is not supported by {cls.pretty_name()}")
 
         return a
 

--- a/mkosi/distribution/fedora.py
+++ b/mkosi/distribution/fedora.py
@@ -324,7 +324,7 @@ class Installer(DistributionInstaller, distribution=Distribution.fedora):
         }.get(arch)  # fmt: skip
 
         if not a:
-            die(f"Architecture {a} is not supported by Fedora")
+            die(f"Architecture {arch} is not supported by Fedora")
 
         return a
 

--- a/mkosi/distribution/mageia.py
+++ b/mkosi/distribution/mageia.py
@@ -62,6 +62,6 @@ class Installer(fedora.Installer, distribution=Distribution.mageia):
         }.get(arch)  # fmt: skip
 
         if not a:
-            die(f"Architecture {a} is not supported by Mageia")
+            die(f"Architecture {arch} is not supported by Mageia")
 
         return a

--- a/mkosi/distribution/openmandriva.py
+++ b/mkosi/distribution/openmandriva.py
@@ -58,6 +58,6 @@ class Installer(fedora.Installer, distribution=Distribution.openmandriva):
         }.get(arch)  # fmt: skip
 
         if not a:
-            die(f"Architecture {a} is not supported by OpenMandriva")
+            die(f"Architecture {arch} is not supported by OpenMandriva")
 
         return a

--- a/mkosi/distribution/opensuse.py
+++ b/mkosi/distribution/opensuse.py
@@ -275,7 +275,7 @@ class Installer(DistributionInstaller, distribution=Distribution.opensuse):
         }.get(arch)  # fmt: skip
 
         if not a:
-            die(f"Architecture {a} is not supported by openSUSE")
+            die(f"Architecture {arch} is not supported by openSUSE")
 
         return a
 

--- a/mkosi/distribution/postmarketos.py
+++ b/mkosi/distribution/postmarketos.py
@@ -133,7 +133,7 @@ class Installer(DistributionInstaller, distribution=Distribution.postmarketos):
         }.get(arch)  # fmt: skip
 
         if not a:
-            die(f"Architecture {a} is not supported by postmarketOS")
+            die(f"Architecture {arch} is not supported by postmarketOS")
 
         return a
 


### PR DESCRIPTION
When an architecture is not supported by a distribution, the error message interpolated 'a', which is the result of dict.get(arch) and is therefore always None on this code path (we only get here when the lookup missed). As a result the message always read "Architecture None is not supported by ..." instead of naming the architecture the user actually requested.

Interpolate 'arch' instead, matching what debian.py and kali.py already do. Affects arch, azure, centos, fedora, mageia, openmandriva, opensuse and postmarketos.