### PR TITLE
mkosi-obs: Only configure MakeScriptsExecutable in the main image

### DIFF
--- a/mkosi/resources/mkosi-obs/mkosi.conf
+++ b/mkosi/resources/mkosi-obs/mkosi.conf
@@ -8,6 +8,3 @@ SecureBoot=no
 SignExpectedPcr=no
 Verity=defer
 Checksum=yes
-
-[Build]
-MakeScriptsExecutable=yes

--- a/mkosi/resources/mkosi-obs/mkosi.conf.d/main.conf
+++ b/mkosi/resources/mkosi-obs/mkosi.conf.d/main.conf
@@ -11,6 +11,7 @@ ToolsTree=
 CacheDirectory=
 Incremental=no
 WithNetwork=never
+MakeScriptsExecutable=yes
 
 [Distribution]
 RepositoryKeyCheck=no


### PR DESCRIPTION
MakeScriptsExecutable= is multiversal and cannot be configured in subimages. Move it to the existing main-image-only drop-in so subimages can include mkosi-obs again and inherit the value.

Follow-up for 427970d8fd336b7eccbb75ef3780f4f47b32ef54

Fixes: https://github.com/systemd/mkosi/issues/4451