### PR TITLE
Allow using SignInitrdPCRs with SplitArtifacts=pcrs

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1721,6 +1721,7 @@ def build_uki(
         die("Could not find ukify")
 
     json_out = False
+    ukify_version = systemd_tool_version(python_binary(context.config), ukify, sandbox=context.sandbox)
 
     arguments: list[PathString] = [
         "--os-release", f"@{workdir(context.root / 'usr/lib/os-release')}",
@@ -1776,8 +1777,6 @@ def build_uki(
             "--pcr-banks", "sha256",
         ]  # fmt: skip
 
-        ukify_version = systemd_tool_version(python_binary(context.config), ukify, sandbox=context.sandbox)
-
         if ukify_version >= "258":
             cert_parameter = "--pcr-certificate"
         else:
@@ -1830,6 +1829,10 @@ def build_uki(
             "--pcr-banks", "sha256",
             "--pcr-certificate", workdir(context.config.sign_expected_pcr_certificate),
         ]  # fmt: skip
+        if context.config.sign_initrd_pcrs == ConfigFeature.enabled or (
+            context.config.sign_initrd_pcrs == ConfigFeature.auto and ukify_version >= "262~"
+        ):
+            arguments += ["--sign-initrd-pcrs"]
         options += [
             "--ro-bind", context.config.sign_expected_pcr_certificate, workdir(context.config.sign_expected_pcr_certificate),  # noqa: E501
         ]  # fmt: skip
@@ -2754,8 +2757,10 @@ def check_inputs(config: Config) -> None:
             hint="Run mkosi genkey to generate a key/certificate pair",
         )
 
-    if config.sign_initrd_pcrs == ConfigFeature.enabled and not want_signed_pcrs(config):
-        die("SignInitrdPCRs= is enabled but PCR signing is not enabled")
+    if config.sign_initrd_pcrs == ConfigFeature.enabled and not (
+        want_signed_pcrs(config) or ArtifactOutput.pcrs in config.split_artifacts
+    ):
+        die("SignInitrdPCRs= is enabled but neither PCR signing nor SplitArtifacts=pcrs are enabled")
 
     if config.secure_boot_key_source != config.sign_expected_pcr_key_source:
         die("Secure boot key source and expected PCR signatures key source have to be the same")

--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -1784,7 +1784,7 @@ def build_uki(
             cert_parameter = "--pcr-public-key"
 
         if context.config.sign_initrd_pcrs == ConfigFeature.enabled or (
-            context.config.sign_initrd_pcrs == ConfigFeature.auto and ukify_version >= "261.999"
+            context.config.sign_initrd_pcrs == ConfigFeature.auto and ukify_version >= "262~"
         ):
             arguments += ["--sign-initrd-pcrs"]
 
@@ -2909,7 +2909,7 @@ def check_tools(config: Config, verb: Verb) -> None:
         if config.sign_initrd_pcrs == ConfigFeature.enabled and want_signed_pcrs(config):
             check_ukify(
                 config,
-                version="261.999",
+                version="262~",
                 reason="sign a PCR policy for the initrd",
             )
 

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1458,11 +1458,18 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 :   Path to the X.509 file containing the certificate for signing the expected PCR signatures.
 
 `SignInitrdPCRs=`, `--sign-initrd-pcrs=`
-:   Whether to generate signed PCR policies that can only be satisfied from the
-    initrd. This is required for initialization of NvPCRs. This takes a boolean value
-    or the special value `auto`, which is the default and is equivalent to a true value
-    if PCR signing is enabled (see `SignExpectedPcr=`) and the version of **ukify** is
-    at least v262. Signing is performed with the key that is supplied to `SignExpectedPcrKey=`.
+:   Whether to generate PCR policies that can only be satisfied from the initrd.
+    This is required for initialization of NvPCRs. This takes a boolean value or
+    the special value `auto`, which is the default and is equivalent to a true
+    value if the version of **ukify** is at least v262 and either PCR signing is
+    enabled (see `SignExpectedPcr=`) or `pcrs` is selected in `SplitArtifacts=`.
+    If enabled explicitly, either PCR signing or `SplitArtifacts=pcrs` must be
+    enabled as well.
+
+    When PCR signing is enabled, the policies are signed with the key supplied to
+    `SignExpectedPcrKey=` and embedded in the UKI. If `SplitArtifacts=pcrs` is
+    enabled and PCR signing is disabled, the policy digests are written unsigned to
+    the split PCR JSON artifact for offline signing.
 
 `SecureBootKeySource=`, `--secure-boot-key-source=`, `VerityKeySource=`, `--verity-key-source=`, `SignExpectedPcrKeySource=`, `--sign-expected-key-source=`
 :   The source of the corresponding private key, to support OpenSSL engines and providers,


### PR DESCRIPTION
Needs https://github.com/systemd/systemd/pull/43609 to work end-to-end