### PR TITLE
sandbox: add force_fallback to acquire_privileges and wire it up via env

### DIFF
--- a/mkosi/__init__.py
+++ b/mkosi/__init__.py
@@ -5111,7 +5111,11 @@ def run_verb(args: Args, tools: Optional[Config], images: Sequence[Config], *, r
     try:
         # Try to get a user namespace with some delegated ranges and the foreign UID range via
         # systemd-nsresourced if we can.
-        acquire_privileges(foreign=True, delegate=3)
+        acquire_privileges(
+            foreign=True,
+            delegate=3,
+            force_fallback=parse_boolean(os.getenv("MKOSI_FORCE_USERNS_FALLBACK", "0")),
+        )
     # Don't fail if systemd-nsresourced is too old, not installed or refuses to provision a user namespace
     # for us unless the foreign UID range was explicitly requested, use a regular unpriv user namespace
     # instead.

--- a/mkosi/sandbox.py
+++ b/mkosi/sandbox.py
@@ -860,6 +860,7 @@ def acquire_privileges(
     delegate: int = 0,
     become_root: bool = False,
     network: bool = False,
+    force_fallback: bool = False,
 ) -> bool:
     if (
         have_effective_cap(CAP_SYS_ADMIN)
@@ -870,7 +871,7 @@ def acquire_privileges(
     ):
         return False
 
-    if not identity or (foreign and not have_effective_cap(CAP_CHOWN)) or delegate:
+    if (not identity or (foreign and not have_effective_cap(CAP_CHOWN)) or delegate) and not force_fallback:
         # nsresource_allocate_user_range() might fail for various reasons and we don't want to leave
         # the process in an empty user namespace if that's the case. Hence we don't unshare our own
         # user namespace but get ourselves a child user namespace which we pass to nsresourced. We only


### PR DESCRIPTION
This adds an environment variable MKOSI_FORCE_USERNS_FALLBACK to force the fallback path that uses an unprivileged userns, that so far was only triggered on errors from nsresourced, making it easier to trigger this without having to disable nsresourced.