### PR TITLE
Add support for Fedora riscv64

### DIFF
--- a/mkosi.conf.d/azure-centos-fedora/mkosi.conf.d/shim.conf
+++ b/mkosi.conf.d/azure-centos-fedora/mkosi.conf.d/shim.conf
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Architecture=|x86-64
+Architecture=|arm64
+
+[Content]
+# A signed shim is only shipped for x86-64 and arm64.
+Packages=
+        shim

--- a/mkosi.conf.d/azure-centos-fedora/mkosi.conf.d/uefi.conf
+++ b/mkosi.conf.d/azure-centos-fedora/mkosi.conf.d/uefi.conf
@@ -6,4 +6,3 @@ Architecture=uefi
 [Content]
 Packages=
         grub2-efi
-        shim

--- a/mkosi.conf.d/fedora/mkosi.conf.d/riscv64.conf
+++ b/mkosi.conf.d/fedora/mkosi.conf.d/riscv64.conf
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[Match]
+Architecture=riscv64
+
+[Output]
+# Fedora's riscv64 kernel is an EFI zboot image which qemu cannot boot directly via -kernel, which is how
+# directory images are booted, so build a disk image and boot it via UEFI instead.
+Format=disk
+
+[Content]
+# Fedora RISC-V only ships an unsigned shim in its staging repository, so boot systemd-boot directly instead
+# of via shim.
+ShimBootloader=none
+
+[Runtime]
+# riscv64 virtual machines are emulated on other architectures, which is slow enough for the root device to
+# not show up within Fedora's default 45s device timeout, so give the virtual machine a few cores and bump
+# systemd's default timeouts.
+CPUs=4
+KernelCommandLineExtra=
+        systemd.default_device_timeout_sec=300
+        systemd.default_timeout_start_sec=300

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -587,10 +587,10 @@ class Architecture(StrEnum):
         if self.is_x86_variant():
             return True
 
-        return self.is_arm_variant() and firmware.is_uefi()
+        return (self.is_arm_variant() or self.is_riscv_variant()) and firmware.is_uefi()
 
     def supports_fw_cfg(self) -> bool:
-        return self.is_x86_variant() or self.is_arm_variant()
+        return self.is_x86_variant() or self.is_arm_variant() or self.is_riscv_variant()
 
     def supports_smm(self) -> bool:
         return self.is_x86_variant()

--- a/mkosi/config.py
+++ b/mkosi/config.py
@@ -640,6 +640,9 @@ class Architecture(StrEnum):
     def is_arm_variant(self) -> bool:
         return self in (Architecture.arm, Architecture.arm64)
 
+    def is_riscv_variant(self) -> bool:
+        return self in (Architecture.riscv32, Architecture.riscv64)
+
     @classmethod
     def native(cls) -> "Architecture":
         return cls.from_uname(platform.machine())

--- a/mkosi/distribution/fedora.py
+++ b/mkosi/distribution/fedora.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+import logging
 import re
 import subprocess
 import tempfile
@@ -135,6 +136,12 @@ class Installer(DistributionInstaller, distribution=Distribution.fedora):
 
     @classmethod
     def setup(cls, context: Context) -> None:
