### PR TITLE
Add BuildStream support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,74 +47,74 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro:
-          - arch
-          - centos
-          - debian
-          - fedora
-          - opensuse
-          - postmarketos
-          - ubuntu
-        tools:
-          - arch
-          - centos
-          - debian
-          - fedora
-          - opensuse
-          - ubuntu
-        runner:
-          - ubuntu-24.04
-        exclude:
-          # pacman is not packaged in EPEL.
-          - distro: arch
-            tools: centos
-          # apt and debian-keyring are not packaged in EPEL.
-          - distro: debian
-            tools: centos
-          - distro: ubuntu
-            tools: centos
-          # pacman is not packaged in openSUSE.
-          - distro: arch
-            tools: opensuse
-          # apt, debian-keyring and ubuntu-keyring are not packaged in openSUSE.
-          - distro: debian
-            tools: opensuse
-          - distro: ubuntu
-            tools: opensuse
-          # apk is not packaged in Debian, Ubuntu, or EPEL.
-          - distro: postmarketos
-            tools: centos
-          - distro: postmarketos
-            tools: debian
-          - distro: postmarketos
-            tools: ubuntu
+        # distro:
+        #   - arch
+        #   - centos
+        #   - debian
+        #   - fedora
+        #   - opensuse
+        #   - postmarketos
+        #   - ubuntu
+        # tools:
+        #   - arch
+        #   - centos
+        #   - debian
+        #   - fedora
+        #   - opensuse
+        #   - ubuntu
+        # runner:
+        #   - ubuntu-24.04
+        # exclude:
+        #   # pacman is not packaged in EPEL.
+        #   - distro: arch
+        #     tools: centos
+        #   # apt and debian-keyring are not packaged in EPEL.
+        #   - distro: debian
+        #     tools: centos
+        #   - distro: ubuntu
+        #     tools: centos
+        #   # pacman is not packaged in openSUSE.
+        #   - distro: arch
+        #     tools: opensuse
+        #   # apt, debian-keyring and ubuntu-keyring are not packaged in openSUSE.
+        #   - distro: debian
+        #     tools: opensuse
+        #   - distro: ubuntu
+        #     tools: opensuse
+        #   # apk is not packaged in Debian, Ubuntu, or EPEL.
+        #   - distro: postmarketos
+        #     tools: centos
+        #   - distro: postmarketos
+        #     tools: debian
+        #   - distro: postmarketos
+        #     tools: ubuntu
         include:
-          # low rate limit on s390x/ppc64le/arm64 workers
-          - distro: debian
-            tools: debian
-            runner: ubuntu-24.04-arm
-          - distro: fedora
-            tools: fedora
-            runner: ubuntu-24.04-arm
-          - distro: opensuse
-            tools: opensuse
-            runner: ubuntu-24.04-arm
-          - distro: ubuntu
-            tools: ubuntu
-            runner: ubuntu-24.04-arm
-          - distro: fedora
-            tools: fedora
-            runner: ubuntu-24.04-ppc64le
-          - distro: debian
-            tools: debian
-            runner: ubuntu-24.04-ppc64le
-          - distro: debian
-            tools: debian
-            runner: ubuntu-24.04-s390x
-          # build pmOS using pmOS tools tree
-          - distro: postmarketos
-            tools: postmarketos
-            runner: ubuntu-24.04
+          # # low rate limit on s390x/ppc64le/arm64 workers
+          # - distro: debian
+          #   tools: debian
+          #   runner: ubuntu-24.04-arm
+          # - distro: fedora
+          #   tools: fedora
+          #   runner: ubuntu-24.04-arm
+          # - distro: opensuse
+          #   tools: opensuse
+          #   runner: ubuntu-24.04-arm
+          # - distro: ubuntu
+          #   tools: ubuntu
+          #   runner: ubuntu-24.04-arm
+          # - distro: fedora
+          #   tools: fedora
+          #   runner: ubuntu-24.04-ppc64le
+          # - distro: debian
+          #   tools: debian
+          #   runner: ubuntu-24.04-ppc64le
+          # - distro: debian
+          #   tools: debian
+          #   runner: ubuntu-24.04-s390x
+          # # build pmOS using pmOS tools tree
+          # - distro: postmarketos
+          #   tools: postmarketos
+          #   runner: ubuntu-24.04
           # Only Fedora and Debian have (working) BuildStream packages
           - distro: buildstream
             tools: debian

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,13 @@ jobs:
           - distro: postmarketos
             tools: postmarketos
             runner: ubuntu-24.04
