### PR TITLE
Fall back to unprivileged user namespace on polkit denial

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5102,11 +5102,13 @@ def run_verb(args: Args, tools: Optional[Config], images: Sequence[Config], *, r
         # Try to get a user namespace with some delegated ranges and the foreign UID range via
         # systemd-nsresourced if we can.
         acquire_privileges(foreign=True, delegate=3)
-    # Don't fail if systemd-nsresourced is too old or not installed unless the foreign UID range was
-    # explicitly requested, use a regular unpriv user namespace instead.
+    # Don't fail if systemd-nsresourced is too old, not installed or refuses to provision a user namespace
+    # for us unless the foreign UID range was explicitly requested, use a regular unpriv user namespace
+    # instead.
     except (FileNotFoundError, VarlinkError, ConnectionRefusedError) as e:
         if isinstance(e, VarlinkError) and e.error not in (
             "org.varlink.service.InvalidParameter",
+            "org.varlink.service.PermissionDenied",
             "io.systemd.NamespaceResource.UserNamespaceInterfaceNotSupported",
         ):
             raise


### PR DESCRIPTION
nsresourced runs a polkit check for the `io.systemd.namespace-resource.allocate-user-namespace` action before handing out a UID range. When that check comes back denied, the `AllocateUserRange()` call fails with `org.varlink.service.PermissionDenied`, which we currently let propagate and abort with a traceback.

A denial is just another way of saying nsresourced won't provision a user namespace for us, so treat it like the other tolerated errors and fall back to a regular unprivileged user namespace. If the foreign UID range was explicitly requested we still die, as before.

This is hit on hosts running polkit older than 124, which does not understand the pidfd based unix-process subject that systemd sends over varlink and answers every such query with `org.freedesktop.PolicyKit1.Error.Failed`. systemd maps that to `PermissionDenied`, so every mkosi invocation aborts. Previously this was masked on systemd 259, where `AllocateUserRange()` has no type, `delegateContainerRanges` or `mapForeign` parameters and the request was rejected with `InvalidParameter` before polkit was ever consulted.