### PR TITLE
run: pass through TERMINFO and TERMINFO_DIRS environment variables

### DIFF
--- a/mkosi/run.py
+++ b/mkosi/run.py
@@ -334,7 +334,7 @@ def spawn(
     if "TMPDIR" in os.environ:
         env["TMPDIR"] = os.environ["TMPDIR"]
 
-    for e in ("SYSTEMD_LOG_LEVEL", "SYSTEMD_LOG_LOCATION", "LD_LIBRARY_PATH"):
+    for e in ("SYSTEMD_LOG_LEVEL", "SYSTEMD_LOG_LOCATION", "LD_LIBRARY_PATH", "TERMINFO", "TERMINFO_DIRS"):
         if e in os.environ:
             env[e] = os.environ[e]
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -3,11 +3,12 @@
 import contextlib
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
-from mkosi.run import fork_and_wait
+from mkosi.run import fork_and_wait, run
 from mkosi.sandbox import EPERM
 
 
@@ -68,3 +69,15 @@ def test_fork_and_wait_sandbox(tmp_path: Path) -> None:
             pytest.skip("CLONE_NEWUSER is not allowed in the test environment")
         raise
     assert result
+
+
+def test_run_terminfo_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TERMINFO", "/custom/terminfo")
+    monkeypatch.setenv("TERMINFO_DIRS", "/custom/terminfo/dirs")
+
+    result = run(
+        [sys.executable, "-c", "import os; print(os.getenv('TERMINFO'), os.getenv('TERMINFO_DIRS'))"],
+        stdout=subprocess.PIPE,
+    )
+    assert result.stdout.strip() == "/custom/terminfo /custom/terminfo/dirs"
+


### PR DESCRIPTION
Fixes #4448

## Summary
Pass through `TERMINFO` and `TERMINFO_DIRS` environment variables in `mkosi/run.py` subprocess spawning alongside `SYSTEMD_LOG_LEVEL`, `SYSTEMD_LOG_LOCATION`, and `LD_LIBRARY_PATH`.

## Motivation
When using terminal emulators such as `xterm-kitty` that rely on non-standard terminfo definitions, commands and VMs spawned via `run()` would fail terminal capabilities detection (`tput: unknown terminal "xterm-kitty"`) when exiting because `TERMINFO` / `TERMINFO_DIRS` were dropped from the sanitized subprocess environment.

## Changes
- In `mkosi/run.py`, added `"TERMINFO"` and `"TERMINFO_DIRS"` to the list of environment variables preserved from `os.environ`.
- Added unit test in `tests/test_run.py` asserting that `TERMINFO` and `TERMINFO_DIRS` are properly passed through by `run()`.

## Validation
- Verified with unit test regression in `tests/test_run.py`.