### PR TITLE
sandbox: reset umask to 0022 before exec

### DIFF
--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2245,6 +2245,7 @@ class Config:
     proxy_client_key: Optional[Path]
     make_scripts_executable: bool
     foreign_uid_range: bool
+    umask: Optional[int]
 
     nspawn_settings: Optional[Path]
     ephemeral: bool
@@ -2630,6 +2631,9 @@ class Config:
         options: Sequence[PathString] = (),
     ) -> AbstractContextManager[list[PathString]]:
         opt: list[PathString] = [*options]
+
+        if self.umask is not None:
+            opt += ["--umask", str(self.umask)]
 
         if not relaxed:
             opt += flatten(("--ro-bind", d, d) for d in self.extra_search_paths)
@@ -4193,6 +4197,15 @@ SETTINGS: list[ConfigSetting[Any]] = [
         parse=config_parse_boolean,
         help="Use the foreign UID range",
         scope=SettingScope.main,
+    ),
+    ConfigSetting(
+        dest="umask",
+        name="UMask",
+        metavar="MASK",
+        section="Build",
+        parse=config_parse_mode,
+        help="Set umask for processes running in the sandbox",
+        scope=SettingScope.multiversal,
     ),
     # Runtime section
     ConfigSetting(
@@ -6037,6 +6050,7 @@ def summary(config: Config) -> str:
                    Proxy Client Key: {none_to_none(config.proxy_client_key)}
 
     Automatically set +x on scripts: {yes_no(config.make_scripts_executable)}
+                      Sandbox UMask: {format_octal_or_default(config.umask)}
 
     {bold("HOST CONFIGURATION")}:
                     NSpawn Settings: {none_to_none(config.nspawn_settings)}

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2633,7 +2633,7 @@ class Config:
         opt: list[PathString] = [*options]
 
         if self.umask is not None:
-            opt += ["--umask", str(self.umask)]
+            opt += ["--umask", f"{self.umask:o}")]
 
         if not relaxed:
             opt += flatten(("--ro-bind", d, d) for d in self.extra_search_paths)

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -2633,7 +2633,7 @@ class Config:
         opt: list[PathString] = [*options]
 
         if self.umask is not None:
-            opt += ["--umask", f"{self.umask:o}")]
+            opt += ["--umask", f"{self.umask:o}"]
 
         if not relaxed:
             opt += flatten(("--ro-bind", d, d) for d in self.extra_search_paths)

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -1860,6 +1860,15 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     systemd-nsresourced and systemd-mountfsd v260 or newer are required on the host
     to make use of this option.
 
+`UMask=`, `--umask=`
+:   Set the umask for all processes running in the build sandbox, including package
+    managers and build scripts. Takes an octal value, e.g. `0022`. If not set, the
+    host umask is inherited.
+
+    This is useful on hardened builder machines where a restrictive system-wide umask
+    (e.g. `0027`) would otherwise leak into the sandbox and cause files installed into
+    the image to have unexpected permissions.
+
 ### [Runtime] Section (previously known as the [Host] section)
 
 `NSpawnSettings=`, `--settings=`

--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -1712,6 +1712,10 @@ def enter(argv: list[str]) -> list[str]:
             os.environ["LISTEN_FDS"] = str(nfds)
             os.environ["LISTEN_PID"] = str(os.getpid())
 
+    # Reset umask so a restrictive host umask (e.g. 0027) doesn't leak into sandboxed processes
+    # and cause package managers/scripts to create files in the rootfs with wrong permissions.
+    os.umask(0o022)
+
     return argv
 
 

--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -1556,7 +1556,7 @@ def enter(argv: list[str]) -> list[str]:
         elif arg == "--suppress-sync":
             suppress_sync = True
         elif arg == "--umask":
-            umask_value = int(argv.pop())
+            umask_value = int(argv.pop(), 8)
         elif arg == "--unshare-net":
             unshare_net = True
         elif arg == "--unshare-ipc":

--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -1421,6 +1421,7 @@ mkosi-sandbox [OPTIONS...] COMMAND [ARGUMENTS...]
      --map-delegate N             Map N additional 64K UID/GID ranges in the sandbox
      --suppress-chown             Make chown() syscalls in the sandbox a noop
      --suppress-sync              Make sync() syscalls in the sandbox a noop
+     --umask MASK                 Set the umask for processes running in the sandbox
      --unshare-net                Unshare the network namespace if possible
      --unshare-ipc                Unshare the IPC namespace if possible
      --debug                      Log each filesystem operation before executing it
@@ -1457,6 +1458,7 @@ def enter(argv: list[str]) -> list[str]:
     pack_fds = False
     map_foreign = False
     map_delegate = 0
+    umask_value = None
     debug = False
 
     try:
@@ -1553,6 +1555,8 @@ def enter(argv: list[str]) -> list[str]:
             suppress_chown = True
         elif arg == "--suppress-sync":
             suppress_sync = True
+        elif arg == "--umask":
+            umask_value = int(argv.pop())
         elif arg == "--unshare-net":
             unshare_net = True
         elif arg == "--unshare-ipc":
@@ -1712,9 +1716,8 @@ def enter(argv: list[str]) -> list[str]:
             os.environ["LISTEN_FDS"] = str(nfds)
             os.environ["LISTEN_PID"] = str(os.getpid())
 
-    # Reset umask so a restrictive host umask (e.g. 0027) doesn't leak into sandboxed processes
-    # and cause package managers/scripts to create files in the rootfs with wrong permissions.
-    os.umask(0o022)
+    if umask_value is not None:
+        os.umask(umask_value)
 
     return argv
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -413,9 +413,9 @@ def test_config() -> None:
             "SysupdateDirectory": "/sysupdate",
             "TPM": "auto",
             "Timezone": null,
-            "UMask": null,
             "ToolsTree": null,
             "ToolsTreeCertificates": true,
+            "UMask": null,
             "UnifiedKernelImageFormat": "myuki",
             "UnifiedKernelImageProfiles": [
                 {

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -542,6 +542,7 @@ def test_config() -> None:
         machine_id=uuid.UUID("b58253b0cc924a348782bcd99b20d07f"),
         machine="machine",
         make_scripts_executable=False,
+        umask=None,
         make_initrd=False,
         manifest_format=[ManifestFormat.json, ManifestFormat.changelog],
         maxmem=123,

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -413,6 +413,7 @@ def test_config() -> None:
             "SysupdateDirectory": "/sysupdate",
             "TPM": "auto",
             "Timezone": null,
+            "UMask": null,
             "ToolsTree": null,
             "ToolsTreeCertificates": true,
             "UnifiedKernelImageFormat": "myuki",


### PR DESCRIPTION
A restrictive host umask (e.g. 0027) would otherwise leak into all sandboxed processes — package managers, build scripts — causing files installed into the rootfs to have wrong permissions (e.g. directories ending up 0750 instead of 0755).

Reset to 0022 at the end of enter(), after the sandbox is fully set up and right before the sandboxed command is exec'd. Both execution paths (preexec fork and standalone sandbox.py prefix) go through enter(), so one change covers both.