### PR TITLE
obs: use policy signing data when available

### DIFF
--- a/mkosi/resources/mkosi-obs/mkosi.build
+++ b/mkosi/resources/mkosi-obs/mkosi.build
@@ -140,14 +140,14 @@ rm -rf nss-db
 while read -r SIG; do
     uki="$OUTPUTDIR/$(basename "$(dirname "${SIG%.sig}")")"
     pcrs="${uki%.efi}.pcrs"
-    pol="$(basename "${SIG%.sig}")"
+    tbs="$(basename "${SIG%.sig}")"
 
     test -f "${pcrs}"
 
-    jq -c --arg pol "$pol" --arg sig "$(base64 -w0 <"$SIG")" '
+    jq -c --arg tbs "$tbs" --arg sig "$(base64 -w0 <"$SIG")" '
         to_entries | map(
             .value |= map(
-                if .pol == $pol then
+                if (.tbs // .pol) == $tbs then
                     .sig = $sig
                 else
                     .

--- a/mkosi/resources/mkosi-obs/mkosi.postoutput
+++ b/mkosi/resources/mkosi-obs/mkosi.postoutput
@@ -41,9 +41,9 @@ for f in "${UKIS[@]}"; do
     test -f "${OUTPUTDIR}/${f}" || continue
     if [ -f "${OUTPUTDIR}/${f%.efi}.pcrs" ]; then
         mkdir -p "hashes/pcrs/$f"
-        while read -r pol; do
-            echo -n "$pol" | tr '[:lower:]' '[:upper:]' | basenc --base16 --decode >"hashes/pcrs/${f}/${pol}"
-        done < <(jq -r 'to_entries[] | .value[].pol' <"${OUTPUTDIR}/${f%.efi}.pcrs")
+        while read -r tbs; do
+            echo -n "$tbs" | tr '[:lower:]' '[:upper:]' | basenc --base16 --decode >"hashes/pcrs/${f}/${tbs}"
+        done < <(jq -r 'to_entries[] | .value[] | .tbs // .pol' <"${OUTPUTDIR}/${f%.efi}.pcrs")
     else
         mkdir -p "$(dirname "hashes/ukis/$f")"
         pesign --force -n sql:"$nss_db" -i "${OUTPUTDIR}/${f}" -E "hashes/ukis/$f"


### PR DESCRIPTION
New systemd-measure output distinguishes the PolicyPCR digest from the complete bytes that must be signed when a policy reference is present.

Use "tbs" for staged signing data and signature lookup, falling back to "pol" for output from older systemd versions.