### PR TITLE
dnf: Only read repositories and variables from the sandbox tree

### DIFF
--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -217,11 +217,15 @@ class Dnf(PackageManager):
         if dnf == "dnf5":
             cmdline += ["--use-host-config"]
         else:
-            cmdline += [
-                "--config=/etc/dnf/dnf.conf",
-                "--setopt=reposdir=/etc/yum.repos.d",
-                "--setopt=varsdir=/etc/dnf/vars",
-            ]
+            cmdline += ["--config=/etc/dnf/dnf.conf"]
+
+        # By default, dnf5 also reads repository definitions and variables from /usr/share/dnf5 which comes
+        # from the tools tree when using one (e.g. Fedora rawhide's fedora-repos ships its repositories there
+        # now), so make sure we only ever use the ones from the sandbox tree.
+        cmdline += [
+            "--setopt=reposdir=/etc/yum.repos.d",
+            "--setopt=varsdir=/etc/dnf/vars",
+        ]
 
         if context.config.proxy_url:
             cmdline += [f"--setopt=proxy={context.config.proxy_url}"]


### PR DESCRIPTION
When using a tools tree, /usr in the sandbox comes from the tools tree.
dnf5 by default also reads repository definitions from
/usr/share/dnf5/repos.d and variables from /usr/share/dnf5/vars.d, and
Fedora rawhide's fedora-repos package now ships its repository
definitions there. As a result, the rawhide and openh264 repositories of
the tools tree are used when building images, which fails outright for
architectures that are not available from the Fedora mirror network:

  Failed to download metadata (metalink: "https://mirrors.fedoraproject.org/metalink?repo=rawhide&arch=riscv64") for repository "rawhide"

Pass --setopt=reposdir=/etc/yum.repos.d and
--setopt=varsdir=/etc/dnf/vars to dnf5 as well, as we already do for
dnf4, so that only the repositories and variables from the sandbox tree
are used.
