### PR TITLE
action: support container-based self-hosted runners

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -22,14 +22,18 @@ runs:
         KERNEL=="vhost-vsock", GROUP="kvm", MODE="0666", OPTIONS+="static_node=vhost-vsock"
         KERNEL=="vhost-net", GROUP="kvm", MODE="0666", OPTIONS+="static_node=vhost-net"
         EOF
-        sudo udevadm control --reload-rules
+        if sudo udevadm control --ping &>/dev/null; then
+          sudo udevadm control --reload-rules
+        fi
         # kvm/vhost might not be available (e.g.: s390x, ppc64le)
         sudo modprobe kvm || true
         sudo modprobe vhost_vsock || true
         sudo modprobe vhost_net || true
-        [[ -e /dev/kvm ]] && sudo udevadm trigger --name-match=kvm
-        [[ -e /dev/vhost-vsock ]] && sudo udevadm trigger --name-match=vhost-vsock
-        [[ -e /dev/vhost-net ]] && sudo udevadm trigger --name-match=vhost-net
+        if sudo test -w /sys; then
+          [[ -e /dev/kvm ]] && sudo udevadm trigger --name-match=kvm
+          [[ -e /dev/vhost-vsock ]] && sudo udevadm trigger --name-match=vhost-vsock
+          [[ -e /dev/vhost-net ]] && sudo udevadm trigger --name-match=vhost-net
+        fi
         [[ -e /dev/kvm ]] && sudo chmod 666 /dev/kvm
         [[ -e /dev/vhost-vsock ]] && sudo chmod 666 /dev/vhost-vsock
         [[ -e /dev/vhost-net ]] && sudo chmod 666 /dev/vhost-net
@@ -75,7 +79,9 @@ runs:
         # This command fails with a non-zero error code even though it unloads the apparmor profiles.
         # https://gitlab.com/apparmor/apparmor/-/issues/403
         sudo aa-teardown || true
-        sudo apt-get remove apparmor
+        if command -v apt-get >/dev/null; then
+          sudo apt-get remove apparmor
+        fi
 
     - name: Ensure git history is available
       shell: bash
@@ -114,6 +120,11 @@ runs:
     - name: Dependencies
       shell: bash
       run: |
+        if ! command -v apt-get >/dev/null; then
+          echo "apt-get not available, skipping dependency installation."
+          exit 0
+        fi
+
         sudo apt-get update
 
         # makepkg and pacman-package-manager were only added in noble (24.04).


### PR DESCRIPTION
The action assumes a GitHub-hosted Ubuntu VM: sysfs is writable, udev is running, and apt-get exists. On a self-hosted runner inside a container none of that holds: sysfs is read-only, so udevadm trigger fails writing uevents, and apt-get doesn't exist on non-Debian hosts.

Run the udevadm calls only when /sys is writable, mirroring udevd's own ConditionPathIsReadWrite=/sys. In containers the device nodes are provided by the container manager, and the direct chmod still applies the permissions. Skip the apt-get calls when apt-get is not available, removing apparmor only exists to work around the broken Ubuntu runner images.

On GitHub-hosted runners all conditions hold, so nothing changes there.