### PR TITLE
tools: add mount to Debian tools tree

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf
@@ -16,6 +16,7 @@ Packages=
         libfido2-1
         libseccomp2
         libtss2-dev
+        mount
         policycoreutils
         python3
         python3-pefile


### PR DESCRIPTION
This is to debug the failure of the initrd tests on Debian