### PR TITLE
run: exchange manual mock of linecache.checkcache for unittest.mock.patch

### DIFF
--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -15,6 +15,7 @@ import signal
 import subprocess
 import sys
 import threading
+import unittest.mock
 import uuid
 from collections.abc import Awaitable, Collection, Iterator, Mapping, Sequence
 from contextlib import AbstractContextManager
@@ -67,12 +68,8 @@ def excepthook(frames: Sequence[FrameType]) -> None:
     # sys.excepthook() triggers linecache.checkcache() which evicts cache entries for source files that are
     # inaccessible. Temporarily disable it to preserve our primed linecache entries for which we might not
     # be able to access the files anymore (because we're sandboxed).
-    checkcache = linecache.checkcache
-    linecache.checkcache = lambda filename=None: None
-    try:
+    with unittest.mock.patch("linecache.checkcache", lambda filename=None: None):
         sys.excepthook(exctype, exc, tb)
-    finally:
-        linecache.checkcache = checkcache
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
This is the successor to #4168 from which all things but one have been fixed. 

The last remaining error ty is showing is

    Object of type `(filename=None) -> None` is not assignable to attribute `checkcache` of type `def checkcache(filename: str | None = None) -> None`

which is a problem with ty's handling of shadowing being more conservative than other typecheckers.

Since what we want to do here is basically a mock, patching linecache.checkcache to a function that won't evict out cache entries, let's use a proper mock instead.