### PR TITLE
Use systemd nightly OBS version in signing PCR policies auto detection

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1783,7 +1783,7 @@ def build_uki(
             cert_parameter = "--pcr-public-key"
 
         if context.config.sign_initrd_pcrs == ConfigFeature.enabled or (
-            context.config.sign_initrd_pcrs == ConfigFeature.auto and ukify_version >= "262~devel"
+            context.config.sign_initrd_pcrs == ConfigFeature.auto and ukify_version >= "261.999"
         ):
             arguments += ["--sign-initrd-pcrs"]
 
@@ -2911,7 +2911,7 @@ def check_tools(config: Config, verb: Verb) -> None:
         if config.sign_initrd_pcrs == ConfigFeature.enabled and want_signed_pcrs(config):
             check_ukify(
                 config,
-                version="262~devel",
+                version="261.999",
                 reason="sign a PCR policy for the initrd",
             )
 


### PR DESCRIPTION
The systemd nightly OBS version during the 262 development is 261.999+NUMBER+gHASH and thus the comparison against 262~devel didn't make the auto detection work.
Compare against the .999 minor version which a proper release won't have.