### PR TITLE
mkosi-tools: Install systemd-tpm on Debian

### DIFF
--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/systemd-tpm.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/debian-kali-ubuntu/mkosi.conf.d/systemd-tpm.conf
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[TriggerMatch]
+Distribution=debian
+Release=!bullseye
+Release=!bookworm
+Release=!trixie
+
+[Content]
+Packages=systemd-tpm


### PR DESCRIPTION
Since 261-2, Debian ships systemd-measure in a separate systemd-tpm binary package. As systemd only recommends it, and we install without recommends, the tools tree ends up without it and building a signed UKI fails:

>  FileNotFoundError: [Errno 2] No such file or directory: '/usr/lib/systemd/systemd-measure'

Only Debian testing and newer have the package: trixie is still on systemd 257, and Ubuntu on 259, so leave those alone until they catch up.