### PR TITLE
news: fix v27 `DiskType=` setting typo

### DIFF
--- a/mkosi/resources/man/mkosi.news.7.md
+++ b/mkosi/resources/man/mkosi.news.7.md
@@ -29,7 +29,7 @@
   images unprivileged without a sufficiently new systemd-nsresourced is still supported.
 - If a `mkosi/` directory exists and no output location is configured, the `.mkosi-private` will be put there.
 - `LocalMirror=` can now be set for tools trees.
-- A new setting `DriveType=` has been added to configures the disk type to use for the root disk when booting
+- A new setting `DiskType=` has been added to configures the disk type to use for the root disk when booting
   a virtual machine.
 - Four new settings `ElTorito=`, `ElToritoSystem=`, `ElToritoVolume=`, and `ElToritoPublisher=` for use with
   systemd-repart's El Torito support have been added.


### PR DESCRIPTION
See e.g.:
https://github.com/systemd/mkosi/blob/1da3299aecc56a1ba590a7fb7ae868275bb46d93/mkosi/resources/man/mkosi.1.md?plain=1#L1934
https://github.com/systemd/mkosi/blob/1da3299aecc56a1ba590a7fb7ae868275bb46d93/tests/test_json.py#L170