+        if context.config.architecture == Architecture.riscv64 and not context.config.local_mirror:
+            logging.warning(
+                f"{cls.pretty_name()} packages for riscv64 are not signed, "
+                "package signatures will not be verified"
+            )
+
         setup_rpm(context)
         Dnf.setup(
             context,
@@ -169,6 +176,69 @@ class Installer(DistributionInstaller, distribution=Distribution.fedora):
             yield RpmRepository(
                 "fedora", f"baseurl={context.config.local_mirror}", gpgurls, repo_gpgcheck=False
             )
+            return
+
+        if context.config.architecture == Architecture.riscv64:
+            # riscv64 is not a primary Fedora architecture yet. Its packages are built by the Fedora RISC-V
+            # SIG on its own Koji instance and are neither published to the Fedora mirror network nor signed.
+            # The repositories below mirror the definitions from the fedora-repos package shipped by Fedora
+            # RISC-V.
+            if context.config.snapshot:
+                die(f"Snapshot= is not supported for riscv64 on {cls.pretty_name()}")
+
+            mirror = context.config.mirror or "https://riscv-koji.fedoraproject.org"
+            tag = "rawhide" if context.config.release == "rawhide" else "f$releasever"
+
+            url = f"baseurl={join_mirror(mirror, f'repos-dist/{tag}/latest')}"
+            yield RpmRepository(
+                "fedora",
+                f"{url}/$basearch",
+                (),
+                gpgcheck=False,
+                repo_gpgcheck=False,
+                priority=99,
+            )
+            yield RpmRepository(
+                "fedora-debuginfo",
+                f"{url}/$basearch/debug",
+                (),
+                enabled=False,
+                gpgcheck=False,
+                repo_gpgcheck=False,
+                priority=99,
+            )
+            yield RpmRepository(
+                "fedora-source",
+                f"{url}/src",
+                (),
+                enabled=False,
+                gpgcheck=False,
+                repo_gpgcheck=False,
+                priority=99,
+            )
+
+            # Fedora RISC-V enables its staging repository by default and gives it a higher priority than the
+            # main repository.
+            if context.config.release != "rawhide":
+                url = f"baseurl={join_mirror(mirror, 'repos-dist/f$releasever-staging/latest')}"
+                yield RpmRepository(
+                    "fedora-staging",
+                    f"{url}/$basearch",
+                    (),
+                    gpgcheck=False,
+                    repo_gpgcheck=False,
+                    priority=98,
+                )
+                yield RpmRepository(
+                    "fedora-staging-source",
+                    f"{url}/src",
+                    (),
+                    enabled=False,
+                    gpgcheck=False,
+                    repo_gpgcheck=False,
+                    priority=98,
+                )
+
             return
 
         if context.config.release == "eln":

--- a/mkosi/installer/dnf.py
+++ b/mkosi/installer/dnf.py
@@ -134,7 +134,7 @@ class Dnf(PackageManager):
                             [{repo.id}]
                             name={repo.id}
                             {repo.url}
-                            gpgcheck=1
+                            gpgcheck={int(repo.gpgcheck)}
                             repo_gpgcheck={int(repo.repo_gpgcheck and not repo_gpgcheck_broken)}
                             enabled={int(repo.enabled)}
                             """

--- a/mkosi/installer/rpm.py
+++ b/mkosi/installer/rpm.py
@@ -23,9 +23,14 @@ class RpmRepository:
     sslclientcert: Optional[Path] = None
     priority: Optional[int] = None
 
+    # True if rpm signatures should be verified. Note that dnf refuses to install unsigned packages when
+    # verification is enabled, so this has to be disabled for repositories whose packages are not signed
+    # (e.g. Fedora riscv64). Independent of repo_gpgcheck, which covers the repository metadata.
+    gpgcheck: bool = True
+
     # True if the repository metadata (repomd.xml) is GPG-signed with a key we configure (e.g. CentOS).
     # False for repositories that don't publish a repomd signature (e.g. Fedora, EPEL) or sign it with
-    # a key we don't have. rpm signatures (gpgcheck) are always verified.
+    # a key we don't have.
     repo_gpgcheck: bool = True
 
 

--- a/mkosi/installer/zypper.py
+++ b/mkosi/installer/zypper.py
@@ -78,7 +78,7 @@ class Zypper(PackageManager):
                             [{repo.id}]
                             name={repo.id}
                             {repo.url}
-                            gpgcheck=1
+                            gpgcheck={int(repo.gpgcheck)}
                             enabled={int(repo.enabled)}
                             autorefresh=0
                             keeppackages=1

--- a/mkosi/qemu.py
+++ b/mkosi/qemu.py
@@ -742,6 +742,15 @@ def finalize_state(config: Config, cid: int) -> Iterator[None]:
             p.unlink(missing_ok=True)
 
 
+def finalize_nic(netdev: str, model: str, config: Config) -> list[PathString]:
+    # The riscv virt machine does not instantiate network devices from the -nic shorthand, so configure the
+    # network backend and the device explicitly there.
+    if config.architecture.is_riscv_variant():
+        return ["-netdev", f"{netdev},id=mkosi-netdev", "-device", f"{model},netdev=mkosi-netdev"]
+
+    return ["-nic", f"{netdev},model={model}"]
+
+
 def finalize_kernel_command_line_extra(args: Args, config: Config) -> list[str]:
     cmdline = [
         # Make sure we set up networking in the VM/container.
@@ -1040,12 +1049,12 @@ def run_qemu(args: Args, config: Config) -> None:
     ]  # fmt: skip
 
     if config.runtime_network == Network.user:
-        cmdline += ["-nic", f"user,model={config.architecture.default_qemu_nic_model()}"]
+        cmdline += finalize_nic("user", config.architecture.default_qemu_nic_model(), config)
     elif config.runtime_network == Network.interface:
         if os.getuid() != 0:
             die("RuntimeNetwork=interface requires root privileges")
 
-        cmdline += ["-nic", "tap,script=no,model=virtio-net-pci"]
+        cmdline += finalize_nic("tap,script=no", "virtio-net-pci", config)
     elif config.runtime_network == Network.none:
         cmdline += ["-nic", "none"]
 

--- a/mkosi/resources/man/mkosi.1.md
+++ b/mkosi/resources/man/mkosi.1.md
@@ -536,21 +536,24 @@ boolean argument: either `1`, `yes`, or `true` to enable, or `0`, `no`,
     The default mirrors for each distribution are as follows (unless
     specified, the same mirror is used for all architectures):
 
-    |                | x86-64                             | aarch64                        |
-    |----------------|------------------------------------|--------------------------------|
-    | `debian`       | http://deb.debian.org              |                                |
-    | `arch`         | https://fastly.mirror.pkgbuild.com | http://mirror.archlinuxarm.org |
-    | `opensuse`     | http://download.opensuse.org       |                                |
-    | `kali`         | http://http.kali.org/kali          |                                |
-    | `ubuntu`       | http://archive.ubuntu.com          | http://ports.ubuntu.com        |
-    | `centos`       | https://mirrors.centos.org         |                                |
-    | `rocky`        | https://mirrors.rockylinux.org     |                                |
-    | `alma`         | https://mirrors.almalinux.org      |                                |
-    | `fedora`       | https://mirrors.fedoraproject.org  |                                |
-    | `rhel-ubi`     | https://cdn-ubi.redhat.com         |                                |
-    | `mageia`       | https://www.mageia.org             |                                |
-    | `openmandriva` | http://mirrors.openmandriva.org    |                                |
-    | `azure`        | https://packages.microsoft.com/    |                                |
+    |                | x86-64                             | aarch64                        | riscv64                                |
+    |----------------|------------------------------------|--------------------------------|----------------------------------------|
+    | `debian`       | http://deb.debian.org              |                                |                                        |
+    | `arch`         | https://fastly.mirror.pkgbuild.com | http://mirror.archlinuxarm.org |                                        |
+    | `opensuse`     | http://download.opensuse.org       |                                |                                        |
+    | `kali`         | http://http.kali.org/kali          |                                |                                        |
+    | `ubuntu`       | http://archive.ubuntu.com          | http://ports.ubuntu.com        |                                        |
+    | `centos`       | https://mirrors.centos.org         |                                |                                        |
+    | `rocky`        | https://mirrors.rockylinux.org     |                                |                                        |
+    | `alma`         | https://mirrors.almalinux.org      |                                |                                        |
+    | `fedora`       | https://mirrors.fedoraproject.org  |                                | https://riscv-koji.fedoraproject.org   |
+    | `rhel-ubi`     | https://cdn-ubi.redhat.com         |                                |                                        |
+    | `mageia`       | https://www.mageia.org             |                                |                                        |
+    | `openmandriva` | http://mirrors.openmandriva.org    |                                |                                        |
+    | `azure`        | https://packages.microsoft.com/    |                                |                                        |
+
+    Note that Fedora RISC-V packages are not signed, so package signatures are not verified for the riscv64
+    `fedora` repositories.
 
 `Snapshot=`
 :   Download packages from the given snapshot instead of downloading the latest

--- a/mkosi/resources/man/mkosi.news.7.md
+++ b/mkosi/resources/man/mkosi.news.7.md
@@ -4,6 +4,11 @@
 
 # mkosi Changelog
 
+## v28
+
+- Credentials and the extra kernel command line are now passed to riscv64 virtual machines via SMBIOS and
+  fw_cfg when booting via UEFI.
+
 ## v27
 
 - Debug output (with `--debug`) will now show the duration of all steps.

--- a/mkosi/resources/man/mkosi.news.7.md
+++ b/mkosi/resources/man/mkosi.news.7.md
@@ -6,6 +6,9 @@
 
 ## v28
 
+- Support for building Fedora Linux images for riscv64 has been added, using the repositories of the Fedora
+  RISC-V SIG. Note that Fedora RISC-V packages are not signed, so package signatures are not verified for
+  these repositories.
 - Credentials and the extra kernel command line are now passed to riscv64 virtual machines via SMBIOS and
   fw_cfg when booting via UEFI.
 

--- a/mkosi/resources/mkosi-tools/mkosi.profiles/runtime/mkosi.conf.d/fedora.conf
+++ b/mkosi/resources/mkosi-tools/mkosi.profiles/runtime/mkosi.conf.d/fedora.conf
@@ -5,6 +5,8 @@ Distribution=fedora
 
 [Content]
 Packages=
+        edk2-riscv64
         qemu-system-aarch64-core
         qemu-system-ppc-core
+        qemu-system-riscv-core
         qemu-system-s390x-core


### PR DESCRIPTION
- **dnf: Only read repositories and variables from the sandbox tree**
- **qemu: Configure the network device explicitly on riscv64**
- **qemu: Enable SMBIOS and fw_cfg support on riscv64**
- **fedora: Add support for riscv64**
- **mkosi-tools: Install qemu and edk2 for riscv64 on Fedora**
- **Support building the default image for riscv64 on Fedora**
