### PR TITLE
Add ToolsTreeSnapshot= for pinning the default tools tree

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -3875,6 +3875,21 @@ SETTINGS: list[ConfigSetting[Any]] = [
         scope=SettingScope.tools,
     ),
     ConfigSetting(
+        dest="tools_tree_snapshot",
+        metavar="SNAPSHOT",
+        section="Build",
+        default_factory_depends=("distribution", "snapshot", "tools_tree_distribution"),
+        default_factory=(
+            lambda ns: (
+                ns["snapshot"]
+                if ns["snapshot"] and ns["distribution"] == ns["tools_tree_distribution"]
+                else None
+            )
+        ),
+        help="Set the distribution snapshot to use for the default tools tree",
+        scope=SettingScope.tools,
+    ),
+    ConfigSetting(
         dest="tools_tree_repositories",
         long="--tools-tree-repository",
         metavar="REPOS",

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -572,6 +572,9 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 
     For any distribution not listed above, snapshots are not supported.
 
+    Note that this setting does not apply to the default tools tree; use
+    `ToolsTreeSnapshot=` for that.
+
 `LocalMirror=`, `--local-mirror=`
 :   The mirror will be used as a local, plain and direct mirror instead
     of using it as a prefix for the full set of repositories normally supported
@@ -1556,6 +1559,11 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 `ToolsTreeMirror=`, `--tools-tree-mirror=`
 :   Set the mirror to use for the default tools tree. By default, the
     default mirror for the tools tree distribution is used.
+
+`ToolsTreeSnapshot=`, `--tools-tree-snapshot=`
+:   Same as `Snapshot=` but for the default tools tree. By default, if the
+    tools tree distribution matches the image's distribution, the image's
+    snapshot is used.
 
 `ToolsTreeRepositories=`, `--tools-tree-repository=`
 :   Same as `Repositories=` but for the default tools tree.
@@ -3206,6 +3214,7 @@ the main image but which are not passed down to subimages:
 - `ToolsTreeRelease=`
 - `ToolsTreeProfiles=`
 - `ToolsTreeMirror=`
+- `ToolsTreeSnapshot=`
 - `ToolsTreeRepositories=`
 - `ToolsTreeSandboxTrees=`
 - `ToolsTreePackages=`


### PR DESCRIPTION
Fixes #4420.

`Snapshot=` has universal scope, so it reaches subimages but not the default tools tree, and there was no `ToolsTree*` counterpart to hand the value across. Replacing `ToolsTreeMirror=` with `Snapshot=` therefore silently dropped the tools tree back to live mirrors.

This adds `ToolsTreeSnapshot=`, modelled directly on `ToolsTreeMirror=`: a tools-scope setting whose default factory takes the image's snapshot when the tools tree distribution matches the image's, so the common same-distribution case is pinned without any extra configuration. Docs get the new setting, a note under `Snapshot=` about the tools tree, and the entry in the main-image-only settings list.

Ran `pytest tests/test_config.py tests/test_json.py` (74 passed). No serialization fixtures change since tools-scope settings aren't part of the image Config.