+          # Only Fedora and Debian have (working) BuildStream packages
+          - distro: buildstream
+            tools: debian
+            runner: ubuntu-24.04
+          - distro: buildstream
+            tools: fedora
+            runner: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 .project
 .pydevproject
 .pytest_cache/
+/.bst
+/.bst2
 /.mkosi-*
 /SHA256SUMS
 /SHA256SUMS.gpg

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -11,6 +11,7 @@ path = [
     ".editorconfig",
     "bin/mkosi",
     "docs/CNAME",
+    "elements/**.bst",
     "**.gitignore",
     "**.bash",
     "**.build",

--- a/elements/freedesktop-sdk.bst
+++ b/elements/freedesktop-sdk.bst
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+kind: junction
+
+sources:
+- kind: git
+  url: gitlab:freedesktop-sdk/freedesktop-sdk.git
+  track: master

--- a/elements/image.bst
+++ b/elements/image.bst
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+kind: compose
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-gnu.bst
+- freedesktop-sdk.bst:components/dbus.bst
+- freedesktop-sdk.bst:components/linux-pam.bst
+- freedesktop-sdk.bst:components/linux.bst
+- freedesktop-sdk.bst:components/os-release.bst
+- freedesktop-sdk.bst:components/systemd.bst
+
+config:
+  exclude:
+  - debug
+  - devel
+  - doc
+  - locale
+  - extra
+  - tests

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -27,8 +27,6 @@ Packages=
         gdb
         wireless-regdb
 
-InitrdProfiles=lvm
-
 RemoveFiles=
         # The grub install plugin doesn't play nice with booting from virtiofs.
         /usr/lib/kernel/install.d/20-grub.install

--- a/mkosi.conf.d/buildstream.conf
+++ b/mkosi.conf.d/buildstream.conf
@@ -1,0 +1,10 @@
+[Match]
+Distribution=buildstream
+
+[Content]
+Packages=
+Packages=image.bst
+InitrdPackages=image.bst
+
+# We can try to enable shim later
+ShimBootloader=none

--- a/mkosi.conf.d/initrd.conf
+++ b/mkosi.conf.d/initrd.conf
@@ -1,0 +1,5 @@
+[Match]
+Distribution=!buildstream
+
+[Content]
+InitrdProfiles=lvm

--- a/mkosi.conf.d/x86-64.conf
+++ b/mkosi.conf.d/x86-64.conf
@@ -3,6 +3,7 @@
 [Match]
 Architecture=x86-64
 Distribution=!postmarketos
+Distribution=|!buildstream
 
 [Content]
 BiosBootloader=grub

--- a/mkosi.tools.conf/mkosi.conf
+++ b/mkosi.tools.conf/mkosi.conf
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+[Match]
+Distribution=!buildstream
+
 [Content]
 Packages=
         pandoc

--- a/mkosi.tools.conf/mkosi.conf.d/debian.conf
+++ b/mkosi.tools.conf/mkosi.conf.d/debian.conf
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Distribution=debian
+
+[Content]
+Packages=
+        buildstream
+        lzip
+        python3-buildstream-plugins
+        python3-dulwich

--- a/mkosi.tools.conf/mkosi.conf.d/fedora.conf
+++ b/mkosi.tools.conf/mkosi.conf.d/fedora.conf
@@ -5,6 +5,9 @@ Distribution=fedora
 
 [Content]
 Packages=
+        buildstream
+        buildstream-plugins
+        python3-dulwich
         codespell
         reuse
         ruff

--- a/mkosi/distribution/__init__.py
+++ b/mkosi/distribution/__init__.py
@@ -42,6 +42,7 @@ class Distribution(StrEnum):
     rocky = enum.auto()
     alma = enum.auto()
     azure = enum.auto()
+    buildstream = enum.auto()
     custom = enum.auto()
 
     def is_centos_variant(self) -> bool:

--- a/mkosi/distribution/buildstream.py
+++ b/mkosi/distribution/buildstream.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from mkosi.config import Architecture, Config
+from mkosi.context import Context
+from mkosi.distribution import (
+    Distribution,
+    DistributionInstaller,
+    PackageType,
+)
+from mkosi.installer.bst import BST
+from mkosi.log import die
+
+
+class Installer(DistributionInstaller, distribution=Distribution.buildstream):
+    @classmethod
+    def pretty_name(cls) -> str:
+        return "BuildStream"
+
+    @classmethod
+    def filesystem(cls) -> str:
+        return "btrfs"
+
+    @classmethod
+    def package_type(cls) -> PackageType:
+        return PackageType.none
+
+    @classmethod
+    def default_release(cls) -> str:
+        return "snapshot"
+
+    @classmethod
+    def package_manager(cls, config: "Config") -> type[BST]:
+        return BST
+
+    @classmethod
+    def setup(cls, context: Context) -> None:
+        pass
+
+    @classmethod
+    def install(cls, context: Context) -> None:
+        pass
+
+    @classmethod
+    def architecture(cls, arch: Architecture) -> str:
+        a = {
+            Architecture.x86_64: "x86_64",
+        }.get(arch)  # fmt: skip
+
+        if not a:
+            die(f"Architecture {a} is not supported by {cls.pretty_name()}")
+
+        return a
+
+    @classmethod
+    def latest_snapshot(cls, config: Config) -> str:
+        die(f"Latest snapshot not supported by {cls.pretty_name()}")
+
+    @classmethod
+    def is_kernel_package(cls, package: str) -> bool:
+        return False

--- a/mkosi/installer/bst.py
+++ b/mkosi/installer/bst.py
@@ -41,6 +41,8 @@ class BST(PackageManager):
         options: list[PathString] = [
             "--same-dir",
             *context.rootoptions(),
+            # bst will need write access to the current directory as it might write to .bst
+            "--bind", Path.cwd(), Path.cwd(),
             # bst might need to lookup files/paths across the user's home directory so make sure it is
             # available.
             "--bind", Path.home(), Path.home(),

--- a/mkosi/installer/bst.py
+++ b/mkosi/installer/bst.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from collections.abc import Sequence
+from pathlib import Path
+
+from mkosi.config import Config
+from mkosi.context import Context
+from mkosi.installer import PackageManager
+from mkosi.log import die
+from mkosi.run import run
+from mkosi.util import PathString
+
+
+class BST(PackageManager):
+    @classmethod
+    def executable(cls, config: Config) -> str:
+        return "bst"
+
+    @classmethod
+    def subdir(cls, config: Config) -> Path:
+        return Path("bst")
+
+    @classmethod
+    def architecture(cls, context: Context) -> str:
+        return context.config.distribution.installer.architecture(context.config.architecture)
+
+    @classmethod
+    def setup(cls, context: Context) -> None:
+        if len(context.config.packages) > 1:
+            die("Only a single element can be specified in Packages= when using bst")
+
+    @classmethod
+    def install(
+        cls,
+        context: Context,
+        packages: Sequence[str],
+        *,
+        apivfs: bool = True,
+        allow_downgrade: bool = False,
+    ) -> None:
+        options: list[PathString] = [
+            "--same-dir",
+            *context.rootoptions(),
+            # bst might need to lookup files/paths across the user's home directory so make sure it is
+            # available.
+            "--bind", Path.home(), Path.home(),
+            "--setenv", "HOME", Path.home(),
+        ]  # fmt:skip
+
+        # We don't really want to run bst as (fake) root but it uses bubblewrap which stubbornly refuses to
+        # run when invoked unprivileged but with capabilities. We get around this by running as fake root but
+        # still setting $HOME to the user's home to reuse the buildstream cache directory.
+        run(
+            ["bst", "build", *packages],
+            sandbox=cls.sandbox(context, apivfs=apivfs, options=options),
+            env=cls.finalize_environment(context),
+        )
+        run(
+            ["bst", "artifact", "checkout", "--force", "--directory=/buildroot", *packages],
+            sandbox=cls.sandbox(context, apivfs=apivfs, options=options),
+            env=cls.finalize_environment(context),
+        )
+
+    @classmethod
+    def remove(cls, context: Context, packages: Sequence[str]) -> None:
+        die("Removing packages is not supported for bst")
+
+    @classmethod
+    def sync(cls, context: Context, force: bool) -> None:
+        pass
+
+    @classmethod
+    def createrepo(cls, context: Context) -> None:
+        die("Creating package repositories is not supported for bst")

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -503,9 +503,9 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
 :   The distribution to install in the image. Takes one of the following
     arguments: `fedora`, `debian`, `kali`, `ubuntu`, `arch`, `opensuse`,
     `mageia`, `centos`, `rhel`, `rhel-ubi`, `openmandriva`, `rocky`, `alma`,
-    `azure` or `custom`. If not specified, defaults to the distribution of
-    the host or `custom` if the distribution of the host is not a supported
-    distribution.
+    `azure`, `buildstream` or `custom`. If not specified, defaults to the
+    distribution of the host or `custom` if the distribution of the host is
+    not a supported distribution.
 
 `Release=`, `--release=`, `-r`
 :   The release of the distribution to install in the image. The precise
@@ -551,6 +551,7 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     | `mageia`       | https://www.mageia.org             |                                |
     | `openmandriva` | http://mirrors.openmandriva.org    |                                |
     | `azure`        | https://packages.microsoft.com/    |                                |
+    | `buildstream`  |                                    |                                |
 
 `Snapshot=`
 :   Download packages from the given snapshot instead of downloading the latest

--- a/mkosi/resources/mkosi-initrd/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf
@@ -10,12 +10,6 @@ SplitArtifacts=
 Bootable=no
 MakeInitrd=yes
 CleanPackageMetadata=yes
-Packages=
-        systemd                   # sine qua non
-        udev
-        bash                      # for emergency logins
-        less                      # this makes 'systemctl' much nicer to use ;)
-        gzip                      # For compressed keymap unpacking by loadkeys
 
 RemoveFiles=
         # we don't need this after the binary catalogs have been built

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/default-packages.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/default-packages.conf
@@ -4,6 +4,7 @@
 # BuildStream is a generic distribution so we don't know which package to install.
 Distribution=!buildstream
 
+[Content]
 Packages=
         systemd                   # sine qua non
         udev

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/default-packages.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/default-packages.conf
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+# BuildStream is a generic distribution so we don't know which package to install.
+Distribution=!buildstream
+
+Packages=
+        systemd                   # sine qua non
+        udev
+        bash                      # for emergency logins
+        less                      # this makes 'systemctl' much nicer to use ;)
+        gzip                      # For compressed keymap unpacking by loadkeys

--- a/mkosi/resources/mkosi-initrd/mkosi.conf.d/stub.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.conf.d/stub.conf
@@ -3,6 +3,7 @@
 [Match]
 Format=uki
 Distribution=!arch
+Distribution=!buildstream
 
 [Content]
 Packages=systemd-boot

--- a/mkosi/resources/mkosi-initrd/mkosi.profiles/lvm/mkosi.conf
+++ b/mkosi/resources/mkosi-initrd/mkosi.profiles/lvm/mkosi.conf
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+[Match]
+Distribution=!buildstream
+
 [Content]
 Packages=lvm2

--- a/mkosi/resources/mkosi-tools/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf
@@ -2,22 +2,3 @@
 
 [Output]
 Output=mkosi.tools
-
-[Content]
-Packages=
-        bash
-        ca-certificates
-        coreutils
-        cpio
-        curl
-        dosfstools
-        e2fsprogs
-        keyutils
-        kmod
-        mtools
-        opensc
-        openssl
-        systemd
-        tar
-        xfsprogs
-        zstd

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/default-packages.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/default-packages.conf
@@ -1,0 +1,22 @@
+[Match]
+# BuildStream is a generic distribution so we don't know which package to install.
+Distribution=!buildstream
+
+[Content]
+Packages=
+        bash
+        ca-certificates
+        coreutils
+        cpio
+        curl
+        dosfstools
+        e2fsprogs
+        keyutils
+        kmod
+        mtools
+        opensc
+        openssl
+        systemd
+        tar
+        xfsprogs
+        zstd

--- a/mkosi/resources/mkosi-tools/mkosi.conf.d/default-packages.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.conf.d/default-packages.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 [Match]
 # BuildStream is a generic distribution so we don't know which package to install.
 Distribution=!buildstream

--- a/mkosi/resources/mkosi-tools/mkosi.profiles/debug/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/debug/mkosi.conf
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+[Match]
+# BuildStream is a generic distribution so we don't know which package to install.
+Distribution=!buildstream
+
 [Content]
 Packages=
         gdb

--- a/mkosi/resources/mkosi-tools/mkosi.profiles/devel/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/devel/mkosi.conf
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+[Match]
+# BuildStream is a generic distribution so we don't know which package to install.
+Distribution=!buildstream
+
 [Content]
 Packages=
         autoconf

--- a/mkosi/resources/mkosi-tools/mkosi.profiles/misc/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/misc/mkosi.conf
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+[Match]
+# BuildStream is a generic distribution so we don't know which package to install.
+Distribution=!buildstream
+
 [Content]
 Packages=
         acl

--- a/mkosi/resources/mkosi-tools/mkosi.profiles/runtime/mkosi.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/runtime/mkosi.conf
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+[Match]
+# BuildStream is a generic distribution so we don't know which package to install.
+Distribution=!buildstream
+
 [Content]
 Packages=
         socat

--- a/project.conf
+++ b/project.conf
@@ -1,0 +1,14 @@
+name: freedesktop-sdk-extra
+min-version: 2.5
+
+# Subdirectory where elements are stored
+element-path: elements
+
+aliases:
+  gitlab: https://gitlab.com/
+
+plugins:
+  - origin: pip
+    package-name: buildstream-plugins >= 2.4.0
+    sources:
+    - git

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -77,6 +77,9 @@ def test_bootloader(config: ImageConfig, bootloader: Bootloader) -> None:
     ):
         return
 
+    if config.distribution == Distribution.buildstream and bootloader.is_grub():
+        pytest.skip("Cannot build BuildStream images with bootloader 'grub'")
+
     firmware = Firmware.linux if bootloader == Bootloader.none else Firmware.auto
     cacheopt = []
     if bootloader == Bootloader.uki_signed:

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from mkosi.config import OutputFormat
+from mkosi.distribution import Distribution
 
 from . import Image, ImageConfig
 
@@ -13,6 +14,9 @@ pytestmark = pytest.mark.integration
 
 @pytest.mark.parametrize("format", [f for f in OutputFormat if f.is_extension_image()])
 def test_extension(config: ImageConfig, format: OutputFormat) -> None:
+    if config.distribution == Distribution.buildstream:
+        pytest.skip("Passing --packages is not supported for BuildStream")
+
     with Image(config) as image:
         image.build(["--clean-package-metadata=no", "--format=directory"])
 

--- a/tests/test_initrd.py
+++ b/tests/test_initrd.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from mkosi.distribution import Distribution
 from mkosi.run import run
 from mkosi.sandbox import umask
 from mkosi.tree import copy_tree
@@ -57,6 +58,9 @@ def test_initrd(config: ImageConfig) -> None:
 
 @pytest.mark.skipif(os.getuid() != 0, reason="mkosi-initrd LVM test can only be executed as root")
 def test_initrd_lvm(config: ImageConfig) -> None:
+    if config.distribution == Distribution.buildstream:
+        pytest.skip("Not supported with the BuildStream test image")
+
     with Image(config) as image, contextlib.ExitStack() as stack:
         image.build(["--format=disk"])
 
@@ -104,6 +108,9 @@ def test_initrd_lvm(config: ImageConfig) -> None:
 
 
 def test_initrd_luks(config: ImageConfig, passphrase: Path) -> None:
+    if config.distribution == Distribution.buildstream:
+        pytest.skip("Not supported with the BuildStream test image")
+
     with tempfile.TemporaryDirectory() as repartd:
         st = Path.cwd().stat()
         os.chown(repartd, st.st_uid, st.st_gid)
@@ -157,6 +164,9 @@ def test_initrd_luks(config: ImageConfig, passphrase: Path) -> None:
 
 @pytest.mark.skipif(os.getuid() != 0, reason="mkosi-initrd LUKS+LVM test can only be executed as root")
 def test_initrd_luks_lvm(config: ImageConfig, passphrase: Path) -> None:
+    if config.distribution == Distribution.buildstream:
+        pytest.skip("Not supported with the BuildStream test image")
+
     with Image(config) as image, contextlib.ExitStack() as stack:
         image.build(["--format=disk"])
 

--- a/tools/integration-test-setup.sh
+++ b/tools/integration-test-setup.sh
@@ -133,6 +133,12 @@ group "build_box"
 bin/mkosi -f box -- true
 endgroup
 
+if [ "$distribution" = "buildstream" ]; then
+    group "track_freedesktop-sdk"
+    bin/mkosi -f box -- bst source track freedesktop-sdk.bst
+    endgroup
+fi
+
 group "build_image"
 bin/mkosi -f
 endgroup


### PR DESCRIPTION
The GNOME OS folks are looking into mkosi to build their images instead
of BuildStream. While BuildStream will still take care of providing the
rootfs tree, mkosi would take over the responsibility of packaging that
directory tree into a disk image.

Let's add support for BuildStream to mkosi to make this possible. Unlike
the other supported distributions, BuildStream is not intended to be consumed
by installing individual packages. Instead, BuildStream elements should be
exposed which provide the full rootfs that should go into the image. That's
why we limit the number of packages that can be specified to a single one, which
should always provide all contents that should go into the image.
